### PR TITLE
Allow to create mutliple jobs for a function in ready list while it's inputs are still full

### DIFF
--- a/flowrlib/src/debugger.rs
+++ b/flowrlib/src/debugger.rs
@@ -102,7 +102,7 @@ impl Debugger {
     pub fn check(&mut self, state: &mut RunState, next_job_id: usize, function_id: usize) -> (bool, bool) {
         if self.break_at_job == next_job_id ||
             self.function_breakpoints.contains(&function_id) {
-            self.client.display("Sending Job:\n");
+            self.client.display(&format!("Sending Job #{}:\n", next_job_id));
             self.print(state, Some(Param::Numeric(function_id)));
             return self.command_loop(state);
         }

--- a/flowrlib/src/execution.rs
+++ b/flowrlib/src/execution.rs
@@ -38,7 +38,7 @@ fn create_executor(name: String, job_rx: Arc<Mutex<Receiver<Job>>>, output_tx: S
 fn execute(job: Job, output_tx: &Sender<Output>) {
     // Run the implementation with the input values and catch the execution result
     let (result, error) = match panic::catch_unwind(|| {
-        job.implementation.run(job.input_values.clone())
+        job.implementation.run(job.input_set.clone())
     }) {
         Ok(result) => (result, None),
         Err(_) => ((None, false), Some("Execution panicked".into())),
@@ -47,7 +47,7 @@ fn execute(job: Job, output_tx: &Sender<Output>) {
     let output = Output {
         job_id: job.job_id,
         function_id: job.function_id,
-        input_values: job.input_values,
+        input_values: job.input_set,
         result,
         destinations: job.destinations,
         error,

--- a/flowrlib/src/function.rs
+++ b/flowrlib/src/function.rs
@@ -128,11 +128,7 @@ impl Function {
     pub fn is_pure(field: &bool) -> bool { !*field }
 
     pub fn write_input(&mut self, input_number: usize, input_value: Value) {
-        if !self.inputs[input_number].full() {
-            self.inputs[input_number].push(input_value);
-        } else {
-            error!("\t\t\tFunction #{} '{}' Input overflow on input number {}", self.id(), self.name(), input_number);
-        }
+        self.inputs[input_number].push(input_value);
     }
 
     pub fn output_destinations(&self) -> &Vec<(String, usize, usize)> {
@@ -170,12 +166,12 @@ impl Function {
     /*
         Read the values from the inputs and return them for use in executing the function
     */
-    pub fn take_input_values(&mut self) -> Vec<Vec<Value>> {
-        let mut input_values: Vec<Vec<Value>> = Vec::new();
-        for input_value in &mut self.inputs {
-            input_values.push(input_value.take());
+    pub fn take_input_set(&mut self) -> Vec<Vec<Value>> {
+        let mut input_set: Vec<Vec<Value>> = Vec::new();
+        for input in &mut self.inputs {
+            input_set.push(input.take());
         }
-        input_values
+        input_set
     }
 }
 
@@ -208,27 +204,27 @@ mod test {
     #[test]
     fn can_send_input_if_empty() {
         let mut function = Function::new("test".to_string(),
-                                        "/context/test".to_string(),
-                                        "/test".to_string(), false,
-                                        vec!(Input::new(1, &None)),
+                                         "/context/test".to_string(),
+                                         "/test".to_string(), false,
+                                         vec!(Input::new(1, &None)),
                                          0,
-                                        &vec!());
+                                         &vec!());
         function.init_inputs(true);
         function.write_input(0, json!(1));
-        assert_eq!(function.take_input_values().remove(0).remove(0), json!(1));
+        assert_eq!(function.take_input_set().remove(0).remove(0), json!(1));
     }
 
     #[test]
     fn cannot_send_input_if_full() {
         let mut function = Function::new("test".to_string(),
-                                        "/context/test".to_string(),
-                                        "/test".to_string(), false,
-                                        vec!(Input::new(1, &None)),
+                                         "/context/test".to_string(),
+                                         "/test".to_string(), false,
+                                         vec!(Input::new(1, &None)),
                                          0,
-                                        &vec!());
+                                         &vec!());
         function.init_inputs(true);
         function.write_input(0, json!(1)); // success
         function.write_input(0, json!(2)); // fail
-        assert_eq!(function.take_input_values().remove(0).remove(0), json!(1));
+        assert_eq!(function.take_input_set().remove(0).remove(0), json!(1));
     }
 }

--- a/guide/src/first_flow/debugging.md
+++ b/guide/src/first_flow/debugging.md
@@ -54,11 +54,11 @@ DEBUG   - Initializing all functions
 DEBUG   -       Initializing function #0 'HEAD-1'
 DEBUG   -               Function initialized by writing 'Number(1)' to input
 DEBUG   -                       Function #0 inputs are ready
-DEBUG   -                       Function #0 not blocked on output, so added to end of 'Will Run' list
+DEBUG   -                       Function #0 not blocked on output, so added to end of 'Ready' list
 DEBUG   -       Initializing function #1 'HEAD'
 DEBUG   -               Value initialized by writing 'Number(1)' to input
 DEBUG   -                       Function #1 inputs are ready
-DEBUG   -                       Function #1 not blocked on output, so added to end of 'Will Run' list
+DEBUG   -                       Function #1 not blocked on output, so added to end of 'Ready' list
 DEBUG   -       Initializing function #2 'sum'
 DEBUG   -       Initializing function #3 'print'
 DEBUG   - Starting execution loop
@@ -66,7 +66,7 @@ DEBUG   - -----------------------------------------------------------------
 DEBUG   - Dispatch count: 0
 DEBUG   -        Can Run: {1, 0}
 DEBUG   -       Blocking: []
-DEBUG   -       Will Run: [0, 1]
+DEBUG   -       Ready: [0, 1]
 DEBUG   - -------------------------------------
 DEBUG   - Function #0 'HEAD-1' dispatched
 DEBUG   -       Function #0 consumed its inputs, removing from the 'Can Run' list
@@ -76,12 +76,12 @@ DEBUG   -                       Function #0 is now blocked on output by Function
 DEBUG   -               Function #0 'HEAD-1' sending output '1' to Function #3 'print' input #0
 DEBUG   -                       Function #0 is now blocked on output by Function #3
 DEBUG   -                       Function #3 inputs are ready
-DEBUG   -                       Function #3 not blocked on output, so added to end of 'Will Run' list
+DEBUG   -                       Function #3 not blocked on output, so added to end of 'Ready' list
 DEBUG   -       Function #0 'HEAD-1' completed
 DEBUG   - Dispatch count: 1
 DEBUG   -        Can Run: {1, 3}
 DEBUG   -       Blocking: [(2, 0), (3, 0)]
-DEBUG   -       Will Run: [1, 3]
+DEBUG   -       Ready: [1, 3]
 DEBUG   - -------------------------------------
 DEBUG   - Function #1 'HEAD' dispatched
 DEBUG   -       Function #1 consumed its inputs, removing from the 'Can Run' list
@@ -92,10 +92,10 @@ DEBUG   -                       Function #0 inputs are ready
 DEBUG   -               Function #1 'HEAD' sending output '1' to Function #2 'sum' input #1
 DEBUG   -                       Function #1 is now blocked on output by Function #2
 DEBUG   -                       Function #2 inputs are ready
-DEBUG   -                       Function #2 not blocked on output, so added to end of 'Will Run' list
+DEBUG   -                       Function #2 not blocked on output, so added to end of 'Ready' list
 DEBUG   -       Function #1 'HEAD' completed
 DEBUG   - Dispatch count: 2
 DEBUG   -        Can Run: {3, 2, 0}
 DEBUG   -       Blocking: [(2, 0), (3, 0), (0, 1), (2, 1)]
-DEBUG   -       Will Run: [3, 2]
+DEBUG   -       Ready: [3, 2]
 ```


### PR DESCRIPTION
When creating a job for a function, don't remove it from the ready list if it's inputs are still full.
this enables us to create multiple (serial or parallel depending on max-Jobs value) jobs
for a single function that has many input values queued up.