### PR TITLE
Regenerate the library manifest file if:

### DIFF
--- a/flowc/src/flow_compile.rs
+++ b/flowc/src/flow_compile.rs
@@ -69,10 +69,9 @@ pub fn compile_flow(url: Url, args: Vec<String>, dump: bool, skip_generation: bo
 */
 fn compile_supplied_implementations(tables: &mut GenerationTables, skip_building: bool) -> Result<String> {
     for function in &mut tables.functions {
-        match function.get_implementation() {
-            Some(_) => compile_wasm::compile_implementation(function, skip_building),
-            None => Ok("OK".into())
-        }?;
+        if let Some(_) = function.get_implementation() {
+            compile_wasm::compile_implementation(function, skip_building)?;
+        };
     }
 
     Ok("All supplied implementations compiled successfully".into())

--- a/flowc/src/main.rs
+++ b/flowc/src/main.rs
@@ -46,6 +46,7 @@ error_chain! {
     foreign_links {
         Provider(provider::errors::Error);
         Compiler(flowclib::errors::Error);
+        Runtime(flowrlib::errors::Error);
         Io(std::io::Error);
     }
 }
@@ -90,7 +91,7 @@ fn run() -> Result<String> {
             .expect("Could not compile flow");
     }
 
-    Ok("OK".into())
+    Ok("flowc completed".into())
 }
 
 

--- a/flowrlib/src/manifest.rs
+++ b/flowrlib/src/manifest.rs
@@ -6,7 +6,7 @@ use crate::provider::Provider;
 
 pub const DEFAULT_MANIFEST_FILENAME: &str = "manifest";
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, PartialEq)]
 pub struct MetaData {
     pub name: String,
     pub version: String,

--- a/provider/src/content/mod.rs
+++ b/provider/src/content/mod.rs
@@ -1,6 +1,6 @@
 //! Content provider for getting content of flows from files, http or library references.
 pub mod provider;
-mod file_provider;
+pub mod file_provider;
 mod lib_provider;
 mod http_provider;
 


### PR DESCRIPTION
- it's missing
- it's different from the one we gather in memory during building
- any functions are compiled to wasm.

Thus any change to the library contents will result in a new manifest file and it can be used in dependency management.