### PR TITLE
Remove "/context" as the root of a flow, and replace it with "/${flow_alias}", using name if no alias is supplied

### DIFF
--- a/flowc/tests/flowc_compiler_tests.rs
+++ b/flowc/tests/flowc_compiler_tests.rs
@@ -96,12 +96,12 @@ fn same_name_flow_ids() {
 
         // buffer function in first child flow should have flow_id = 1
         let buffer_function = tables.functions.iter()
-            .find(|f| f.route() == &Route::from("/context/child/buffer")).unwrap();
+            .find(|f| f.route() == &Route::from("/parent/child/buffer")).unwrap();
         assert_eq!(buffer_function.get_flow_id(), 1);
 
         // buffer function in second child flow should have flow_id = 2
         let buffer2_function = tables.functions.iter()
-            .find(|f| f.route() == &Route::from("/context/child2/buffer")).unwrap();
+            .find(|f| f.route() == &Route::from("/parent/child2/buffer")).unwrap();
         assert_eq!(buffer2_function.get_flow_id(), 2);
     } else {
         assert!(false, "Process loaded was not a flow");
@@ -235,7 +235,7 @@ fn flow_input_initialized_and_propogated_to_function_in_subflow() {
         Ok(FlowProcess(context)) => {
             let tables = compile::compile(&context).unwrap();
 
-            match tables.functions.iter().find(|&f| f.route() == &Route::from("/context/sequence/compare")) {
+            match tables.functions.iter().find(|&f| f.route() == &Route::from("/subflow_function_input_init/sequence/compare")) {
                 Some(tap_function) => {
                     if let Some(inputs) = tap_function.get_inputs() {
                         let in_input = inputs.get(1).unwrap();
@@ -249,7 +249,7 @@ fn flow_input_initialized_and_propogated_to_function_in_subflow() {
                         panic!("Could not find any inputs");
                     }
                 }
-                None => panic!("Could not find function at route '/context/sequence/compare'")
+                None => panic!("Could not find function at route '/subflow_function_input_init/sequence/compare'")
             }
         }
         _ => panic!("Couldn't load the flow from test file at '{}'", url)

--- a/flowc/tests/flowc_loader_tests.rs
+++ b/flowc/tests/flowc_loader_tests.rs
@@ -89,6 +89,19 @@ fn function_input_initialized() {
     }
 }
 
+
+#[test]
+fn root_flow_takes_name_from_file() {
+    let meta_provider = MetaProvider {};
+    // Relative path from project root to the test file
+    let url = helper::absolute_file_url_from_relative_path("flowc/tests/test-flows/names.toml");
+
+    match loader::load_context(&url, &meta_provider) {
+        Ok(FlowProcess(flow)) => assert_eq!(flow.name, Name::from("names")),
+        _ => panic!("Flow could not be loaded")
+    }
+}
+
 /*
     This tests that an initalizer on an input to a flow process is passed onto function processes
     inside the flow, via a connection from the flow input to the function input

--- a/flowc/tests/flowc_loader_tests.rs
+++ b/flowc/tests/flowc_loader_tests.rs
@@ -110,7 +110,7 @@ fn flow_input_initialized_and_propogated_to_function() {
                         if let Some(inputs) = tap_function.get_inputs() {
                             let in_input = inputs.get(0).unwrap();
                             assert_eq!(Name::from("left"), *in_input.alias(), "Input's name is not 'left' as expected");
-                            assert_eq!(Route::from("/context/count/compare/left"), *in_input.route(), "Input's route is not as expected");
+                            assert_eq!(Route::from("/flow_input_init/count/compare/left"), *in_input.route(), "Input's route is not as expected");
                             let initial_value = in_input.get_initializer();
                             match initial_value {
                                 Some(OneTime(one_time)) => assert_eq!(one_time.once, 10),

--- a/flowc/tests/test-flows/names.toml
+++ b/flowc/tests/test-flows/names.toml
@@ -1,5 +1,13 @@
 flow = "names"
 
-[[process]]
-alias = "print"
+## DO NOT run this flow in tests as the subflow hangs on stdin
+
+[[process]] # Flow process_ref
+source = "subflow.toml"
+
+[[process]] # Function process_ref
 source = "lib://flowruntime/stdio/stdout"
+
+[[connection]]
+from = "subflow/out"
+to = "stdout"

--- a/flowc/tests/test-flows/names.toml
+++ b/flowc/tests/test-flows/names.toml
@@ -1,0 +1,5 @@
+flow = "names"
+
+[[process]]
+alias = "print"
+source = "lib://flowruntime/stdio/stdout"

--- a/flowc/tests/test-flows/subflow.toml
+++ b/flowc/tests/test-flows/subflow.toml
@@ -1,0 +1,11 @@
+flow = "subflow"
+
+[[output]]
+name = "out"
+
+[[process]]
+source = "lib://flowruntime/stdio/stdin"
+
+[[connection]]
+from = "stdin"
+to = "output/out"

--- a/flowclib/src/compiler/compile.rs
+++ b/flowclib/src/compiler/compile.rs
@@ -50,9 +50,9 @@ mod test {
     use super::compile;
 
     /*
-                                            Test for a function that is dead code. It has no connections to it or from it so will
-                                            never run. So it should be removed by the optimizer and not fail at check stage.
-                                        */
+                                                Test for a function that is dead code. It has no connections to it or from it so will
+                                                never run. So it should be removed by the optimizer and not fail at check stage.
+                                            */
     #[test]
     fn dead_function() {
         let function = Function::new(Name::from("Stdout"),
@@ -60,10 +60,10 @@ mod test {
                                      Some("lib://flowruntime/stdio/stdout.toml".to_string()),
                                      Name::from("test-function"),
                                      Some(vec!(IO::new("String",
-                                                       &Route::from("/context/print")))),
+                                                       &Route::from("/print")))),
                                      Some(vec!()),
                                      "lib://flowruntime/stdio/stdout.toml",
-                                     Route::from("/context/print"),
+                                     Route::from("/print"),
                                      Some("lib://flowruntime/stdio/stdout.toml".to_string()),
                                      vec!(),
                                      0,

--- a/flowclib/src/compiler/connector.rs
+++ b/flowclib/src/compiler/connector.rs
@@ -288,10 +288,10 @@ mod test {
     fn collapse_a_connection() {
         let mut left_side = Connection {
             name: Some(Name::from("left")),
-            from: Route::from("/context/function1"),
-            to: Route::from("/context/flow2/a"),
-            from_io: IO::new("String", &Route::from("/context/function1")),
-            to_io: IO::new("String", &Route::from("/context/flow2/a")),
+            from: Route::from("/function1"),
+            to: Route::from("/flow2/a"),
+            from_io: IO::new("String", &Route::from("/function1")),
+            to_io: IO::new("String", &Route::from("/flow2/a")),
             level: 0,
         };
         left_side.from_io.set_flow_io(IOType::FunctionIO);
@@ -300,21 +300,21 @@ mod test {
 // This one goes to a flow but then nowhere, so should be dropped
         let mut extra_one = Connection {
             name: Some(Name::from("unused")),
-            from: Route::from("/context/flow2/a"),
-            to: Route::from("/context/flow2/f4/a"),
-            from_io: IO::new("String", &Route::from("/context/flow2/a")),
-            to_io: IO::new("String", &Route::from("/context/flow2/f4/a")),
+            from: Route::from("/flow2/a"),
+            to: Route::from("/flow2/f4/a"),
+            from_io: IO::new("String", &Route::from("/flow2/a")),
+            to_io: IO::new("String", &Route::from("/flow2/f4/a")),
             level: 1,
         };
         extra_one.from_io.set_flow_io(IOType::FlowInput);
-        extra_one.to_io.set_flow_io(IOType::FlowInput); // /context/flow2/f4 doesn't exist
+        extra_one.to_io.set_flow_io(IOType::FlowInput); // /flow2/f4 doesn't exist
 
         let mut right_side = Connection {
             name: Some(Name::from("right")),
-            from: Route::from("/context/flow2/a"),
-            to: Route::from("/context/flow2/function3"),
-            from_io: IO::new("String", &Route::from("/context/flow2/a")),
-            to_io: IO::new("String", &Route::from("/context/flow2/function3")),
+            from: Route::from("/flow2/a"),
+            to: Route::from("/flow2/function3"),
+            from_io: IO::new("String", &Route::from("/flow2/a")),
+            to_io: IO::new("String", &Route::from("/flow2/function3")),
             level: 1,
         };
         right_side.from_io.set_flow_io(IOType::FlowInput);
@@ -324,8 +324,8 @@ mod test {
 
         let collapsed = collapse_connections(&connections);
         assert_eq!(collapsed.len(), 1);
-        assert_eq!(*collapsed[0].from_io.route(), Route::from("/context/function1"));
-        assert_eq!(*collapsed[0].to_io.route(), Route::from("/context/flow2/function3"));
+        assert_eq!(*collapsed[0].from_io.route(), Route::from("/function1"));
+        assert_eq!(*collapsed[0].to_io.route(), Route::from("/flow2/function3"));
     }
 
     /*
@@ -338,10 +338,10 @@ mod test {
     fn two_connections_from_flow_boundary() {
         let mut left_side = Connection {
             name: Some(Name::from("left")),
-            from: Route::from("/context/f1"),
-            to: Route::from("/context/f2/a"),
-            from_io: IO::new("String", &Route::from("/context/f1")),
-            to_io: IO::new("String", &Route::from("/context/f2/a")),
+            from: Route::from("/f1"),
+            to: Route::from("/f2/a"),
+            from_io: IO::new("String", &Route::from("/f1")),
+            to_io: IO::new("String", &Route::from("/f2/a")),
             level: 0,
         };
         left_side.from_io.set_flow_io(IOType::FunctionIO);
@@ -349,10 +349,10 @@ mod test {
 
         let mut right_side_one = Connection {
             name: Some(Name::from("right1")),
-            from: Route::from("/context/f2/a"),
-            to: Route::from("/context/f2/value1"),
-            from_io: IO::new("String", &Route::from("/context/f2/a")),
-            to_io: IO::new("String", &Route::from("/context/f2/value1")),
+            from: Route::from("/f2/a"),
+            to: Route::from("/f2/value1"),
+            from_io: IO::new("String", &Route::from("/f2/a")),
+            to_io: IO::new("String", &Route::from("/f2/value1")),
             level: 1,
         };
         right_side_one.from_io.set_flow_io(IOType::FlowInput);
@@ -360,10 +360,10 @@ mod test {
 
         let mut right_side_two = Connection {
             name: Some(Name::from("right2")),
-            from: Route::from("/context/f2/a"),
-            to: Route::from("/context/f2/value2"),
-            from_io: IO::new("String", &Route::from("/context/f2/a")),
-            to_io: IO::new("String", &Route::from("/context/f2/value2")),
+            from: Route::from("/f2/a"),
+            to: Route::from("/f2/value2"),
+            from_io: IO::new("String", &Route::from("/f2/a")),
+            to_io: IO::new("String", &Route::from("/f2/value2")),
             level: 1,
         };
         right_side_two.from_io.set_flow_io(IOType::FlowInput);
@@ -374,20 +374,20 @@ mod test {
 
         let collapsed = collapse_connections(&connections);
         assert_eq!(2, collapsed.len());
-        assert_eq!(Route::from("/context/f1"), *collapsed[0].from_io.route());
-        assert_eq!(Route::from("/context/f2/value1"), *collapsed[0].to_io.route());
-        assert_eq!(Route::from("/context/f1"), *collapsed[1].from_io.route());
-        assert_eq!(Route::from("/context/f2/value2"), *collapsed[1].to_io.route());
+        assert_eq!(Route::from("/f1"), *collapsed[0].from_io.route());
+        assert_eq!(Route::from("/f2/value1"), *collapsed[0].to_io.route());
+        assert_eq!(Route::from("/f1"), *collapsed[1].from_io.route());
+        assert_eq!(Route::from("/f2/value2"), *collapsed[1].to_io.route());
     }
 
     #[test]
     fn collapses_connection_into_subflow() {
         let mut first_level = Connection {
             name: Some(Name::from("value-to-f1:a at context level")),
-            from: Route::from("/context/value"),
-            to: Route::from("/context/flow1/a"),
-            from_io: IO::new("String", &Route::from("/context/value")),
-            to_io: IO::new("String", &Route::from("/context/flow1/a")),
+            from: Route::from("/value"),
+            to: Route::from("/flow1/a"),
+            from_io: IO::new("String", &Route::from("/value")),
+            to_io: IO::new("String", &Route::from("/flow1/a")),
             level: 0,
         };
         first_level.from_io.set_flow_io(IOType::FunctionIO);
@@ -395,10 +395,10 @@ mod test {
 
         let mut second_level = Connection {
             name: Some(Name::from("subflow_connection")),
-            from: Route::from("/context/flow1/a"),
-            to: Route::from("/context/flow1/flow2/a"),
-            from_io: IO::new("String", &Route::from("/context/flow1/a")),
-            to_io: IO::new("String", &Route::from("/context/flow1/flow2/a")),
+            from: Route::from("/flow1/a"),
+            to: Route::from("/flow1/flow2/a"),
+            from_io: IO::new("String", &Route::from("/flow1/a")),
+            to_io: IO::new("String", &Route::from("/flow1/flow2/a")),
             level: 1,
         };
         second_level.from_io.set_flow_io(IOType::FlowInput);
@@ -406,10 +406,10 @@ mod test {
 
         let mut third_level = Connection {
             name: Some(Name::from("subsubflow_connection")),
-            from: Route::from("/context/flow1/flow2/a"),
-            to: Route::from("/context/flow1/flow2/func/in"),
-            from_io: IO::new("String", &Route::from("/context/flow1/flow2/a")),
-            to_io: IO::new("String", &Route::from("/context/flow1/flow2/func/in")),
+            from: Route::from("/flow1/flow2/a"),
+            to: Route::from("/flow1/flow2/func/in"),
+            from_io: IO::new("String", &Route::from("/flow1/flow2/a")),
+            to_io: IO::new("String", &Route::from("/flow1/flow2/func/in")),
             level: 2,
         };
         third_level.from_io.set_flow_io(IOType::FlowInput);
@@ -421,8 +421,8 @@ mod test {
 
         let collapsed = collapse_connections(&connections);
         assert_eq!(1, collapsed.len());
-        assert_eq!(Route::from("/context/value"), *collapsed[0].from_io.route());
-        assert_eq!(Route::from("/context/flow1/flow2/func/in"), *collapsed[0].to_io.route());
+        assert_eq!(Route::from("/value"), *collapsed[0].from_io.route());
+        assert_eq!(Route::from("/flow1/flow2/func/in"), *collapsed[0].to_io.route());
     }
 
     #[test]

--- a/flowclib/src/compiler/loader.rs
+++ b/flowclib/src/compiler/loader.rs
@@ -67,7 +67,7 @@ pub trait Validate {
 /// flowclib::compiler::loader::load_context("file:///example.toml", &dummy_provider).unwrap();
 /// ```
 pub fn load_context(url: &str, provider: &dyn Provider) -> Result<Process> {
-    load_process(&Route::from(""), &Name::from("context"),
+    load_process(&Route::from(""), &Name::from(""),
                  0, &mut 0, url, provider, &None, &None)
 }
 
@@ -156,7 +156,11 @@ fn config_function(function: &mut Function, implementation_url: &str, parent_rou
 fn config_flow(flow: &mut Flow, source_url: &str, parent_route: &Route, alias: &Name, id: usize,
                initializations: &Option<HashMap<String, InputInitializer>>) -> Result<()> {
     flow.id = id;
-    flow.alias = alias.clone();
+    if alias.is_empty() {
+        flow.alias = flow.name.clone();
+    } else {
+        flow.alias = alias.clone();
+    }
     flow.source_url = source_url.to_string();
     IO::set_initial_values(flow.inputs_mut(), initializations);
     flow.set_routes_from_parent(parent_route);

--- a/flowclib/src/compiler/loader.rs
+++ b/flowclib/src/compiler/loader.rs
@@ -67,7 +67,7 @@ pub trait Validate {
 /// flowclib::compiler::loader::load_context("file:///example.toml", &dummy_provider).unwrap();
 /// ```
 pub fn load_context(url: &str, provider: &dyn Provider) -> Result<Process> {
-    load_process(&Route::from(""), &Name::from(""),
+    load_process(&Route::default(), &Name::default(),
                  0, &mut 0, url, provider, &None, &None)
 }
 
@@ -127,6 +127,16 @@ fn load_process_refs(flow: &mut Flow, flow_count: &mut usize, provider: &dyn Pro
                                                provider, &process_ref.initializations,
                                                &process_ref.depths)?;
 
+            // if loaded by the defaul alias in the process ref then set the alias to be the name of the loaded process
+            if process_ref.alias.is_empty() {
+                process_ref.alias = Name::from(match process_ref.process {
+                    FlowProcess(ref mut flow) => flow.name().to_lowercase(),
+                    FunctionProcess(ref mut function) => {
+                        function.name().to_lowercase()
+                    }
+                });
+            }
+
             if let FunctionProcess(ref mut function) = process_ref.process {
                 if let Some(lib_ref) = function.get_lib_reference() {
                     flow.lib_references.push(format!("{}/{}", lib_ref, function.name()));
@@ -153,14 +163,10 @@ fn config_function(function: &mut Function, implementation_url: &str, parent_rou
     function.validate()
 }
 
-fn config_flow(flow: &mut Flow, source_url: &str, parent_route: &Route, alias: &Name, id: usize,
+fn config_flow(flow: &mut Flow, source_url: &str, parent_route: &Route, alias_from_reference: &Name, id: usize,
                initializations: &Option<HashMap<String, InputInitializer>>) -> Result<()> {
     flow.id = id;
-    if alias.is_empty() {
-        flow.alias = flow.name.clone();
-    } else {
-        flow.alias = alias.clone();
-    }
+    flow.set_alias(alias_from_reference);
     flow.source_url = source_url.to_string();
     IO::set_initial_values(flow.inputs_mut(), initializations);
     flow.set_routes_from_parent(parent_route);

--- a/flowclib/src/model/flow.rs
+++ b/flowclib/src/model/flow.rs
@@ -168,7 +168,11 @@ impl HasRoute for Flow {
 
 impl SetRoute for Flow {
     fn set_routes_from_parent(&mut self, parent_route: &Route) {
-        self.route = Route::from(format!("{}/{}", parent_route, self.alias));
+        if parent_route.is_empty() {
+            self.route = Route::from(format!("/{}", self.alias));
+        } else {
+            self.route = Route::from(format!("{}/{}", parent_route, self.alias));
+        }
         self.inputs.set_io_routes_from_parent(&self.route, IOType::FlowInput);
         self.outputs.set_io_routes_from_parent(&self.route, IOType::FlowOutput);
     }
@@ -253,14 +257,14 @@ impl Flow {
         match (&direction, segments[0]) {
             (&Direction::FROM, "input")  if segments.len() == 2 => {
                 self.inputs.find_by_name(&Name::from(segments[1]), &None)
-            }, // an input to this flow
-            (&Direction::TO,   "output") if segments.len() == 2 => {
+            } // an input to this flow
+            (&Direction::TO, "output") if segments.len() == 2 => {
                 self.outputs.find_by_name(&Name::from(segments[1]), &None)
-            }, // an output from this flow
-            (&Direction::TO,   _) | (&Direction::FROM, _) => {
+            } // an output from this flow
+            (&Direction::TO, _) | (&Direction::FROM, _) => {
                 let sub_route = Route::from(segments[1..].join("/"));
                 self.get_io_subprocess(&Name::from(segments[0]), direction, &sub_route, initial_value)
-            }, // input or output of a sub-process
+            } // input or output of a sub-process
         }
     }
 

--- a/flowclib/src/model/flow.rs
+++ b/flowclib/src/model/flow.rs
@@ -64,12 +64,6 @@ pub struct Flow {
 impl Validate for Flow {
     // check the correctness of all the fields in this flow, prior to loading sub-elements
     fn validate(&self) -> Result<()> {
-        if let Some(ref process_refs) = self.process_refs {
-            for process_ref in process_refs {
-                process_ref.validate()?;
-            }
-        }
-
         if let Some(ref inputs) = self.inputs {
             for input in inputs {
                 input.validate()?;
@@ -197,6 +191,14 @@ impl Flow {
 
     pub fn default_email() -> String {
         "unknown@unknown.com".to_string()
+    }
+
+    pub fn set_alias(&mut self, alias: &Name) {
+        if alias.is_empty() {
+            self.alias = self.name.clone();
+        } else {
+            self.alias = alias.clone();
+        }
     }
 
     pub fn inputs(&self) -> &IOSet {

--- a/flowclib/src/model/function.rs
+++ b/flowclib/src/model/function.rs
@@ -202,7 +202,11 @@ impl Function {
     }
 
     pub fn set_alias(&mut self, alias: &Name) {
-        self.alias = alias.clone();
+        if alias.is_empty() {
+            self.alias = self.name.clone();
+        } else {
+            self.alias = alias.clone();
+        }
     }
 
     pub fn set_implementation_url(&mut self, source: &str) {

--- a/flowclib/src/model/name.rs
+++ b/flowclib/src/model/name.rs
@@ -44,6 +44,12 @@ impl From<&str> for Name {
     }
 }
 
+impl From<String> for Name {
+    fn from(string: String) -> Self {
+        Name(string)
+    }
+}
+
 impl From<&String> for Name {
     fn from(string: &String) -> Self {
         Name(string.to_string())

--- a/flowclib/src/model/process_reference.rs
+++ b/flowclib/src/model/process_reference.rs
@@ -16,6 +16,7 @@ use crate::model::route::Route;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProcessReference {
+    #[serde(default = "Name::default")]
     pub alias: Name,
     pub source: String,
     #[serde(rename = "input")]

--- a/flowr/tests/flowr_loader_tests.rs
+++ b/flowr/tests/flowr_loader_tests.rs
@@ -106,7 +106,7 @@ pub fn get_manifest() -> LibraryManifest {
 #[test]
 fn resolve_lib_implementation_test() {
     let f_a = Function::new("fA".to_string(), // name
-                            "/context/fA".to_string(),
+                            "/fA".to_string(),
                             "lib://flowruntime/stdio/stdin/Stdin".to_string(),
                             vec!(),
                             0, 0,
@@ -126,7 +126,7 @@ fn resolve_lib_implementation_test() {
 #[test]
 fn unresolved_lib_functions_test() {
     let f_a = Function::new("fA".to_string(), // name
-                            "/context/fA".to_string(),
+                            "/fA".to_string(),
                             "lib://flowruntime/stdio/stdin/Foo".to_string(),
                             vec!(),
                             0, 0,

--- a/flowrlib/src/function.rs
+++ b/flowrlib/src/function.rs
@@ -277,7 +277,7 @@ mod test {
     #[test]
     fn can_send_simple_object() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, false)),
                                          0, 0,
@@ -291,7 +291,7 @@ mod test {
     #[test]
     fn can_send_array_object() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, true)),
                                          0, 0,
@@ -305,7 +305,7 @@ mod test {
     #[test]
     fn can_send_simple_object_to_array_input() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, true)),
                                          0, 0,
@@ -319,7 +319,7 @@ mod test {
     #[test]
     fn can_send_array_to_simple_object_depth_1() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, false)),
                                          0, 0,
@@ -333,7 +333,7 @@ mod test {
     #[test]
     fn second_value_overwrites_on_oversend() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, false)),
                                          0, 0,
@@ -349,7 +349,7 @@ mod test {
     #[should_panic]
     fn cannot_take_input_set_if_not_full() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, false)),
                                          0, 0,
@@ -363,7 +363,7 @@ mod test {
     #[test]
     fn can_send_array_to_simple_object_depth_2() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(2, &None, false)),
                                          0, 0,
@@ -377,7 +377,7 @@ mod test {
     #[test]
     fn can_send_simple_object_when_depth_more_than_1() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(2, &None, false)),
                                          0, 0,
@@ -392,7 +392,7 @@ mod test {
     #[test]
     fn can_send_array_objects_when_input_depth_more_than_1() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(2, &None, true)),
                                          0, 0,
@@ -408,7 +408,7 @@ mod test {
     #[should_panic]
     fn cannot_take_input_set_if_not_full_depth_2() {
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(2, &None, false)),
                                          0, 0,
@@ -422,7 +422,7 @@ mod test {
         let out_conn = OutputConnection::new("/other/input/1".to_string(),
                                              1, 1, 0, None);
         Function::new("test".to_string(),
-                      "/context/test".to_string(),
+                      "/test".to_string(),
                       "/implementation".to_string(),
                       vec!(Input::new(2, &None, false)),
                       1, 0,
@@ -457,7 +457,7 @@ mod test {
         let output_route = OutputConnection::new("/other/input/1".to_string(),
                                                  1, 1, 0, None);
         let mut function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(2, &None, false)),
                                          0, 0,

--- a/flowrlib/src/manifest.rs
+++ b/flowrlib/src/manifest.rs
@@ -104,7 +104,7 @@ mod test {
     #[test]
     fn add_function() {
         let function = Function::new("test".to_string(),
-                                         "/context/test".to_string(),
+                                         "/test".to_string(),
                                          "/test".to_string(),
                                          vec!(Input::new(1, &None, false)),
                                          0, 0,
@@ -131,7 +131,7 @@ mod test {
             \"functions\": [
                 {
                     \"name\": \"print\",
-                    \"route\": \"/context/print\",
+                    \"route\": \"/print\",
                     \"id\": 0,
                     \"flow_id\": 0,
                     \"implementation_location\": \"lib://flowruntime/stdio/stdout/Stdout\",

--- a/flowrlib/src/run_state.rs
+++ b/flowrlib/src/run_state.rs
@@ -1013,10 +1013,10 @@ mod test {
     fn test_function_a_to_b_not_init() -> Function {
         let connection_to_f1 = OutputConnection::new("".to_string(),
                                                      1, 0, 0,
-                                                     Some("/context/fB".to_string()));
+                                                     Some("/fB".to_string()));
 
         Function::new("fA".to_string(), // name
-                      "/context/fA".to_string(),
+                      "/fA".to_string(),
                       "/test".to_string(),
                       vec!(Input::new(1, &None, false)),
                       0, 0,
@@ -1026,9 +1026,9 @@ mod test {
     fn test_function_a_to_b() -> Function {
         let connection_to_f1 = OutputConnection::new("".to_string(),
                                                      1, 0, 0,
-                                                     Some("/context/fB".to_string()));
+                                                     Some("/fB".to_string()));
         Function::new("fA".to_string(), // name
-                      "/context/fA".to_string(),
+                      "/fA".to_string(),
                       "/test".to_string(),
                       vec!(Input::new(1,
                                       &Some(OneTime(OneTimeInputInitializer { once: json!(1) })),
@@ -1039,7 +1039,7 @@ mod test {
 
     fn test_function_a_init() -> Function {
         Function::new("fA".to_string(), // name
-                      "/context/fA".to_string(),
+                      "/fA".to_string(),
                       "/test".to_string(),
                       vec!(Input::new(1,
                                       &Some(OneTime(OneTimeInputInitializer { once: json!(1) })),
@@ -1050,7 +1050,7 @@ mod test {
 
     fn test_function_b_not_init() -> Function {
         Function::new("fB".to_string(), // name
-                      "/context/fB".to_string(),
+                      "/fB".to_string(),
                       "/test".to_string(),
                       vec!(Input::new(1, &None, false)),
                       1, 0,
@@ -1059,7 +1059,7 @@ mod test {
 
     fn test_function_b_init() -> Function {
         Function::new("fB".to_string(), // name
-                      "/context/fB".to_string(),
+                      "/fB".to_string(),
                       "/test".to_string(),
                       vec!(Input::new(1,
                                       &Some(OneTime(OneTimeInputInitializer { once: json!(1) })),
@@ -1267,7 +1267,7 @@ mod test {
         #[test]
         fn to_waiting_on_init() {
             let f_a = Function::new("fA".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     0, 0,
@@ -1302,7 +1302,7 @@ mod test {
         #[test]
         fn unready_not_to_running_on_next() {
             let f_a = Function::new("fA".to_string(),
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     0, 0,
@@ -1366,7 +1366,7 @@ mod test {
         #[test]
         fn running_to_ready_on_done() {
             let f_a = Function::new("fA".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1,
                                                     &Some(Constant(ConstantInputInitializer { constant: json!(1) })),
@@ -1440,7 +1440,7 @@ mod test {
         fn running_to_blocked_on_done() {
             let out_conn = OutputConnection::new("".to_string(), 1, 0, 0, None);
             let f_a = Function::new("fA".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1,
                                                     &Some(Constant(ConstantInputInitializer { constant: json!(1) })),
@@ -1448,7 +1448,7 @@ mod test {
                                     0, 0,
                                     &vec!(out_conn), false); // outputs to fB:0
             let f_b = Function::new("fB".to_string(), // name
-                                    "/context/fB".to_string(),
+                                    "/fB".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     1, 0,
@@ -1478,14 +1478,14 @@ mod test {
         #[test]
         fn waiting_to_ready_on_input() {
             let f_a = Function::new("fA".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     0, 0,
                                     &vec!(), false);
             let out_conn = OutputConnection::new("".into(), 0, 0, 0, None);
             let f_b = Function::new("fB".to_string(), // name
-                                    "/context/fB".to_string(),
+                                    "/fB".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     1, 0,
@@ -1510,7 +1510,7 @@ mod test {
             let f_a = super::test_function_a_to_b_not_init();
             let out_conn = OutputConnection::new("".into(), 0, 0, 0, None);
             let f_b = Function::new("fB".to_string(), // name
-                                    "/context/fB".to_string(),
+                                    "/fB".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1,
                                                     &Some(Constant(ConstantInputInitializer { constant: json!(1) })),
@@ -1544,7 +1544,7 @@ mod test {
             let out_conn0 = OutputConnection::new("".to_string(), 0, 0, 0, None);
             let out_conn1 = OutputConnection::new("".to_string(), 1, 0, 0, None);
             let f_a = Function::new("fA".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1,
                                                     &Some(OneTime(OneTimeInputInitializer { once: json!(1) })),
@@ -1555,7 +1555,7 @@ mod test {
                                         out_conn1 // outputs to f_b:0
                                     ), false);
             let f_b = Function::new("fB".to_string(), // name
-                                    "/context/fB".to_string(),
+                                    "/fB".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     1, 0,
@@ -1635,20 +1635,20 @@ mod test {
             let out_conn1 = OutputConnection::new("".to_string(), 1, 0, 0, None);
             let out_conn2 = OutputConnection::new("".to_string(), 2, 0, 0, None);
             let p0 = Function::new("p0".to_string(), // name
-                                   "/context/p0".to_string(),
+                                   "/p0".to_string(),
                                    "/test".to_string(),
                                    vec!(), // input array
                                    0, 0,
                                    &vec!(out_conn1, out_conn2) // destinations
                                    , false);    // implementation
             let p1 = Function::new("p1".to_string(),
-                                   "/context/p1".to_string(),
+                                   "/p1".to_string(),
                                    "/test".to_string(),
                                    vec!(Input::new(1, &None, false)), // inputs array
                                    1, 0,
                                    &vec!(), false);
             let p2 = Function::new("p2".to_string(),
-                                   "/context/p2".to_string(),
+                                   "/p2".to_string(),
                                    "/test".to_string(),
                                    vec!(Input::new(1, &None, false)), // inputs array
                                    2, 0,
@@ -1810,7 +1810,7 @@ mod test {
         #[test]
         fn can_create_multiple_jobs_from_array_of_inputs() {
             let f_a = Function::new("f_a".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     0, 0,
@@ -1836,7 +1836,7 @@ mod test {
         #[test]
         fn can_create_multiple_jobs_from_array() {
             let f_a = Function::new("f_a".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false)),
                                     0, 0,
@@ -1864,7 +1864,7 @@ mod test {
         #[test]
         fn can_create_multiple_jobs_with_initializer() {
             let f_a = Function::new("f_a".to_string(), // name
-                                    "/context/fA".to_string(),
+                                    "/fA".to_string(),
                                     "/test".to_string(),
                                     vec!(Input::new(1, &None, false),
                                          Input::new(1,

--- a/samples/args/DESCRIPTION.md
+++ b/samples/args/DESCRIPTION.md
@@ -9,6 +9,7 @@ Features Used
 ===
 * Context Flow
 * Library Functions used (`stdio/stdout` from `flowruntime`)
+* Reduced syntax so that `alias` of referenced processes default to their names (`get` and `stdout`)
 * Selecting a specific indexed entry of an `Array` output
 * Library Flows used (`args/get` from `flowstdlib`)
 * Connections between functions

--- a/samples/args/context.toml
+++ b/samples/args/context.toml
@@ -1,13 +1,11 @@
 flow = "arg-print"
 
 [[process]]
-alias = "args"
 source = "lib://flowruntime/args/get"
 
 [[process]]
-alias = "print"
 source = "lib://flowruntime/stdio/stdout"
 
 [[connection]]
-from = "args/2"
-to = "print"
+from = "get/2"
+to = "stdout"


### PR DESCRIPTION
Fixes #519