### PR TITLE
Use function_names directly from function.toml definition in process_refs and dnot lowercase them. Rename them so names match and is more intuitive.

### DIFF
--- a/flowc/src/compiler/loader.rs
+++ b/flowc/src/compiler/loader.rs
@@ -162,15 +162,7 @@ fn load_process_refs(flow: &mut Flow, flow_count: &mut usize, provider: &dyn Pro
                                                flow.id, flow_count, subprocess_url.as_str(),
                                                provider, &process_ref.initializations)?;
 
-            // if loaded by the default alias in the process ref then set the alias to be the name of the loaded process
-            if process_ref.alias.is_empty() {
-                process_ref.alias = Name::from(match process_ref.process {
-                    FlowProcess(ref mut flow) => flow.name().to_lowercase(),
-                    FunctionProcess(ref mut function) => {
-                        function.name().to_lowercase()
-                    }
-                });
-            }
+            process_ref.set_alias();
 
             // runtime needs references to library functions to be able to load the implementations at load time
             // library flow definitions are "compiled down" to just library function references at compile time.

--- a/flowc/src/model/flow.rs
+++ b/flowc/src/model/flow.rs
@@ -215,7 +215,7 @@ impl Flow {
 
     // TODO create a trait HasInputs and HasOutputs and implement it for function and flow
     // and process so this below can avoid the match
-    fn get_io_subprocess(&mut self, subprocess_alias: &Name, direction: Direction, route: &Route,
+    fn get_io_subprocess(&mut self, subprocess_alias: &Name, direction: Direction, sub_route: &Route,
                          initial_value: &Option<InputInitializer>) -> Result<IO> {
         if let Some(ref mut process_refs) = self.process_refs {
             for process_ref in process_refs {
@@ -224,7 +224,7 @@ impl Flow {
                     return match process_ref.process {
                         FlowProcess(ref mut sub_flow) => {
                             debug!("\tFlow sub-process with matching name found, name = '{}'", process_ref.alias);
-                            let io_name = Name::from(route);
+                            let io_name = Name::from(sub_route);
                             match direction {
                                 Direction::TO => sub_flow.inputs.find_by_name(&io_name, initial_value),
                                 Direction::FROM => sub_flow.outputs.find_by_name(&io_name, &None)
@@ -232,17 +232,17 @@ impl Flow {
                         }
                         FunctionProcess(ref mut function) => {
                             match direction {
-                                Direction::TO => function.inputs.find_by_route(route, initial_value),
-                                Direction::FROM => function.get_outputs().find_by_route(route, &None)
+                                Direction::TO => function.inputs.find_by_route(sub_route, initial_value),
+                                Direction::FROM => function.get_outputs().find_by_route(sub_route, &None)
                             }
                         }
-                    };
+                    }
                 }
             }
             bail!("Could not find sub-process named '{}'", subprocess_alias);
         }
 
-        bail!("No sub-processes present");
+        Err(Error::from("No sub-processes present"))
     }
 
     // TODO consider finding the object first using it's type and name (flow, subflow, value, function)

--- a/flowc/src/model/process_reference.rs
+++ b/flowc/src/model/process_reference.rs
@@ -10,6 +10,8 @@ use crate::errors::*;
 use crate::model::name::HasName;
 use crate::model::name::Name;
 use crate::model::process::Process;
+use crate::model::process::Process::FlowProcess;
+use crate::model::process::Process::FunctionProcess;
 use crate::model::route::HasRoute;
 use crate::model::route::Route;
 
@@ -24,6 +26,19 @@ pub struct ProcessReference {
     // Map of initializers of inputs for this reference
     #[serde(skip)]
     pub process: Process,
+}
+
+impl ProcessReference {
+    /// if the ProcessRef does not specify an alias for the process to be loaded
+    /// then set the alias to be the name of the loaded process
+    pub fn set_alias(&mut self) {
+        if self.alias.is_empty() {
+            self.alias = match self.process {
+                FlowProcess(ref mut flow) => flow.name().clone(),
+                FunctionProcess(ref mut function) => function.name().clone()
+            };
+        }
+    }
 }
 
 impl HasName for ProcessReference {

--- a/flowr/tests/flowr-loader_tests.rs
+++ b/flowr/tests/flowr-loader_tests.rs
@@ -93,12 +93,12 @@ fn get_manifest() -> LibraryManifest {
     };
     let mut manifest = LibraryManifest::new(metadata);
 
-    manifest.locators.insert("lib://flowruntime/args/get/Get".to_string(), Native(Arc::new(Fake {})));
-    manifest.locators.insert("lib://flowruntime/file/file_write/FileWrite".to_string(), Native(Arc::new(Fake {})));
-    manifest.locators.insert("lib://flowruntime/stdio/readline/Readline".to_string(), Native(Arc::new(Fake {})));
-    manifest.locators.insert("lib://flowruntime/stdio/stdin/Stdin".to_string(), Native(Arc::new(Fake {})));
-    manifest.locators.insert("lib://flowruntime/stdio/stdout/Stdout".to_string(), Native(Arc::new(Fake {})));
-    manifest.locators.insert("lib://flowruntime/stdio/stderr/Stderr".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/args/get/get".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/file/file_write/file_write".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/stdio/readline/readline".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/stdio/stdin/stdin".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/stdio/stdout/stdout".to_string(), Native(Arc::new(Fake {})));
+    manifest.locators.insert("lib://flowruntime/stdio/stderr/stderr".to_string(), Native(Arc::new(Fake {})));
 
     manifest
 }
@@ -118,7 +118,7 @@ fn write_manifest(manifest: &Manifest, filename: &PathBuf) -> Result<(), String>
 fn load_manifest_from_file() {
     let f_a = Function::new("fA".to_string(), // name
                             "/fA".to_string(),
-                            "lib://flowstdlib/control/join/Join".to_string(),
+                            "lib://flowstdlib/control/join/join".to_string(),
                             vec!(),
                             0, 0,
                             &[], false);
@@ -142,7 +142,7 @@ fn load_manifest_from_file() {
 fn resolve_lib_implementation_test() {
     let f_a = Function::new("fA".to_string(), // name
                             "/fA".to_string(),
-                            "lib://flowruntime/stdio/stdin/Stdin".to_string(),
+                            "lib://flowruntime/stdio/stdin/stdin".to_string(),
                             vec!(),
                             0, 0,
                             &[], false);
@@ -162,7 +162,7 @@ fn resolve_lib_implementation_test() {
 fn unresolved_lib_functions_test() {
     let f_a = Function::new("fA".to_string(), // name
                             "/fA".to_string(),
-                            "lib://flowruntime/stdio/stdin/Foo".to_string(),
+                            "lib://flowruntime/stdio/stdin/foo".to_string(),
                             vec!(),
                             0, 0,
                             &[], false);
@@ -178,6 +178,6 @@ fn unresolved_lib_functions_test() {
     assert!(loader.resolve_implementations(&mut manifest, &manifest_url, &provider).is_err());
 }
 
-// TODO add a wasm provided implementationn loading test
+// TODO add a wasm provided implementation loading test
 
 // TODO add a wasm and native execution test

--- a/flowruntime/args/get.toml
+++ b/flowruntime/args/get.toml
@@ -1,4 +1,4 @@
-function = "Get"
+function = "get"
 implementation = "get.rs"
 impure = true
 

--- a/flowruntime/file/file_write.toml
+++ b/flowruntime/file/file_write.toml
@@ -1,4 +1,4 @@
-function = "FileWrite"
+function = "file_write"
 implementation = "file_write.rs"
 impure = true
 

--- a/flowruntime/image/image_buffer.toml
+++ b/flowruntime/image/image_buffer.toml
@@ -1,4 +1,4 @@
-function = "ImageBuffer"
+function = "image_buffer"
 implementation = "image_buffer.rs"
 impure = true
 

--- a/flowruntime/lib.rs
+++ b/flowruntime/lib.rs
@@ -27,19 +27,19 @@ pub fn get_manifest(client: Arc<Mutex<dyn RuntimeClient>>) -> LibraryManifest {
     };
     let mut manifest = LibraryManifest::new(metadata);
 
-    manifest.locators.insert("lib://flowruntime/args/get/Get".to_string(),
+    manifest.locators.insert("lib://flowruntime/args/get/get".to_string(),
                              Native(Arc::new(args::get::Get { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/file/file_write/FileWrite".to_string(),
+    manifest.locators.insert("lib://flowruntime/file/file_write/file_write".to_string(),
                              Native(Arc::new(file::file_write::FileWrite { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/image/image_buffer/ImageBuffer".to_string(),
+    manifest.locators.insert("lib://flowruntime/image/image_buffer/image_buffer".to_string(),
                              Native(Arc::new(image::image_buffer::ImageBuffer { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/stdio/readline/Readline".to_string(),
+    manifest.locators.insert("lib://flowruntime/stdio/readline/readline".to_string(),
                              Native(Arc::new(stdio::readline::Readline { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/stdio/stdin/Stdin".to_string(),
+    manifest.locators.insert("lib://flowruntime/stdio/stdin/stdin".to_string(),
                              Native(Arc::new(stdio::stdin::Stdin { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/stdio/stdout/Stdout".to_string(),
+    manifest.locators.insert("lib://flowruntime/stdio/stdout/stdout".to_string(),
                              Native(Arc::new(stdio::stdout::Stdout { client: client.clone() })));
-    manifest.locators.insert("lib://flowruntime/stdio/stderr/Stderr".to_string(),
+    manifest.locators.insert("lib://flowruntime/stdio/stderr/stderr".to_string(),
                              Native(Arc::new(stdio::stderr::Stderr { client: client.clone() })));
 
     manifest

--- a/flowruntime/stdio/readline.toml
+++ b/flowruntime/stdio/readline.toml
@@ -1,4 +1,4 @@
-function = "Readline"
+function = "readline"
 implementation = "readline.rs"
 impure = true
 

--- a/flowruntime/stdio/stderr.toml
+++ b/flowruntime/stdio/stderr.toml
@@ -1,4 +1,4 @@
-function = "Stderr"
+function = "stderr"
 implementation = "stderr.rs"
 impure = true
 

--- a/flowruntime/stdio/stdin.toml
+++ b/flowruntime/stdio/stdin.toml
@@ -1,4 +1,4 @@
-function = "Stdin"
+function = "stdin"
 implementation = "stdin.rs"
 impure = true
 

--- a/flowruntime/stdio/stdout.toml
+++ b/flowruntime/stdio/stdout.toml
@@ -1,4 +1,4 @@
-function = "Stdout"
+function = "stdout"
 implementation = "stdout.rs"
 impure = true
 

--- a/flowstdlib/control/compare_switch/compare_switch.toml
+++ b/flowstdlib/control/compare_switch/compare_switch.toml
@@ -1,4 +1,4 @@
-function = "CompareSwitch"
+function = "compare_switch"
 implementation = "compare_switch.rs"
 
 [[input]]

--- a/flowstdlib/control/index/index.toml
+++ b/flowstdlib/control/index/index.toml
@@ -1,4 +1,4 @@
-function = "Index"
+function = "index"
 implementation = "index.rs"
 
 [[input]]

--- a/flowstdlib/control/join/join.toml
+++ b/flowstdlib/control/join/join.toml
@@ -1,4 +1,4 @@
-function = "Join"
+function = "join"
 implementation = "join.rs"
 
 [[input]]

--- a/flowstdlib/control/route/route.toml
+++ b/flowstdlib/control/route/route.toml
@@ -1,4 +1,4 @@
-function = "Route"
+function = "route"
 implementation = "route.rs"
 
 [[input]]

--- a/flowstdlib/control/select/select.toml
+++ b/flowstdlib/control/select/select.toml
@@ -1,4 +1,4 @@
-function = "Select"
+function = "select"
 implementation = "select.rs"
 
 [[input]]

--- a/flowstdlib/control/tap/tap.toml
+++ b/flowstdlib/control/tap/tap.toml
@@ -1,4 +1,4 @@
-function = "Tap"
+function = "tap"
 implementation = "tap.rs"
 
 [[input]]

--- a/flowstdlib/data/accumulate/accumulate.toml
+++ b/flowstdlib/data/accumulate/accumulate.toml
@@ -1,4 +1,4 @@
-function = "Accumulate"
+function = "accumulate"
 implementation = "accumulate.rs"
 
 [[input]]

--- a/flowstdlib/data/append/append.toml
+++ b/flowstdlib/data/append/append.toml
@@ -1,4 +1,4 @@
-function = "Append"
+function = "append"
 implementation = "append.rs"
 
 [[input]]

--- a/flowstdlib/data/buffer/buffer.toml
+++ b/flowstdlib/data/buffer/buffer.toml
@@ -1,4 +1,4 @@
-function = "Buffer"
+function = "buffer"
 implementation = "buffer.rs"
 
 [[input]]

--- a/flowstdlib/data/count/count.toml
+++ b/flowstdlib/data/count/count.toml
@@ -1,4 +1,4 @@
-function = "Count"
+function = "count"
 implementation = "count.rs"
 
 [[input]]

--- a/flowstdlib/data/duplicate/duplicate.toml
+++ b/flowstdlib/data/duplicate/duplicate.toml
@@ -1,4 +1,4 @@
-function = "Duplicate"
+function = "duplicate"
 implementation = "duplicate.rs"
 
 [[input]]

--- a/flowstdlib/data/duplicate_rows/duplicate_rows.toml
+++ b/flowstdlib/data/duplicate_rows/duplicate_rows.toml
@@ -1,4 +1,4 @@
-function = "DuplicateRows"
+function = "duplicate_rows"
 implementation = "duplicate_rows.rs"
 
 [[input]]

--- a/flowstdlib/data/enumerate/enumerate.toml
+++ b/flowstdlib/data/enumerate/enumerate.toml
@@ -1,4 +1,4 @@
-function = "Enumerate"
+function = "enumerate"
 implementation = "enumerate.rs"
 
 [[input]]

--- a/flowstdlib/data/info/info.toml
+++ b/flowstdlib/data/info/info.toml
@@ -1,4 +1,4 @@
-function = "Info"
+function = "info"
 implementation = "info.rs"
 
 [[input]] # - Input value

--- a/flowstdlib/data/multiply_row/multiply_row.toml
+++ b/flowstdlib/data/multiply_row/multiply_row.toml
@@ -1,4 +1,4 @@
-function = "MultiplyRow"
+function = "multiply_row"
 implementation = "multiply_row.rs"
 
 [[input]]

--- a/flowstdlib/data/ordered_split/ordered_split.toml
+++ b/flowstdlib/data/ordered_split/ordered_split.toml
@@ -1,4 +1,4 @@
-function = "OrderedSplit"
+function = "ordered_split"
 implementation = "ordered_split.rs"
 
 [[input]]

--- a/flowstdlib/data/remove/remove.toml
+++ b/flowstdlib/data/remove/remove.toml
@@ -1,4 +1,4 @@
-function = "Remove"
+function = "remove"
 implementation = "remove.rs"
 
 [[input]]

--- a/flowstdlib/data/sort/sort.toml
+++ b/flowstdlib/data/sort/sort.toml
@@ -1,4 +1,4 @@
-function = "Sort"
+function = "sort"
 implementation = "sort.rs"
 
 [[input]]

--- a/flowstdlib/data/split/split.toml
+++ b/flowstdlib/data/split/split.toml
@@ -1,4 +1,4 @@
-function = "Split"
+function = "split"
 implementation = "split.rs"
 
 [[input]]

--- a/flowstdlib/data/transpose/transpose.toml
+++ b/flowstdlib/data/transpose/transpose.toml
@@ -1,4 +1,4 @@
-function = "Transpose"
+function = "transpose"
 implementation = "transpose.rs"
 
 [[input]]

--- a/flowstdlib/data/zip/zip.toml
+++ b/flowstdlib/data/zip/zip.toml
@@ -1,4 +1,4 @@
-function = "Zip"
+function = "zip"
 implementation = "zip.rs"
 
 [[input]]

--- a/flowstdlib/fmt/reverse/reverse.toml
+++ b/flowstdlib/fmt/reverse/reverse.toml
@@ -1,4 +1,4 @@
-function = "Reverse"
+function = "reverse"
 implementation = "reverse.rs"
 
 [[input]]

--- a/flowstdlib/fmt/to_json/to_json.toml
+++ b/flowstdlib/fmt/to_json/to_json.toml
@@ -1,4 +1,4 @@
-function = "ToJson"
+function = "to_json"
 implementation = "to_json.rs"
 
 [[input]]

--- a/flowstdlib/fmt/to_string/to_string.toml
+++ b/flowstdlib/fmt/to_string/to_string.toml
@@ -1,4 +1,4 @@
-function = "ToString"
+function = "to_string"
 implementation = "to_string.rs"
 
 [[input]]

--- a/flowstdlib/img/format_png/format_png.toml
+++ b/flowstdlib/img/format_png/format_png.toml
@@ -1,4 +1,4 @@
-function = "FormatPNG"
+function = "format_png"
 implementation = "format_png.rs"
 
 [[input]]

--- a/flowstdlib/lib.rs
+++ b/flowstdlib/lib.rs
@@ -30,75 +30,75 @@ pub fn get_manifest() -> LibraryManifest {
 
 
     // Control
-    manifest.locators.insert("lib://flowstdlib/control/compare_switch/CompareSwitch".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/compare_switch/compare_switch".to_string(),
                              Native(Arc::new(control::compare_switch::CompareSwitch)));
-    manifest.locators.insert("lib://flowstdlib/control/index/Index".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/index/index".to_string(),
                              Native(Arc::new(control::index::Index)));
-    manifest.locators.insert("lib://flowstdlib/control/join/Join".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/join/join".to_string(),
                              Native(Arc::new(control::join::Join)));
-    manifest.locators.insert("lib://flowstdlib/control/route/Route".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/route/route".to_string(),
                              Native(Arc::new(control::route::Route)));
-    manifest.locators.insert("lib://flowstdlib/control/select/Select".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/select/select".to_string(),
                              Native(Arc::new(control::select::Select)));
-    manifest.locators.insert("lib://flowstdlib/control/tap/Tap".to_string(),
+    manifest.locators.insert("lib://flowstdlib/control/tap/tap".to_string(),
                              Native(Arc::new(control::tap::Tap)));
 
     // Data
-    manifest.locators.insert("lib://flowstdlib/data/append/Append".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/append/append".to_string(),
                              Native(Arc::new(data::append::Append)));
-    manifest.locators.insert("lib://flowstdlib/data/accumulate/Accumulate".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/accumulate/accumulate".to_string(),
                              Native(Arc::new(data::accumulate::Accumulate)));
-    manifest.locators.insert("lib://flowstdlib/data/buffer/Buffer".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/buffer/buffer".to_string(),
                              Native(Arc::new(data::buffer::Buffer)));
-    manifest.locators.insert("lib://flowstdlib/data/count/Count".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/count/count".to_string(),
                              Native(Arc::new(data::count::Count)));
-    manifest.locators.insert("lib://flowstdlib/data/duplicate_rows/DuplicateRows".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/duplicate_rows/duplicate_rows".to_string(),
                              Native(Arc::new(data::duplicate_rows::DuplicateRows)));
-    manifest.locators.insert("lib://flowstdlib/data/duplicate/Duplicate".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/duplicate/duplicate".to_string(),
                              Native(Arc::new(data::duplicate::Duplicate)));
-    manifest.locators.insert("lib://flowstdlib/data/enumerate/Enumerate".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/enumerate/enumerate".to_string(),
                              Native(Arc::new(data::enumerate::Enumerate)));
-    manifest.locators.insert("lib://flowstdlib/data/info/Info".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/info/info".to_string(),
                              Native(Arc::new(data::info::Info)));
-    manifest.locators.insert("lib://flowstdlib/data/multiply_row/MultiplyRow".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/multiply_row/multiply_row".to_string(),
                              Native(Arc::new(data::multiply_row::MultiplyRow)));
-    manifest.locators.insert("lib://flowstdlib/data/ordered_split/OrderedSplit".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/ordered_split/ordered_split".to_string(),
                              Native(Arc::new(data::ordered_split::OrderedSplit)));
-    manifest.locators.insert("lib://flowstdlib/data/remove/Remove".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/remove/remove".to_string(),
                              Native(Arc::new(data::remove::Remove)));
-    manifest.locators.insert("lib://flowstdlib/data/sort/Sort".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/sort/sort".to_string(),
                              Native(Arc::new(data::sort::Sort)));
-    manifest.locators.insert("lib://flowstdlib/data/split/Split".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/split/split".to_string(),
                              Native(Arc::new(data::split::Split)));
-    manifest.locators.insert("lib://flowstdlib/data/transpose/Transpose".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/transpose/transpose".to_string(),
                              Native(Arc::new(data::transpose::Transpose)));
-    manifest.locators.insert("lib://flowstdlib/data/zip/Zip".to_string(),
+    manifest.locators.insert("lib://flowstdlib/data/zip/zip".to_string(),
                              Native(Arc::new(data::zip::Zip)));
 
     // Format
-    manifest.locators.insert("lib://flowstdlib/fmt/reverse/Reverse".to_string(),
+    manifest.locators.insert("lib://flowstdlib/fmt/reverse/reverse".to_string(),
                              Native(Arc::new(fmt::reverse::Reverse)));
-    manifest.locators.insert("lib://flowstdlib/fmt/to_json/ToJson".to_string(),
+    manifest.locators.insert("lib://flowstdlib/fmt/to_json/to_json".to_string(),
                              Native(Arc::new(fmt::to_json::ToJson)));
-    manifest.locators.insert("lib://flowstdlib/fmt/to_string/ToString".to_string(),
+    manifest.locators.insert("lib://flowstdlib/fmt/to_string/to_string".to_string(),
                              Native(Arc::new(fmt::to_string::ToString)));
 
     // Img
-    manifest.locators.insert("lib://flowstdlib/img/format_png/FormatPNG".to_string(),
+    manifest.locators.insert("lib://flowstdlib/img/format_png/format_png".to_string(),
                              Native(Arc::new(img::format_png::FormatPNG)));
 
     // Math
-    manifest.locators.insert("lib://flowstdlib/math/add/Add".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/add/add".to_string(),
                              Native(Arc::new(math::add::Add)));
-    manifest.locators.insert("lib://flowstdlib/math/compare/Compare".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/compare/compare".to_string(),
                              Native(Arc::new(math::compare::Compare)));
-    manifest.locators.insert("lib://flowstdlib/math/divide/Divide".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/divide/divide".to_string(),
                              Native(Arc::new(math::divide::Divide)));
-    manifest.locators.insert("lib://flowstdlib/math/multiply/Multiply".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/multiply/multiply".to_string(),
                              Native(Arc::new(math::multiply::Multiply)));
-    manifest.locators.insert("lib://flowstdlib/math/sqrt/Sqrt".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/sqrt/sqrt".to_string(),
                              Native(Arc::new(math::sqrt::Sqrt)));
-    manifest.locators.insert("lib://flowstdlib/math/subtract/Subtract".to_string(),
+    manifest.locators.insert("lib://flowstdlib/math/subtract/subtract".to_string(),
                              Native(Arc::new(math::subtract::Subtract)));
 
     manifest

--- a/flowstdlib/math/add/add.toml
+++ b/flowstdlib/math/add/add.toml
@@ -1,4 +1,4 @@
-function = "Add"
+function = "add"
 implementation = "add.rs"
 
 [[input]]

--- a/flowstdlib/math/compare/compare.toml
+++ b/flowstdlib/math/compare/compare.toml
@@ -1,4 +1,4 @@
-function = "Compare"
+function = "compare"
 implementation = "compare.rs"
 
 [[input]]

--- a/flowstdlib/math/divide/divide.toml
+++ b/flowstdlib/math/divide/divide.toml
@@ -1,4 +1,4 @@
-function = "Divide"
+function = "divide"
 implementation = "divide.rs"
 
 [[input]]

--- a/flowstdlib/math/multiply/multiply.toml
+++ b/flowstdlib/math/multiply/multiply.toml
@@ -1,4 +1,4 @@
-function = "Multiply"
+function = "multiply"
 implementation = "multiply.rs"
 
 [[input]]

--- a/flowstdlib/math/sqrt/sqrt.toml
+++ b/flowstdlib/math/sqrt/sqrt.toml
@@ -1,4 +1,4 @@
-function = "Sqrt"
+function = "sqrt"
 implementation = "sqrt.rs"
 
 [[input]]

--- a/flowstdlib/math/subtract/subtract.toml
+++ b/flowstdlib/math/subtract/subtract.toml
@@ -1,4 +1,4 @@
-function = "Subtract"
+function = "subtract"
 implementation = "subtract.rs"
 
 [[input]]

--- a/samples/mandlebrot/pixel_to_point/pixel_to_point.toml
+++ b/samples/mandlebrot/pixel_to_point/pixel_to_point.toml
@@ -1,4 +1,4 @@
-function = "PixelToPoint"
+function = "pixel_to_point"
 implementation = "pixel_to_point.rs"
 
 [[input]]

--- a/samples/mandlebrot/render.toml
+++ b/samples/mandlebrot/render.toml
@@ -71,7 +71,6 @@ to = "p2v/pixel_point"
 
 # An image buffer to accumulate the results
 [[process]]
-alias = "image_buffer"
 source = "lib://flowruntime/image/image_buffer"
 
 # connect up the image buffer with filename and size - buffering them for each pixel

--- a/samples/mandlebrot/render_pixel/render_pixel.toml
+++ b/samples/mandlebrot/render_pixel/render_pixel.toml
@@ -1,4 +1,4 @@
-function = "RenderPixel"
+function = "render_pixel"
 implementation = "render_pixel.rs"
 
 [[input]]

--- a/samples/reverse-echo/reverse/reverse.toml
+++ b/samples/reverse-echo/reverse/reverse.toml
@@ -1,4 +1,4 @@
-function = "Reverse"
+function = "reverse"
 implementation = "reverse.rs"
 
 [[input]]


### PR DESCRIPTION
Fix function naming inconsistenies. Fixes #629