### PR TITLE
Remove comment for flow input on test - types no longer needed on flow inputs/outputs

### DIFF
--- a/flowc/tests/test-flows/array-input/subflow.toml
+++ b/flowc/tests/test-flows/array-input/subflow.toml
@@ -2,7 +2,6 @@ flow = "subflow"
 
 [[input]]
 name = "array_input"
-#type = "Array/String"
 
 [[process]]
 source = "lib://flowruntime/stdio/stdout"


### PR DESCRIPTION
Fixes #747