### PR TITLE
Don't block at end of flow execution

### DIFF
--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -434,13 +434,13 @@ impl Coordinator {
                         self.runtime_server_context
                             .lock()
                             .map_err(|_| "Could not lock server context")?
-                            .send_event(Event::FlowEnd(metrics))?;
+                            .send_event_only(Event::FlowEnd(metrics))?;
                     }
                     #[cfg(not(feature = "metrics"))]
                     self.runtime_server_context
                         .lock()
                         .map_err(|_| "Could not lock server context")?
-                        .send_event(Event::FlowEnd)?;
+                        .send_event_only(Event::FlowEnd)?;
                     debug!("{}", state);
                     break 'flow_execution;
                 }


### PR DESCRIPTION
Allow server to complete execution loop each time and be able to accept another submisison. Fixing #912