### PR TITLE
remove fixed jobs limit

### DIFF
--- a/flowcore/src/model/submission.rs
+++ b/flowcore/src/model/submission.rs
@@ -11,8 +11,8 @@ use url::Url;
 pub struct Submission {
     /// The URL where the manifest of the flow to execute can be found
     pub manifest_url: Url,
-    /// The maximum number of jobs you want dispatched/executing in parallel
-    pub max_parallel_jobs: usize,
+    /// An optional maximum number of jobs you want dispatched/executing in parallel
+    pub max_parallel_jobs: Option<usize>,
     /// The Duration to wait before timing out when waiting for jobs to complete
     pub job_timeout: Duration,
     /// Whether to debug the flow while executing it
@@ -22,14 +22,16 @@ pub struct Submission {
 
 impl Submission {
     /// Create a new `Submission` of a `Flow` for execution with the specified `Manifest`
-    /// of `Functions`, executing it with a maximum of `mac_parallel_jobs` running in parallel
-    /// connecting via the optional `DebugClient`
+    /// of `Functions`, optionally setting a limit for the number of jobs running in parallel
+    /// via `max_parallel_jobs`
     pub fn new(
         manifest_url: &Url,
-        max_parallel_jobs: usize,
+        max_parallel_jobs: Option<usize>,
         #[cfg(feature = "debugger")] debug: bool,
     ) -> Submission {
-        info!("Maximum jobs in parallel limited to {}", max_parallel_jobs);
+        if let Some(limit) = max_parallel_jobs {
+            info!("Maximum jobs in parallel limited to {limit}");
+        }
 
         Submission {
             manifest_url: manifest_url.to_owned(),
@@ -44,7 +46,9 @@ impl fmt::Display for Submission {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Submission:")?;
         writeln!(f, "         Manifest URL: {}", self.manifest_url)?;
-        writeln!(f, "Maximum Parallel Jobs: {}", self.max_parallel_jobs)?;
+        if let Some(limit) = self.max_parallel_jobs {
+            writeln!(f, "Maximum Parallel Jobs: {limit}")?;
+        }
         write!(f,   "          Job Timeout: {:?}", self.job_timeout)
     }
 }

--- a/flowr/src/cli_debug_client.rs
+++ b/flowr/src/cli_debug_client.rs
@@ -450,7 +450,7 @@ mod test {
         let functions = vec![f_b, f_a];
         let submission = Submission::new(
             &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-            1,
+            None,
             true,
         );
         let state = RunState::new(&functions, submission);

--- a/flowr/src/main.rs
+++ b/flowr/src/main.rs
@@ -431,7 +431,8 @@ fn client(
 
     let flow_manifest_url = parse_flow_url(&matches)?;
     let flow_args = get_flow_args(&matches, &flow_manifest_url);
-    let max_parallel_jobs = num_parallel_jobs(&matches);
+    let max_parallel_jobs: Option<usize> = matches.value_of("jobs")
+        .and_then(|value| value.parse::<usize>().ok());
     let submission = Submission::new(
         &flow_manifest_url,
         max_parallel_jobs,
@@ -487,32 +488,6 @@ fn num_threads(matches: &ArgMatches) -> usize {
     }
 
     num_threads
-}
-
-// Determine the number of parallel jobs to be run in parallel based on a default of 2 times
-// the number of cores in the device, or any override from the command line.
-fn num_parallel_jobs(
-    matches: &ArgMatches,
-) -> usize {
-    let mut num_jobs: usize = 0;
-
-    if let Some(value) = matches.value_of("jobs") {
-        if let Ok(jobs) = value.parse::<usize>() {
-            if jobs < 1 {
-                error!("Minimum number of parallel jobs is '0', \
-                so option of '{jobs}' has been overridden to be '1'");
-                num_jobs = 1;
-            } else {
-                num_jobs = jobs;
-            }
-        }
-    }
-
-    if num_jobs == 0 {
-        num_jobs = thread::available_parallelism().map(|n| 2 * n.get()).unwrap_or(1);
-    }
-
-    num_jobs
 }
 
 // Parse the command line arguments using clap

--- a/flowrlib/src/coordinator.rs
+++ b/flowrlib/src/coordinator.rs
@@ -294,7 +294,7 @@ mod test {
         let manifest_url = Url::parse("file:///temp/fake/flow.toml").expect("Could not create Url");
         let _ = Submission::new(
             &manifest_url,
-            1,
+            Some(1),
             #[cfg(feature = "debugger")]
             false,
         );

--- a/flowrlib/src/debugger.rs
+++ b/flowrlib/src/debugger.rs
@@ -545,7 +545,7 @@ impl<'a> Debugger<'a> {
     fn modify_variables(&mut self, state: &mut RunState, specs: Option<Vec<String>>) {
         match specs.as_deref() {
             None | Some([]) => self.debug_server.message("State variables that can be modified are:\
-            \n'jobs' - maximum number of parallel jobs (integer)".to_string()),
+            \n'jobs' - maximum number of parallel jobs (integer) or 0 for no limit".to_string()),
             Some(specs) => {
                 for spec in specs {
                     let parts: Vec<&str> = spec.trim().split('=').collect();
@@ -558,7 +558,11 @@ impl<'a> Debugger<'a> {
                     match parts[0] {
                         "jobs" => {
                             if let Ok(value) = parts[1].parse::<usize>() {
-                                state.submission.max_parallel_jobs = value;
+                                if value == 0 {
+                                    state.submission.max_parallel_jobs = None;
+                                } else {
+                                    state.submission.max_parallel_jobs = Some(value);
+                                }
                                 self.debug_server.message(format!("State variable '{}' set to {}",
                                     parts[0], parts[1]));
                             } else {

--- a/flowrlib/src/run_state.rs
+++ b/flowrlib/src/run_state.rs
@@ -430,9 +430,11 @@ impl RunState {
     /// Return the next job ready to be run, if there is one and there are not
     /// too many jobs already running
     pub(crate) fn next_job(&mut self) -> Option<Job> {
-        if self.number_jobs_running() >= self.submission.max_parallel_jobs {
-            trace!("Max Pending Job count of {} reached, skipping new jobs", self.submission.max_parallel_jobs);
-            return None;
+        if let Some(limit) = self.submission.max_parallel_jobs {
+            if self.number_jobs_running() >= limit {
+                trace!("Max Pending Job count of {limit} reached, skipping new jobs");
+                return None;
+            }
         }
 
         let function_id = self.ready.remove(0)?;
@@ -1229,7 +1231,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1247,7 +1249,7 @@ mod test {
         fn jobs_created_zero_at_init() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1262,7 +1264,7 @@ mod test {
         fn zero_blocks_at_init() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1280,7 +1282,7 @@ mod test {
         fn zero_running_at_init() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1298,7 +1300,7 @@ mod test {
         fn zero_blocked_at_init() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1340,7 +1342,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1365,7 +1367,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1397,7 +1399,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1416,7 +1418,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1442,7 +1444,7 @@ mod test {
             let functions = vec![f_b, f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1487,7 +1489,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1506,7 +1508,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1532,7 +1534,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1555,7 +1557,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1606,7 +1608,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1695,7 +1697,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1740,7 +1742,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1810,7 +1812,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1882,7 +1884,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -1948,7 +1950,7 @@ mod test {
             let functions = vec![f_a, f_b];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2042,7 +2044,7 @@ mod test {
             let functions = vec![f_a, f_b]; // NOTE the order!
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2201,7 +2203,7 @@ mod test {
         fn blocked_works() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2229,7 +2231,7 @@ mod test {
         fn get_works() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2242,7 +2244,7 @@ mod test {
         fn no_next_if_none_ready() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2255,7 +2257,7 @@ mod test {
         fn next_works() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2274,7 +2276,7 @@ mod test {
         fn inputs_ready_makes_ready() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2294,7 +2296,7 @@ mod test {
         fn blocked_is_not_ready() {
             let submission = Submission::new(
                 &Url::parse("file://temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2327,7 +2329,7 @@ mod test {
         fn unblocking_makes_ready() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2368,7 +2370,7 @@ mod test {
         fn unblocking_doubly_blocked_functions_not_ready() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2417,7 +2419,7 @@ mod test {
         fn wont_return_too_many_jobs() {
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );
@@ -2447,7 +2449,7 @@ mod test {
             let functions = vec![f_a];
             let submission = Submission::new(
                 &Url::parse("file:///temp/fake.toml").expect("Could not create Url"),
-                1,
+                None,
                 #[cfg(feature = "debugger")]
                 true,
             );


### PR DESCRIPTION
Allow the number of jobs to be determines by the logic of the flow and the executors ability to absorbe them (possibly later via the queue length for sending to each one).

This will allow the number of jobs to grow and shrink as peers are discovered/lost on the network.