### PR TITLE
Move connection parameters to Input

### DIFF
--- a/flowc/src/lib/compiler/compile.rs
+++ b/flowc/src/lib/compiler/compile.rs
@@ -192,8 +192,6 @@ fn configure_output_connections(tables: &mut CompilerTables) -> Result<()> {
             *destination_function_id,
             *destination_input_index,
             *destination_flow_id,
-            connection.to_io().datatypes()[0].array_order()?, // TODO
-            connection.to_io().datatypes()[0].is_generic(), // TODO
             connection.to_io().route().to_string(),
             #[cfg(feature = "debugger")]
                 connection.name().to_string(),
@@ -228,10 +226,10 @@ fn get_source(
         match source_routes.get(&source_route) {
             Some((Output(io_sub_route), function_index)) => {
                 return if io_sub_route.is_empty() {
-                    Some((Output(format!("{}", sub_route)), *function_index))
+                    Some((Output(format!("{sub_route}")), *function_index))
                 } else {
                     Some((
-                        Output(format!("/{}{}", io_sub_route, sub_route)),
+                        Output(format!("/{io_sub_route}{sub_route}")),
                         *function_index,
                     ))
                 }
@@ -286,15 +284,15 @@ mod test {
         use super::super::get_source;
 
         /*
-                                                                                    Create a HashTable of routes for use in tests.
-                                                                                    Each entry (K, V) is:
-                                                                                    - Key   - the route to a function's IO
-                                                                                    - Value - a tuple of
-                                                                                                - sub-route (or IO name) from the function to be used at runtime
-                                                                                                - the id number of the function in the functions table, to select it at runtime
+                                                                                            Create a HashTable of routes for use in tests.
+                                                                                            Each entry (K, V) is:
+                                                                                            - Key   - the route to a function's IO
+                                                                                            - Value - a tuple of
+                                                                                                        - sub-route (or IO name) from the function to be used at runtime
+                                                                                                        - the id number of the function in the functions table, to select it at runtime
 
-                                                                                    Plus a vector of test cases with the Route to search for and the expected function_id and output sub-route
-                                                                                */
+                                                                                            Plus a vector of test cases with the Route to search for and the expected function_id and output sub-route
+                                                                                        */
         #[allow(clippy::type_complexity)]
         fn test_source_routes() -> (
             BTreeMap<Route, (Source, usize)>,

--- a/flowc/src/lib/compiler/compile_wasm.rs
+++ b/flowc/src/lib/compiler/compile_wasm.rs
@@ -349,8 +349,6 @@ mod test {
                 1,
                 0,
                 0,
-                0,
-                false,
                 String::default(),
                 #[cfg(feature = "debugger")]
                 String::default(),

--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -149,12 +149,7 @@ fn implementation_location_relative(function: &FunctionDefinition, manifest_url:
     } else {
         let implementation_path = function.get_implementation();
         let implementation_url = Url::from_file_path(implementation_path)
-            .map_err(|_| {
-                format!(
-                    "Could not create Url from file path: {}",
-                    implementation_path
-                )
-            })?
+            .map_err(|_| { format!("Could not create Url from file path: {implementation_path}") })?
             .to_string();
 
         let mut manifest_base_url = manifest_url.clone();
@@ -164,7 +159,7 @@ fn implementation_location_relative(function: &FunctionDefinition, manifest_url:
             .pop();
 
         info!("Manifest base = '{}'", manifest_base_url.to_string());
-        info!("Absolute implementation path = '{}'", implementation_path);
+        info!("Absolute implementation path = '{implementation_path}'");
         let relative_path =
             implementation_url.replace(&format!("{}/", manifest_base_url.as_str()), "");
         info!("Relative implementation path = '{}'", relative_path);
@@ -210,8 +205,6 @@ mod test {
                     1,
                     0,
                     0,
-                    0,
-                    false,
                     String::default(),
                     #[cfg(feature = "debugger")]
                     String::default(),
@@ -221,8 +214,6 @@ mod test {
                     2,
                     0,
                     0,
-                    0,
-                    false,
                     String::default(),
                     #[cfg(feature = "debugger")]
                     String::default(),
@@ -285,8 +276,6 @@ mod test {
                 1,
                 0,
                 0,
-                0,
-                false,
                 String::default(),
                 #[cfg(feature = "debugger")]
                 String::default(),
@@ -304,62 +293,6 @@ mod test {
       'destination_id': 1,
       'destination_io_number': 0,
       'flow_id': 0
-    }
-  ]
-}";
-
-        let br = Box::new(function) as Box<FunctionDefinition>;
-
-        let process = function_to_runtimefunction(
-            &Url::parse("file://test").expect("Couldn't parse test Url"),
-            &br,
-            false,
-        )
-        .expect("Could not convert compile time function to runtime function");
-
-        let serialized_process = serde_json::to_string_pretty(&process)
-            .expect("Could not convert function content to json");
-        assert_eq!(serialized_process, expected.replace('\'', "\""));
-    }
-
-    #[test]
-    fn function_generation_with_array_order() {
-        let function = FunctionDefinition::new(
-            Name::from("Stdout"),
-            false,
-            "context://stdio/stdout".to_string(),
-            Name::from("print"),
-            vec![],
-            vec![IO::new(vec!(STRING_TYPE.into()), Route::default())],
-            Url::parse("file:///fake/file").expect("Could not parse Url"),
-            Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
-            vec![OutputConnection::new(
-                Source::default(),
-                1,
-                0,
-                0,
-                1,
-                false,
-                String::default(),
-                #[cfg(feature = "debugger")]
-                String::default(),
-            )],
-            0,
-            0,
-        );
-
-        let expected = "{
-  'function_id': 0,
-  'flow_id': 0,
-  'implementation_location': 'context://stdio/stdout',
-  'output_connections': [
-    {
-      'destination_id': 1,
-      'destination_io_number': 0,
-      'flow_id': 0,
-      'destination_array_order': 1
     }
   ]
 }";
@@ -497,7 +430,9 @@ mod test {
   'flow_id': 0,
   'implementation_location': 'context://stdio/stdout',
   'inputs': [
-    {}
+    {
+      'array_order': 1
+    }
   ]
 }";
 
@@ -532,8 +467,6 @@ mod test {
                 1,
                 0,
                 0,
-                0,
-                false,
                 String::default(),
                 #[cfg(feature = "debugger")]
                 String::default(),
@@ -607,8 +540,6 @@ mod test {
                 1,
                 0,
                 0,
-                0,
-                false,
                 String::default(),
                 #[cfg(feature = "debugger")]
                 String::default(),

--- a/flowcore/src/meta_provider.rs
+++ b/flowcore/src/meta_provider.rs
@@ -193,7 +193,9 @@ impl Provider for MetaProvider {
 
 #[cfg(test)]
 mod test {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
+    #[cfg(feature = "context")]
+    use std::path::PathBuf;
 
     use simpath::Simpath;
     use url::Url;

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -192,7 +192,7 @@ mod test {
             #[cfg(feature = "debugger")]
             "/test",
             "file://fake/test",
-            vec![Input::new("", 0, false, None, None)],
+            vec![Input::new(#[cfg(feature = "debugger")] "", 0, false, None, None)],
             0,
             0,
             &[],

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -192,7 +192,7 @@ mod test {
             #[cfg(feature = "debugger")]
             "/test",
             "file://fake/test",
-            vec![Input::new("", None, None)],
+            vec![Input::new("", 0, false, None, None)],
             0,
             0,
             &[],

--- a/flowcore/src/model/function_definition.rs
+++ b/flowcore/src/model/function_definition.rs
@@ -217,7 +217,7 @@ impl FunctionDefinition {
     // A function can only be impure if it is provided by 'context'
     fn check_impurity(&self, url: &Url) -> Result<()> {
         if self.impure && url.scheme() != "context" {
-            bail!("Only functions provided by 'context' can be impure ('{}')", url);
+            bail!("Only functions provided by 'context' can be impure ('{url}')");
         }
 
         Ok(())
@@ -429,8 +429,6 @@ mod test {
                 0,
                 0,
                 0,
-                0,
-                false,
                 String::default(),
                 #[cfg(feature = "debugger")]
                 String::default(),

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -114,9 +114,13 @@ impl Input {
     /// Create a new `Input` with an optional `InputInitializer`
     #[cfg(not(feature = "debugger"))]
     pub fn new(
+        array_order: i32,
+        generic: bool,
         initializer: Option<InputInitializer>,
         flow_initializer: Option<InputInitializer>) -> Self {
         Input {
+            array_order,
+            generic,
             initializer,
             flow_initializer,
             received: Vec::new(),
@@ -258,33 +262,33 @@ mod test {
 
     #[test]
     fn no_inputs_initially() {
-        let input = Input::new("", 0, false, None, None);
+        let input = Input::new(#[cfg(feature = "debugger")] "", 0, false, None, None);
         assert!(input.is_empty());
     }
 
     #[test]
     fn take_from_empty_fails() {
-        let mut input = Input::new("", 0, false,  None, None);
+        let mut input = Input::new(#[cfg(feature = "debugger")] "", 0, false,  None, None);
         assert!(input.take().is_err());
     }
 
     #[test]
     fn accepts_value() {
-        let mut input = Input::new("", 0, false,  None, None);
+        let mut input = Input::new(#[cfg(feature = "debugger")] "", 0, false,  None, None);
         input.send(Value::Null);
         assert!(!input.is_empty());
     }
 
     #[test]
     fn accepts_array() {
-        let mut input = Input::new("", 0, false,  None, None);
+        let mut input = Input::new(#[cfg(feature = "debugger")] "", 0, false,  None, None);
         input.send_array(vec![json!(5), json!(10), json!(15)]);
         assert!(!input.is_empty());
     }
 
     #[test]
     fn take_empties() {
-        let mut input = Input::new("", 0, false,  None, None);
+        let mut input = Input::new(#[cfg(feature = "debugger")] "", 0, false,  None, None);
         input.send(json!(10));
         assert!(!input.is_empty());
         let _value = input.take().expect("Could not take the input value as expected");
@@ -294,7 +298,7 @@ mod test {
     #[cfg(feature = "debugger")]
     #[test]
     fn reset_empties() {
-        let mut input = Input::new("", 0,  false, None, None);
+        let mut input = Input::new(#[cfg(feature = "debugger")] "", 0,  false, None, None);
         input.send(json!(10));
         assert!(!input.is_empty());
         input.reset();

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -337,7 +337,7 @@ mod test {
                 .take_input_set()
                 .expect("Couldn't get input set")
                 .remove(0),
-            json!([1, 2]),
+            json!(1),
             "The value from input set wasn't what was expected"
         );
     }
@@ -358,7 +358,8 @@ mod test {
             #[cfg(feature = "debugger")]
             "/test",
             "file://fake/implementation",
-            vec![Input::new("", 0, false, None, None)],
+            vec![Input::new(#[cfg(feature = "debugger")] "",
+                            0, false, None, None)],
             1,
             0,
             &[out_conn],

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -195,9 +195,7 @@ impl RuntimeFunction {
     /// Do the necessary serialization of an array to values, or wrapping of a value into an array
     /// in order to convert the value on expected by the destination, if possible, send the value
     /// and return true. If the conversion cannot be done and no value is sent, return false.
-    pub fn type_convert_and_send(&mut self,
-        connection: &OutputConnection,
-        value: &Value) -> bool {
+    pub fn type_convert_and_send(&mut self, connection: &OutputConnection, value: &Value) -> bool {
         if connection.is_generic() {
             self.send(connection.destination_io_number, value);
         } else {
@@ -206,12 +204,12 @@ impl RuntimeFunction {
                 value,
             ) {
                 (0, _) => self.send(connection.destination_io_number, value),
-                (1, Value::Array(array)) => self.send_iter(connection.destination_io_number,
-                                                           array),
+                (1, Value::Array(array)) => self.send_array(connection.destination_io_number,
+                                                            array),
                 (2, Value::Array(array_2)) => {
                     for array in array_2.iter() {
                         if let Value::Array(sub_array) = array {
-                            self.send_iter(connection.destination_io_number, sub_array)
+                            self.send_array(connection.destination_io_number, sub_array)
                         }
                     }
                 }
@@ -226,14 +224,14 @@ impl RuntimeFunction {
         true // a value was sent!
     }
 
-    // write a value to a `RuntimeFunction`'s `input`
+    // Send a value to a `RuntimeFunction`'s `input`'s `Input` numbered `input_number`
     fn send(&mut self, input_number: usize, value: &Value) {
-        self.inputs[input_number].push(value.clone());
+        self.inputs[input_number].send(value.clone());
     }
 
-    // write an array of values to a `RuntimeFunction` `input`
-    fn send_iter(&mut self, input_number: usize, array: &[Value]) {
-        self.inputs[input_number].push_array(array.iter());
+    // Send an array of values to this `RuntimeFunction`'s `Input` numbered `input_number`
+    fn send_array(&mut self, input_number: usize, array: &[Value]) {
+        self.inputs[input_number].send_array(array);
     }
 
     /// Accessor for a `RuntimeFunction` `output_connections` field

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -299,7 +299,7 @@ mod test {
 
     #[test]
     fn can_send_simple_object() {
-        let mut function = test_function();
+        let mut function = test_function(0);
         function.init_inputs(true, false);
         function.send(0, json!(1));
         assert_eq!(
@@ -314,7 +314,7 @@ mod test {
 
     #[test]
     fn can_send_array_object() {
-        let mut function = test_function();
+        let mut function = test_function(1);
         function.init_inputs(true,  false);
         function.send(0, json!([1, 2]));
         assert_eq!(
@@ -329,7 +329,7 @@ mod test {
 
     #[test]
     fn test_array_to_non_array() {
-        let mut function = test_function();
+        let mut function = test_function(0);
         function.init_inputs(true,  false);
         function.send(0, json!([1, 2]));
         assert_eq!(
@@ -342,7 +342,7 @@ mod test {
         );
     }
 
-    fn test_function() -> RuntimeFunction {
+    fn test_function(array_order: i32) -> RuntimeFunction {
         let out_conn = OutputConnection::new(
             Output("/other/input/1".into()),
             1,
@@ -359,7 +359,7 @@ mod test {
             "/test",
             "file://fake/implementation",
             vec![Input::new(#[cfg(feature = "debugger")] "",
-                            0, false, None, None)],
+                            array_order, false, None, None)],
             1,
             0,
             &[out_conn],
@@ -370,7 +370,7 @@ mod test {
     #[cfg(feature = "debugger")]
     #[test]
     fn debugger_can_inspect_non_full_input() {
-        let mut function = test_function();
+        let mut function = test_function(0);
         function.init_inputs(true,  false);
         function.send(0, json!(1));
         assert_eq!(
@@ -389,7 +389,7 @@ mod test {
     #[cfg(feature = "debugger")]
     #[test]
     fn can_display_function() {
-        let function = test_function();
+        let function = test_function(0);
         let _ = format!("{}", function);
     }
 
@@ -429,7 +429,7 @@ mod test {
 
     #[test]
     fn can_get_function_name_and_id_and_location() {
-        let function = test_function();
+        let function = test_function(0);
         #[cfg(feature = "debugger")]
         assert_eq!("test".to_string(), function.name());
         assert_eq!(1, function.id());
@@ -441,7 +441,7 @@ mod test {
 
     #[test]
     fn can_set_and_get_implementation() {
-        let mut function = test_function();
+        let mut function = test_function(0);
         let inf = Arc::new(ImplementationNotFound {});
         function.set_implementation(inf);
         let _ = function.get_implementation();

--- a/flowr/src/cli/cli_debug_client.rs
+++ b/flowr/src/cli/cli_debug_client.rs
@@ -410,7 +410,7 @@ mod test {
             #[cfg(feature = "debugger")]
             "/fB",
             "file://fake/test",
-            vec![Input::new("", Some(Once(json!(1))), None)],
+            vec![Input::new("", 0, false, Some(Once(json!(1))), None)],
             1,
             0,
             &[],
@@ -424,8 +424,6 @@ mod test {
             1,
             0,
             0,
-            0,
-            false,
             "/fB".to_string(),
             #[cfg(feature = "debugger")]
             String::default(),
@@ -436,7 +434,7 @@ mod test {
             #[cfg(feature = "debugger")]
             "/fA",
             "file://fake/test",
-            vec![Input::new("", Some(Once(json!(1))), None)],
+            vec![Input::new("", 0, false, Some(Once(json!(1))), None)],
             0,
             0,
             &[connection_to_f1],

--- a/flowr/src/cli/file/file_write.toml
+++ b/flowr/src/cli/file/file_write.toml
@@ -9,4 +9,4 @@ type = "string"
 
 [[input]]
 name = "bytes"
-type = "array"
+type = "array/number"

--- a/flowrlib/src/debugger.rs
+++ b/flowrlib/src/debugger.rs
@@ -822,7 +822,7 @@ mod test {
                 "/fA",
             "file://fake/test",
             vec![Input::new(
-                #[cfg(feature = "debugger")] "",
+                #[cfg(feature = "debugger")] "", 0, false,
                 Some(Once(json!(1))), None)],
             id,
             0,

--- a/flowrlib/src/run_state.rs
+++ b/flowrlib/src/run_state.rs
@@ -552,7 +552,7 @@ impl RunState {
                                 job.function_id,
                                 job.flow_id,
                                 connection,
-                                value,
+                                value.clone(),
                                 #[cfg(feature = "metrics")] metrics,
                                 #[cfg(feature = "debugger")] debugger,
                         )?;
@@ -613,7 +613,7 @@ impl RunState {
         source_id: usize,
         source_flow_id: usize,
         connection: &OutputConnection,
-        output_value: &Value,
+        output_value: Value,
         #[cfg(feature = "metrics")] metrics: &mut Metrics,
         #[cfg(feature = "debugger")] debugger: &mut Debugger,
     ) -> Result<(bool, bool)> {
@@ -642,7 +642,7 @@ impl RunState {
                 self,
                 source_id,
                 route,
-                output_value,
+                &output_value,
                 connection.destination_id,
                 connection.destination_io_number,
             )?;
@@ -651,7 +651,7 @@ impl RunState {
         let function = self.get_mut(connection.destination_id)
             .ok_or("Could not get function")?;
         let count_before = function.input_set_count();
-        function.send(connection, output_value);
+        function.send(connection.destination_io_number, output_value);
 
         #[cfg(feature = "metrics")]
         metrics.increment_outputs_sent(); // not distinguishing array serialization / wrapping etc


### PR DESCRIPTION
This cleans up what fields are on which struct, ones associated with the destination of a connection are now on that Input struct (arr_order and generic)

This i sa step to be able to have initializers that are Arrays of values