### PR TITLE
Fix unneeded cast warnings

### DIFF
--- a/flowrlib/src/wasm.rs
+++ b/flowrlib/src/wasm.rs
@@ -34,7 +34,7 @@ impl WasmExecutor {
         self.memory
             .write(store, offset as usize, &input_data)
             .map_err(|_| "Could not write to WASM Linear Memory")?;
-        Ok((offset as i32, input_data.len() as i32))
+        Ok((offset, input_data.len() as i32))
     }
 
     // Call the "alloc" wasm function
@@ -47,7 +47,7 @@ impl WasmExecutor {
             .map_err(|_| "WASM alloc() call failed")?;
 
         match results[0] {
-            Val::I32(offset) => Ok(offset as i32),
+            Val::I32(offset) => Ok(offset),
             _ => bail!("WASM alloc() failed"),
         }
     }

--- a/flowsamples/mandlebrot/pixel_to_point/pixel_to_point.rs
+++ b/flowsamples/mandlebrot/pixel_to_point/pixel_to_point.rs
@@ -20,12 +20,12 @@ fn pixel_run(inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
     let bounds = inputs[0].as_array().ok_or("Could not get array")?;
 
     let upper_left = bounds[0].as_array().ok_or("Could not get array")?;
-    let upper_left_c = [upper_left[0].as_f64().ok_or("Could not get f64")? as f64,
-                                upper_left[1].as_f64().ok_or("Could not get f64")? as f64];
+    let upper_left_c = [upper_left[0].as_f64().ok_or("Could not get f64")?,
+                                upper_left[1].as_f64().ok_or("Could not get f64")?];
 
     let lower_right = bounds[1].as_array().ok_or("Could not get array")?;
-    let lower_right_c = [lower_right[0].as_f64().ok_or("Could not get f64")? as f64,
-                                lower_right[1].as_f64().ok_or("Could not get f64")? as f64];
+    let lower_right_c = [lower_right[0].as_f64().ok_or("Could not get f64")?,
+                                lower_right[1].as_f64().ok_or("Could not get f64")?];
 
     let pixel = inputs[1].as_array().ok_or("Could not get array")?;
     let x = pixel[0].as_i64().ok_or("Could not get i64")? as usize;

--- a/flowstdlib/math/compare/compare.rs
+++ b/flowstdlib/math/compare/compare.rs
@@ -120,8 +120,8 @@ mod test {
                 false, // gte
             ),
             (
-                json!((i64::MAX as u64 + 10) as u64), // force a u64
-                json!((i64::MAX as u64 + 20) as u64), // force a u64
+                json!((i64::MAX as u64 + 10)), // force a u64
+                json!((i64::MAX as u64 + 20)), // force a u64
                 false,                                // eq
                 true,                                // ne
                 true,                                 // lt

--- a/flowstdlib/math/divide/divide.rs
+++ b/flowstdlib/math/divide/divide.rs
@@ -41,7 +41,7 @@ mod test {
         assert_eq!(divisor, &json!(test_data.1 as f64));
 
         let result = outputs.pointer("/result").expect("Could not get /result");
-        assert_eq!(result, &json!(test_data.2 as f64));
+        assert_eq!(result, &json!(test_data.2 ));
 
         let remainder = outputs
             .pointer("/remainder")


### PR DESCRIPTION
Clippy introduced new warnings causing master to fail, this fixes them.