### PR TITLE
Revert to rust stable

### DIFF
--- a/flowc/src/lib/compiler/cargo_build.rs
+++ b/flowc/src/lib/compiler/cargo_build.rs
@@ -42,7 +42,7 @@ fn cargo_test(manifest_path: PathBuf, build_dir: PathBuf) -> Result<()> {
 
     let manifest_arg = format!("--manifest-path={}", manifest_path.display());
     let target_dir_arg = format!("--target-dir={}", build_dir.display());
-    let test_args = vec!["test", &manifest_arg, &target_dir_arg];
+    let test_args = vec!["+nightly", "test", &manifest_arg, &target_dir_arg];
 
     println!(
         "   {} {} WASM Project",
@@ -89,7 +89,7 @@ fn cargo_build(
         implementation_source_path.display()
     );
 
-    let mut command_args = vec!["build"];
+    let mut command_args = vec!["+nightly", "build"];
 
     if release_build {
         command_args.push("--release");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-# force a working nightly for minimal-lexical dependency
-# see: https://github.com/Alexhuszagh/minimal-lexical/issues/14#issuecomment-1186389682
-channel = "nightly"


### PR DESCRIPTION
Fixes #1368
By forcing +nightly in cargo builds of wasm files, but nowhere else