### PR TITLE
Handle state in subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,6 @@ dependencies = [
  "simpath",
  "simpdiscover",
  "tempdir",
- "tokio",
  "url",
  "zmq",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "simpath",
  "simpdiscover",
  "tempdir",
+ "tokio",
  "url",
  "zmq",
 ]

--- a/flowide/Cargo.toml
+++ b/flowide/Cargo.toml
@@ -30,10 +30,13 @@ zmq = "0.10.0"
 simpdiscover = "0.6.2"
 iced = { version = "0.9.0", features = ["canvas", "tokio", "debug"] }
 iced_aw = { version = "0.5.2", default-features = false, features = ["tabs", "card", "modal",] }
-once_cell = "1.17.2"
+once_cell = "1.16.0"
+tokio = { version = "1", features = ["sync"] }
+
 # TODO to remove
 image = "=0.24.6"
 rustyline = "11.0.0"
+
 
 [dev-dependencies]
 tempdir = "~0.3.5"

--- a/flowide/Cargo.toml
+++ b/flowide/Cargo.toml
@@ -36,9 +36,7 @@ image = "=0.24.6"
 rustyline = "11.0.0"
 
 # TODO remove later
-[dependencies.tokio]
-version = "1"
-features = ["time"]
+tokio = { version = "1", features = ["time", "sync"] }
 
 [dev-dependencies]
 tempdir = "~0.3.5"

--- a/flowide/Cargo.toml
+++ b/flowide/Cargo.toml
@@ -35,9 +35,6 @@ once_cell = "1.17.2"
 image = "=0.24.6"
 rustyline = "11.0.0"
 
-# TODO remove later
-tokio = { version = "1", features = ["time", "sync"] }
-
 [dev-dependencies]
 tempdir = "~0.3.5"
 serial_test = "2.0.0"

--- a/flowide/src/coordinator.rs
+++ b/flowide/src/coordinator.rs
@@ -69,9 +69,6 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
 
                         CoordinatorState::Connected(mut app_receiver,
                                                     coordinator) => {
-                            // If I don't do this - the app doesn't receive the message before panic below
-                            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-
                             // read the Submit message from the app
                             match app_receiver.recv().await {
                                 Some(client_message) => {

--- a/flowide/src/coordinator.rs
+++ b/flowide/src/coordinator.rs
@@ -48,7 +48,7 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
                         CoordinatorState::None => {
                             // TODO maybe try discovering one and start if not...
                             let (address, _) = start(settings.clone());
-                            println!("Coordinator started at address '{}'", address);
+                            info!("Coordinator started at address '{}'", address);
                             state = CoordinatorState::Disconnected(address)
                         },
 
@@ -62,7 +62,7 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
                             // Send the Sender to the App in a Message, for App to use to send us messages
                             let _ = app_sender.try_send(CoordinatorMessage::Connected(app_side_sender));
 
-                            println!("Connected to Coordinator at address: {}", address);
+                            info!("Connected to Coordinator at address: {}", address);
                             state = CoordinatorState::Connected(app_receiver,
                                                                 coordinator);
                         },
@@ -96,8 +96,6 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
                             // TODO Maybe handle Coordinator exiting message here and update state???
                             // TODO maybe add a state for ended and process flow ended state also?
 
-                            println!("Waiting for message from coordinator");
-
                             // read the message back from the Coordinator
                             let coordinator_message: CoordinatorMessage = coordinator
                                 .lock().unwrap().receive().unwrap(); // TODO
@@ -108,7 +106,6 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
                             // read the message from the app to send to the coordinator
                             match app_receiver.recv().await {
                                 Some(client_message) => {
-                                    println!("FlowStarted state: message from app: {}", client_message);
                                     coordinator.lock().unwrap().send(client_message).unwrap();
                                 }
                                 None => error!("Error receiving from app"),

--- a/flowide/src/gui/coordinator_message.rs
+++ b/flowide/src/gui/coordinator_message.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::sync::mpsc;
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -14,7 +13,7 @@ pub enum CoordinatorMessage {
     #[serde(skip_deserializing, skip_serializing)]
     /// ** These messages are used to communicate to the app the connection status to the Coordinator
     /// A connection has been made
-    Connected(mpsc::SyncSender<ClientMessage>),
+    Connected(tokio::sync::mpsc::Sender<ClientMessage>),
 
     /// ** These messages are used to implement the `SubmissionProtocol` between the coordinator
     /// and the cli_client

--- a/flowide/src/gui/coordinator_message.rs
+++ b/flowide/src/gui/coordinator_message.rs
@@ -12,8 +12,10 @@ use crate::gui::client_message::ClientMessage;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CoordinatorMessage {
     #[serde(skip_deserializing, skip_serializing)]
+    /// ** These messages are used to communicate to the app the connection status to the Coordinator
     /// A connection has been made
     Connected(mpsc::SyncSender<ClientMessage>),
+
     /// ** These messages are used to implement the `SubmissionProtocol` between the coordinator
     /// and the cli_client
     /// A flow has started executing


### PR DESCRIPTION
Fixes #1792
Handles correctly the state of the communication sbetween the app and the Coordinator in the subscription, using async methods to avoid need for tokio::time to avoid blocking.