### PR TITLE
Add code signing for binaries build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ YUM := $(shell command -v yum 2> /dev/null)
 DNF := $(shell command -v dnf 2> /dev/null)
 BREW := $(shell command -v brew 2> /dev/null)
 RUSTUP := $(shell command -v rustup 2> /dev/null)
+CODESIGN := $(shell command -v codesign 2> /dev/null) # Detect codesigning app on mac to avoid security dialogs
+
 export SHELL := /bin/bash
 export PATH := $(PWD)/target/debug:$(PWD)/target/release:$(PATH)
 
@@ -82,9 +84,12 @@ clean:
 .PHONY: build
 build:
 	@echo "build<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-	@cargo build -p flowc # Used to compile flowstdlib, so needed first
+	@cargo build -p flowc # Used to compile flowstdlib and flowsamples, so needed first
 	@cargo build -p flowstdlib # Used by flowsamples so needed first
 	@cargo build
+ifeq ($(CODESIGN),)
+	find target -name "flow*" -perm +111 -type f | xargs codesign -fs self
+endif
 
 .PHONY: clippy
 clippy: build
@@ -99,8 +104,13 @@ test: build
 .PHONY: coverage
 coverage: clean-start
 	@echo "coverage<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-	@find . -name "*.profraw"  | xargs rm -rf {}
+	@find . -name "*.profraw"  | xargs rm -rf {} # Remove old coverage measurements
+	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo build -p flowc # Used to compile flowstdlib and flowsamples, so needed first
+	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo build -p flowstdlib # Used by flowsamples so needed first
 	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo build
+ifeq ($(CODESIGN),)
+	find target -perm +111 -type f | xargs codesign -fs self
+endif
 	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo clippy --tests -- -D warnings
 	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo test
 	@RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="flow-%p-%m.profraw" cargo doc --no-deps --target-dir=target/html/code

--- a/flowr/src/bin/flowrcli/cli/connections.rs
+++ b/flowr/src/bin/flowrcli/cli/connections.rs
@@ -242,6 +242,7 @@ mod test {
         }
     }
 
+    // Requires network access
     #[test]
     #[serial]
     fn coordinator_receive_wait_get_reply() {
@@ -281,6 +282,7 @@ mod test {
         assert_eq!(coordinator_message, CoordinatorMessage::World);
     }
 
+    // Requires network access
     #[test]
     #[serial]
     fn coordinator_receive_nowait_get_reply() {

--- a/flowsamples/build.rs
+++ b/flowsamples/build.rs
@@ -24,7 +24,6 @@ fn main() -> io::Result<()> {
             fs::create_dir_all(sample_out_dir).expect("Could not create output dir");
             compile_sample(&e.path().to_string_lossy(),
                            &sample_out_dir.to_string_lossy());
-            println!("cargo:rerun-if-changed={}", &sample_out_dir.to_string_lossy());
         }
     }
 

--- a/flowstdlib/build.rs
+++ b/flowstdlib/build.rs
@@ -11,7 +11,6 @@ fn main() -> io::Result<()> {
 
     // Tell Cargo that if any file changes it should rerun this build script
     println!("cargo:rerun-if-changed={lib_root_dir_str}");
-    println!("cargo:rerun-if-changed={out_dir}");
 
     let mut command = Command::new("flowc");
     // flowc options:   -v info : to log output at INFO level,


### PR DESCRIPTION
Fixes #1811 

Dialogs due to untrusted binaries can be fixed by code signing, but others remain due to the Firewall being on (corporate machine and security policies), and I cannot avoid those.