### PR TITLE
Add codesigning test runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "darwin")']
+runner = "mac_test_runner.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/*.rs.bk
 **/*.profraw
 **/.rustc_info.json
-.cargo
 coverage.info
 coverage
 flowstdlib/src/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,18 @@ checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
 
 [[package]]
 name = "glow"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
@@ -1519,6 +1531,18 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glow_glyph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4e62c64947b9a24fe20e2bba9ad819ecb506ef5c8df7ffc4737464c6df9510"
+dependencies = [
+ "bytemuck",
+ "glow 0.11.2",
+ "glyph_brush",
+ "log",
 ]
 
 [[package]]
@@ -1713,10 +1737,12 @@ checksum = "efbddf356d01e9d41cd394a9d04d62bfd89650a30f12fda5839cabb8c4591c88"
 dependencies = [
  "iced_core",
  "iced_futures",
+ "iced_glow",
  "iced_graphics",
  "iced_native",
  "iced_wgpu",
  "iced_winit",
+ "image",
  "thiserror",
 ]
 
@@ -1756,6 +1782,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_glow"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc5b081015f5c75777c96ad75e2288916e7d444c97396d6d136517877ef9129"
+dependencies = [
+ "bytemuck",
+ "euclid",
+ "glow 0.11.2",
+ "glow_glyph",
+ "glyph_brush",
+ "iced_graphics",
+ "iced_native",
+ "log",
+]
+
+[[package]]
 name = "iced_graphics"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1808,8 @@ dependencies = [
  "glam",
  "iced_native",
  "iced_style",
+ "image",
+ "kamadak-exif",
  "log",
  "lyon",
  "raw-window-handle 0.5.2",
@@ -1995,6 +2039,15 @@ checksum = "5dbcda57db8b6dc067e589628b7348639014e793d9e8137d8cf215e8b133a0bd"
 dependencies = [
  "crossbeam",
  "rayon",
+]
+
+[[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
 ]
 
 [[package]]
@@ -2259,6 +2312,12 @@ checksum = "70db9248a93dc36a36d9a47898caa007a32755c7ad140ec64eeeb50d5a730631"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "naga"
@@ -4166,7 +4225,7 @@ dependencies = [
  "d3d12",
  "foreign-types 0.3.2",
  "fxhash",
- "glow",
+ "glow 0.12.2",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,3 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"]
 inherits = "release"
 debug = true
 split-debuginfo = "packed"
-

--- a/mac_test_runner.sh
+++ b/mac_test_runner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#code sign the test binary
+codesign -s self $1
+
+echo "MacOS test runner: Signed executable $1, now running it"
+
+#execute the test binary that was passed as an arg
+$1

--- a/mac_test_runner.sh
+++ b/mac_test_runner.sh
@@ -1,8 +1,21 @@
-#!/usr/bin/env bash
-#code sign the test binary
-codesign -s self $1
+#!/bin/bash
 
-echo "MacOS test runner: Signed executable $1, now running it"
+# shellcheck disable=SC2046
+if [ $(which codesign) ]
+then
+  #echo "codesign detected"
+  if [ $(which security) ]
+  then
+    SELFCERT=$(security find-certificate -c "self" 2>&1 | grep "self")
+    if [ -n "$SELFCERT" ]
+    then
+      #echo "self certificate detected"
+      #code sign the test binary
+      codesign -s self "$1"
+      echo "MacOS test runner: Signed executable '$1'"
+    fi
+  fi
+fi
 
 #execute the test binary that was passed as an arg
 $1


### PR DESCRIPTION
Adds a script that is run to execute tests when on app-darwin in order to sign the test executable first