### PR TITLE
Fix use after free in wasm

### DIFF
--- a/flowmacro/src/lib.rs
+++ b/flowmacro/src/lib.rs
@@ -137,7 +137,7 @@ fn generate_code(function_implementation: TokenStream,
 
     let struct_name = format_ident!("{}", FunctionDefinition::camel_case(&definition.name.to_string()));
 
-    // This code will be compile dto wasm along with the Implementation's run() function
+    // This code will be compiled to wasm along with the Implementation's run() function
     // and it will be running on the wasm side - hence it includes code to build the serde_json
     // input structure expected by run(), and build a flat memory return from the serde_json
     // returned from run()
@@ -158,9 +158,9 @@ fn generate_code(function_implementation: TokenStream,
         #[no_mangle]
         pub extern "C" fn run_wasm(input_data_ptr: *mut std::os::raw::c_void, input_data_length: i32) -> i32 {
             use std::ptr::copy;
-            let input_data: Vec<u8> = unsafe {
-                Vec::from_raw_parts(input_data_ptr as *mut u8,
-                                      input_data_length as usize, input_data_length as usize)
+            let input_data: &[u8] = unsafe {
+                std::slice::from_raw_parts(input_data_ptr as *mut u8,
+                                      input_data_length as usize)
             };
 
             let inputs: Vec<Value> = serde_json::from_slice(&input_data).unwrap();


### PR DESCRIPTION
Use after free was always there - but started failing recently. this fixes it.