### PR TITLE
Replace simpdiscover with mdns-sd for service discovery (#2025)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2026-04-13
           override: true
           components: clippy
       - name: Checkout
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2026-04-13
           override: true
           target: wasm32-unknown-unknown
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2026-04-13
+          toolchain: nightly
           override: true
           components: clippy
       - name: Checkout
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2026-04-13
+          toolchain: nightly
           override: true
           target: wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "flowcore",
  "flowmacro",
  "serde_json",
+ "serial_test",
  "simpath",
  "tempfile",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,7 @@ dependencies = [
  "iced_aw",
  "image",
  "log",
+ "mdns-sd",
  "multimap",
  "once_cell",
  "portpicker",
@@ -1621,7 +1622,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "simpath",
- "simpdiscover",
  "tempfile",
  "tokio",
  "url",
@@ -1644,6 +1644,15 @@ dependencies = [
  "simpath",
  "tempfile",
  "url",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -2385,6 +2394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2871,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451927183d65d600e52b4e877a1251e051576f84fa01e5b4a50b450dfaaa537c"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4539,16 +4573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simpdiscover"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3254b3833bdc5c7dddeca4b9de62fb144f4ea33bac5d28af19274dd40e6e4586"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "skrifa"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4665,6 +4689,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,6 +4738,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5176,9 +5220,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -6092,6 +6136,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6123,11 +6176,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6152,6 +6222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6162,6 +6238,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6176,10 +6258,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6194,6 +6288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6204,6 +6304,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6218,6 +6324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6228,6 +6340,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -60,7 +60,7 @@ multimap = "~0.10"
 portpicker = "0.1.1"
 zmq = "0.10.0"
 image = "=0.25.10"
-simpdiscover = "0.7"
+mdns-sd = { version = "0.19", default-features = false }
 
 # for flowrlib
 rand = "0.10"

--- a/flowr/examples/sequence-of-sequences/main.rs
+++ b/flowr/examples/sequence-of-sequences/main.rs
@@ -9,7 +9,7 @@ mod test {
     use std::path::PathBuf;
 
     #[test]
-    #[ignore = "Due to nested loops issue still unresolved"]
+    #[ignore = "Due to nested loops issue still unresolved: https://github.com/andrewdavidmackenzie/flow/issues/2061"]
     fn test_sequence_of_sequences_example() {
         let _ = env::set_current_dir(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/flowr/examples/sequence-of-sequences/main.rs
+++ b/flowr/examples/sequence-of-sequences/main.rs
@@ -9,7 +9,9 @@ mod test {
     use std::path::PathBuf;
 
     #[test]
-    #[ignore = "Due to nested loops issue still unresolved: https://github.com/andrewdavidmackenzie/flow/issues/2061"]
+    #[ignore = "Due to nested loops issue still unresolved: \
+    https://github.com/andrewdavidmackenzie/flow/issues/2061 and \
+    https://github.com/andrewdavidmackenzie/flow/issues/2170"]
     fn test_sequence_of_sequences_example() {
         let _ = env::set_current_dir(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/flowr/src/bin/flowrcli/cli/connections.rs
+++ b/flowr/src/bin/flowrcli/cli/connections.rs
@@ -1,49 +1,22 @@
 use std::fmt::Display;
-use std::time::Duration;
 
 /// This is the message-queue implementation of the Client<-->[Coordinator][flowrlib::coordinator::Coordinator]
 /// communications
 use log::{debug, info, trace};
-use simpdiscoverylib::{BeaconListener, BeaconSender};
 use zmq::Socket;
 
-use flowcore::errors::{bail, Result, ResultExt};
+use flowcore::errors::{Result, ResultExt};
+
+pub use flowrlib::discovery::{discover_service, enable_service_discovery};
+pub use flowrlib::services::COORDINATOR_SERVICE_NAME;
+#[cfg(feature = "debugger")]
+pub use flowrlib::services::DEBUG_SERVICE_NAME;
 
 /// WAIT for a message to arrive when performing a `receive()`
 pub const WAIT: i32 = 0;
 
 /// Do NOT WAIT for a message to arrive when performing a `receive()`
 pub static DONT_WAIT: i32 = zmq::DONTWAIT;
-
-/// Use this to discover the coordinator service by name
-pub const COORDINATOR_SERVICE_NAME: &str = "runtime._flowr._tcp.local";
-
-/// Use this to discover the debug service by name
-#[cfg(feature = "debugger")]
-pub const DEBUG_SERVICE_NAME: &str = "debug._flowr._tcp.local";
-
-/// Try to discover a particular service by name
-pub fn discover_service(discovery_port: u16, name: &str) -> Result<String> {
-    let listener = BeaconListener::new(name.as_bytes(), discovery_port)?;
-    let beacon = listener.wait(None)?;
-    let address = format!("{}:{}", beacon.service_ip, beacon.service_port);
-    Ok(address)
-}
-
-/// Start a background thread that sends out beacons for service discovery by a client every second
-pub fn enable_service_discovery(discovery_port: u16, name: &str, service_port: u16) -> Result<()> {
-    match BeaconSender::new(service_port, name.as_bytes(), discovery_port) {
-        Ok(beacon) => {
-            info!("Discovery beacon announcing service named '{name}', on port: {service_port}");
-            std::thread::spawn(move || {
-                let _ = beacon.send_loop(Duration::from_secs(1));
-            });
-        }
-        Err(e) => bail!("Error starting discovery beacon: {}", e.to_string()),
-    }
-
-    Ok(())
-}
 
 /// `ClientConnection` stores information related to the connection from a client
 /// to the [Coordinator][flowrlib::coordinator::Coordinator] and is used each time a message is to
@@ -121,7 +94,7 @@ pub struct CoordinatorConnection {
 impl CoordinatorConnection {
     /// Create a new [Coordinator][flowrlib::coordinator::Coordinator]
     /// side of the client/coordinator Connection
-    pub fn new(service_name: &'static str, port: u16) -> Result<Self> {
+    pub fn new(service_name: &str, port: u16) -> Result<Self> {
         let context = zmq::Context::new();
         let responder = context
             .socket(zmq::REP)
@@ -256,15 +229,15 @@ mod test {
     #[serial]
     fn coordinator_receive_wait_get_reply() {
         let test_port = pick_unused_port().expect("No ports free");
-        let mut coordinator_connection = CoordinatorConnection::new("test", test_port)
+        let service_name = format!("test-{test_port}");
+        let mut coordinator_connection = CoordinatorConnection::new(&service_name, test_port)
             .expect("Could not create CoordinatorConnection");
 
-        let discovery_port = pick_unused_port().expect("No ports free");
-        enable_service_discovery(discovery_port, "test", test_port)
+        let _mdns = enable_service_discovery(&service_name, test_port)
             .expect("Could not enable service discovery");
 
         let coordinator_address =
-            discover_service(discovery_port, "test").expect("Could not discover service");
+            discover_service(&service_name).expect("Could not discover service");
         let client =
             ClientConnection::new(&coordinator_address).expect("Could not create ClientConnection");
 
@@ -296,14 +269,14 @@ mod test {
     #[serial]
     fn coordinator_receive_nowait_get_reply() {
         let test_port = pick_unused_port().expect("No ports free");
-        let mut coordinator_connection = CoordinatorConnection::new("test", test_port)
+        let service_name = format!("test-{test_port}");
+        let mut coordinator_connection = CoordinatorConnection::new(&service_name, test_port)
             .expect("Could not create CoordinatorConnection");
-        let discovery_port = pick_unused_port().expect("No ports free");
-        enable_service_discovery(discovery_port, "test", test_port)
+        let _mdns = enable_service_discovery(&service_name, test_port)
             .expect("Could not enable service discovery");
 
         let coordinator_address =
-            discover_service(discovery_port, "test").expect("Could discovery service");
+            discover_service(&service_name).expect("Could not discover service");
         let client =
             ClientConnection::new(&coordinator_address).expect("Could not create ClientConnection");
 

--- a/flowr/src/bin/flowrcli/cli/test_helper.rs
+++ b/flowr/src/bin/flowrcli/cli/test_helper.rs
@@ -14,20 +14,19 @@ pub mod test {
         then_send: ClientMessage,
     ) -> Arc<Mutex<CoordinatorConnection>> {
         let test_port = pick_unused_port().expect("No ports free");
+        let service_name = format!("test-{test_port}");
         let server_connection = Arc::new(Mutex::new(
-            CoordinatorConnection::new("foo", test_port)
+            CoordinatorConnection::new(&service_name, test_port)
                 .expect("Could not create server connection"),
         ));
-        let discovery_port = pick_unused_port().expect("No ports free");
-        enable_service_discovery(discovery_port, "foo", test_port)
+        let _mdns = enable_service_discovery(&service_name, test_port)
             .expect("Could not enable service discovery");
 
         let connection = server_connection
             .lock()
             .expect("Could not get access to server connection");
 
-        let server_address =
-            discover_service(discovery_port, "foo").expect("Could discovery service");
+        let server_address = discover_service(&service_name).expect("Could not discover service");
         let client_connection =
             ClientConnection::new(&server_address).expect("Could not create ClientConnection");
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -59,12 +59,12 @@ use flowrlib::coordinator::Coordinator;
 use flowrlib::dispatcher::Dispatcher;
 use flowrlib::executor::Executor;
 use flowrlib::info as flowrlib_info;
-use flowrlib::services::{
-    CONTROL_SERVICE_NAME, JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
-};
+use flowrlib::services::{CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME};
 
+#[cfg(feature = "debugger")]
+use crate::cli::connections::DEBUG_SERVICE_NAME;
 use crate::cli::connections::{
-    discover_service, enable_service_discovery, COORDINATOR_SERVICE_NAME, DEBUG_SERVICE_NAME,
+    discover_service, enable_service_discovery, COORDINATOR_SERVICE_NAME,
 };
 
 /// Include the module that implements the context functions
@@ -152,13 +152,12 @@ fn run() -> Result<()> {
     let lib_search_path = get_lib_search_path(&lib_dirs);
     let num_threads = num_threads(&matches);
 
-    if let Some(discovery_port) = matches.get_one::<u16>("client") {
+    if matches.get_flag("client") {
         client_only(
             &matches,
             lib_search_path,
             #[cfg(feature = "debugger")]
             debug_this_flow,
-            *discovery_port,
         )?;
     } else if matches.get_flag("server") {
         coordinator_only(num_threads, lib_search_path, native_flowstdlib)?;
@@ -185,17 +184,17 @@ fn coordinator_only(
     let coordinator_port = pick_unused_port().chain_err(|| "No ports free")?;
     let coordinator_connection =
         CoordinatorConnection::new(COORDINATOR_SERVICE_NAME, coordinator_port)?;
-    let discovery_port = pick_unused_port().chain_err(|| "No ports free")?;
-    enable_service_discovery(discovery_port, COORDINATOR_SERVICE_NAME, coordinator_port)?;
+    let _mdns_coordinator = enable_service_discovery(COORDINATOR_SERVICE_NAME, coordinator_port)?;
 
     #[cfg(feature = "debugger")]
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     #[cfg(feature = "debugger")]
     let debug_server_connection = CoordinatorConnection::new(DEBUG_SERVICE_NAME, debug_port)?;
     #[cfg(feature = "debugger")]
-    enable_service_discovery(discovery_port, DEBUG_SERVICE_NAME, debug_port)?;
+    let _mdns_debug = enable_service_discovery(DEBUG_SERVICE_NAME, debug_port)?;
 
-    println!("{discovery_port}");
+    // Signal to the parent process (e.g. test harness) that the server is ready
+    println!("ready");
 
     info!("Starting coordinator in main thread");
     coordinator(
@@ -226,14 +225,14 @@ fn client_and_coordinator(
     let coordinator_connection =
         CoordinatorConnection::new(COORDINATOR_SERVICE_NAME, runtime_port)?;
 
-    let discovery_port = pick_unused_port().chain_err(|| "No ports free")?;
-    enable_service_discovery(discovery_port, COORDINATOR_SERVICE_NAME, runtime_port)?;
+    let _mdns_coordinator = enable_service_discovery(COORDINATOR_SERVICE_NAME, runtime_port)?;
 
     #[cfg(feature = "debugger")]
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     #[cfg(feature = "debugger")]
     let debug_connection = CoordinatorConnection::new(DEBUG_SERVICE_NAME, debug_port)?;
-    enable_service_discovery(discovery_port, DEBUG_SERVICE_NAME, debug_port)?;
+    #[cfg(feature = "debugger")]
+    let _mdns_debug = enable_service_discovery(DEBUG_SERVICE_NAME, debug_port)?;
 
     let coordinator_lib_search_path = lib_search_path.clone();
 
@@ -250,7 +249,7 @@ fn client_and_coordinator(
         );
     });
 
-    let coordinator_address = discover_service(discovery_port, COORDINATOR_SERVICE_NAME)?;
+    let coordinator_address = discover_service(COORDINATOR_SERVICE_NAME)?;
 
     let runtime_client_connection = ClientConnection::new(&coordinator_address)?;
 
@@ -260,8 +259,6 @@ fn client_and_coordinator(
         &runtime_client_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
-        #[cfg(feature = "debugger")]
-        discovery_port,
     )
 }
 
@@ -290,9 +287,9 @@ fn coordinator(
     trace!("Announcing three job queues and a control socket on ports: {ports:?}");
     let job_queues = get_bind_addresses(ports);
     let dispatcher = Dispatcher::new(&job_queues)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME, ports.0)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, RESULTS_JOB_SERVICE_NAME, ports.2)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, CONTROL_SERVICE_NAME, ports.3)?;
+    let _mdns_jobs = enable_service_discovery(JOB_SERVICE_NAME, ports.0)?;
+    let _mdns_results = enable_service_discovery(RESULTS_JOB_SERVICE_NAME, ports.2)?;
+    let _mdns_control = enable_service_discovery(CONTROL_SERVICE_NAME, ports.3)?;
 
     let (job_source_name, context_job_source_name, results_sink, control_socket) =
         get_connect_addresses(ports);
@@ -348,9 +345,8 @@ fn client_only(
     matches: &ArgMatches,
     lib_search_path: Simpath,
     #[cfg(feature = "debugger")] debug_this_flow: bool,
-    discovery_port: u16,
 ) -> Result<()> {
-    let coordinator_address = discover_service(discovery_port, COORDINATOR_SERVICE_NAME)?;
+    let coordinator_address = discover_service(COORDINATOR_SERVICE_NAME)?;
     let client_connection = ClientConnection::new(&coordinator_address)?;
 
     client(
@@ -359,8 +355,6 @@ fn client_only(
         &client_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
-        #[cfg(feature = "debugger")]
-        discovery_port,
     )
 }
 
@@ -371,7 +365,6 @@ fn client(
     lib_search_path: Simpath,
     client_connection: &ClientConnection,
     #[cfg(feature = "debugger")] debug_this_flow: bool,
-    #[cfg(feature = "debugger")] discovery_port: u16,
 ) -> Result<()> {
     // keep an Arc Mutex protected set of override args that debug client can override
     let override_args = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -402,7 +395,7 @@ fn client(
 
     #[cfg(feature = "debugger")]
     if debug_this_flow {
-        let debug_server_address = discover_service(discovery_port, DEBUG_SERVICE_NAME)?;
+        let debug_server_address = discover_service(DEBUG_SERVICE_NAME)?;
         let debug_client_connection = ClientConnection::new(&debug_server_address)?;
         let debug_client = CliDebugClient::new(debug_client_connection, override_args);
         let _ = thread::spawn(move || {
@@ -474,8 +467,7 @@ fn get_matches() -> ArgMatches {
         .arg(Arg::new("client")
              .short('c')
              .long("client")
-             .number_of_values(1)
-             .value_parser(clap::value_parser!(u16))
+             .action(clap::ArgAction::SetTrue)
              .conflicts_with("server")
              .help("Launch only a client (no coordinator) to connect to a remote coordinator"),
         )

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -14,9 +14,9 @@ use std::{env, thread};
 
 use clap::{Arg, ArgMatches, Command};
 use env_logger::Builder;
+use flowrlib::discovery::discover_service;
 use log::{error, info, trace, LevelFilter};
 use simpath::Simpath;
-use simpdiscoverylib::BeaconListener;
 #[cfg(feature = "flowstdlib")]
 use url::Url;
 
@@ -25,21 +25,11 @@ use flowcore::meta_provider::MetaProvider;
 use flowcore::provider::Provider;
 use flowrlib::executor::Executor;
 use flowrlib::info as flowrlib_info;
-use flowrlib::services::{
-    CONTROL_SERVICE_NAME, JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
-};
+use flowrlib::services::{CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME};
 
 /// We'll put our errors in an `errors` module, and other modules in this crate will
 /// `use crate::errors::*;` to get access to everything `error_chain` creates.
 pub mod errors;
-
-/// Try to discover a server offering a particular service by name
-fn discover_service(discovery_port: u16, name: &str) -> Result<String> {
-    let listener = BeaconListener::new(name.as_bytes(), discovery_port)?;
-    let beacon = listener.wait(None)?;
-    let server_address = format!("{}:{}", beacon.service_ip, beacon.service_port);
-    Ok(server_address)
-}
 
 /// Main for flowrex binary - call `run()` and print any error that results or exit silently if OK
 fn main() {
@@ -104,19 +94,10 @@ fn start_executors(num_threads: usize) -> Result<()> {
         let provider =
             Arc::new(MetaProvider::new(Simpath::new(""), PathBuf::from("/"))) as Arc<dyn Provider>;
 
-        let job_service = format!(
-            "tcp://{}",
-            discover_service(JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME)?
-        );
-        let results_service = format!(
-            "tcp://{}",
-            discover_service(JOB_QUEUES_DISCOVERY_PORT, RESULTS_JOB_SERVICE_NAME)?
-        );
+        let job_service = format!("tcp://{}", discover_service(JOB_SERVICE_NAME)?);
+        let results_service = format!("tcp://{}", discover_service(RESULTS_JOB_SERVICE_NAME)?);
 
-        let control_service = format!(
-            "tcp://{}",
-            discover_service(JOB_QUEUES_DISCOVERY_PORT, CONTROL_SERVICE_NAME)?
-        );
+        let control_service = format!("tcp://{}", discover_service(CONTROL_SERVICE_NAME)?);
 
         trace!("Starting '{}' executors", env!("CARGO_PKG_NAME"));
         executor.start(

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -14,9 +14,7 @@ use flowcore::provider::Provider;
 use flowrlib::coordinator::Coordinator;
 use flowrlib::dispatcher::Dispatcher;
 use flowrlib::executor::Executor;
-use flowrlib::services::{
-    CONTROL_SERVICE_NAME, JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
-};
+use flowrlib::services::{CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME};
 
 use crate::errors::{Result, ResultExt};
 use crate::gui::client_connection::{discover_service, ClientConnection};
@@ -33,7 +31,7 @@ use crate::{context, CoordinatorSettings, ServerSettings};
 /// States in which the Connection to the Coordinator can find itself
 pub enum CoordinatorState {
     Init(ServerSettings),
-    Discovery(u16),
+    Discovery,
     Discovered(String),
     Connected(Receiver<ClientMessage>, Arc<Mutex<ClientConnection>>),
 }
@@ -57,20 +55,19 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
         move |mut app_sender: iced::futures::channel::mpsc::Sender<CoordinatorMessage>| async move {
             let mut state = match settings {
                 CoordinatorSettings::Server(sett) => CoordinatorState::Init(sett.clone()),
-                CoordinatorSettings::ClientOnly(port) => CoordinatorState::Discovery(port),
+                CoordinatorSettings::ClientOnly(_) => CoordinatorState::Discovery,
             };
 
             let mut running = false;
             loop {
                 match state {
                     CoordinatorState::Init(settings) => {
-                        let discovery_port = start_server(settings).unwrap(); // TODO
-                        state = CoordinatorState::Discovery(discovery_port);
+                        start_server(settings).unwrap(); // TODO
+                        state = CoordinatorState::Discovery;
                     }
 
-                    CoordinatorState::Discovery(discovery_port) => {
-                        let address =
-                            discover_service(discovery_port, COORDINATOR_SERVICE_NAME).unwrap(); // TODO
+                    CoordinatorState::Discovery => {
+                        let address = discover_service(COORDINATOR_SERVICE_NAME).unwrap(); // TODO
                         state = CoordinatorState::Discovered(address);
                     }
 
@@ -130,17 +127,16 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
 }
 
 // Start a coordinator server in a background thread, then discover it and return the address
-fn start_server(coordinator_settings: ServerSettings) -> Result<u16> {
+fn start_server(coordinator_settings: ServerSettings) -> Result<()> {
     let runtime_port = pick_unused_port().chain_err(|| "No ports free")?;
     let coordinator_connection =
         CoordinatorConnection::new(COORDINATOR_SERVICE_NAME, runtime_port)?;
 
-    let discovery_port = pick_unused_port().chain_err(|| "No ports free")?;
-    enable_service_discovery(discovery_port, COORDINATOR_SERVICE_NAME, runtime_port)?;
+    let _mdns_coordinator = enable_service_discovery(COORDINATOR_SERVICE_NAME, runtime_port)?;
 
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     let debug_connection = CoordinatorConnection::new(DEBUG_SERVICE_NAME, debug_port)?;
-    enable_service_discovery(discovery_port, DEBUG_SERVICE_NAME, debug_port)?;
+    let _mdns_debug = enable_service_discovery(DEBUG_SERVICE_NAME, debug_port)?;
 
     info!("Starting coordinator in background thread");
     thread::spawn(move || {
@@ -152,7 +148,7 @@ fn start_server(coordinator_settings: ServerSettings) -> Result<u16> {
         );
     });
 
-    Ok(discovery_port)
+    Ok(())
 }
 
 fn coordinator(
@@ -176,9 +172,9 @@ fn coordinator(
     trace!("Announcing three job queues and a control socket on ports: {ports:?}");
     let job_queues = get_bind_addresses(ports);
     let dispatcher = Dispatcher::new(&job_queues)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, JOB_SERVICE_NAME, ports.0)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, RESULTS_JOB_SERVICE_NAME, ports.2)?;
-    enable_service_discovery(JOB_QUEUES_DISCOVERY_PORT, CONTROL_SERVICE_NAME, ports.3)?;
+    let _mdns_jobs = enable_service_discovery(JOB_SERVICE_NAME, ports.0)?;
+    let _mdns_results = enable_service_discovery(RESULTS_JOB_SERVICE_NAME, ports.2)?;
+    let _mdns_control = enable_service_discovery(CONTROL_SERVICE_NAME, ports.3)?;
 
     let (job_source_name, context_job_source_name, results_sink, control_socket) =
         get_connect_addresses(ports);

--- a/flowr/src/bin/flowrgui/gui/client_connection.rs
+++ b/flowr/src/bin/flowrgui/gui/client_connection.rs
@@ -1,21 +1,13 @@
 use std::fmt::Display;
 
 use flowcore::errors::{Result, ResultExt};
+pub use flowrlib::discovery::discover_service;
 /// This is the message-queue implementation of the Client<-->[Coordinator][flowrlib::coordinator::Coordinator]
 /// communications
 use log::{info, trace};
-use simpdiscoverylib::BeaconListener;
 use zmq::Socket;
 
 use crate::gui::coordinator_connection::WAIT;
-
-/// Try to discover a particular service by name
-pub fn discover_service(discovery_port: u16, name: &str) -> Result<String> {
-    let listener = BeaconListener::new(name.as_bytes(), discovery_port)?;
-    let beacon = listener.wait(None)?;
-    let address = format!("{}:{}", beacon.service_ip, beacon.service_port);
-    Ok(address)
-}
 
 /// `ClientConnection` stores information related to the connection from a client
 /// to the [Coordinator][flowrlib::coordinator::Coordinator] and is used each time a message is to

--- a/flowr/src/bin/flowrgui/gui/coordinator_connection.rs
+++ b/flowr/src/bin/flowrgui/gui/coordinator_connection.rs
@@ -1,12 +1,12 @@
+use flowcore::errors::{Result, ResultExt};
 use std::fmt::Display;
-use std::time::Duration;
 
-use flowcore::errors::{bail, Result, ResultExt};
-
+pub use flowrlib::discovery::enable_service_discovery;
+pub use flowrlib::services::COORDINATOR_SERVICE_NAME;
+pub use flowrlib::services::DEBUG_SERVICE_NAME;
 /// This is the message-queue implementation of the Client<-->[Coordinator][flowrlib::coordinator::Coordinator]
 /// communications
 use log::{debug, info, trace};
-use simpdiscoverylib::BeaconSender;
 use zmq::Socket;
 
 /// WAIT for a message to arrive when performing a `receive()`
@@ -14,27 +14,6 @@ pub const WAIT: i32 = 0;
 
 /// Do NOT WAIT for a message to arrive when performing a `receive()`
 pub static DONT_WAIT: i32 = zmq::DONTWAIT;
-
-/// Use this to discover the coordinator service by name
-pub const COORDINATOR_SERVICE_NAME: &str = "runtime._flowr._tcp.local";
-
-/// Use this to discover the debug service by name
-pub const DEBUG_SERVICE_NAME: &str = "debug._flowr._tcp.local";
-
-/// Start a background thread that sends out beacons for service discovery by a client every second
-pub fn enable_service_discovery(discovery_port: u16, name: &str, service_port: u16) -> Result<()> {
-    match BeaconSender::new(service_port, name.as_bytes(), discovery_port) {
-        Ok(beacon) => {
-            info!("Discovery beacon announcing service named '{name}', on port: {service_port}");
-            std::thread::spawn(move || {
-                let _ = beacon.send_loop(Duration::from_secs(1));
-            });
-        }
-        Err(e) => bail!("Error starting discovery beacon: {}", e.to_string()),
-    }
-
-    Ok(())
-}
 
 /// [`CoordinatorConnection`] store information about the [Coordinator][flowrlib::coordinator::Coordinator]
 /// side of the client/coordinator communications between a client and a [Coordinator][flowrlib::coordinator::Coordinator]
@@ -48,7 +27,7 @@ pub struct CoordinatorConnection {
 impl CoordinatorConnection {
     /// Create a new [Coordinator][flowrlib::coordinator::Coordinator]
     /// side of the client/coordinator Connection
-    pub fn new(service_name: &'static str, port: u16) -> Result<Self> {
+    pub fn new(service_name: &str, port: u16) -> Result<Self> {
         let context = zmq::Context::new();
         let responder = context
             .socket(zmq::REP)

--- a/flowr/src/bin/flowrgui/gui/coordinator_connection.rs
+++ b/flowr/src/bin/flowrgui/gui/coordinator_connection.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 
 pub use flowrlib::discovery::enable_service_discovery;
 pub use flowrlib::services::COORDINATOR_SERVICE_NAME;
+#[cfg(feature = "debugger")]
 pub use flowrlib::services::DEBUG_SERVICE_NAME;
 /// This is the message-queue implementation of the Client<-->[Coordinator][flowrlib::coordinator::Coordinator]
 /// communications

--- a/flowr/src/bin/flowrgui/gui/test_helper.rs
+++ b/flowr/src/bin/flowrgui/gui/test_helper.rs
@@ -16,20 +16,19 @@ pub mod test {
         then_send: ClientMessage,
     ) -> Arc<Mutex<CoordinatorConnection>> {
         let test_port = pick_unused_port().expect("No ports free");
+        let service_name = format!("test-{test_port}");
         let server_connection = Arc::new(Mutex::new(
-            CoordinatorConnection::new("foo", test_port)
+            CoordinatorConnection::new(&service_name, test_port)
                 .expect("Could not create server connection"),
         ));
-        let discovery_port = pick_unused_port().expect("No ports free");
-        enable_service_discovery(discovery_port, "foo", test_port)
+        let _mdns = enable_service_discovery(&service_name, test_port)
             .expect("Could not enable service discovery");
 
         let connection = server_connection
             .lock()
             .expect("Could not get access to server connection");
 
-        let server_address =
-            discover_service(discovery_port, "foo").expect("Could discovery service");
+        let server_address = discover_service(&service_name).expect("Could not discover service");
         let client_connection =
             ClientConnection::new(&server_address).expect("Could not create ClientConnection");
 

--- a/flowr/src/lib/discovery.rs
+++ b/flowr/src/lib/discovery.rs
@@ -1,0 +1,76 @@
+//! Optional mDNS-SD service discovery helpers.
+//!
+//! These functions provide a convenient way to advertise and discover flow services
+//! using mDNS-SD. They are not required — other binaries using `flowrlib` can
+//! implement their own discovery mechanism.
+
+use log::info;
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+
+use flowcore::errors::{bail, Result};
+
+use crate::services::FLOW_SERVICE_TYPE;
+
+/// Register a service for mDNS-SD discovery.
+///
+/// The returned `ServiceDaemon` must be kept alive by the caller — the service is
+/// unregistered when the daemon is dropped.
+pub fn enable_service_discovery(name: &str, service_port: u16) -> Result<ServiceDaemon> {
+    let mdns = ServiceDaemon::new().map_err(|e| format!("Could not create mDNS daemon: {e}"))?;
+
+    let service_hostname = format!("{name}.local.");
+
+    let service_info = ServiceInfo::new(
+        FLOW_SERVICE_TYPE,
+        name,
+        &service_hostname,
+        "",
+        service_port,
+        None,
+    )
+    .map_err(|e| format!("Could not create mDNS ServiceInfo: {e}"))?
+    .enable_addr_auto();
+
+    mdns.register(service_info)
+        .map_err(|e| format!("Could not register mDNS service: {e}"))?;
+
+    info!("mDNS service registered: '{name}' on port {service_port}");
+
+    Ok(mdns)
+}
+
+/// Discover a service by name using mDNS-SD. Blocks until the service is found.
+///
+/// Returns the service address as `"{ip}:{port}"`.
+pub fn discover_service(name: &str) -> Result<String> {
+    let mdns = ServiceDaemon::new().map_err(|e| format!("Could not create mDNS daemon: {e}"))?;
+
+    let receiver = mdns
+        .browse(FLOW_SERVICE_TYPE)
+        .map_err(|e| format!("Could not browse for mDNS services: {e}"))?;
+
+    let full_name_suffix = format!(".{FLOW_SERVICE_TYPE}");
+
+    loop {
+        match receiver.recv() {
+            Ok(ServiceEvent::ServiceResolved(info)) => {
+                let instance = info
+                    .get_fullname()
+                    .strip_suffix(&full_name_suffix)
+                    .unwrap_or(info.get_fullname());
+
+                if instance == name {
+                    let port = info.get_port();
+                    if let Some(addr) = info.get_addresses_v4().into_iter().next() {
+                        let address = format!("{addr}:{port}");
+                        info!("Discovered mDNS service '{name}' at {address}");
+                        mdns.shutdown().ok();
+                        return Ok(address);
+                    }
+                }
+            }
+            Err(e) => bail!(format!("mDNS discovery error for '{name}': {e}")),
+            _ => {} // Ignore other events (SearchStarted, ServiceFound, etc.)
+        }
+    }
+}

--- a/flowr/src/lib/discovery.rs
+++ b/flowr/src/lib/discovery.rs
@@ -4,12 +4,16 @@
 //! using mDNS-SD. They are not required — other binaries using `flowrlib` can
 //! implement their own discovery mechanism.
 
+use std::time::{Duration, Instant};
+
 use log::info;
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 
 use flowcore::errors::{bail, Result};
 
 use crate::services::FLOW_SERVICE_TYPE;
+
+const DEFAULT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Register a service for mDNS-SD discovery.
 ///
@@ -39,7 +43,8 @@ pub fn enable_service_discovery(name: &str, service_port: u16) -> Result<Service
     Ok(mdns)
 }
 
-/// Discover a service by name using mDNS-SD. Blocks until the service is found.
+/// Discover a service by name using mDNS-SD. Blocks until the service is found
+/// or the default timeout (30 seconds) expires.
 ///
 /// Returns the service address as `"{ip}:{port}"`.
 pub fn discover_service(name: &str) -> Result<String> {
@@ -50,9 +55,18 @@ pub fn discover_service(name: &str) -> Result<String> {
         .map_err(|e| format!("Could not browse for mDNS services: {e}"))?;
 
     let full_name_suffix = format!(".{FLOW_SERVICE_TYPE}");
+    let start = Instant::now();
 
     loop {
-        match receiver.recv() {
+        if start.elapsed() > DEFAULT_DISCOVERY_TIMEOUT {
+            mdns.shutdown().ok();
+            bail!(format!(
+                "mDNS discovery timed out after {}s for '{name}'",
+                DEFAULT_DISCOVERY_TIMEOUT.as_secs()
+            ));
+        }
+
+        match receiver.recv_timeout(Duration::from_millis(500)) {
             Ok(ServiceEvent::ServiceResolved(info)) => {
                 let instance = info
                     .get_fullname()
@@ -69,8 +83,8 @@ pub fn discover_service(name: &str) -> Result<String> {
                     }
                 }
             }
-            Err(e) => bail!(format!("mDNS discovery error for '{name}': {e}")),
-            _ => {} // Ignore other events (SearchStarted, ServiceFound, etc.)
+            Err(_) => continue, // Timeout or disconnected — retry until overall timeout
+            _ => {}             // Ignore other events (SearchStarted, ServiceFound, etc.)
         }
     }
 }

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -53,6 +53,9 @@ pub mod run_state;
 /// Provides well-known service names used across multiple binary crates
 pub mod services;
 
+/// Optional mDNS-SD service discovery helpers
+pub mod discovery;
+
 #[cfg(feature = "debugger")]
 mod debugger;
 

--- a/flowr/src/lib/services.rs
+++ b/flowr/src/lib/services.rs
@@ -1,12 +1,19 @@
+/// The mDNS service type for flow services
+pub const FLOW_SERVICE_TYPE: &str = "_flowr._tcp.local.";
+
 /// `JOB_SERVICE_NAME` can be used to discover the queue serving jobs for execution
-pub const JOB_SERVICE_NAME: &str = "jobs._flowr._tcp.local";
+pub const JOB_SERVICE_NAME: &str = "jobs";
 
 /// `RESULTS_JOB_SERVICE_NAME` can be used to discover the queue where to send job results
-pub const RESULTS_JOB_SERVICE_NAME: &str = "results._flowr._tcp.local";
+pub const RESULTS_JOB_SERVICE_NAME: &str = "results";
 
 /// `CONTROL_SERVICE_NAME` is a control PUB/SUB socket used to control executors that
 /// are listening on the `JOB_SERVICE` and sending results back via the `RESULTS_SERVICE`
-pub const CONTROL_SERVICE_NAME: &str = "control._flowr._tcp.local";
+pub const CONTROL_SERVICE_NAME: &str = "control";
 
-/// This is the port for announcing and discovering the job queues
-pub const JOB_QUEUES_DISCOVERY_PORT: u16 = 15003;
+/// Use this to discover the coordinator service by name
+pub const COORDINATOR_SERVICE_NAME: &str = "runtime";
+
+/// Use this to discover the debug service by name
+#[cfg(feature = "debugger")]
+pub const DEBUG_SERVICE_NAME: &str = "debug";

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -248,20 +248,20 @@ pub fn execute_flow_client_server(example_name: &str, manifest: PathBuf) {
         .spawn()
         .expect("Failed to spawn flowrcli");
 
-    // capture the discovery port by reading one line of stdout
+    // wait for the server to signal it's ready
     let stdout = server
         .stdout
         .as_mut()
         .expect("Could not read stdout of server");
     let mut reader = BufReader::new(stdout);
-    let mut discovery_port = String::new();
+    let mut ready_line = String::new();
     reader
-        .read_line(&mut discovery_port)
-        .expect("Could not read line");
+        .read_line(&mut ready_line)
+        .expect("Could not read ready line from server");
 
     let mut client = Command::new("flowrcli");
     let manifest_str = manifest.to_string_lossy();
-    let client_args = vec!["-c", discovery_port.trim(), &manifest_str];
+    let client_args = vec!["-c", &manifest_str];
     println!(
         "Starting 'flowrcli' client with command line: 'flowr {}'",
         client_args.join(" ")

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -255,9 +255,13 @@ pub fn execute_flow_client_server(example_name: &str, manifest: PathBuf) {
         .expect("Could not read stdout of server");
     let mut reader = BufReader::new(stdout);
     let mut ready_line = String::new();
-    reader
+    let bytes_read = reader
         .read_line(&mut ready_line)
         .expect("Could not read ready line from server");
+    assert!(
+        bytes_read > 0 && ready_line.trim() == "ready",
+        "Server did not report ready. First stdout line: {ready_line:?}"
+    );
 
     let mut client = Command::new("flowrcli");
     let manifest_str = manifest.to_string_lossy();

--- a/flowstdlib/Cargo.toml
+++ b/flowstdlib/Cargo.toml
@@ -32,6 +32,7 @@ error-chain = "0.12.2"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3.4.0"
 flowcore = {path = "../flowcore", version = "0.142.0" }
 flowmacro = {path = "../flowmacro", version = "0.142.0" }
 serde_json = { version = "1.0", default-features = false }

--- a/flowstdlib/src/math/range.rs
+++ b/flowstdlib/src/math/range.rs
@@ -9,6 +9,8 @@ mod test {
 
     use super::super::super::test::execute_flow;
 
+    // Serialized to avoid mDNS service name collision when multiple flowc
+    // instances run in parallel — see https://github.com/andrewdavidmackenzie/flow/issues/2563
     #[test]
     #[serial]
     fn test_range_flow() {

--- a/flowstdlib/src/math/range.rs
+++ b/flowstdlib/src/math/range.rs
@@ -4,11 +4,13 @@ mod test {
     use std::fs::File;
     use std::io::Write;
 
+    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::super::super::test::execute_flow;
 
     #[test]
+    #[serial]
     fn test_range_flow() {
         let flow = "\
 flow = \"range_test\"

--- a/flowstdlib/src/math/sequence.rs
+++ b/flowstdlib/src/math/sequence.rs
@@ -9,6 +9,8 @@ mod test {
 
     use super::super::super::test::execute_flow;
 
+    // Serialized to avoid mDNS service name collision when multiple flowc
+    // instances run in parallel — see https://github.com/andrewdavidmackenzie/flow/issues/2563
     #[test]
     #[serial]
     fn test_single_value_initializers() {

--- a/flowstdlib/src/math/sequence.rs
+++ b/flowstdlib/src/math/sequence.rs
@@ -51,7 +51,10 @@ to = "stdout"
     }
 
     #[test]
-    #[ignore = "Problem with propagating array initializers into functions inside flows"]
+    #[ignore = "Problem with propagating array initializers into functions inside flows, see\
+    https://github.com/andrewdavidmackenzie/flow/issues/1418, \
+    https://github.com/andrewdavidmackenzie/flow/issues/513 and \
+    https://github.com/andrewdavidmackenzie/flow/issues/743"]
     fn test_array_initializers() {
         let flow = r#"
 flow = "sequence-of-sequences"

--- a/flowstdlib/src/math/sequence.rs
+++ b/flowstdlib/src/math/sequence.rs
@@ -4,11 +4,13 @@ mod test {
     use std::fs::File;
     use std::io::Write;
 
+    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::super::super::test::execute_flow;
 
     #[test]
+    #[serial]
     fn test_single_value_initializers() {
         let flow = r#"
 flow = "sequence_test"

--- a/flowstdlib/src/matrix/multiply.rs
+++ b/flowstdlib/src/matrix/multiply.rs
@@ -4,11 +4,13 @@ mod test {
     use std::fs::File;
     use std::io::Write;
 
+    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::super::super::test::execute_flow;
 
     #[test]
+    #[serial]
     fn test_multiply_flow() {
         let flow = "\
 flow = \"matrix_multiply_test\"

--- a/flowstdlib/src/matrix/multiply.rs
+++ b/flowstdlib/src/matrix/multiply.rs
@@ -9,6 +9,8 @@ mod test {
 
     use super::super::super::test::execute_flow;
 
+    // Serialized to avoid mDNS service name collision when multiple flowc
+    // instances run in parallel — see https://github.com/andrewdavidmackenzie/flow/issues/2563
     #[test]
     #[serial]
     fn test_multiply_flow() {


### PR DESCRIPTION
## Summary
- Replace `simpdiscover` with `mdns-sd` for standard mDNS-SD service discovery
- Consolidate duplicated discovery code into `flowrlib::discovery` module
- Move service name constants to `flowrlib::services`
- Remove custom discovery port (uses standard mDNS port 5353)
- Use unique service names per test to avoid stale mDNS registrations
- Fix `execute_flow()` pipe deadlock with `wait_with_output()`

Fixes #2025

## Test plan
- [x] All unit tests pass locally
- [x] Integration tests pass locally (except 3 flowstdlib tests that hang on macOS Sequoia due to ZMQ LNP issue #2560 — pre-existing, not a regression)
- [x] `make clippy` passes
- [x] `cargo fmt` applied
- [ ] CI passes on macos-14, ubuntu-24.04, ubuntu-24.04-arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined mDNS service discovery: discovery port configuration is no longer required
  * Unified service discovery implementation across components for improved consistency
  * Simplified CLI: the --client flag is now a boolean flag instead of requiring a port number
  * Coordinator startup now signals readiness via "ready" instead of emitting a discovery port

* **Tests**
  * Selected integration/unit tests annotated to run serially to avoid parallel interference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->