### PR TITLE
Replace deprecated serde_yaml with serde_yml (#2189)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "simpath",
  "toml 1.1.2+spec-1.1.0",
  "url",
@@ -2708,6 +2708,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -4467,16 +4477,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -5193,12 +5205,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -37,7 +37,7 @@ url = { version = "2.2", features = ["serde"] }
 log = {version = "0.4.29"}
 serde = { version = "~1.0.228"}
 toml = { version = "1.1.2" }
-serde_yaml = { version = "~0.9" }
+serde_yml = "0.0.12"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 curl = {version = "~0.4" }

--- a/flowcore/src/deserializers/yaml_deserializer.rs
+++ b/flowcore/src/deserializers/yaml_deserializer.rs
@@ -31,7 +31,7 @@ where
     T: DeserializeOwned,
 {
     fn deserialize(&self, contents: &'a str, url: Option<&Url>) -> Result<T> {
-        serde_yaml::from_str(contents).chain_err(|| {
+        serde_yml::from_str(contents).chain_err(|| {
             format!(
                 "Error deserializing Yaml from: '{}'",
                 url.map_or("URL was None".to_owned(), std::string::ToString::to_string)
@@ -47,7 +47,7 @@ where
 #[cfg(test)]
 mod test {
     use serde_derive::{Deserialize, Serialize};
-    use serde_yaml::Error;
+    use serde_yml::Error;
 
     use crate::model::metadata::MetaData;
 
@@ -93,7 +93,7 @@ description: \"ok\"
 authors: [\"Andrew <andrew@foo.com>\"]
     ";
 
-        let result: Result<MetaData, Error> = serde_yaml::from_str(metadata);
+        let result: Result<MetaData, Error> = serde_yml::from_str(metadata);
         match result {
             Ok(md) => {
                 assert_eq!(md.name, "me".to_string());


### PR DESCRIPTION
## Summary
- Replace `serde_yaml` (deprecated, archived) with `serde_yml` (maintained fork)
- API is identical — only the crate name changes
- Affects only `flowcore/src/deserializers/yaml_deserializer.rs`

Fixes #2189

## Test plan
- [x] All yaml deserializer tests pass
- [x] `make clippy` passes
- [x] `cargo fmt` applied
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML processing library to improve internal handling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->