### PR TITLE
flowedit: Phase 6 — multi-window, sub-flow & function editing

### DIFF
--- a/book/editing/flowedit.md
+++ b/book/editing/flowedit.md
@@ -89,8 +89,19 @@ Input ports that have initializer values show:
 - The initializer value and type displayed to the left of the port in yellow text
 
 Initializer types:
-- **once** — the value is provided once at flow startup (e.g., `1 once`)
-- **always** — the value is provided every time the function runs (e.g., `0 always`)
+- **once** — the value is provided once at flow startup (e.g., `once: 1`)
+- **always** — the value is provided every time the function runs (e.g., `always: 0`)
+
+**Right-click** on an input port to edit its initializer. A dialog appears with:
+- A dropdown to select the type (none, once, always)
+- A JSON value field (shown only when type is not "none")
+- Apply and Cancel buttons
+
+### Resizing Nodes
+
+When a node is selected, 8 yellow resize handles appear on its edges and corners.
+Drag any handle to resize the node. Edge handles resize one dimension, corner
+handles resize both.
 
 ## Connections
 
@@ -133,8 +144,14 @@ and its name appears in the status bar. Click on empty canvas to deselect.
 Click and drag a selected node to reposition it on the canvas. All connections to
 and from the node are automatically redrawn as the node moves.
 
-The cursor changes to a grab hand when hovering over a node, and a grabbing hand
-while dragging.
+The cursor changes contextually:
+- **Grab hand** over nodes (draggable)
+- **Grabbing hand** while dragging a node or panning
+- **Crosshair** over ports or while connecting
+- **Directional resize arrows** over resize handles
+- **Pointer** over the pencil icon on openable nodes
+
+Hover over a node with a truncated source label to see the full path in a tooltip.
 
 ### Deleting Nodes
 
@@ -144,12 +161,15 @@ All connections to and from the deleted node are also removed.
 ### Creating Connections
 
 Click and drag from any port (input or output) to start creating a connection.
-A green bezier curve preview follows the cursor as you drag. Compatible target
-ports highlight when you hover over them.
+A green bezier curve preview follows the cursor as you drag.
 
 - **Output → Input**: drag from a right-side port to a left-side port
 - **Input → Output**: drag from a left-side port to a right-side port (the
   connection direction is determined automatically)
+
+While dragging, **compatible target ports** are highlighted with a green circle.
+Port type compatibility is checked — if both ports have type information, at
+least one type must match. Ports with unknown types accept any connection.
 
 Release the mouse on a valid target port to complete the connection. Release on
 empty canvas or an incompatible port to cancel.
@@ -206,7 +226,8 @@ nodes on initial load.
 
 ### Zooming
 
-- **Ctrl + mouse wheel** (Cmd on macOS) — zoom in/out centered on cursor
+- **Cmd + mouse wheel** (Ctrl on Linux) — zoom in/out centered on cursor
+  (without modifier, scroll wheel pans the canvas)
 - **Zoom controls** — floating buttons in the bottom-right corner:
   - **+** — zoom in
   - **−** — zoom out
@@ -246,6 +267,8 @@ The left panel shows available processes organized in a collapsible tree:
 
 Click a function name to add it as a new node on the canvas. The node is
 placed to the right of existing nodes and auto-fit adjusts the view if enabled.
+If a function with the same name already exists, the new node gets a unique
+alias (e.g., `add_2`, `add_3`).
 
 ## Opening Sub-flows and Functions
 

--- a/book/editing/flowedit.md
+++ b/book/editing/flowedit.md
@@ -38,7 +38,7 @@ The editor window has three main areas:
 
 The main editing area where flow process nodes and their connections are displayed.
 When a flow is loaded, each process appears as a colored rounded rectangle (a "node")
-with connection lines drawn between them as bezier curves.
+with connection lines drawn between them as Bézier curves.
 
 ### Status Bar
 
@@ -105,7 +105,7 @@ handles resize both.
 
 ## Connections
 
-Connections between nodes are drawn as smooth bezier curves from an output port on
+Connections between nodes are drawn as smooth Bézier curves from an output port on
 one node to an input port on another node. Each connection has a filled arrow head
 at the destination (input) end to indicate the direction of data flow.
 
@@ -161,7 +161,7 @@ All connections to and from the deleted node are also removed.
 ### Creating Connections
 
 Click and drag from any port (input or output) to start creating a connection.
-A green bezier curve preview follows the cursor as you drag.
+A green Bézier curve preview follows the cursor as you drag.
 
 - **Output → Input**: drag from a right-side port to a left-side port
 - **Input → Output**: drag from a left-side port to a right-side port (the
@@ -302,7 +302,7 @@ editor showing:
 - **✕** buttons to delete existing ports
 - **Source file link** — click the filename to view the Rust source code,
   or click "..." to browse for a different source file
-- **Docs button** — if a `.md` documentation file exists alongside the function
+- **Docs tab** — if a `.md` documentation file exists alongside the function
 
 The **💾 Save** button writes the function definition to disk:
 - Updates the `.toml` definition file with the current name, inputs, and outputs

--- a/book/editing/flowedit.md
+++ b/book/editing/flowedit.md
@@ -79,9 +79,8 @@ Ports are the connection points on the edges of a node:
 - **Input ports** — small circles on the **left** edge, labeled with the port name
 - **Output ports** — small circles on the **right** edge, labeled with the port name
 
-Ports are discovered from two sources:
-1. **Input initializers** defined on the process reference (e.g., `input.start = {once = 1}`)
-2. **Connections** in the flow definition that reference the node's ports
+Ports are resolved from the actual function or flow definition by loading
+each subprocess source. This provides real port names and data types.
 
 ### Input Initializers
 
@@ -248,6 +247,65 @@ The left panel shows available processes organized in a collapsible tree:
 Click a function name to add it as a new node on the canvas. The node is
 placed to the right of existing nodes and auto-fit adjusts the view if enabled.
 
+## Opening Sub-flows and Functions
+
+Nodes that represent sub-flows (nested `.toml` files) or provided implementations
+(custom `.rs` functions) display a pencil icon (✎) in the top-right corner. The
+cursor changes to a pointer when hovering over the icon.
+
+### Sub-flow Windows
+
+Clicking the pencil on a sub-flow node opens it in a new editor window within
+the same process. The sub-flow window shows:
+
+- A **rounded bounding box** around all subprocess nodes
+- **Flow input ports** as blue semicircles on the left edge of the box
+- **Flow output ports** as orange semicircles on the right edge of the box
+- **Bezier connections** from the flow I/O ports to the internal subprocess ports
+
+Sub-flow windows do not show the Build button (only the root flow can be compiled).
+Clicking the pencil icon on an already-open sub-flow brings the existing window
+to the front instead of opening a duplicate.
+
+### Function Definition Editor
+
+Clicking the pencil on a provided implementation node opens a function definition
+editor showing:
+
+- **Editable function name** centered at the top
+- **Input ports** on the left with editable name and type fields
+- **Output ports** on the right with editable name and type fields
+- **+** buttons to add new input or output ports
+- **✕** buttons to delete existing ports
+- **Source file link** — click the filename to view the Rust source code,
+  or click "..." to browse for a different source file
+- **Docs button** — if a `.md` documentation file exists alongside the function
+
+The **💾 Save** button writes the function definition to disk:
+- Updates the `.toml` definition file with the current name, inputs, and outputs
+- Generates a skeleton `.rs` source file if one doesn't exist (with the
+  `#[flow_function]` boilerplate and correct input bindings)
+- Generates a `function.toml` Cargo manifest if one doesn't exist
+
+## Compiling
+
+Click the **🔨 Build** button in the status bar (or press **Cmd+B**) to compile
+the current flow to a manifest. The flow must be saved before compiling — if the
+flow has never been saved, a Save As dialog appears first. Any unsaved edits are
+automatically saved before compilation.
+
+The compiled manifest is written to the same directory as the flow file.
+
+## Window Management
+
+`flowedit` uses multi-window support — sub-flows and functions open in separate
+windows within the same application process.
+
+- **Cmd+W** — close the currently focused window
+- **Cmd+Q** — quit the entire application (prompts to save if there are unsaved changes)
+- Closing the root window exits the entire application
+- Closing a child window only closes that window
+
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
@@ -258,6 +316,9 @@ placed to the right of existing nodes and auto-fit adjusts the view if enabled.
 | Cmd+Shift+S | Save As |
 | Cmd+O | Open |
 | Cmd+N | New |
+| Cmd+B | Build (compile) |
+| Cmd+W | Close window |
+| Cmd+Q | Quit all |
 | Cmd+= | Zoom in |
 | Cmd+- | Zoom out |
 | Delete / Backspace | Delete selected node or connection |

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -441,6 +441,8 @@ correctly. Provided implementation skeletons compile.
 - Add UI dialog to add custom library search paths or specific libraries at runtime
   (the `-L` CLI flag already supports this at startup, but there is no in-app way
   to add paths during an editing session)
+- Implement CLI options for loading, compiling and running a flow compatible with
+  flowrgui, to enable using the same automated tests for both editors
 
 ## 9. Key Design Decisions
 

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -356,8 +356,8 @@ Initializer values saved correctly.
 
 ### Phase 6: Nested flows, new processes & polish
 
-**Step 1: Double-click sub-flow to open nested editor**
-- Double-click a node whose source is a relative `.toml` (sub-flow) to open it
+**Step 1: Click the pencil icon on a sub-flow to open nested editor**
+- Click the pencil icon on a node whose source is a relative `.toml` (sub-flow) to open it
   in a new editor window
 - Demo: `mandlebrot/root.toml` → double-click `generate_pixels` or `render`
 - Update user manual
@@ -370,9 +370,9 @@ Initializer values saved correctly.
   still compiles
 - Update user manual
 
-**Step 3: Double-click provided implementation to view/edit**
-- Double-click a node whose source is a `.rs` file (provided implementation)
-  to open a tabbed viewer/editor:
+**Step 3: Click the pencil icon on a provided implementation to view/edit**
+- Click the pencil icon on a node whose source is a `.rs` file (provided implementation)
+  to open the function definition editor:
   - Tab 1: TOML definition (function name, inputs, outputs, source)
   - Tab 2: Rust source (`.rs` file)
   - Tab 3: Documentation (`.md` file, if it exists)

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -443,6 +443,12 @@ correctly. Provided implementation skeletons compile.
   to add paths during an editing session)
 - Implement CLI options for loading, compiling and running a flow compatible with
   flowrgui, to enable using the same automated tests for both editors
+- Flow hierarchy navigator panel: add a collapsible tree view above the Process
+  Library panel showing the structure of the loaded flow — root flow at the top,
+  child sub-flows and functions as children, recursively. Double-click to open
+  an editing window for that node. For library-defined functions/flows (lib://),
+  open a read-only view window similar to the existing editor windows.
+- Automated UI testing for interactive features described in the user manual
 
 ## 9. Key Design Decisions
 

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -356,17 +356,58 @@ Initializer values saved correctly.
 
 ### Phase 6: Nested flows, new processes & polish
 
-**Work** (for follow-up PR):
-- Double-click flow node to open nested editor
-- Nested editor shows flow inputs on left edge, outputs on right edge
-- Create new sub-flow: user specifies name, inputs, outputs; opens nested flow editor
-- Create new provided implementation: user specifies name, inputs, outputs, source files
-- Error display for compilation failures
-- Flow metadata editing (name, description, authors)
+**Step 1: Double-click sub-flow to open nested editor**
+- Double-click a node whose source is a relative `.toml` (sub-flow) to open it
+  in a new editor window
+- Demo: `mandlebrot/root.toml` → double-click `generate_pixels` or `render`
+- Update user manual
 
-**Tests**: Nested flow can be edited and saved. New sub-flows and provided implementations
-can be created with correct definitions. Undo/redo works for node moves, connection
-changes, and process additions. Metadata saved correctly.
+**Step 2: Nested flow editor with input/output editing**
+- Nested editor shows the flow's declared `[[input]]` ports on the left edge
+  and `[[output]]` ports on the right edge as visual anchors (not process boxes)
+- Provide UI to add, edit (name, type), and delete flow inputs and outputs
+- Demo: open a sub-flow, modify its inputs/outputs, save, confirm parent
+  still compiles
+- Update user manual
+
+**Step 3: Double-click provided implementation to view/edit**
+- Double-click a node whose source is a `.rs` file (provided implementation)
+  to open a tabbed viewer/editor:
+  - Tab 1: TOML definition (function name, inputs, outputs, source)
+  - Tab 2: Rust source (`.rs` file)
+  - Tab 3: Documentation (`.md` file, if it exists)
+- Allow editing inputs/outputs (name, type) in the TOML tab
+- Demo: `reverse-echo/root.toml` → double-click `reverse`; also try a
+  flowstdlib function like `add` which has all three files
+- Update user manual
+
+**Step 4: Create new sub-flow**
+- User specifies: flow name, inputs (name + type), outputs (name + type),
+  and selects a filename/location for the new `.toml`
+- Save the new sub-flow `.toml` with declared inputs/outputs
+- Add a `source = "relative/path.toml"` process reference in the parent flow
+- Open the new sub-flow in a nested editor
+- Demo: create a sub-flow from scratch in a test flow
+- Update user manual
+
+**Step 5: Create new provided implementation**
+- User specifies: function name, inputs (name + type), outputs (name + type),
+  and selects a filename/location
+- Create the function `.toml` definition and a skeleton `.rs` source file
+  (with `#[flow_function]` boilerplate, correct input count, imports)
+- Allow editing inputs/outputs (name, type) — same UI as step 3
+- Add a `source = "relative/path"` process reference in the parent flow
+- Demo: create a new function from scratch, view the generated skeleton
+- Update user manual
+
+**Step 6: Flow metadata editing**
+- Edit flow name, description, authors on any flow
+- Update user manual
+
+**Tests**: Nested flow can be edited and saved. New sub-flows and provided
+implementations can be created with correct definitions. Undo/redo works
+for node moves, connection changes, and process additions. Metadata saved
+correctly. Provided implementation skeletons compile.
 
 **Deliverable**: Production-ready flow editor.
 

--- a/docs/superpowers/plans/2026-04-19-multi-window-daemon.md
+++ b/docs/superpowers/plans/2026-04-19-multi-window-daemon.md
@@ -1,0 +1,523 @@
+# Multi-Window Daemon Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor flowedit from `iced::application` (single window) to `iced::daemon` (multi-window) so sub-flows can be opened in new windows within the same process, sharing state and lifecycle.
+
+**Architecture:** Extract per-window state into a `WindowState` struct, keyed by `iced::window::Id` in a `HashMap`. The top-level `FlowEdit` becomes the app-wide state holding the window map, library tree, and shared config. The daemon's `view(state, window_id)` and `title(state, window_id)` dispatch to the correct window. Window lifecycle (open/close/exit) is handled via `iced::window::open/close/close_requests` and `iced::exit`.
+
+**Tech Stack:** Rust, iced 0.14.0 (`daemon` API, `window::open`, `window::close`, `window::close_requests`)
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `flowedit/src/main.rs` | Major: extract `WindowState`, switch `main()` to `daemon()`, add `window::Id` routing to `view`/`title`/`update`, add window lifecycle messages, rewrite `open_node` to use `window::open` |
+| `flowedit/src/canvas_view.rs` | None (already receives data by reference, no state changes needed) |
+| `flowedit/src/history.rs` | None (already per-window, just needs to live inside `WindowState`) |
+| `flowedit/src/library_panel.rs` | None (shared across windows, stays in top-level state) |
+
+All changes are in `flowedit/src/main.rs`. The refactor is large but confined to one file.
+
+---
+
+### Task 1: Extract WindowState struct
+
+Extract per-window fields from `FlowEdit` into a new `WindowState` struct. Keep `FlowEdit` as app-wide state with a `HashMap<window::Id, WindowState>`.
+
+**Files:**
+- Modify: `flowedit/src/main.rs:94-129` (struct FlowEdit)
+
+- [ ] **Step 1: Define WindowState and refactor FlowEdit**
+
+Add `WindowState` struct above `FlowEdit`. Move per-window fields into it. Add `windows` map and `root_window` to `FlowEdit`.
+
+```rust
+use iced::window;
+
+/// Per-window editor state.
+struct WindowState {
+    flow_name: String,
+    nodes: Vec<NodeLayout>,
+    edges: Vec<EdgeLayout>,
+    canvas_state: FlowCanvasState,
+    status: String,
+    selected_node: Option<usize>,
+    selected_connection: Option<usize>,
+    history: EditHistory,
+    auto_fit_pending: bool,
+    auto_fit_enabled: bool,
+    unsaved_edits: i32,
+    compiled_manifest: Option<PathBuf>,
+    file_path: Option<PathBuf>,
+    flow_definition: FlowDefinition,
+    tooltip: Option<(String, f32, f32)>,
+    initializer_editor: Option<InitializerEditor>,
+    is_root: bool,
+}
+
+struct FlowEdit {
+    windows: HashMap<window::Id, WindowState>,
+    root_window: Option<window::Id>,
+    library_tree: LibraryTree,
+}
+```
+
+- [ ] **Step 2: Add WindowState constructor**
+
+```rust
+impl WindowState {
+    fn new(
+        flow_name: String,
+        nodes: Vec<NodeLayout>,
+        edges: Vec<EdgeLayout>,
+        file_path: Option<PathBuf>,
+        flow_definition: FlowDefinition,
+        is_root: bool,
+    ) -> Self {
+        let has_nodes = !nodes.is_empty();
+        Self {
+            flow_name,
+            nodes,
+            edges,
+            canvas_state: FlowCanvasState::default(),
+            status: String::from("Ready"),
+            selected_node: None,
+            selected_connection: None,
+            history: EditHistory::default(),
+            auto_fit_pending: has_nodes,
+            auto_fit_enabled: true,
+            unsaved_edits: 0,
+            compiled_manifest: None,
+            file_path,
+            flow_definition,
+            tooltip: None,
+            initializer_editor: None,
+            is_root,
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build — expect many errors**
+
+Run: `cargo build -p flowedit 2>&1 | head -30`
+Expected: Many errors because all the methods still reference `self.nodes`, `self.edges`, etc. directly on `FlowEdit`. This confirms the struct split compiled but methods need updating.
+
+- [ ] **Step 4: Commit checkpoint**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "WIP: extract WindowState struct from FlowEdit"
+```
+
+---
+
+### Task 2: Switch main() to daemon and open root window
+
+Change `main()` from `iced::application()` to `iced::daemon()`. Open the root window in `new()` via `window::open()`. Add window lifecycle messages.
+
+**Files:**
+- Modify: `flowedit/src/main.rs:44-79` (Message enum)
+- Modify: `flowedit/src/main.rs:134-141` (main function)
+- Modify: `flowedit/src/main.rs:145-257` (FlowEdit::new)
+
+- [ ] **Step 1: Add window lifecycle messages**
+
+Add to the `Message` enum:
+
+```rust
+enum Message {
+    // ... existing variants ...
+    /// A window was opened (the task from window::open completed)
+    WindowOpened(window::Id),
+    /// The user requested closing a window (clicked the X button)
+    CloseRequested(window::Id),
+}
+```
+
+- [ ] **Step 2: Switch main() to daemon**
+
+```rust
+fn main() -> iced::Result {
+    env_logger::init();
+    iced::daemon(FlowEdit::new, FlowEdit::update, FlowEdit::view)
+        .title(FlowEdit::title)
+        .subscription(FlowEdit::subscription)
+        .antialiasing(true)
+        .run()
+}
+```
+
+- [ ] **Step 3: Update new() to open root window**
+
+In `new()`, after parsing CLI args and loading the flow, open the root window via `window::open()` and store the window state:
+
+```rust
+fn new() -> (Self, Task<Message>) {
+    // ... existing CLI parsing and flow loading ...
+
+    let library_tree = LibraryTree::scan();
+
+    let (root_id, open_task) = window::open(window::Settings {
+        size: iced::Size::new(1024.0, 768.0),
+        ..Default::default()
+    });
+
+    let win_state = WindowState::new(
+        flow_name, nodes, edges, file_path, flow_definition, true,
+    );
+
+    let mut windows = HashMap::new();
+    windows.insert(root_id, win_state);
+
+    let app = FlowEdit {
+        windows,
+        root_window: Some(root_id),
+        library_tree,
+    };
+
+    (app, open_task.discard())
+}
+```
+
+- [ ] **Step 4: Update title() to accept window::Id**
+
+```rust
+fn title(&self, window_id: window::Id) -> String {
+    let Some(win) = self.windows.get(&window_id) else {
+        return String::from("flowedit");
+    };
+    let modified = if win.unsaved_edits > 0 { " *" } else { "" };
+    let file = win
+        .file_path
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("untitled");
+    format!("flowedit - {} ({}){modified}", win.flow_name, file)
+}
+```
+
+- [ ] **Step 5: Update view() to accept window::Id**
+
+```rust
+fn view(&self, window_id: window::Id) -> Element<'_, Message> {
+    let Some(win) = self.windows.get(&window_id) else {
+        return Text::new("Window not found").into();
+    };
+    // ... existing view code, but reading from `win` instead of `self` ...
+    // The compile button is only shown for root windows (win.is_root)
+}
+```
+
+- [ ] **Step 6: Update subscription() with close_requests**
+
+```rust
+fn subscription(&self) -> Subscription<Message> {
+    Subscription::batch(vec![
+        keyboard::listen().filter_map(|event| match event {
+            // ... existing keyboard handling ...
+        }),
+        window::close_requests().map(Message::CloseRequested),
+    ])
+}
+```
+
+- [ ] **Step 7: Handle CloseRequested in update()**
+
+When any window close is requested: if it's the root window, exit the entire app. If it's a child window, just close that window.
+
+```rust
+Message::CloseRequested(id) => {
+    if self.root_window == Some(id) {
+        // Root window closed — exit the whole app
+        return iced::exit();
+    }
+    // Child window — just close it
+    self.windows.remove(&id);
+    return window::close(id);
+}
+```
+
+- [ ] **Step 8: Build and fix compilation errors**
+
+Run: `cargo build -p flowedit 2>&1`
+
+This is the main integration step. All the `self.nodes`, `self.edges`, etc. references in methods like `update()` need to become `win.nodes`, `win.edges` where `win` is looked up from `self.windows` using the appropriate window ID.
+
+For `update()`, most messages need a "current window" context. Since iced's `update` doesn't receive a window ID, messages that come from canvas interactions need to carry the window ID. The approach: wrap canvas messages with a window ID.
+
+Add a new message variant:
+```rust
+/// A message from a specific window's canvas
+WindowCanvas(window::Id, CanvasMessage),
+```
+
+And in `view()`, map canvas messages to include the window ID:
+```rust
+let canvas = win.canvas_state
+    .view(&win.nodes, &win.edges, win.auto_fit_pending, win.auto_fit_enabled)
+    .map(move |msg| Message::WindowCanvas(window_id, msg));
+```
+
+Then in `update()`, extract the window ID from `WindowCanvas` and look up the right `WindowState`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "Switch from iced::application to iced::daemon with multi-window support"
+```
+
+---
+
+### Task 3: Migrate all update handlers to per-window dispatch
+
+Route every message to the correct `WindowState` via the window ID. This is the bulk of the mechanical refactor.
+
+**Files:**
+- Modify: `flowedit/src/main.rs` (update method and all helper methods)
+
+- [ ] **Step 1: Add active_window tracking**
+
+Since some messages (keyboard shortcuts, library panel) don't carry a window ID, track the "focused" window. Use `window::events()` to detect focus changes, or default to the root window.
+
+A simpler approach: keyboard shortcuts and library panel additions always target the root window (or most recently focused). For now, use `root_window` as the default target for non-window-specific messages.
+
+- [ ] **Step 2: Refactor update() message routing**
+
+The pattern for each message is:
+1. Determine which window it targets (from the message or default to root)
+2. Get `&mut WindowState` from `self.windows`
+3. Perform the operation on that window state
+
+Example for `Message::Save`:
+```rust
+Message::Save => {
+    if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
+        if let Some(path) = win.file_path.clone() {
+            Self::perform_save(win, &path);
+        } else {
+            Self::perform_save_as(win);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Convert instance methods to take &mut WindowState**
+
+Methods like `perform_save`, `perform_open`, `record_edit`, `apply_undo`, `apply_redo`, `apply_initializer_edit`, `sync_flow_definition`, `add_library_function`, `perform_compile`, etc. currently take `&mut self` (FlowEdit). They need to either:
+- Become associated functions taking `&mut WindowState`
+- Or take a window ID parameter and look up the window
+
+The associated function approach is cleaner:
+```rust
+fn perform_save(win: &mut WindowState, path: &PathBuf) { ... }
+fn record_edit(win: &mut WindowState, action: EditAction) { ... }
+```
+
+- [ ] **Step 4: Build and iterate on errors**
+
+Run: `cargo build -p flowedit 2>&1`
+Fix errors one by one. This is mechanical but tedious.
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test 2>&1 | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "Route all update handlers through per-window WindowState"
+```
+
+---
+
+### Task 4: Implement open_node with window::open
+
+Replace the subprocess spawn in `open_node` with `window::open()` to create a new in-process window.
+
+**Files:**
+- Modify: `flowedit/src/main.rs` (open_node method)
+
+- [ ] **Step 1: Rewrite open_node to use window::open**
+
+```rust
+fn open_node(&mut self, window_id: window::Id, idx: usize) -> Task<Message> {
+    let Some(win) = self.windows.get(&window_id) else {
+        return Task::none();
+    };
+    let Some(node) = win.nodes.get(idx) else {
+        return Task::none();
+    };
+    let source = node.source.clone();
+
+    let Some(path) = Self::resolve_node_source(win, &source) else {
+        if let Some(w) = self.windows.get_mut(&window_id) {
+            w.status = format!("Could not resolve source: {source}");
+        }
+        return Task::none();
+    };
+
+    // Load the flow from the resolved path
+    match load_flow(&path) {
+        Ok((name, nodes, edges, flow_def)) => {
+            let (new_id, open_task) = window::open(window::Settings {
+                size: iced::Size::new(1024.0, 768.0),
+                ..Default::default()
+            });
+            let child = WindowState::new(
+                name, nodes, edges, Some(path.clone()), flow_def, false,
+            );
+            self.windows.insert(new_id, child);
+            if let Some(w) = self.windows.get_mut(&window_id) {
+                w.status = format!("Opened: {}", path.display());
+            }
+            open_task.discard()
+        }
+        Err(e) => {
+            // Could be a function definition — show status
+            if let Some(w) = self.windows.get_mut(&window_id) {
+                w.status = format!("Could not open '{}': {e}", source);
+            }
+            Task::none()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update Message::WindowCanvas(OpenNode) handler to return Task**
+
+In the `update()` match arm for `OpenNode`:
+```rust
+CanvasMessage::OpenNode(idx) => {
+    return self.open_node(win_id, idx);
+}
+```
+
+Note: `update()` already returns `Task<Message>`, so this works. Just make sure the other arms that currently don't return a task still return `Task::none()`.
+
+- [ ] **Step 3: Child windows hide compile button**
+
+In `view()`, when building the status bar for a window, check `win.is_root`:
+```rust
+if win.is_root {
+    // Show compile button
+} else {
+    // No compile button for child windows
+}
+```
+
+- [ ] **Step 4: Build and test manually**
+
+Run: `cargo build -p flowedit && cargo run -p flowedit -- flowr/examples/mandlebrot/root.toml`
+
+Click the ↗ icon on a sub-flow node. A new window should open within the same process showing the sub-flow's contents.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo fmt -p flowedit && cargo clippy -p flowedit && make test 2>&1 | tail -5`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "Open sub-flows in new in-process windows via iced::daemon"
+```
+
+---
+
+### Task 5: Window close lifecycle and exit
+
+Ensure closing any child window removes its state. Closing the root window exits the entire application.
+
+**Files:**
+- Modify: `flowedit/src/main.rs` (subscription, update)
+
+- [ ] **Step 1: Handle unsaved changes on close**
+
+Before closing a window with unsaved edits, prompt the user:
+```rust
+Message::CloseRequested(id) => {
+    if let Some(win) = self.windows.get(&id) {
+        if win.unsaved_edits > 0 {
+            // For now, just close without prompting (Phase 7 will add save prompt)
+        }
+    }
+    if self.root_window == Some(id) {
+        return iced::exit();
+    }
+    self.windows.remove(&id);
+    return window::close(id);
+}
+```
+
+- [ ] **Step 2: Test close behavior**
+
+Open mandlebrot, click ↗ on a sub-flow. Close the child window — root should stay open. Close the root window — app should exit entirely.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "Handle window close lifecycle: child closes independently, root exits app"
+```
+
+---
+
+### Task 6: Final cleanup and manual testing
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cargo fmt -p flowedit && cargo clippy -p flowedit && make test
+```
+
+- [ ] **Step 2: Manual test with mandlebrot**
+
+```bash
+cargo run -p flowedit -- flowr/examples/mandlebrot/root.toml
+```
+
+Verify:
+- Root window shows "flowedit - my-mandlebrot (root.toml)"
+- Sub-flow nodes (generate_pixels, render, parse_args) show ↗ icon
+- lib:// and context:// nodes do NOT show ↗ icon
+- Clicking ↗ opens sub-flow in a new window within the same process
+- Child window title shows the sub-flow name
+- Child window has no Compile button
+- Closing child window leaves root open
+- Closing root window exits the application
+
+- [ ] **Step 3: Manual test with reverse-echo**
+
+```bash
+cargo run -p flowedit -- flowr/examples/reverse-echo/root.toml
+```
+
+Verify:
+- `reverse` node (provided implementation) shows ↗ icon
+- Clicking ↗ shows status message "Could not open 'reverse/reverse': ..." (function, not a flow)
+
+- [ ] **Step 4: Manual test with fibonacci**
+
+```bash
+cargo run -p flowedit -- flowr/examples/fibonacci/root.toml
+```
+
+Verify:
+- `add` (lib://) and `stdout` (context://) nodes do NOT show ↗ icon
+- All existing features (drag, connect, resize, undo, save, compile) still work
+
+- [ ] **Step 5: Commit final**
+
+```bash
+git add -A
+git commit -m "Phase 6 Step 1: Multi-window daemon with sub-flow opening"
+```

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -669,7 +669,7 @@ impl FlowCanvasState {
         }
 
         // Extra margin when flow I/O bounding box is drawn (padding + port labels)
-        let flow_io_margin = if has_flow_io { 160.0 } else { 0.0 };
+        let flow_io_margin = if has_flow_io { 200.0 } else { 0.0 };
 
         let mut min_x = f32::MAX;
         let mut min_y = f32::MAX;
@@ -1278,14 +1278,49 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         .and_capture(),
                     )
                 } else {
-                    // Track hover for tooltip
+                    // Check port hover for type tooltip
+                    if let Some((node_idx, port_name, is_output)) =
+                        hit_test_port(self.nodes, cursor_position, zoom, offset)
+                    {
+                        if let Some(node) = self.nodes.get(node_idx) {
+                            let ports = if is_output {
+                                &node.outputs
+                            } else {
+                                &node.inputs
+                            };
+                            let type_text = ports
+                                .iter()
+                                .find(|p| p.name == port_name)
+                                .map(|p| {
+                                    if p.datatypes.is_empty() {
+                                        format!("{port_name}: (any)")
+                                    } else {
+                                        format!("{port_name}: {}", p.datatypes.join(", "))
+                                    }
+                                })
+                                .unwrap_or_else(|| port_name.clone());
+                            state.hover_node = None;
+                            return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
+                                Some((type_text, cursor_position.x, cursor_position.y - 20.0)),
+                            )));
+                        }
+                    }
+
+                    // Track hover for node source tooltip
                     let new_hover = hit_test_node(self.nodes, world_pos);
                     if new_hover != state.hover_node {
                         state.hover_node = new_hover;
                         let tooltip_data = new_hover
                             .and_then(|idx| self.nodes.get(idx))
                             .filter(|n| n.source.len() > MAX_SOURCE_CHARS)
-                            .map(|n| (n.source.clone(), cursor_position.x, cursor_position.y));
+                            .map(|n| {
+                                let bottom_center = transform_point(
+                                    Point::new(n.x + n.width / 2.0, n.y + n.height),
+                                    zoom,
+                                    offset,
+                                );
+                                (n.source.clone(), bottom_center.x, bottom_center.y)
+                            });
                         return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
                             tooltip_data,
                         )));
@@ -1911,12 +1946,13 @@ fn draw_flow_io_ports(
         });
         frame.fill(&semi, input_color);
 
-        let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
+        let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
         frame.fill_text(CanvasText {
             content: input.name.clone(),
             position: label_pos,
             color: input_color,
             size: (font_size * zoom).into(),
+            align_x: iced::alignment::Horizontal::Right.into(),
             align_y: iced::alignment::Vertical::Center,
             ..CanvasText::default()
         });
@@ -1945,13 +1981,12 @@ fn draw_flow_io_ports(
         });
         frame.fill(&semi, output_color);
 
-        let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
+        let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
         frame.fill_text(CanvasText {
             content: output.name.clone(),
             position: label_pos,
             color: output_color,
             size: (font_size * zoom).into(),
-            align_x: iced::alignment::Horizontal::Right.into(),
             align_y: iced::alignment::Vertical::Center,
             ..CanvasText::default()
         });

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -85,6 +85,8 @@ pub(crate) enum CanvasMessage {
     AutoFitViewport(Size),
     /// Hover state changed — full source path and screen position for tooltip (or None to hide)
     HoverChanged(Option<(String, f32, f32)>),
+    /// Right-click on empty canvas — show context menu at screen position
+    ContextMenu(f32, f32),
 }
 
 /// Tracks the drag-in-progress state: which node and the cursor offset from its origin.
@@ -617,12 +619,14 @@ impl Default for FlowCanvasState {
 
 impl FlowCanvasState {
     /// Create the canvas [`Element`] for displaying the given nodes and edges.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn view<'a>(
         &'a self,
         nodes: &'a [NodeLayout],
         edges: &'a [EdgeLayout],
         flow_inputs: &'a [PortInfo],
         flow_outputs: &'a [PortInfo],
+        is_subflow: bool,
         auto_fit_pending: bool,
         auto_fit_enabled: bool,
     ) -> Element<'a, CanvasMessage> {
@@ -632,6 +636,7 @@ impl FlowCanvasState {
             edges,
             flow_inputs,
             flow_outputs,
+            is_subflow,
             auto_fit_pending,
             auto_fit_enabled,
         })
@@ -671,10 +676,11 @@ impl FlowCanvasState {
         // Extra margin when flow I/O bounding box is drawn (padding + port labels)
         let flow_io_margin = if has_flow_io { 200.0 } else { 0.0 };
 
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
+        let (mut min_x, mut min_y, mut max_x, mut max_y) = if nodes.is_empty() {
+            (100.0, 100.0, 400.0, 250.0)
+        } else {
+            (f32::MAX, f32::MAX, f32::MIN, f32::MIN)
+        };
         for node in nodes {
             let init_margin = if node.initializers.is_empty() {
                 0.0
@@ -754,6 +760,8 @@ struct FlowCanvas<'a> {
     flow_inputs: &'a [PortInfo],
     /// Flow-level output ports (displayed on right edge for sub-flows)
     flow_outputs: &'a [PortInfo],
+    /// Whether this is a sub-flow (always draws bounding box)
+    is_subflow: bool,
     /// Whether an auto-fit should be triggered on the next event
     auto_fit_pending: bool,
     /// Whether auto-fit mode is active (continuously fits to window)
@@ -1174,7 +1182,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 }
             }
 
-            // Right mouse button pressed — edit initializer on input port
+            // Right mouse button pressed — edit initializer on input port, or context menu
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
                 if let Some((node_idx, port_name, is_output)) =
                     hit_test_port(self.nodes, cursor_position, zoom, offset)
@@ -1187,6 +1195,16 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                             .and_capture(),
                         );
                     }
+                }
+                // Right-click on empty canvas — show context menu
+                if hit_test_node(self.nodes, world_pos).is_none() {
+                    return Some(
+                        canvas::Action::publish(CanvasMessage::ContextMenu(
+                            cursor_position.x,
+                            cursor_position.y,
+                        ))
+                        .and_capture(),
+                    );
                 }
                 None
             }
@@ -1486,6 +1504,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 self.flow_outputs,
                 self.nodes,
                 self.edges,
+                self.is_subflow,
                 zoom,
                 offset,
             );
@@ -1869,16 +1888,18 @@ fn draw_nodes(frame: &mut Frame, nodes: &[NodeLayout], zoom: f32, offset: Point)
 
 /// Draw a rounded bounding box around all subprocess nodes with flow I/O
 /// ports on the box edges and bezier connections to internal nodes.
+#[allow(clippy::too_many_arguments)]
 fn draw_flow_io_ports(
     frame: &mut Frame,
     flow_inputs: &[PortInfo],
     flow_outputs: &[PortInfo],
     nodes: &[NodeLayout],
     edges: &[EdgeLayout],
+    is_subflow: bool,
     zoom: f32,
     offset: Point,
 ) {
-    if flow_inputs.is_empty() && flow_outputs.is_empty() {
+    if !is_subflow {
         return;
     }
 
@@ -1889,7 +1910,7 @@ fn draw_flow_io_ports(
     let corner = 16.0;
 
     let (min_x, max_x, min_y, max_y) = if nodes.is_empty() {
-        (0.0, 200.0, 0.0, 100.0)
+        (100.0, 400.0, 100.0, 250.0)
     } else {
         (
             nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min),

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -75,6 +75,8 @@ pub(crate) enum CanvasMessage {
     /// Right-click on an input port to edit its initializer.
     /// (node_index, port_name)
     InitializerEdit(usize, String),
+    /// Open a sub-flow or provided implementation in a new editor.
+    OpenNode(usize),
     /// Pan the canvas by a world-space delta.
     Pan(f32, f32),
     /// Zoom the canvas by a multiplicative factor.
@@ -165,8 +167,6 @@ pub(crate) struct CanvasInteractionState {
     last_bounds: Option<Size>,
     /// Index of the node currently under the cursor (for hover tooltip)
     hover_node: Option<usize>,
-    /// Current cursor screen position (for tooltip placement)
-    hover_screen_pos: Point,
 }
 
 /// Tracks a middle-mouse-button pan in progress.
@@ -207,8 +207,6 @@ const GRID_ORIGIN_X: f32 = 50.0;
 const GRID_ORIGIN_Y: f32 = 50.0;
 /// Corner radius for rounded rectangles
 const CORNER_RADIUS: f32 = 10.0;
-/// Border stroke width for node rectangles
-const BORDER_WIDTH: f32 = 2.0;
 /// Title font size (minimum readable)
 const TITLE_FONT_SIZE: f32 = 16.0;
 /// Source label font size (minimum readable)
@@ -279,6 +277,11 @@ impl NodeLayout {
         } else {
             Color::from_rgb(0.9, 0.6, 0.2) // Orange for nested flows
         }
+    }
+
+    /// Whether this node's source can be opened (sub-flow or provided implementation).
+    pub(crate) fn is_openable(&self) -> bool {
+        !self.source.starts_with("lib://") && !self.source.starts_with("context://")
     }
 
     /// Get the position of an output port (right edge of node)
@@ -764,6 +767,27 @@ fn hit_test_node(nodes: &[NodeLayout], point: Point) -> Option<usize> {
     })
 }
 
+/// Check whether `point` (world coords) is on the open icon of an openable node.
+/// The icon occupies a 16x16 area in the top-right corner of the node.
+fn hit_test_open_icon(nodes: &[NodeLayout], point: Point) -> Option<usize> {
+    nodes.iter().enumerate().find_map(|(i, node)| {
+        if !node.is_openable() {
+            return None;
+        }
+        let icon_x = node.x + node.width - 20.0;
+        let icon_y = node.y + 4.0;
+        if point.x >= icon_x
+            && point.x <= icon_x + 16.0
+            && point.y >= icon_y
+            && point.y <= icon_y + 16.0
+        {
+            Some(i)
+        } else {
+            None
+        }
+    })
+}
+
 /// Check whether `screen_pos` is within [`RESIZE_HANDLE_HIT`] pixels of any resize handle
 /// on the node at `node_index`. Returns the handle variant if hit.
 ///
@@ -1113,7 +1137,14 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     }
                 }
 
-                // 4. Check if cursor is on a node — select/drag it
+                // 4. Check if cursor is on an openable node's open icon
+                if let Some(idx) = hit_test_open_icon(self.nodes, world_pos) {
+                    return Some(
+                        canvas::Action::publish(CanvasMessage::OpenNode(idx)).and_capture(),
+                    );
+                }
+
+                // 6. Check if cursor is on a node — select/drag it
                 if let Some(idx) = hit_test_node(self.nodes, world_pos) {
                     let node = self.nodes.get(idx)?;
                     state.selected_node = Some(idx);
@@ -1127,7 +1158,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     });
                     Some(canvas::Action::publish(CanvasMessage::Selected(Some(idx))).and_capture())
                 } else {
-                    // 5. Clicked empty canvas — deselect all
+                    // 7. Clicked empty canvas — deselect all
                     state.selected_node = None;
                     state.selected_connection = None;
                     state.dragging = None;
@@ -1727,7 +1758,7 @@ fn draw_bezier_connection(
         .with_color(conn_color);
 
     if let Some((nx, ny, nw, nh)) = node_bounds {
-        let (box_right, box_bottom, box_left, mid_x) =
+        let (box_right, box_bottom, box_left, _mid_x) =
             loopback_waypoints(nx, ny, nw, nh, zoom, offset);
 
         let path = Path::new(|builder| {
@@ -1828,6 +1859,23 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
         ..CanvasText::default()
     };
     frame.fill_text(source_label);
+
+    // Draw open icon for sub-flows and provided implementations
+    if node.is_openable() {
+        let icon_size = 14.0 * zoom;
+        let icon_x = node.x + node.width - 18.0;
+        let icon_y = node.y + 6.0;
+        let icon_pos = transform_point(Point::new(icon_x, icon_y), zoom, offset);
+
+        let icon_text = CanvasText {
+            content: "\u{2197}".to_string(), // ↗ arrow
+            position: icon_pos,
+            color: Color::from_rgba(1.0, 1.0, 1.0, 0.8),
+            size: icon_size.into(),
+            ..CanvasText::default()
+        };
+        frame.fill_text(icon_text);
+    }
 
     // Draw input ports on the left edge
     for (i, input_port) in node.inputs.iter().enumerate() {

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -661,7 +661,7 @@ impl FlowCanvasState {
     ///
     /// If `nodes` is empty, resets to default zoom and offset.
     pub(crate) fn auto_fit(&mut self, nodes: &[NodeLayout], has_flow_io: bool, viewport: Size) {
-        if nodes.is_empty() {
+        if nodes.is_empty() && !has_flow_io {
             self.zoom = 1.0;
             self.scroll_offset = Point::new(0.0, 0.0);
             self.cache.clear();
@@ -1843,7 +1843,7 @@ fn draw_flow_io_ports(
     zoom: f32,
     offset: Point,
 ) {
-    if (flow_inputs.is_empty() && flow_outputs.is_empty()) || nodes.is_empty() {
+    if flow_inputs.is_empty() && flow_outputs.is_empty() {
         return;
     }
 
@@ -1853,13 +1853,19 @@ fn draw_flow_io_ports(
     let padding = 80.0;
     let corner = 16.0;
 
-    let min_x = nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min);
-    let max_x = nodes.iter().map(|n| n.x + n.width).fold(f32::MIN, f32::max);
-    let min_y = nodes.iter().map(|n| n.y).fold(f32::MAX, f32::min);
-    let max_y = nodes
-        .iter()
-        .map(|n| n.y + n.height)
-        .fold(f32::MIN, f32::max);
+    let (min_x, max_x, min_y, max_y) = if nodes.is_empty() {
+        (0.0, 200.0, 0.0, 100.0)
+    } else {
+        (
+            nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min),
+            nodes.iter().map(|n| n.x + n.width).fold(f32::MIN, f32::max),
+            nodes.iter().map(|n| n.y).fold(f32::MAX, f32::min),
+            nodes
+                .iter()
+                .map(|n| n.y + n.height)
+                .fold(f32::MIN, f32::max),
+        )
+    };
 
     let box_x = min_x - padding;
     let box_y = min_y - padding;
@@ -1966,7 +1972,8 @@ fn draw_flow_io_ports(
         }
         // Connections to flow outputs: to_node == "output"
         if edge.to_node == "output" {
-            if let Some(&to_world) = output_positions.get(&edge.to_port) {
+            let output_name = edge.to_port.split('/').next().unwrap_or(&edge.to_port);
+            if let Some(&to_world) = output_positions.get(output_name) {
                 if let Some(from_world) =
                     find_node_output_pos(nodes, &edge.from_node, &edge.from_port)
                 {

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -621,6 +621,8 @@ impl FlowCanvasState {
         &'a self,
         nodes: &'a [NodeLayout],
         edges: &'a [EdgeLayout],
+        flow_inputs: &'a [PortInfo],
+        flow_outputs: &'a [PortInfo],
         auto_fit_pending: bool,
         auto_fit_enabled: bool,
     ) -> Element<'a, CanvasMessage> {
@@ -628,6 +630,8 @@ impl FlowCanvasState {
             state: self,
             nodes,
             edges,
+            flow_inputs,
+            flow_outputs,
             auto_fit_pending,
             auto_fit_enabled,
         })
@@ -656,7 +660,7 @@ impl FlowCanvasState {
     /// Compute zoom and offset so that all nodes fit within the given viewport with padding.
     ///
     /// If `nodes` is empty, resets to default zoom and offset.
-    pub(crate) fn auto_fit(&mut self, nodes: &[NodeLayout], viewport: Size) {
+    pub(crate) fn auto_fit(&mut self, nodes: &[NodeLayout], has_flow_io: bool, viewport: Size) {
         if nodes.is_empty() {
             self.zoom = 1.0;
             self.scroll_offset = Point::new(0.0, 0.0);
@@ -664,14 +668,14 @@ impl FlowCanvasState {
             return;
         }
 
-        // Find bounding box of all nodes in world coordinates,
-        // accounting for initializer text drawn to the left of input ports.
+        // Extra margin when flow I/O bounding box is drawn (padding + port labels)
+        let flow_io_margin = if has_flow_io { 160.0 } else { 0.0 };
+
         let mut min_x = f32::MAX;
         let mut min_y = f32::MAX;
         let mut max_x = f32::MIN;
         let mut max_y = f32::MIN;
         for node in nodes {
-            // Estimate extra left margin for initializer text (~8px per character)
             let init_margin = if node.initializers.is_empty() {
                 0.0
             } else {
@@ -697,8 +701,8 @@ impl FlowCanvasState {
             }
         }
 
-        let content_width = max_x - min_x + AUTO_FIT_PADDING * 2.0;
-        let content_height = max_y - min_y + AUTO_FIT_PADDING * 2.0;
+        let content_width = max_x - min_x + AUTO_FIT_PADDING * 2.0 + flow_io_margin * 2.0;
+        let content_height = max_y - min_y + AUTO_FIT_PADDING * 2.0 + flow_io_margin;
 
         // Avoid division by zero
         if content_width <= 0.0 || content_height <= 0.0 {
@@ -746,6 +750,10 @@ struct FlowCanvas<'a> {
     nodes: &'a [NodeLayout],
     /// Edges to render
     edges: &'a [EdgeLayout],
+    /// Flow-level input ports (displayed on left edge for sub-flows)
+    flow_inputs: &'a [PortInfo],
+    /// Flow-level output ports (displayed on right edge for sub-flows)
+    flow_outputs: &'a [PortInfo],
     /// Whether an auto-fit should be triggered on the next event
     auto_fit_pending: bool,
     /// Whether auto-fit mode is active (continuously fits to window)
@@ -1434,9 +1442,18 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         let zoom = self.state.zoom;
         let offset = self.state.scroll_offset;
 
-        // Draw the main cached content (edges and nodes) with zoom/scroll transform
+        // Draw the main cached content (edges, nodes, and flow I/O ports)
         let content = self.state.cache.draw(renderer, bounds.size(), |frame| {
             draw_nodes(frame, self.nodes, zoom, offset);
+            draw_flow_io_ports(
+                frame,
+                self.flow_inputs,
+                self.flow_outputs,
+                self.nodes,
+                self.edges,
+                zoom,
+                offset,
+            );
             draw_edges(
                 frame,
                 self.edges,
@@ -1604,6 +1621,11 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             }
 
             let world_pos = screen_to_world(pos, self.state.zoom, self.state.scroll_offset);
+
+            if hit_test_open_icon(self.nodes, world_pos).is_some() {
+                return mouse::Interaction::Pointer;
+            }
+
             if hit_test_node(self.nodes, world_pos).is_some() {
                 return mouse::Interaction::Grab;
             }
@@ -1808,6 +1830,193 @@ fn draw_nodes(frame: &mut Frame, nodes: &[NodeLayout], zoom: f32, offset: Point)
     for node in nodes {
         draw_node(frame, node, zoom, offset);
     }
+}
+
+/// Draw a rounded bounding box around all subprocess nodes with flow I/O
+/// ports on the box edges and bezier connections to internal nodes.
+fn draw_flow_io_ports(
+    frame: &mut Frame,
+    flow_inputs: &[PortInfo],
+    flow_outputs: &[PortInfo],
+    nodes: &[NodeLayout],
+    edges: &[EdgeLayout],
+    zoom: f32,
+    offset: Point,
+) {
+    if (flow_inputs.is_empty() && flow_outputs.is_empty()) || nodes.is_empty() {
+        return;
+    }
+
+    let port_radius = 6.0;
+    let font_size = 13.0;
+    let spacing = 28.0;
+    let padding = 80.0;
+    let corner = 16.0;
+
+    let min_x = nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min);
+    let max_x = nodes.iter().map(|n| n.x + n.width).fold(f32::MIN, f32::max);
+    let min_y = nodes.iter().map(|n| n.y).fold(f32::MAX, f32::min);
+    let max_y = nodes
+        .iter()
+        .map(|n| n.y + n.height)
+        .fold(f32::MIN, f32::max);
+
+    let box_x = min_x - padding;
+    let box_y = min_y - padding;
+    let box_w = (max_x - min_x) + 2.0 * padding;
+    let box_h = (max_y - min_y) + 2.0 * padding;
+
+    // Draw the rounded bounding box
+    let top_left = transform_point(Point::new(box_x, box_y), zoom, offset);
+    let size = Size::new(box_w * zoom, box_h * zoom);
+    let border_path = Path::new(|builder| {
+        rounded_rect(builder, top_left, size, corner * zoom);
+    });
+    frame.stroke(
+        &border_path,
+        Stroke::default()
+            .with_width(2.0)
+            .with_color(Color::from_rgba(0.6, 0.6, 0.6, 0.5)),
+    );
+
+    let center_y = (min_y + max_y) / 2.0;
+    let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+    let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+
+    // Compute and draw flow input ports on the left edge
+    let mut input_positions: HashMap<String, Point> = HashMap::new();
+    let input_start_y = center_y - (flow_inputs.len() as f32 - 1.0) * spacing / 2.0;
+    for (i, input) in flow_inputs.iter().enumerate() {
+        let world_y = input_start_y + i as f32 * spacing;
+        let world_pos = Point::new(box_x, world_y);
+        input_positions.insert(input.name.clone(), world_pos);
+        let screen_pos = transform_point(world_pos, zoom, offset);
+        let scaled_r = port_radius * zoom;
+
+        use std::f32::consts::PI;
+        let semi = Path::new(|builder| {
+            builder.arc(canvas::path::Arc {
+                center: screen_pos,
+                radius: scaled_r,
+                start_angle: (PI / 2.0).into(),
+                end_angle: (3.0 * PI / 2.0).into(),
+            });
+            builder.close();
+        });
+        frame.fill(&semi, input_color);
+
+        let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
+        frame.fill_text(CanvasText {
+            content: input.name.clone(),
+            position: label_pos,
+            color: input_color,
+            size: (font_size * zoom).into(),
+            align_y: iced::alignment::Vertical::Center,
+            ..CanvasText::default()
+        });
+    }
+
+    // Compute and draw flow output ports on the right edge
+    let mut output_positions: HashMap<String, Point> = HashMap::new();
+    let right_x = box_x + box_w;
+    let output_start_y = center_y - (flow_outputs.len() as f32 - 1.0) * spacing / 2.0;
+    for (i, output) in flow_outputs.iter().enumerate() {
+        let world_y = output_start_y + i as f32 * spacing;
+        let world_pos = Point::new(right_x, world_y);
+        output_positions.insert(output.name.clone(), world_pos);
+        let screen_pos = transform_point(world_pos, zoom, offset);
+        let scaled_r = port_radius * zoom;
+
+        use std::f32::consts::PI;
+        let semi = Path::new(|builder| {
+            builder.arc(canvas::path::Arc {
+                center: screen_pos,
+                radius: scaled_r,
+                start_angle: (-PI / 2.0).into(),
+                end_angle: (PI / 2.0).into(),
+            });
+            builder.close();
+        });
+        frame.fill(&semi, output_color);
+
+        let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
+        frame.fill_text(CanvasText {
+            content: output.name.clone(),
+            position: label_pos,
+            color: output_color,
+            size: (font_size * zoom).into(),
+            align_x: iced::alignment::Horizontal::Right.into(),
+            align_y: iced::alignment::Vertical::Center,
+            ..CanvasText::default()
+        });
+    }
+
+    // Draw bezier connections from flow inputs to internal node ports
+    let conn_color = Color::from_rgba(0.7, 0.7, 0.7, 0.6);
+    for edge in edges {
+        // Connections from flow inputs: from_node == "input"
+        if edge.from_node == "input" {
+            // from_port is "name/subroute" — extract the input name (first segment)
+            let input_name = edge.from_port.split('/').next().unwrap_or(&edge.from_port);
+            if let Some(&from_world) = input_positions.get(input_name) {
+                if let Some(to_world) = find_node_input_pos(nodes, &edge.to_node, &edge.to_port) {
+                    draw_flow_io_bezier(frame, from_world, to_world, zoom, offset, conn_color);
+                }
+            }
+        }
+        // Connections to flow outputs: to_node == "output"
+        if edge.to_node == "output" {
+            if let Some(&to_world) = output_positions.get(&edge.to_port) {
+                if let Some(from_world) =
+                    find_node_output_pos(nodes, &edge.from_node, &edge.from_port)
+                {
+                    draw_flow_io_bezier(frame, from_world, to_world, zoom, offset, conn_color);
+                }
+            }
+        }
+    }
+}
+
+fn find_node_input_pos(nodes: &[NodeLayout], alias: &str, port: &str) -> Option<Point> {
+    let node = nodes.iter().find(|n| n.alias == alias)?;
+    let port_idx = node.inputs.iter().position(|p| p.name == port).unwrap_or(0);
+    Some(node.input_port_position(port_idx))
+}
+
+fn find_node_output_pos(nodes: &[NodeLayout], alias: &str, port: &str) -> Option<Point> {
+    let node = nodes.iter().find(|n| n.alias == alias)?;
+    if port.is_empty() {
+        Some(node.output_port_position(0))
+    } else {
+        let port_idx = node
+            .outputs
+            .iter()
+            .position(|p| p.name == port)
+            .unwrap_or(0);
+        Some(node.output_port_position(port_idx))
+    }
+}
+
+fn draw_flow_io_bezier(
+    frame: &mut Frame,
+    from: Point,
+    to: Point,
+    zoom: f32,
+    offset: Point,
+    color: Color,
+) {
+    let from_s = transform_point(from, zoom, offset);
+    let to_s = transform_point(to, zoom, offset);
+    let dx = (to_s.x - from_s.x).abs().max(40.0 * zoom) * 0.4;
+    let path = Path::new(|builder| {
+        builder.move_to(from_s);
+        builder.bezier_curve_to(
+            Point::new(from_s.x + dx, from_s.y),
+            Point::new(to_s.x - dx, to_s.y),
+            to_s,
+        );
+    });
+    frame.stroke(&path, Stroke::default().with_width(1.5).with_color(color));
 }
 
 /// Draw a single node as a rounded rectangle with title, source, and ports.

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -782,12 +782,12 @@ fn hit_test_open_icon(nodes: &[NodeLayout], point: Point) -> Option<usize> {
         if !node.is_openable() {
             return None;
         }
-        let icon_x = node.x + node.width - 20.0;
-        let icon_y = node.y + 4.0;
+        let icon_x = node.x + node.width - 24.0;
+        let icon_y = node.y + 2.0;
         if point.x >= icon_x
-            && point.x <= icon_x + 16.0
+            && point.x <= icon_x + 22.0
             && point.y >= icon_y
-            && point.y <= icon_y + 16.0
+            && point.y <= icon_y + 22.0
         {
             Some(i)
         } else {
@@ -2071,13 +2071,13 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
 
     // Draw open icon for sub-flows and provided implementations
     if node.is_openable() {
-        let icon_size = 14.0 * zoom;
-        let icon_x = node.x + node.width - 18.0;
-        let icon_y = node.y + 6.0;
+        let icon_size = 26.0 * zoom;
+        let icon_x = node.x + node.width - 22.0;
+        let icon_y = node.y + 4.0;
         let icon_pos = transform_point(Point::new(icon_x, icon_y), zoom, offset);
 
         let icon_text = CanvasText {
-            content: "\u{2197}".to_string(), // ↗ arrow
+            content: "\u{270E}".to_string(), // ✎ pencil
             position: icon_pos,
             color: Color::from_rgba(1.0, 1.0, 1.0, 0.8),
             size: icon_size.into(),

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -677,7 +677,7 @@ impl FlowCanvasState {
         let flow_io_margin = if has_flow_io { 200.0 } else { 0.0 };
 
         let (mut min_x, mut min_y, mut max_x, mut max_y) = if nodes.is_empty() {
-            (100.0, 100.0, 400.0, 250.0)
+            (150.0, 50.0, 350.0, 450.0)
         } else {
             (f32::MAX, f32::MAX, f32::MIN, f32::MIN)
         };
@@ -790,12 +790,12 @@ fn hit_test_open_icon(nodes: &[NodeLayout], point: Point) -> Option<usize> {
         if !node.is_openable() {
             return None;
         }
-        let icon_x = node.x + node.width - 24.0;
-        let icon_y = node.y + 2.0;
+        let icon_x = node.x + node.width - 22.0;
+        let icon_y = node.y + 4.0;
         if point.x >= icon_x
-            && point.x <= icon_x + 22.0
+            && point.x <= icon_x + 24.0
             && point.y >= icon_y
-            && point.y <= icon_y + 22.0
+            && point.y <= icon_y + 24.0
         {
             Some(i)
         } else {
@@ -1909,8 +1909,10 @@ fn draw_flow_io_ports(
     let padding = 80.0;
     let corner = 16.0;
 
+    let max_ports = flow_inputs.len().max(flow_outputs.len()).max(1) as f32;
+    let default_h = max_ports * spacing + 60.0;
     let (min_x, max_x, min_y, max_y) = if nodes.is_empty() {
-        (100.0, 400.0, 100.0, 250.0)
+        (150.0, 350.0, 100.0, 100.0 + default_h)
     } else {
         (
             nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min),

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -84,20 +84,12 @@ pub(crate) enum EditAction {
 }
 
 /// Edit history supporting undo and redo.
+#[derive(Default)]
 pub(crate) struct EditHistory {
     /// Stack of actions that can be undone (most recent last)
     undo_stack: Vec<EditAction>,
     /// Stack of actions that can be redone (most recent last)
     redo_stack: Vec<EditAction>,
-}
-
-impl Default for EditHistory {
-    fn default() -> Self {
-        Self {
-            undo_stack: Vec::new(),
-            redo_stack: Vec::new(),
-        }
-    }
 }
 
 impl EditHistory {
@@ -121,13 +113,13 @@ impl EditHistory {
         Some(action)
     }
 
-    /// Whether there are actions to undo.
-    pub(crate) fn can_undo(&self) -> bool {
+    #[cfg(test)]
+    fn can_undo(&self) -> bool {
         !self.undo_stack.is_empty()
     }
 
-    /// Whether there are actions to redo.
-    pub(crate) fn can_redo(&self) -> bool {
+    #[cfg(test)]
+    fn can_redo(&self) -> bool {
         !self.redo_stack.is_empty()
     }
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -101,6 +101,22 @@ enum Message {
     FunctionOutputTypeChanged(window::Id, usize, String),
     /// Save function definition to disk
     FunctionSave(window::Id),
+    /// Add a flow-level input port
+    FlowAddInput(window::Id),
+    /// Add a flow-level output port
+    FlowAddOutput(window::Id),
+    /// Delete a flow-level input port
+    FlowDeleteInput(window::Id, usize),
+    /// Delete a flow-level output port
+    FlowDeleteOutput(window::Id, usize),
+    /// Flow input port name changed
+    FlowInputNameChanged(window::Id, usize, String),
+    /// Flow input port type changed
+    FlowInputTypeChanged(window::Id, usize, String),
+    /// Flow output port name changed
+    FlowOutputNameChanged(window::Id, usize, String),
+    /// Flow output port type changed
+    FlowOutputTypeChanged(window::Id, usize, String),
     /// A window close was requested
     CloseRequested(window::Id),
     /// Close the currently focused window (Cmd+W)
@@ -830,6 +846,80 @@ impl FlowEdit {
                     }
                 }
             }
+            Message::FlowAddInput(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_inputs.push(PortInfo {
+                        name: format!("input{}", win.flow_inputs.len()),
+                        datatypes: vec![String::from("string")],
+                    });
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
+            Message::FlowAddOutput(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_outputs.push(PortInfo {
+                        name: format!("output{}", win.flow_outputs.len()),
+                        datatypes: vec![String::from("string")],
+                    });
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
+            Message::FlowDeleteInput(win_id, idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if idx < win.flow_inputs.len() {
+                        win.flow_inputs.remove(idx);
+                        win.unsaved_edits += 1;
+                        win.canvas_state.request_redraw();
+                    }
+                }
+            }
+            Message::FlowDeleteOutput(win_id, idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if idx < win.flow_outputs.len() {
+                        win.flow_outputs.remove(idx);
+                        win.unsaved_edits += 1;
+                        win.canvas_state.request_redraw();
+                    }
+                }
+            }
+            Message::FlowInputNameChanged(win_id, idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(port) = win.flow_inputs.get_mut(idx) {
+                        port.name = name;
+                    }
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
+            Message::FlowInputTypeChanged(win_id, idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(port) = win.flow_inputs.get_mut(idx) {
+                        port.datatypes = vec![dtype];
+                    }
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
+            Message::FlowOutputNameChanged(win_id, idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(port) = win.flow_outputs.get_mut(idx) {
+                        port.name = name;
+                    }
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
+            Message::FlowOutputTypeChanged(win_id, idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(port) = win.flow_outputs.get_mut(idx) {
+                        port.datatypes = vec![dtype];
+                    }
+                    win.unsaved_edits += 1;
+                    win.canvas_state.request_redraw();
+                }
+            }
             Message::CloseRequested(_) | Message::CloseActiveWindow => {
                 let target = match message {
                     Message::CloseRequested(win_id) => Some(win_id),
@@ -954,10 +1044,10 @@ impl FlowEdit {
                     }),
             )
             .padding(iced::Padding {
-                top: ty + 20.0,
+                top: ty + 6.0,
                 right: 0.0,
                 bottom: 0.0,
-                left: tx + 16.0,
+                left: (tx - 80.0).max(0.0),
             });
             canvas_stack.push(tooltip_widget.into());
         }
@@ -1071,8 +1161,113 @@ impl FlowEdit {
 
         let mut layout = Column::new().push(container(main_content).width(Fill).height(Fill));
 
+        // Flow I/O editor panel for sub-flow windows
+        if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
+            layout = layout.push(self.view_flow_io_panel(window_id, win));
+        }
+
         layout = layout.push(container(status_bar).width(Fill).padding(5));
         layout.into()
+    }
+
+    fn view_flow_io_panel<'a>(
+        &'a self,
+        window_id: window::Id,
+        win: &'a WindowState,
+    ) -> Element<'a, Message> {
+        let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+
+        let mut input_col = Column::new().spacing(4);
+        for (i, port) in win.flow_inputs.iter().enumerate() {
+            let dtype = port.datatypes.first().cloned().unwrap_or_default();
+            let row = Row::new()
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .push(Text::new("\u{25D7}").size(18).color(input_color))
+                .push(
+                    text_input("name", &port.name)
+                        .on_input(move |s| Message::FlowInputNameChanged(window_id, i, s))
+                        .size(12)
+                        .padding(3)
+                        .width(80),
+                )
+                .push(
+                    text_input("type", &dtype)
+                        .on_input(move |s| Message::FlowInputTypeChanged(window_id, i, s))
+                        .size(11)
+                        .padding(3)
+                        .width(70),
+                )
+                .push(
+                    button(Text::new("\u{2715}").size(10).center())
+                        .on_press(Message::FlowDeleteInput(window_id, i))
+                        .style(button::danger)
+                        .padding([2, 5]),
+                );
+            input_col = input_col.push(row);
+        }
+        input_col = input_col.push(
+            button(Text::new("+").size(12).center())
+                .on_press(Message::FlowAddInput(window_id))
+                .style(button::secondary)
+                .padding([2, 8]),
+        );
+
+        let mut output_col = Column::new().spacing(4).align_x(iced::Alignment::End);
+        for (i, port) in win.flow_outputs.iter().enumerate() {
+            let dtype = port.datatypes.first().cloned().unwrap_or_default();
+            let row = Row::new()
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .push(
+                    button(Text::new("\u{2715}").size(10).center())
+                        .on_press(Message::FlowDeleteOutput(window_id, i))
+                        .style(button::danger)
+                        .padding([2, 5]),
+                )
+                .push(
+                    text_input("type", &dtype)
+                        .on_input(move |s| Message::FlowOutputTypeChanged(window_id, i, s))
+                        .size(11)
+                        .padding(3)
+                        .width(70),
+                )
+                .push(
+                    text_input("name", &port.name)
+                        .on_input(move |s| Message::FlowOutputNameChanged(window_id, i, s))
+                        .size(12)
+                        .padding(3)
+                        .width(80),
+                )
+                .push(Text::new("\u{25D6}").size(18).color(output_color));
+            output_col = output_col.push(row);
+        }
+        output_col = output_col.push(
+            button(Text::new("+").size(12).center())
+                .on_press(Message::FlowAddOutput(window_id))
+                .style(button::secondary)
+                .padding([2, 8]),
+        );
+
+        container(
+            Row::new()
+                .padding([6, 12])
+                .push(input_col)
+                .push(iced::widget::Space::new().width(Fill))
+                .push(output_col),
+        )
+        .style(|_theme: &Theme| container::Style {
+            background: Some(iced::Background::Color(Color::from_rgb(0.14, 0.14, 0.18))),
+            border: iced::Border {
+                color: Color::from_rgb(0.3, 0.3, 0.3),
+                width: 1.0,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(Fill)
+        .into()
     }
 
     fn view_function<'a>(

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -763,15 +763,11 @@ impl FlowEdit {
                                 name: format!("output{}", v.outputs.len()),
                                 datatypes: vec![String::from("string")],
                             }),
-                            Message::FunctionDeleteInput(_, idx) => {
-                                if idx < v.inputs.len() {
-                                    v.inputs.remove(idx);
-                                }
+                            Message::FunctionDeleteInput(_, idx) if idx < v.inputs.len() => {
+                                v.inputs.remove(idx);
                             }
-                            Message::FunctionDeleteOutput(_, idx) => {
-                                if idx < v.outputs.len() {
-                                    v.outputs.remove(idx);
-                                }
+                            Message::FunctionDeleteOutput(_, idx) if idx < v.outputs.len() => {
+                                v.outputs.remove(idx);
                             }
                             _ => {}
                         }
@@ -834,21 +830,34 @@ impl FlowEdit {
                     }
                 }
             }
-            Message::CloseRequested(id) => {
+            Message::CloseRequested(_) | Message::CloseActiveWindow => {
+                let target = match message {
+                    Message::CloseRequested(win_id) => Some(win_id),
+                    Message::CloseActiveWindow => self.focused_window.or(self.root_window),
+                    _ => None,
+                };
+                let Some(id) = target else {
+                    return Task::none();
+                };
+                if let Some(win) = self.windows.get(&id) {
+                    if win.unsaved_edits > 0 {
+                        let dialog = rfd::MessageDialog::new()
+                            .set_title("Unsaved Changes")
+                            .set_description(
+                                "This window has unsaved changes. Close without saving?",
+                            )
+                            .set_buttons(rfd::MessageButtons::YesNo)
+                            .set_level(rfd::MessageLevel::Warning);
+                        if dialog.show() != rfd::MessageDialogResult::Yes {
+                            return Task::none();
+                        }
+                    }
+                }
                 self.windows.remove(&id);
                 if self.root_window == Some(id) || self.windows.is_empty() {
                     return iced::exit();
                 }
                 return window::close(id);
-            }
-            Message::CloseActiveWindow => {
-                if let Some(id) = self.focused_window.or(self.root_window) {
-                    self.windows.remove(&id);
-                    if self.root_window == Some(id) || self.windows.is_empty() {
-                        return iced::exit();
-                    }
-                    return window::close(id);
-                }
             }
             Message::QuitAll => {
                 // Check for unsaved edits in any window

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1288,7 +1288,7 @@ impl FlowEdit {
             input_col = input_col.push(row);
         }
         input_col = input_col.push(
-            button(Text::new("+").size(12).center())
+            button(Text::new("+ Input").size(11).center())
                 .on_press(Message::FlowAddInput(window_id))
                 .style(button::secondary)
                 .padding([2, 8]),
@@ -1324,7 +1324,7 @@ impl FlowEdit {
             output_col = output_col.push(row);
         }
         output_col = output_col.push(
-            button(Text::new("+").size(12).center())
+            button(Text::new("+ Output").size(11).center())
                 .on_press(Message::FlowAddOutput(window_id))
                 .style(button::secondary)
                 .padding([2, 8]),
@@ -1415,10 +1415,10 @@ impl FlowEdit {
                     input_col = input_col.push(row);
                 }
                 input_col = input_col.push(
-                    button(Text::new("+").size(14).center())
+                    button(Text::new("+ Input").size(11).center())
                         .on_press(Message::FunctionAddInput(window_id))
                         .style(button::secondary)
-                        .padding([2, 10]),
+                        .padding([2, 8]),
                 );
 
                 // Output ports inside box: delete, type, name, semicircle ◖ (flat right)
@@ -1456,10 +1456,10 @@ impl FlowEdit {
                     output_col = output_col.push(row);
                 }
                 output_col = output_col.push(
-                    button(Text::new("+").size(14).center())
+                    button(Text::new("+ Output").size(11).center())
                         .on_press(Message::FunctionAddOutput(window_id))
                         .style(button::secondary)
-                        .padding([2, 10]),
+                        .padding([2, 8]),
                 );
 
                 let name_input = container(

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -101,6 +101,10 @@ enum Message {
     FunctionOutputTypeChanged(window::Id, usize, String),
     /// Save function definition to disk
     FunctionSave(window::Id),
+    /// Create a new sub-flow and add it to the current flow
+    NewSubFlow,
+    /// Create a new provided implementation and add it to the current flow
+    NewFunction,
     /// Add a flow-level input port
     FlowAddInput(window::Id),
     /// Add a flow-level output port
@@ -199,6 +203,8 @@ struct WindowState {
     flow_inputs: Vec<PortInfo>,
     /// Flow-level output ports (for sub-flow display)
     flow_outputs: Vec<PortInfo>,
+    /// Context menu position (screen coords), if showing
+    context_menu: Option<(f32, f32)>,
 }
 
 /// Top-level application state
@@ -347,6 +353,7 @@ impl FlowEdit {
             is_root: true,
             flow_inputs: fi,
             flow_outputs: fo,
+            context_menu: None,
         };
 
         let mut windows = HashMap::new();
@@ -388,6 +395,7 @@ impl FlowEdit {
                 match canvas_msg {
                     CanvasMessage::Selected(idx) => {
                         win.selected_node = idx;
+                        win.context_menu = None;
                         if win.selected_connection.is_some() {
                             win.selected_connection = None;
                             win.canvas_state.request_redraw();
@@ -608,6 +616,11 @@ impl FlowEdit {
                     CanvasMessage::OpenNode(idx) => {
                         return self.open_node(win_id, idx);
                     }
+                    CanvasMessage::ContextMenu(x, y) => {
+                        if let Some(win) = self.windows.get_mut(&win_id) {
+                            win.context_menu = Some((x, y));
+                        }
+                    }
                 }
             }
             Message::Library(win_id, ref lib_msg) => {
@@ -701,6 +714,19 @@ impl FlowEdit {
                         }
                     }
                 }
+            }
+            Message::NewSubFlow => {
+                // Dismiss any open context menu
+                for win in self.windows.values_mut() {
+                    win.context_menu = None;
+                }
+                return self.create_new_subflow();
+            }
+            Message::NewFunction => {
+                for win in self.windows.values_mut() {
+                    win.context_menu = None;
+                }
+                return self.create_new_function();
             }
             Message::InitializerTypeChanged(win_id, new_type) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -985,6 +1011,7 @@ impl FlowEdit {
                 &win.edges,
                 &win.flow_inputs,
                 &win.flow_outputs,
+                !win.is_root,
                 win.auto_fit_pending,
                 win.auto_fit_enabled,
             )
@@ -1117,6 +1144,47 @@ impl FlowEdit {
             canvas_stack.push(dialog.into());
         }
 
+        // Context menu overlay (right-click on empty canvas)
+        if let Some((cx, cy)) = win.context_menu {
+            let menu = container(
+                Column::new()
+                    .spacing(2)
+                    .push(
+                        button(Text::new("+ New Sub-flow").size(13))
+                            .on_press(Message::NewSubFlow)
+                            .style(button::text)
+                            .padding([6, 16])
+                            .width(Fill),
+                    )
+                    .push(
+                        button(Text::new("+ New Function").size(13))
+                            .on_press(Message::NewFunction)
+                            .style(button::text)
+                            .padding([6, 16])
+                            .width(Fill),
+                    ),
+            )
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
+                border: iced::Border {
+                    color: Color::from_rgb(0.4, 0.4, 0.4),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+            .width(160)
+            .padding(4);
+
+            let positioned = container(menu).padding(iced::Padding {
+                top: cy,
+                left: cx,
+                right: 0.0,
+                bottom: 0.0,
+            });
+            canvas_stack.push(positioned.into());
+        }
+
         let canvas_with_controls = stack(canvas_stack);
 
         let library_panel = self
@@ -1147,10 +1215,22 @@ impl FlowEdit {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
+            let new_subflow_btn = button(Text::new("+ Sub-flow").size(12).center())
+                .on_press(Message::NewSubFlow)
+                .style(button::secondary)
+                .padding([4, 10]);
+
+            let new_func_btn = button(Text::new("+ Function").size(12).center())
+                .on_press(Message::NewFunction)
+                .style(button::secondary)
+                .padding([4, 10]);
+
             Row::new()
                 .spacing(8)
                 .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
                 .push(iced::widget::Space::new().width(Fill))
+                .push(new_subflow_btn)
+                .push(new_func_btn)
                 .push(compile_btn)
         } else {
             Row::new()
@@ -1250,24 +1330,43 @@ impl FlowEdit {
                 .padding([2, 8]),
         );
 
-        container(
-            Row::new()
-                .padding([6, 12])
-                .push(input_col)
-                .push(iced::widget::Space::new().width(Fill))
-                .push(output_col),
+        let flow_name_label = container(
+            Text::new(&win.flow_name)
+                .size(14)
+                .color(Color::from_rgb(0.9, 0.6, 0.2)),
+        )
+        .center_x(Fill);
+
+        let io_box = container(
+            Column::new()
+                .spacing(12)
+                .padding(iced::Padding {
+                    top: 12.0,
+                    bottom: 12.0,
+                    left: 0.0,
+                    right: 0.0,
+                })
+                .push(flow_name_label)
+                .push(
+                    Row::new()
+                        .push(input_col)
+                        .push(iced::widget::Space::new().width(Fill))
+                        .push(output_col),
+                ),
         )
         .style(|_theme: &Theme| container::Style {
-            background: Some(iced::Background::Color(Color::from_rgb(0.14, 0.14, 0.18))),
+            background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
             border: iced::Border {
-                color: Color::from_rgb(0.3, 0.3, 0.3),
-                width: 1.0,
-                radius: 0.0.into(),
+                color: Color::from_rgb(0.9, 0.6, 0.2),
+                width: 2.0,
+                radius: 12.0.into(),
             },
             ..Default::default()
         })
         .width(Fill)
-        .into()
+        .padding([0, 8]);
+
+        container(io_box).padding([6, 12]).width(Fill).into()
     }
 
     fn view_function<'a>(
@@ -1606,6 +1705,7 @@ impl FlowEdit {
                     is_root: false,
                     flow_inputs: fi,
                     flow_outputs: fo,
+                    context_menu: None,
                 };
                 self.windows.insert(new_id, child);
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -1675,12 +1775,256 @@ impl FlowEdit {
             is_root: false,
             flow_inputs: Vec::new(),
             flow_outputs: Vec::new(),
+            context_menu: None,
         };
 
         self.windows.insert(new_id, child);
         if let Some(win) = self.windows.get_mut(&parent_win_id) {
             win.status = format!("Opened function: {func_name}");
         }
+        open_task.discard()
+    }
+
+    fn create_new_subflow(&mut self) -> Task<Message> {
+        let Some(root_id) = self.root_window else {
+            return Task::none();
+        };
+
+        // Get the parent flow's directory for relative path resolution
+        let base_dir = self
+            .windows
+            .get(&root_id)
+            .and_then(|w| w.file_path.as_ref())
+            .and_then(|p| p.parent())
+            .map(Path::to_path_buf);
+
+        let Some(base) = base_dir else {
+            if let Some(win) = self.windows.get_mut(&root_id) {
+                win.status = String::from("Save the flow first before creating a sub-flow");
+            }
+            return Task::none();
+        };
+
+        // Prompt user to choose where to save the new sub-flow
+        let dialog = rfd::FileDialog::new()
+            .add_filter("Flow", &["toml"])
+            .set_directory(&base)
+            .set_file_name("new_subflow.toml");
+        let Some(path) = dialog.save_file() else {
+            return Task::none();
+        };
+
+        // Derive flow name from filename
+        let flow_name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("subflow")
+            .to_string();
+
+        // Create the sub-flow definition with empty content
+        let flow_def = FlowDefinition {
+            name: flow_name.clone(),
+            ..FlowDefinition::default()
+        };
+
+        // Write the initial TOML file
+        let toml = format!("flow = \"{flow_name}\"\n");
+        if let Err(e) = std::fs::write(&path, &toml) {
+            if let Some(win) = self.windows.get_mut(&root_id) {
+                win.status = format!("Could not create sub-flow: {e}");
+            }
+            return Task::none();
+        }
+
+        // Compute relative source path from parent flow to new sub-flow
+        let source = path
+            .strip_prefix(&base)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        // Strip .toml extension for the source reference
+        let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
+
+        // Add a process reference in the parent flow
+        if let Some(win) = self.windows.get_mut(&root_id) {
+            let alias = generate_unique_alias(&flow_name, &win.nodes);
+            let (x, y) = next_node_position(&win.nodes);
+
+            let node = NodeLayout {
+                alias: alias.clone(),
+                source: source.clone(),
+                x,
+                y,
+                width: 180.0,
+                height: 120.0,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                initializers: HashMap::new(),
+            };
+            win.nodes.push(node);
+            win.flow_definition.process_refs.push(ProcessReference {
+                alias: alias.clone(),
+                source,
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(x),
+                y: Some(y),
+                width: Some(180.0),
+                height: Some(120.0),
+            });
+            win.unsaved_edits += 1;
+            win.canvas_state.request_redraw();
+            win.status = format!("Created sub-flow: {alias}");
+        }
+
+        // Open the new sub-flow in a child window
+        let (new_id, open_task) = window::open(window::Settings {
+            size: iced::Size::new(1024.0, 768.0),
+            ..Default::default()
+        });
+
+        let child = WindowState {
+            kind: WindowKind::FlowEditor,
+            flow_name: flow_name.clone(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            canvas_state: FlowCanvasState::default(),
+            status: format!("New sub-flow: {flow_name}"),
+            selected_node: None,
+            selected_connection: None,
+            history: EditHistory::default(),
+            auto_fit_pending: false,
+            auto_fit_enabled: true,
+            unsaved_edits: 0,
+            compiled_manifest: None,
+            file_path: Some(path),
+            flow_definition: flow_def,
+            tooltip: None,
+            initializer_editor: None,
+            is_root: false,
+            flow_inputs: Vec::new(),
+            flow_outputs: Vec::new(),
+            context_menu: None,
+        };
+
+        self.windows.insert(new_id, child);
+        open_task.discard()
+    }
+
+    fn create_new_function(&mut self) -> Task<Message> {
+        let Some(root_id) = self.root_window else {
+            return Task::none();
+        };
+
+        let base_dir = self
+            .windows
+            .get(&root_id)
+            .and_then(|w| w.file_path.as_ref())
+            .and_then(|p| p.parent())
+            .map(Path::to_path_buf);
+
+        let Some(base) = base_dir else {
+            if let Some(win) = self.windows.get_mut(&root_id) {
+                win.status = String::from("Save the flow first before creating a function");
+            }
+            return Task::none();
+        };
+
+        // Prompt user to choose where to save the new function definition
+        let dialog = rfd::FileDialog::new()
+            .add_filter("Flow Function", &["toml"])
+            .set_directory(&base)
+            .set_file_name("new_function.toml");
+        let Some(path) = dialog.save_file() else {
+            return Task::none();
+        };
+
+        let func_name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("function")
+            .to_string();
+
+        let rs_filename = format!("{func_name}.rs");
+
+        // Compute relative source from parent flow
+        let source = path
+            .strip_prefix(&base)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
+
+        // Add process reference in the parent flow
+        if let Some(win) = self.windows.get_mut(&root_id) {
+            let alias = generate_unique_alias(&func_name, &win.nodes);
+            let (x, y) = next_node_position(&win.nodes);
+
+            let node = NodeLayout {
+                alias: alias.clone(),
+                source: source.clone(),
+                x,
+                y,
+                width: 180.0,
+                height: 120.0,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                initializers: HashMap::new(),
+            };
+            win.nodes.push(node);
+            win.flow_definition.process_refs.push(ProcessReference {
+                alias: alias.clone(),
+                source,
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(x),
+                y: Some(y),
+                width: Some(180.0),
+                height: Some(120.0),
+            });
+            win.unsaved_edits += 1;
+            win.canvas_state.request_redraw();
+            win.status = format!("Created function: {alias}");
+        }
+
+        // Open the function viewer window
+        let (new_id, open_task) = window::open(window::Settings {
+            size: iced::Size::new(700.0, 500.0),
+            ..Default::default()
+        });
+
+        let viewer = FunctionViewer {
+            name: func_name.clone(),
+            source_file: rs_filename,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            rs_content: String::from("// Save to generate skeleton source"),
+            docs_content: None,
+            active_tab: 0,
+            toml_path: path.clone(),
+        };
+
+        let child = WindowState {
+            kind: WindowKind::FunctionViewer(viewer),
+            flow_name: func_name,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            canvas_state: FlowCanvasState::default(),
+            status: String::from("New function — add ports and Save"),
+            selected_node: None,
+            selected_connection: None,
+            history: EditHistory::default(),
+            auto_fit_pending: false,
+            auto_fit_enabled: false,
+            unsaved_edits: 1,
+            compiled_manifest: None,
+            file_path: Some(path),
+            flow_definition: FlowDefinition::default(),
+            tooltip: None,
+            initializer_editor: None,
+            is_root: false,
+            flow_inputs: Vec::new(),
+            flow_outputs: Vec::new(),
+            context_menu: None,
+        };
+
+        self.windows.insert(new_id, child);
         open_task.discard()
     }
 }
@@ -1971,18 +2315,18 @@ fn add_library_function(win: &mut WindowState, source: &str, func_name: &str) {
 /// Resolve a node's source path relative to the current flow file.
 fn resolve_node_source(win: &WindowState, source: &str) -> Option<PathBuf> {
     let base_dir = win.file_path.as_ref()?.parent()?;
+    let canonicalize = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
     let candidate = base_dir.join(source);
     if candidate.exists() {
-        return Some(candidate);
+        return Some(canonicalize(candidate));
     }
     let with_ext = base_dir.join(format!("{source}.toml"));
     if with_ext.exists() {
-        return Some(with_ext);
+        return Some(canonicalize(with_ext));
     }
-    // Try as directory/default.toml
     let dir_default = base_dir.join(source).join("default.toml");
     if dir_default.exists() {
-        return Some(dir_default);
+        return Some(canonicalize(dir_default));
     }
     None
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use clap::{Arg, ArgAction, Command as ClapCommand};
 use iced::keyboard;
 use iced::widget::{button, container, pick_list, stack, text_input, Column, Row, Text};
+use iced::window;
 use iced::{Color, Element, Fill, Subscription, Task, Theme};
 use log::info;
 use simpath::Simpath;
@@ -44,16 +45,16 @@ use library_panel::{LibraryMessage, LibraryTree};
 /// Messages handled by the flowedit application
 #[derive(Debug, Clone)]
 enum Message {
-    /// A message from the interactive canvas (select, move, delete)
-    Canvas(CanvasMessage),
-    /// A message from the library side panel
-    Library(LibraryMessage),
-    /// Zoom in by one step
-    ZoomIn,
-    /// Zoom out by one step
-    ZoomOut,
-    /// Toggle auto-fit mode
-    ToggleAutoFit,
+    /// A message from the interactive canvas, tagged with its window ID
+    WindowCanvas(window::Id, CanvasMessage),
+    /// A message from the library side panel, tagged with the originating window ID
+    Library(window::Id, LibraryMessage),
+    /// Zoom in by one step, tagged with the originating window ID
+    ZoomIn(window::Id),
+    /// Zoom out by one step, tagged with the originating window ID
+    ZoomOut(window::Id),
+    /// Toggle auto-fit mode, tagged with the originating window ID
+    ToggleAutoFit(window::Id),
     /// Undo the last edit action
     Undo,
     /// Redo the last undone action
@@ -68,14 +69,18 @@ enum Message {
     New,
     /// Compile the current flow
     Compile,
-    /// Initializer type changed in the editor dialog
-    InitializerTypeChanged(String),
-    /// Initializer value changed in the editor dialog
-    InitializerValueChanged(String),
-    /// Apply the initializer edit
-    InitializerApply,
-    /// Cancel the initializer edit
-    InitializerCancel,
+    /// Initializer type changed in the editor dialog, tagged with the originating window ID
+    InitializerTypeChanged(window::Id, String),
+    /// Initializer value changed in the editor dialog, tagged with the originating window ID
+    InitializerValueChanged(window::Id, String),
+    /// Apply the initializer edit, tagged with the originating window ID
+    InitializerApply(window::Id),
+    /// Cancel the initializer edit, tagged with the originating window ID
+    InitializerCancel(window::Id),
+    /// A window close was requested
+    CloseRequested(window::Id),
+    /// A window received focus
+    WindowFocused(window::Id),
 }
 
 /// State for the initializer editing dialog.
@@ -90,8 +95,8 @@ struct InitializerEditor {
     value_text: String,
 }
 
-/// Top-level application state
-struct FlowEdit {
+/// Per-window state for the flow editor.
+struct WindowState {
     /// The name of the flow being viewed
     flow_name: String,
     /// Positioned nodes derived from the flow's process references
@@ -124,6 +129,18 @@ struct FlowEdit {
     tooltip: Option<(String, f32, f32)>,
     /// Active initializer editor dialog, if any
     initializer_editor: Option<InitializerEditor>,
+    /// Whether this is the root (main) window
+    is_root: bool,
+}
+
+/// Top-level application state
+struct FlowEdit {
+    /// Per-window states, keyed by window ID
+    windows: HashMap<window::Id, WindowState>,
+    /// The ID of the root (main) window, if known
+    root_window: Option<window::Id>,
+    /// The ID of the currently focused window (updated on focus events)
+    focused_window: Option<window::Id>,
     /// Library panel tree for process discovery
     library_tree: LibraryTree,
 }
@@ -133,7 +150,7 @@ struct FlowEdit {
 /// Parses CLI arguments, loads the flow definition, and launches the iced GUI.
 fn main() -> iced::Result {
     env_logger::init();
-    iced::application(FlowEdit::new, FlowEdit::update, FlowEdit::view)
+    iced::daemon(FlowEdit::new, FlowEdit::update, FlowEdit::view)
         .title(FlowEdit::title)
         .subscription(FlowEdit::subscription)
         .antialiasing(true)
@@ -233,7 +250,14 @@ impl FlowEdit {
 
         let has_nodes = !nodes.is_empty();
         let library_tree = LibraryTree::scan();
-        let app = FlowEdit {
+
+        // Open the root window via daemon API
+        let (root_id, open_task) = window::open(window::Settings {
+            size: iced::Size::new(1024.0, 768.0),
+            ..Default::default()
+        });
+
+        let win_state = WindowState {
             flow_name,
             nodes,
             edges,
@@ -250,84 +274,94 @@ impl FlowEdit {
             flow_definition,
             tooltip: None,
             initializer_editor: None,
+            is_root: true,
+        };
+
+        let mut windows = HashMap::new();
+        windows.insert(root_id, win_state);
+
+        let app = FlowEdit {
+            windows,
+            root_window: Some(root_id),
+            focused_window: Some(root_id),
             library_tree,
         };
 
-        (app, Task::none())
+        (app, open_task.discard())
     }
 
-    /// Return the window title, showing the file name and unsaved indicator.
-    fn title(&self) -> String {
-        let modified = if self.unsaved_edits > 0 { " *" } else { "" };
-        let name = self
-            .file_path
-            .as_ref()
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .unwrap_or(&self.flow_name);
-        format!("flowedit - {name}{modified}")
+    /// Return the window title, showing the flow name, file name, and unsaved indicator.
+    fn title(&self, window_id: window::Id) -> String {
+        if let Some(win) = self.windows.get(&window_id) {
+            let modified = if win.unsaved_edits > 0 { " *" } else { "" };
+            let file = win
+                .file_path
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("untitled");
+            format!("flowedit - {} ({}){modified}", win.flow_name, file)
+        } else {
+            String::from("flowedit")
+        }
     }
 
     /// Handle messages from canvas interactions.
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
-            Message::Canvas(canvas_msg) => match canvas_msg {
-                CanvasMessage::Selected(idx) => {
-                    self.selected_node = idx;
-                    if self.selected_connection.is_some() {
-                        self.selected_connection = None;
-                        self.canvas_state.request_redraw();
-                    }
-                    if let Some(i) = idx {
-                        if let Some(node) = self.nodes.get(i) {
-                            self.status = format!("Selected: {}", node.alias);
+            Message::WindowCanvas(win_id, canvas_msg) => {
+                let Some(win) = self.windows.get_mut(&win_id) else {
+                    return Task::none();
+                };
+                match canvas_msg {
+                    CanvasMessage::Selected(idx) => {
+                        win.selected_node = idx;
+                        if win.selected_connection.is_some() {
+                            win.selected_connection = None;
+                            win.canvas_state.request_redraw();
                         }
-                    } else {
-                        self.status = String::from("Ready");
+                        if let Some(i) = idx {
+                            if let Some(node) = win.nodes.get(i) {
+                                win.status = format!("Selected: {}", node.alias);
+                            }
+                        } else {
+                            win.status = String::from("Ready");
+                        }
                     }
-                }
-                CanvasMessage::Moved(idx, x, y) => {
-                    if let Some(node) = self.nodes.get_mut(idx) {
-                        node.x = x;
-                        node.y = y;
-                        self.canvas_state.request_redraw();
+                    CanvasMessage::Moved(idx, x, y) => {
+                        if let Some(node) = win.nodes.get_mut(idx) {
+                            node.x = x;
+                            node.y = y;
+                            win.canvas_state.request_redraw();
+                        }
                     }
-                }
-                CanvasMessage::Resized(idx, x, y, w, h) => {
-                    if let Some(node) = self.nodes.get_mut(idx) {
-                        node.x = x;
-                        node.y = y;
-                        node.width = w;
-                        node.height = h;
-                        self.canvas_state.request_redraw();
+                    CanvasMessage::Resized(idx, x, y, w, h) => {
+                        if let Some(node) = win.nodes.get_mut(idx) {
+                            node.x = x;
+                            node.y = y;
+                            node.width = w;
+                            node.height = h;
+                            win.canvas_state.request_redraw();
+                        }
                     }
-                }
-                CanvasMessage::MoveCompleted(idx, old_x, old_y, new_x, new_y) => {
-                    info!("MoveCompleted: idx={idx}, ({old_x},{old_y}) -> ({new_x},{new_y})");
-                    if (old_x - new_x).abs() > 0.5 || (old_y - new_y).abs() > 0.5 {
-                        self.record_edit(EditAction::MoveNode {
-                            index: idx,
-                            old_x,
-                            old_y,
-                            new_x,
-                            new_y,
-                        });
+                    CanvasMessage::MoveCompleted(idx, old_x, old_y, new_x, new_y) => {
+                        info!("MoveCompleted: idx={idx}, ({old_x},{old_y}) -> ({new_x},{new_y})");
+                        if (old_x - new_x).abs() > 0.5 || (old_y - new_y).abs() > 0.5 {
+                            record_edit(
+                                win,
+                                EditAction::MoveNode {
+                                    index: idx,
+                                    old_x,
+                                    old_y,
+                                    new_x,
+                                    new_y,
+                                },
+                            );
+                        }
                     }
-                }
-                #[allow(clippy::similar_names)]
-                CanvasMessage::ResizeCompleted(
-                    idx,
-                    old_x,
-                    old_y,
-                    old_w,
-                    old_h,
-                    new_x,
-                    new_y,
-                    new_w,
-                    new_h,
-                ) => {
-                    self.record_edit(EditAction::ResizeNode {
-                        index: idx,
+                    #[allow(clippy::similar_names)]
+                    CanvasMessage::ResizeCompleted(
+                        idx,
                         old_x,
                         old_y,
                         old_w,
@@ -336,248 +370,321 @@ impl FlowEdit {
                         new_y,
                         new_w,
                         new_h,
-                    });
-                }
-                CanvasMessage::Deleted(idx) => {
-                    if idx < self.nodes.len() {
-                        let node = if let Some(node) = self.nodes.get(idx) {
-                            node.clone()
-                        } else {
-                            return Task::none();
-                        };
-                        let alias = node.alias.clone();
-                        let removed_edges: Vec<EdgeLayout> = self
-                            .edges
-                            .iter()
-                            .filter(|e| e.references_node(&alias))
-                            .cloned()
-                            .collect();
-                        self.nodes.remove(idx);
-                        self.edges.retain(|e| !e.references_node(&alias));
-                        self.record_edit(EditAction::DeleteNode {
-                            index: idx,
-                            node,
-                            removed_edges,
-                        });
-                        self.selected_node = None;
-                        self.selected_connection = None;
-                        self.canvas_state.request_redraw();
-                        let nc = self.nodes.len();
-                        let ec = self.edges.len();
-                        self.status = format!("Node deleted - {nc} nodes, {ec} connections");
-                        if self.auto_fit_enabled {
-                            self.auto_fit_pending = true;
-                        }
+                    ) => {
+                        record_edit(
+                            win,
+                            EditAction::ResizeNode {
+                                index: idx,
+                                old_x,
+                                old_y,
+                                old_w,
+                                old_h,
+                                new_x,
+                                new_y,
+                                new_w,
+                                new_h,
+                            },
+                        );
                     }
-                }
-                CanvasMessage::ConnectionCreated {
-                    from_node,
-                    from_port,
-                    to_node,
-                    to_port,
-                } => {
-                    let edge = EdgeLayout::new(
-                        from_node.clone(),
-                        from_port.clone(),
-                        to_node.clone(),
-                        to_port.clone(),
-                    );
-                    self.record_edit(EditAction::CreateConnection { edge: edge.clone() });
-                    self.edges.push(edge);
-                    self.canvas_state.request_redraw();
-                    let nc = self.nodes.len();
-                    let ec = self.edges.len();
-                    self.status = format!(
-                        "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
-                    );
-                }
-                CanvasMessage::ConnectionSelected(idx) => {
-                    self.selected_connection = idx;
-                    self.selected_node = None;
-                    self.canvas_state.request_redraw();
-                    if let Some(i) = idx {
-                        if let Some(edge) = self.edges.get(i) {
-                            self.status = format!(
-                                "Connection: {} -> {}",
-                                format_endpoint(&edge.from_node, &edge.from_port),
-                                format_endpoint(&edge.to_node, &edge.to_port),
-                            );
-                        }
-                    } else {
-                        self.status = String::from("Ready");
-                    }
-                }
-                CanvasMessage::ConnectionDeleted(idx) => {
-                    if idx < self.edges.len() {
-                        let edge = self.edges.remove(idx);
-                        self.record_edit(EditAction::DeleteConnection { index: idx, edge });
-                        self.selected_connection = None;
-                        self.canvas_state.request_redraw();
-                        let nc = self.nodes.len();
-                        let ec = self.edges.len();
-                        self.status = format!("Connection deleted - {nc} nodes, {ec} connections");
-                    }
-                }
-                CanvasMessage::HoverChanged(data) => {
-                    self.tooltip = data;
-                }
-                CanvasMessage::AutoFitViewport(viewport) => {
-                    if self.auto_fit_enabled || self.auto_fit_pending {
-                        self.canvas_state.auto_fit(&self.nodes, viewport);
-                        self.auto_fit_pending = false;
-                    }
-                }
-                CanvasMessage::Pan(dx, dy) => {
-                    self.auto_fit_enabled = false; // Manual pan disables auto-fit
-                    self.canvas_state.scroll_offset.x += dx;
-                    self.canvas_state.scroll_offset.y += dy;
-                    self.canvas_state.request_redraw();
-                }
-                CanvasMessage::ZoomBy(factor) => {
-                    self.auto_fit_enabled = false; // Manual zoom disables auto-fit
-                    self.canvas_state.zoom = (self.canvas_state.zoom * factor).clamp(0.1, 5.0);
-                    self.canvas_state.request_redraw();
-                    let pct = (self.canvas_state.zoom * 100.0) as u32;
-                    self.status = format!("Zoom: {pct}%");
-                }
-                CanvasMessage::InitializerEdit(node_idx, port_name) => {
-                    // Look up current initializer from the model (flow definition)
-                    let alias = self
-                        .nodes
-                        .get(node_idx)
-                        .map(|n| n.alias.clone())
-                        .unwrap_or_default();
-                    let (init_type, value_text) = self
-                        .flow_definition
-                        .process_refs
-                        .iter()
-                        .find(|pr| {
-                            let pr_alias = if pr.alias.is_empty() {
-                                derive_short_name(&pr.source)
+                    CanvasMessage::Deleted(idx) => {
+                        if idx < win.nodes.len() {
+                            let node = if let Some(node) = win.nodes.get(idx) {
+                                node.clone()
                             } else {
-                                pr.alias.to_string()
+                                return Task::none();
                             };
-                            pr_alias == alias
-                        })
-                        .and_then(|pr| pr.initializations.get(&port_name))
-                        .map(|init| match init {
-                            InputInitializer::Once(v) => (
-                                "once".to_string(),
-                                serde_json::to_string(v).unwrap_or_default(),
-                            ),
-                            InputInitializer::Always(v) => (
-                                "always".to_string(),
-                                serde_json::to_string(v).unwrap_or_default(),
-                            ),
-                        })
-                        .unwrap_or_else(|| ("none".to_string(), String::new()));
+                            let alias = node.alias.clone();
+                            let removed_edges: Vec<EdgeLayout> = win
+                                .edges
+                                .iter()
+                                .filter(|e| e.references_node(&alias))
+                                .cloned()
+                                .collect();
+                            win.nodes.remove(idx);
+                            win.edges.retain(|e| !e.references_node(&alias));
+                            record_edit(
+                                win,
+                                EditAction::DeleteNode {
+                                    index: idx,
+                                    node,
+                                    removed_edges,
+                                },
+                            );
+                            win.selected_node = None;
+                            win.selected_connection = None;
+                            win.canvas_state.request_redraw();
+                            let nc = win.nodes.len();
+                            let ec = win.edges.len();
+                            win.status = format!("Node deleted - {nc} nodes, {ec} connections");
+                            if win.auto_fit_enabled {
+                                win.auto_fit_pending = true;
+                            }
+                        }
+                    }
+                    CanvasMessage::ConnectionCreated {
+                        from_node,
+                        from_port,
+                        to_node,
+                        to_port,
+                    } => {
+                        let edge = EdgeLayout::new(
+                            from_node.clone(),
+                            from_port.clone(),
+                            to_node.clone(),
+                            to_port.clone(),
+                        );
+                        record_edit(win, EditAction::CreateConnection { edge: edge.clone() });
+                        win.edges.push(edge);
+                        win.canvas_state.request_redraw();
+                        let nc = win.nodes.len();
+                        let ec = win.edges.len();
+                        win.status = format!(
+                            "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
+                        );
+                    }
+                    CanvasMessage::ConnectionSelected(idx) => {
+                        win.selected_connection = idx;
+                        win.selected_node = None;
+                        win.canvas_state.request_redraw();
+                        if let Some(i) = idx {
+                            if let Some(edge) = win.edges.get(i) {
+                                win.status = format!(
+                                    "Connection: {} -> {}",
+                                    format_endpoint(&edge.from_node, &edge.from_port),
+                                    format_endpoint(&edge.to_node, &edge.to_port),
+                                );
+                            }
+                        } else {
+                            win.status = String::from("Ready");
+                        }
+                    }
+                    CanvasMessage::ConnectionDeleted(idx) => {
+                        if idx < win.edges.len() {
+                            let edge = win.edges.remove(idx);
+                            record_edit(win, EditAction::DeleteConnection { index: idx, edge });
+                            win.selected_connection = None;
+                            win.canvas_state.request_redraw();
+                            let nc = win.nodes.len();
+                            let ec = win.edges.len();
+                            win.status =
+                                format!("Connection deleted - {nc} nodes, {ec} connections");
+                        }
+                    }
+                    CanvasMessage::HoverChanged(data) => {
+                        win.tooltip = data;
+                    }
+                    CanvasMessage::AutoFitViewport(viewport) => {
+                        if win.auto_fit_enabled || win.auto_fit_pending {
+                            win.canvas_state.auto_fit(&win.nodes, viewport);
+                            win.auto_fit_pending = false;
+                        }
+                    }
+                    CanvasMessage::Pan(dx, dy) => {
+                        win.auto_fit_enabled = false; // Manual pan disables auto-fit
+                        win.canvas_state.scroll_offset.x += dx;
+                        win.canvas_state.scroll_offset.y += dy;
+                        win.canvas_state.request_redraw();
+                    }
+                    CanvasMessage::ZoomBy(factor) => {
+                        win.auto_fit_enabled = false; // Manual zoom disables auto-fit
+                        win.canvas_state.zoom = (win.canvas_state.zoom * factor).clamp(0.1, 5.0);
+                        win.canvas_state.request_redraw();
+                        let pct = (win.canvas_state.zoom * 100.0) as u32;
+                        win.status = format!("Zoom: {pct}%");
+                    }
+                    CanvasMessage::InitializerEdit(node_idx, port_name) => {
+                        // Look up current initializer from the model (flow definition)
+                        let alias = win
+                            .nodes
+                            .get(node_idx)
+                            .map(|n| n.alias.clone())
+                            .unwrap_or_default();
+                        let (init_type, value_text) = win
+                            .flow_definition
+                            .process_refs
+                            .iter()
+                            .find(|pr| {
+                                let pr_alias = if pr.alias.is_empty() {
+                                    derive_short_name(&pr.source)
+                                } else {
+                                    pr.alias.to_string()
+                                };
+                                pr_alias == alias
+                            })
+                            .and_then(|pr| pr.initializations.get(&port_name))
+                            .map(|init| match init {
+                                InputInitializer::Once(v) => (
+                                    "once".to_string(),
+                                    serde_json::to_string(v).unwrap_or_default(),
+                                ),
+                                InputInitializer::Always(v) => (
+                                    "always".to_string(),
+                                    serde_json::to_string(v).unwrap_or_default(),
+                                ),
+                            })
+                            .unwrap_or_else(|| ("none".to_string(), String::new()));
 
-                    self.initializer_editor = Some(InitializerEditor {
-                        node_index: node_idx,
-                        port_name,
-                        init_type,
-                        value_text,
-                    });
+                        win.initializer_editor = Some(InitializerEditor {
+                            node_index: node_idx,
+                            port_name,
+                            init_type,
+                            value_text,
+                        });
+                    }
+                    CanvasMessage::OpenNode(idx) => {
+                        return self.open_node(win_id, idx);
+                    }
                 }
-            },
-            Message::Library(ref lib_msg) => {
+            }
+            Message::Library(win_id, ref lib_msg) => {
                 if let Some((source, func_name)) = self.library_tree.update(lib_msg) {
-                    self.add_library_function(&source, &func_name);
+                    if let Some(win) = self.windows.get_mut(&win_id) {
+                        add_library_function(win, &source, &func_name);
+                    }
                 }
             }
-            Message::ZoomIn => {
-                self.auto_fit_enabled = false;
-                self.canvas_state.zoom_in();
-                let pct = (self.canvas_state.zoom * 100.0) as u32;
-                self.status = format!("Zoom: {pct}%");
+            Message::ZoomIn(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.auto_fit_enabled = false;
+                    win.canvas_state.zoom_in();
+                    let pct = (win.canvas_state.zoom * 100.0) as u32;
+                    win.status = format!("Zoom: {pct}%");
+                }
             }
-            Message::ZoomOut => {
-                self.auto_fit_enabled = false;
-                self.canvas_state.zoom_out();
-                let pct = (self.canvas_state.zoom * 100.0) as u32;
-                self.status = format!("Zoom: {pct}%");
+            Message::ZoomOut(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.auto_fit_enabled = false;
+                    win.canvas_state.zoom_out();
+                    let pct = (win.canvas_state.zoom * 100.0) as u32;
+                    win.status = format!("Zoom: {pct}%");
+                }
             }
-            Message::ToggleAutoFit => {
-                self.auto_fit_enabled = !self.auto_fit_enabled;
-                if self.auto_fit_enabled {
-                    self.auto_fit_pending = true;
-                    self.canvas_state.request_redraw();
-                    self.status = String::from("Auto-fit enabled");
-                } else {
-                    self.status = String::from("Auto-fit disabled");
+            Message::ToggleAutoFit(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.auto_fit_enabled = !win.auto_fit_enabled;
+                    if win.auto_fit_enabled {
+                        win.auto_fit_pending = true;
+                        win.canvas_state.request_redraw();
+                        win.status = String::from("Auto-fit enabled");
+                    } else {
+                        win.status = String::from("Auto-fit disabled");
+                    }
                 }
             }
             Message::Undo => {
-                self.apply_undo();
-                self.unsaved_edits = (self.unsaved_edits - 1).max(0);
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    apply_undo(win);
+                    win.unsaved_edits = (win.unsaved_edits - 1).max(0);
+                }
             }
             Message::Redo => {
-                self.apply_redo();
-                self.unsaved_edits += 1;
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    apply_redo(win);
+                    win.unsaved_edits += 1;
+                }
             }
             Message::Save => {
-                if let Some(path) = self.file_path.clone() {
-                    self.perform_save(&path);
-                } else {
-                    self.perform_save_as();
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    if let Some(path) = win.file_path.clone() {
+                        perform_save(win, &path);
+                    } else {
+                        perform_save_as(win);
+                    }
                 }
             }
             Message::SaveAs => {
-                self.perform_save_as();
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    perform_save_as(win);
+                }
             }
             Message::Open => {
-                self.perform_open();
+                if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
+                    perform_open(win);
+                }
             }
             Message::New => {
-                self.perform_new();
+                if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
+                    perform_new(win);
+                }
             }
             Message::Compile => {
-                if !self.nodes.is_empty() {
-                    match self.perform_compile() {
-                        Ok(path) => {
-                            self.compiled_manifest = Some(path.clone());
-                            self.status = format!("Compiled: {}", path.display());
-                        }
-                        Err(e) => {
-                            self.compiled_manifest = None;
-                            self.status = e.to_string();
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    if !win.nodes.is_empty() {
+                        match perform_compile(win) {
+                            Ok(path) => {
+                                win.compiled_manifest = Some(path.clone());
+                                win.status = format!("Compiled: {}", path.display());
+                            }
+                            Err(e) => {
+                                win.compiled_manifest = None;
+                                win.status = e.to_string();
+                            }
                         }
                     }
                 }
             }
-            Message::InitializerTypeChanged(new_type) => {
-                if let Some(ref mut editor) = self.initializer_editor {
-                    editor.init_type = new_type;
+            Message::InitializerTypeChanged(win_id, new_type) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(ref mut editor) = win.initializer_editor {
+                        editor.init_type = new_type;
+                    }
                 }
             }
-            Message::InitializerValueChanged(new_value) => {
-                if let Some(ref mut editor) = self.initializer_editor {
-                    editor.value_text = new_value;
+            Message::InitializerValueChanged(win_id, new_value) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(ref mut editor) = win.initializer_editor {
+                        editor.value_text = new_value;
+                    }
                 }
             }
-            Message::InitializerApply => {
-                if let Some(editor) = self.initializer_editor.take() {
-                    self.apply_initializer_edit(&editor);
+            Message::InitializerApply(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let Some(editor) = win.initializer_editor.take() {
+                        apply_initializer_edit(win, &editor);
+                    }
                 }
             }
-            Message::InitializerCancel => {
-                self.initializer_editor = None;
+            Message::InitializerCancel(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.initializer_editor = None;
+                }
+            }
+            Message::WindowFocused(id) => {
+                self.focused_window = Some(id);
+            }
+            Message::CloseRequested(id) => {
+                // Check if this is the root window
+                if self.root_window == Some(id) {
+                    return iced::exit();
+                }
+                // Otherwise, close the child window and remove its state
+                self.windows.remove(&id);
+                return window::close(id);
             }
         }
         Task::none()
     }
 
     /// Build the view: a canvas area with zoom controls overlaid, and a status bar at the bottom.
-    fn view(&self) -> Element<'_, Message> {
-        let canvas = self
+    fn view(&self, window_id: window::Id) -> Element<'_, Message> {
+        let Some(win) = self.windows.get(&window_id) else {
+            return Text::new("Window not found").into();
+        };
+
+        let canvas = win
             .canvas_state
             .view(
-                &self.nodes,
-                &self.edges,
-                self.auto_fit_pending,
-                self.auto_fit_enabled,
+                &win.nodes,
+                &win.edges,
+                win.auto_fit_pending,
+                win.auto_fit_enabled,
             )
-            .map(Message::Canvas);
+            .map(move |msg| Message::WindowCanvas(window_id, msg));
 
         let btn_width = 40;
         let zoom_controls = container(
@@ -586,21 +693,21 @@ impl FlowEdit {
                     .spacing(4)
                     .push(
                         button(Text::new("+").center())
-                            .on_press(Message::ZoomIn)
+                            .on_press(Message::ZoomIn(window_id))
                             .width(btn_width)
                             .style(button::secondary),
                     )
                     .push(
                         button(Text::new("\u{2212}").center())
-                            .on_press(Message::ZoomOut)
+                            .on_press(Message::ZoomOut(window_id))
                             .width(btn_width)
                             .style(button::secondary),
                     )
                     .push(
                         button(Text::new("Fit").center())
-                            .on_press(Message::ToggleAutoFit)
+                            .on_press(Message::ToggleAutoFit(window_id))
                             .width(btn_width)
-                            .style(if self.auto_fit_enabled {
+                            .style(if win.auto_fit_enabled {
                                 button::primary
                             } else {
                                 button::secondary
@@ -614,9 +721,9 @@ impl FlowEdit {
         .align_bottom(Fill)
         .padding(10);
 
-        let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas.into(), zoom_controls.into()];
+        let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
 
-        if let Some((ref tip_text, tx, ty)) = self.tooltip {
+        if let Some((ref tip_text, tx, ty)) = win.tooltip {
             let tooltip_widget = container(
                 container(Text::new(tip_text.clone()).size(20).color(Color::WHITE))
                     .padding(8)
@@ -642,8 +749,8 @@ impl FlowEdit {
         }
 
         // Initializer editor dialog overlay
-        if let Some(ref editor) = self.initializer_editor {
-            let port_label = if let Some(node) = self.nodes.get(editor.node_index) {
+        if let Some(ref editor) = win.initializer_editor {
+            let port_label = if let Some(node) = win.nodes.get(editor.node_index) {
                 format!("{}/{}", node.alias, editor.port_name)
             } else {
                 editor.port_name.clone()
@@ -658,8 +765,8 @@ impl FlowEdit {
                 .padding(12)
                 .push(Text::new(format!("Initializer: {port_label}")).size(14))
                 .push(
-                    pick_list(init_types, selected, |s: &str| {
-                        Message::InitializerTypeChanged(s.to_string())
+                    pick_list(init_types, selected, move |s: &str| {
+                        Message::InitializerTypeChanged(window_id, s.to_string())
                     })
                     .text_size(12),
                 );
@@ -667,7 +774,7 @@ impl FlowEdit {
             if editor.init_type != "none" {
                 dialog_col = dialog_col.push(
                     text_input("JSON value (e.g. 42, \"hello\", true)", &editor.value_text)
-                        .on_input(Message::InitializerValueChanged)
+                        .on_input(move |v| Message::InitializerValueChanged(window_id, v))
                         .size(12)
                         .padding(6),
                 );
@@ -678,13 +785,13 @@ impl FlowEdit {
                     .spacing(8)
                     .push(
                         button(Text::new("Apply").size(12).center())
-                            .on_press(Message::InitializerApply)
+                            .on_press(Message::InitializerApply(window_id))
                             .style(button::primary)
                             .padding(6),
                     )
                     .push(
                         button(Text::new("Cancel").size(12).center())
-                            .on_press(Message::InitializerCancel)
+                            .on_press(Message::InitializerCancel(window_id))
                             .style(button::secondary)
                             .padding(6),
                     ),
@@ -708,31 +815,41 @@ impl FlowEdit {
 
         let canvas_with_controls = stack(canvas_stack);
 
-        let library_panel = self.library_tree.view().map(Message::Library);
+        let library_panel = self
+            .library_tree
+            .view()
+            .map(move |msg| Message::Library(window_id, msg));
 
         let main_content = Row::new()
             .push(library_panel)
             .push(container(canvas_with_controls).width(Fill).height(Fill));
 
-        let edit_indicator = if self.unsaved_edits > 0 {
-            format!("  |  {} unsaved edit(s)", self.unsaved_edits)
+        let edit_indicator = if win.unsaved_edits > 0 {
+            format!("  |  {} unsaved edit(s)", win.unsaved_edits)
         } else {
             String::from("  |  saved")
         };
 
-        // Compile button — enabled when there are nodes
-        let mut compile_btn = button(Text::new("Compile").size(12).center())
-            .style(button::secondary)
-            .padding(4);
-        if !self.nodes.is_empty() {
-            compile_btn = compile_btn.on_press(Message::Compile);
-        }
+        // Build status bar — compile button only for root windows
+        let status_bar: Row<'_, Message> = if win.is_root {
+            let mut compile_btn = button(Text::new("Compile").size(12).center())
+                .style(button::secondary)
+                .padding(4);
+            if !win.nodes.is_empty() {
+                compile_btn = compile_btn.on_press(Message::Compile);
+            }
 
-        let status_bar: Row<'_, Message> = Row::new()
-            .spacing(8)
-            .push(Text::new(format!("{}{}", self.status, edit_indicator)).size(14))
-            .push(iced::widget::Space::new().width(Fill))
-            .push(compile_btn);
+            Row::new()
+                .spacing(8)
+                .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
+                .push(iced::widget::Space::new().width(Fill))
+                .push(compile_btn)
+        } else {
+            Row::new()
+                .spacing(8)
+                .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
+                .push(iced::widget::Space::new().width(Fill))
+        };
 
         let mut layout = Column::new().push(container(main_content).width(Fill).height(Fill));
 
@@ -741,7 +858,7 @@ impl FlowEdit {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        keyboard::listen().filter_map(|event| match event {
+        let keyboard_sub = keyboard::listen().filter_map(|event| match event {
             keyboard::Event::KeyPressed {
                 key: keyboard::Key::Character(ref c),
                 modifiers,
@@ -754,556 +871,669 @@ impl FlowEdit {
                 "o" => Some(Message::Open),
                 "n" => Some(Message::New),
                 "b" => Some(Message::Compile),
-                "=" | "+" => Some(Message::ZoomIn),
-                "-" => Some(Message::ZoomOut),
                 _ => None,
             },
             _ => None,
+        });
+
+        let close_sub = window::close_requests().map(Message::CloseRequested);
+
+        let focus_sub = iced::event::listen_with(|event, _status, id| {
+            if let iced::Event::Window(iced::window::Event::Focused) = event {
+                Some(Message::WindowFocused(id))
+            } else {
+                None
+            }
+        });
+
+        Subscription::batch(vec![keyboard_sub, close_sub, focus_sub])
+    }
+
+    /// Open a sub-flow in a new in-process window, or show a status message
+    /// if the node resolves to a function rather than a flow.
+    fn open_node(&mut self, parent_win_id: window::Id, idx: usize) -> Task<Message> {
+        // Extract source and resolved path from the parent window (immutable borrow)
+        let (source, resolved_path) = {
+            let Some(win) = self.windows.get(&parent_win_id) else {
+                return Task::none();
+            };
+            let Some(node) = win.nodes.get(idx) else {
+                return Task::none();
+            };
+            let source = node.source.clone();
+            let path = resolve_node_source(win, &source);
+            (source, path)
+        };
+
+        let Some(path) = resolved_path else {
+            if let Some(win) = self.windows.get_mut(&parent_win_id) {
+                win.status = format!("Could not resolve source: {source}");
+            }
+            return Task::none();
+        };
+
+        // Check whether the resolved file is a flow or a function
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            if let Ok(url) = Url::from_file_path(&path) {
+                if let Ok(deserializer) = get::<Process>(&url) {
+                    if let Ok(Process::FunctionProcess(_)) =
+                        deserializer.deserialize(&contents, Some(&url))
+                    {
+                        if let Some(win) = self.windows.get_mut(&parent_win_id) {
+                            win.status =
+                                format!("'{}' is a function -- viewer not yet implemented", source);
+                        }
+                        return Task::none();
+                    }
+                }
+            }
+        }
+
+        // Load the sub-flow and open it in a new window
+        match load_flow(&path) {
+            Ok((name, nodes, edges, flow_def)) => {
+                let has_nodes = !nodes.is_empty();
+                let (new_id, open_task) = window::open(window::Settings {
+                    size: iced::Size::new(1024.0, 768.0),
+                    ..Default::default()
+                });
+                let nc = nodes.len();
+                let ec = edges.len();
+                let child = WindowState {
+                    flow_name: name,
+                    nodes,
+                    edges,
+                    canvas_state: FlowCanvasState::default(),
+                    status: format!("Ready - {nc} nodes, {ec} connections"),
+                    selected_node: None,
+                    selected_connection: None,
+                    history: EditHistory::default(),
+                    auto_fit_pending: has_nodes,
+                    auto_fit_enabled: true,
+                    unsaved_edits: 0,
+                    compiled_manifest: None,
+                    file_path: Some(path.clone()),
+                    flow_definition: flow_def,
+                    tooltip: None,
+                    initializer_editor: None,
+                    is_root: false,
+                };
+                self.windows.insert(new_id, child);
+                if let Some(win) = self.windows.get_mut(&parent_win_id) {
+                    win.status = format!("Opened: {}", path.display());
+                }
+                open_task.discard()
+            }
+            Err(e) => {
+                if let Some(win) = self.windows.get_mut(&parent_win_id) {
+                    win.status = format!("Could not open '{}': {e}", source);
+                }
+                Task::none()
+            }
+        }
+    }
+}
+
+/// Record an edit action in the history and increment the unsaved edit count.
+fn record_edit(win: &mut WindowState, action: EditAction) {
+    win.history.record(action);
+    win.unsaved_edits += 1;
+    win.compiled_manifest = None; // Invalidate compilation on any edit
+}
+
+/// Apply an undo action -- reverse the last edit.
+fn apply_undo(win: &mut WindowState) {
+    if let Some(action) = win.history.undo() {
+        match action {
+            EditAction::MoveNode {
+                index,
+                old_x,
+                old_y,
+                ..
+            } => {
+                if let Some(node) = win.nodes.get_mut(index) {
+                    node.x = old_x;
+                    node.y = old_y;
+                }
+                win.status = String::from("Undo: move");
+            }
+            EditAction::ResizeNode {
+                index,
+                old_x,
+                old_y,
+                old_w,
+                old_h,
+                ..
+            } => {
+                if let Some(node) = win.nodes.get_mut(index) {
+                    node.x = old_x;
+                    node.y = old_y;
+                    node.width = old_w;
+                    node.height = old_h;
+                }
+                win.status = String::from("Undo: resize");
+            }
+            EditAction::DeleteNode {
+                index,
+                node,
+                removed_edges,
+            } => {
+                win.nodes.insert(index, node);
+                win.edges.extend(removed_edges);
+                win.status = String::from("Undo: delete node");
+            }
+            EditAction::CreateConnection { edge } => {
+                win.edges.retain(|e| {
+                    e.from_node != edge.from_node
+                        || e.from_port != edge.from_port
+                        || e.to_node != edge.to_node
+                        || e.to_port != edge.to_port
+                });
+                win.status = String::from("Undo: create connection");
+            }
+            EditAction::DeleteConnection { index, edge } => {
+                win.edges.insert(index, edge);
+                win.status = String::from("Undo: delete connection");
+            }
+            EditAction::EditInitializer {
+                node_index,
+                ref port_name,
+                ref old_init,
+                ref old_display,
+                ..
+            } => {
+                apply_initializer_state(
+                    win,
+                    node_index,
+                    port_name,
+                    old_init.as_ref(),
+                    old_display.as_ref(),
+                );
+                win.status = String::from("Undo: initializer");
+            }
+        }
+        win.canvas_state.request_redraw();
+    }
+}
+
+/// Save the current flow to the given path.
+fn perform_save(win: &mut WindowState, path: &PathBuf) {
+    sync_flow_definition(win);
+    match save_flow_toml(&win.flow_definition, &win.edges, path) {
+        Ok(()) => {
+            win.unsaved_edits = 0;
+            win.file_path = Some(path.clone());
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                win.status = format!("Saved to {name}");
+            } else {
+                win.status = String::from("Saved");
+            }
+        }
+        Err(e) => {
+            win.status = format!("Save failed: {e}");
+        }
+    }
+}
+
+/// Prompt the user with a save dialog and save to the chosen path.
+fn perform_save_as(win: &mut WindowState) {
+    let dialog = rfd::FileDialog::new()
+        .add_filter("Flow", &["toml"])
+        .set_file_name(format!("{}.toml", win.flow_name));
+    if let Some(path) = dialog.save_file() {
+        perform_save(win, &path);
+    }
+}
+
+/// Prompt the user with an open dialog and load the selected flow file.
+fn perform_open(win: &mut WindowState) {
+    let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
+    if let Some(path) = dialog.pick_file() {
+        match load_flow(&path) {
+            Ok((name, node_list, edge_list, flow_def)) => {
+                let nc = node_list.len();
+                let ec = edge_list.len();
+                win.flow_name = name;
+                win.nodes = node_list;
+                win.edges = edge_list;
+                win.flow_definition = flow_def;
+                win.file_path = Some(path);
+                win.selected_node = None;
+                win.selected_connection = None;
+                win.history = EditHistory::default();
+                win.unsaved_edits = 0;
+                win.auto_fit_pending = true;
+                win.auto_fit_enabled = true;
+                win.canvas_state = FlowCanvasState::default();
+                win.status = format!("Loaded - {nc} nodes, {ec} connections");
+            }
+            Err(e) => {
+                win.status = format!("Open failed: {e}");
+            }
+        }
+    }
+}
+
+/// Clear the canvas and reset to an empty flow state.
+fn perform_new(win: &mut WindowState) {
+    win.flow_name = String::from("(new flow)");
+    win.nodes = Vec::new();
+    win.edges = Vec::new();
+    win.flow_definition = FlowDefinition::default();
+    win.file_path = None;
+    win.selected_node = None;
+    win.selected_connection = None;
+    win.history = EditHistory::default();
+    win.unsaved_edits = 0;
+    win.auto_fit_pending = false;
+    win.auto_fit_enabled = true;
+    win.canvas_state = FlowCanvasState::default();
+    win.status = String::from("New flow");
+}
+
+/// Compile the current flow to a manifest.
+///
+/// Writes a temporary copy of the current editor state for the compiler
+/// to parse -- the user's flow definition file is never modified.
+///
+/// Returns the path to the generated manifest on success, or a human-readable
+/// error message on failure.
+fn perform_compile(win: &mut WindowState) -> Result<PathBuf, String> {
+    // New flows must be saved first so the compiler has a real file path
+    if win.file_path.is_none() {
+        perform_save_as(win);
+    }
+    let Some(flow_path) = win.file_path.clone() else {
+        return Err("Flow must be saved before compiling".to_string());
+    };
+
+    // Save any unsaved edits so the file on disk matches the editor state
+    if win.unsaved_edits > 0 {
+        perform_save(win, &flow_path);
+    }
+
+    let flow_path = &flow_path;
+    let abs_path = if flow_path.is_absolute() {
+        flow_path.clone()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("Could not get current directory: {e}"))?
+            .join(flow_path)
+    };
+
+    let provider = build_meta_provider();
+
+    let url = Url::from_file_path(&abs_path)
+        .map_err(|()| format!("Invalid file path: {}", abs_path.display()))?;
+    let process = flowrclib::compiler::parser::parse(&url, &provider)
+        .map_err(|e| format!("Parse error: {e}"))?;
+    let flow = match process {
+        Process::FlowProcess(f) => f,
+        Process::FunctionProcess(_) => return Err("Not a flow definition".to_string()),
+    };
+
+    let output_dir = abs_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let mut source_urls = BTreeMap::<String, Url>::new();
+    let tables =
+        flowrclib::compiler::compile::compile(&flow, &output_dir, false, false, &mut source_urls)
+            .map_err(|e| e.to_string())?;
+
+    let manifest_path = flowrclib::generator::generate::write_flow_manifest(
+        &flow,
+        false,
+        &output_dir,
+        &tables,
+        source_urls,
+    )
+    .map_err(|e| format!("Manifest error: {e}"))?;
+
+    Ok(manifest_path)
+}
+
+/// Add a function from the library panel as a new node on the canvas.
+///
+/// Creates a `NodeLayout` at a default position and a `ProcessReference`
+/// in the flow definition, and records the action in the edit history.
+fn add_library_function(win: &mut WindowState, source: &str, func_name: &str) {
+    // Generate a unique alias: if the name already exists, append a number
+    let alias = generate_unique_alias(func_name, &win.nodes);
+
+    // Place the new node at a default position offset from existing nodes
+    let (x, y) = next_node_position(&win.nodes);
+
+    // Resolve port info from the function definition
+    let (inputs, outputs) = resolve_single_function_ports(source, None);
+
+    let node = NodeLayout {
+        alias: alias.clone(),
+        source: source.to_string(),
+        x,
+        y,
+        width: 180.0,
+        height: 120.0,
+        inputs,
+        outputs,
+        initializers: HashMap::new(),
+    };
+
+    let index = win.nodes.len();
+    win.nodes.push(node.clone());
+
+    // Also add to the flow definition
+    let pref = ProcessReference {
+        alias: alias.clone(),
+        source: source.to_string(),
+        initializations: std::collections::BTreeMap::new(),
+        x: Some(x),
+        y: Some(y),
+        width: Some(180.0),
+        height: Some(120.0),
+    };
+    win.flow_definition.process_refs.push(pref);
+
+    record_edit(
+        win,
+        EditAction::DeleteNode {
+            index,
+            node,
+            removed_edges: Vec::new(),
+        },
+    );
+    // Note: We record a DeleteNode so that *undo* removes the added node.
+    // This is intentional: undoing an "add" means deleting what was added.
+
+    win.selected_node = Some(index);
+    win.canvas_state.request_redraw();
+    // Trigger auto-fit if enabled so the new node is visible
+    if win.auto_fit_enabled {
+        win.auto_fit_pending = true;
+    }
+    let nc = win.nodes.len();
+    win.status = format!("Added {alias} from library - {nc} nodes");
+}
+
+/// Resolve a node's source path relative to the current flow file.
+fn resolve_node_source(win: &WindowState, source: &str) -> Option<PathBuf> {
+    let base_dir = win.file_path.as_ref()?.parent()?;
+    let candidate = base_dir.join(source);
+    if candidate.exists() {
+        return Some(candidate);
+    }
+    let with_ext = base_dir.join(format!("{source}.toml"));
+    if with_ext.exists() {
+        return Some(with_ext);
+    }
+    // Try as directory/default.toml
+    let dir_default = base_dir.join(source).join("default.toml");
+    if dir_default.exists() {
+        return Some(dir_default);
+    }
+    None
+}
+
+/// Apply an initializer edit to the flow definition and update the node display.
+fn apply_initializer_edit(win: &mut WindowState, editor: &InitializerEditor) {
+    let alias = win
+        .nodes
+        .get(editor.node_index)
+        .map(|n| n.alias.clone())
+        .unwrap_or_default();
+
+    // Capture old state for undo
+    let old_init = win
+        .flow_definition
+        .process_refs
+        .iter()
+        .find(|pr| {
+            let pr_alias = if pr.alias.is_empty() {
+                derive_short_name(&pr.source)
+            } else {
+                pr.alias.to_string()
+            };
+            pr_alias == alias
         })
+        .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
+    let old_display = win
+        .nodes
+        .get(editor.node_index)
+        .and_then(|n| n.initializers.get(&editor.port_name).cloned());
+
+    // Compute new initializer and display
+    let (new_init, new_display) = match editor.init_type.as_str() {
+        "none" => (None, None),
+        "once" | "always" => {
+            let value = serde_json::from_str(&editor.value_text)
+                .unwrap_or_else(|_| serde_json::Value::String(editor.value_text.clone()));
+            let init = if editor.init_type == "once" {
+                InputInitializer::Once(value)
+            } else {
+                InputInitializer::Always(value)
+            };
+            let display = format!("{}: {}", editor.init_type, editor.value_text);
+            (Some(init), Some(display))
+        }
+        _ => return,
+    };
+
+    // Apply to model
+    if let Some(pref) = win.flow_definition.process_refs.iter_mut().find(|pr| {
+        let pr_alias = if pr.alias.is_empty() {
+            derive_short_name(&pr.source)
+        } else {
+            pr.alias.to_string()
+        };
+        pr_alias == alias
+    }) {
+        match &new_init {
+            Some(init) => {
+                pref.initializations
+                    .insert(editor.port_name.clone(), init.clone());
+            }
+            None => {
+                pref.initializations.remove(&editor.port_name);
+            }
+        }
     }
 
-    /// Record an edit action in the history and increment the unsaved edit count.
-    fn record_edit(&mut self, action: EditAction) {
-        self.history.record(action);
-        self.unsaved_edits += 1;
-        self.compiled_manifest = None; // Invalidate compilation on any edit
+    // Apply to display
+    if let Some(node) = win.nodes.get_mut(editor.node_index) {
+        match &new_display {
+            Some(display) => {
+                node.initializers
+                    .insert(editor.port_name.clone(), display.clone());
+            }
+            None => {
+                node.initializers.remove(&editor.port_name);
+            }
+        }
     }
 
-    /// Apply an undo action — reverse the last edit.
-    fn apply_undo(&mut self) {
-        if let Some(action) = self.history.undo() {
-            match action {
-                EditAction::MoveNode {
-                    index,
-                    old_x,
-                    old_y,
-                    ..
-                } => {
-                    if let Some(node) = self.nodes.get_mut(index) {
-                        node.x = old_x;
-                        node.y = old_y;
-                    }
-                    self.status = String::from("Undo: move");
+    win.history.record(EditAction::EditInitializer {
+        node_index: editor.node_index,
+        port_name: editor.port_name.clone(),
+        old_init,
+        old_display,
+        new_init,
+        new_display,
+    });
+    win.unsaved_edits += 1;
+    win.compiled_manifest = None;
+    win.canvas_state.request_redraw();
+    win.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
+}
+
+/// Synchronize the in-memory `FlowDefinition` with the current editor state
+/// so that process references and the flow name are up to date.
+/// Connections are handled separately via `EdgeLayout` during save.
+fn sync_flow_definition(win: &mut WindowState) {
+    // Update or rebuild process_refs from current NodeLayout data
+    let mut new_refs: Vec<ProcessReference> = Vec::with_capacity(win.nodes.len());
+    for node in &win.nodes {
+        // Try to find the original ProcessReference by alias to preserve initializations
+        let original = win
+            .flow_definition
+            .process_refs
+            .iter()
+            .find(|pr| {
+                let alias = if pr.alias.is_empty() {
+                    derive_short_name(&pr.source)
+                } else {
+                    pr.alias.to_string()
+                };
+                alias == node.alias
+            })
+            .cloned();
+
+        let pref = if let Some(mut orig) = original {
+            orig.x = Some(node.x);
+            orig.y = Some(node.y);
+            orig.width = Some(node.width);
+            orig.height = Some(node.height);
+            orig
+        } else {
+            // New node without an original -- build from scratch
+            ProcessReference {
+                alias: node.alias.clone(),
+                source: node.source.clone(),
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(node.x),
+                y: Some(node.y),
+                width: Some(node.width),
+                height: Some(node.height),
+            }
+        };
+        new_refs.push(pref);
+    }
+    win.flow_definition.process_refs = new_refs;
+
+    // Update the flow name
+    win.flow_definition.name = win.flow_name.clone();
+}
+
+/// Apply a redo action -- re-apply the last undone edit.
+fn apply_redo(win: &mut WindowState) {
+    if let Some(action) = win.history.redo() {
+        match action {
+            EditAction::MoveNode {
+                index,
+                new_x,
+                new_y,
+                ..
+            } => {
+                if let Some(node) = win.nodes.get_mut(index) {
+                    node.x = new_x;
+                    node.y = new_y;
                 }
-                EditAction::ResizeNode {
-                    index,
-                    old_x,
-                    old_y,
-                    old_w,
-                    old_h,
-                    ..
-                } => {
-                    if let Some(node) = self.nodes.get_mut(index) {
-                        node.x = old_x;
-                        node.y = old_y;
-                        node.width = old_w;
-                        node.height = old_h;
-                    }
-                    self.status = String::from("Undo: resize");
+                win.status = String::from("Redo: move");
+            }
+            EditAction::ResizeNode {
+                index,
+                new_x,
+                new_y,
+                new_w,
+                new_h,
+                ..
+            } => {
+                if let Some(node) = win.nodes.get_mut(index) {
+                    node.x = new_x;
+                    node.y = new_y;
+                    node.width = new_w;
+                    node.height = new_h;
                 }
-                EditAction::DeleteNode {
-                    index,
-                    node,
-                    removed_edges,
-                } => {
-                    self.nodes.insert(index, node);
-                    self.edges.extend(removed_edges);
-                    self.status = String::from("Undo: delete node");
+                win.status = String::from("Redo: resize");
+            }
+            EditAction::DeleteNode {
+                index,
+                removed_edges,
+                node,
+                ..
+            } => {
+                let alias = node.alias.clone();
+                if index <= win.nodes.len() {
+                    win.nodes.remove(index);
                 }
-                EditAction::CreateConnection { edge } => {
-                    self.edges.retain(|e| {
+                for edge in &removed_edges {
+                    win.edges.retain(|e| {
                         e.from_node != edge.from_node
                             || e.from_port != edge.from_port
                             || e.to_node != edge.to_node
                             || e.to_port != edge.to_port
                     });
-                    self.status = String::from("Undo: create connection");
                 }
-                EditAction::DeleteConnection { index, edge } => {
-                    self.edges.insert(index, edge);
-                    self.status = String::from("Undo: delete connection");
+                let _ = alias; // used for edge cleanup above
+                win.status = String::from("Redo: delete node");
+            }
+            EditAction::CreateConnection { edge } => {
+                win.edges.push(edge);
+                win.status = String::from("Redo: create connection");
+            }
+            EditAction::DeleteConnection { index, .. } => {
+                if index < win.edges.len() {
+                    win.edges.remove(index);
                 }
-                EditAction::EditInitializer {
+                win.status = String::from("Redo: delete connection");
+            }
+            EditAction::EditInitializer {
+                node_index,
+                ref port_name,
+                ref new_init,
+                ref new_display,
+                ..
+            } => {
+                apply_initializer_state(
+                    win,
                     node_index,
-                    ref port_name,
-                    ref old_init,
-                    ref old_display,
-                    ..
-                } => {
-                    self.apply_initializer_state(
-                        node_index,
-                        port_name,
-                        old_init.as_ref(),
-                        old_display.as_ref(),
-                    );
-                    self.status = String::from("Undo: initializer");
-                }
-            }
-            self.canvas_state.request_redraw();
-        }
-    }
-
-    /// Save the current flow to the given path.
-    fn perform_save(&mut self, path: &PathBuf) {
-        self.sync_flow_definition();
-        match save_flow_toml(&self.flow_definition, &self.edges, path) {
-            Ok(()) => {
-                self.unsaved_edits = 0;
-                self.file_path = Some(path.clone());
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    self.status = format!("Saved to {name}");
-                } else {
-                    self.status = String::from("Saved");
-                }
-            }
-            Err(e) => {
-                self.status = format!("Save failed: {e}");
+                    port_name,
+                    new_init.as_ref(),
+                    new_display.as_ref(),
+                );
+                win.status = String::from("Redo: initializer");
             }
         }
+        win.canvas_state.request_redraw();
     }
+}
 
-    /// Prompt the user with a save dialog and save to the chosen path.
-    fn perform_save_as(&mut self) {
-        let dialog = rfd::FileDialog::new()
-            .add_filter("Flow", &["toml"])
-            .set_file_name(format!("{}.toml", self.flow_name));
-        if let Some(path) = dialog.save_file() {
-            self.perform_save(&path);
-        }
-    }
+/// Apply an initializer state to both the model and display.
+fn apply_initializer_state(
+    win: &mut WindowState,
+    node_index: usize,
+    port_name: &str,
+    init: Option<&InputInitializer>,
+    display: Option<&String>,
+) {
+    let alias = win
+        .nodes
+        .get(node_index)
+        .map(|n| n.alias.clone())
+        .unwrap_or_default();
 
-    /// Prompt the user with an open dialog and load the selected flow file.
-    fn perform_open(&mut self) {
-        let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
-        if let Some(path) = dialog.pick_file() {
-            match load_flow(&path) {
-                Ok((name, node_list, edge_list, flow_def)) => {
-                    let nc = node_list.len();
-                    let ec = edge_list.len();
-                    self.flow_name = name;
-                    self.nodes = node_list;
-                    self.edges = edge_list;
-                    self.flow_definition = flow_def;
-                    self.file_path = Some(path);
-                    self.selected_node = None;
-                    self.selected_connection = None;
-                    self.history = EditHistory::default();
-                    self.unsaved_edits = 0;
-                    self.auto_fit_pending = true;
-                    self.auto_fit_enabled = true;
-                    self.canvas_state = FlowCanvasState::default();
-                    self.status = format!("Loaded - {nc} nodes, {ec} connections");
-                }
-                Err(e) => {
-                    self.status = format!("Open failed: {e}");
-                }
-            }
-        }
-    }
-
-    /// Clear the canvas and reset to an empty flow state.
-    fn perform_new(&mut self) {
-        self.flow_name = String::from("(new flow)");
-        self.nodes = Vec::new();
-        self.edges = Vec::new();
-        self.flow_definition = FlowDefinition::default();
-        self.file_path = None;
-        self.selected_node = None;
-        self.selected_connection = None;
-        self.history = EditHistory::default();
-        self.unsaved_edits = 0;
-        self.auto_fit_pending = false;
-        self.auto_fit_enabled = true;
-        self.canvas_state = FlowCanvasState::default();
-        self.status = String::from("New flow");
-    }
-
-    /// Compile the current flow to a manifest.
-    ///
-    /// Writes a temporary copy of the current editor state for the compiler
-    /// to parse — the user's flow definition file is never modified.
-    ///
-    /// Returns the path to the generated manifest on success, or a human-readable
-    /// error message on failure.
-    fn perform_compile(&mut self) -> Result<PathBuf, String> {
-        // New flows must be saved first so the compiler has a real file path
-        if self.file_path.is_none() {
-            self.perform_save_as();
-        }
-        let Some(flow_path) = self.file_path.clone() else {
-            return Err("Flow must be saved before compiling".to_string());
-        };
-
-        // Save any unsaved edits so the file on disk matches the editor state
-        if self.unsaved_edits > 0 {
-            self.perform_save(&flow_path);
-        }
-
-        let flow_path = &flow_path;
-        let abs_path = if flow_path.is_absolute() {
-            flow_path.clone()
+    if let Some(pref) = win.flow_definition.process_refs.iter_mut().find(|pr| {
+        let pr_alias = if pr.alias.is_empty() {
+            derive_short_name(&pr.source)
         } else {
-            std::env::current_dir()
-                .map_err(|e| format!("Could not get current directory: {e}"))?
-                .join(flow_path)
+            pr.alias.to_string()
         };
-
-        let provider = build_meta_provider();
-
-        let url = Url::from_file_path(&abs_path)
-            .map_err(|()| format!("Invalid file path: {}", abs_path.display()))?;
-        let process = flowrclib::compiler::parser::parse(&url, &provider)
-            .map_err(|e| format!("Parse error: {e}"))?;
-        let flow = match process {
-            Process::FlowProcess(f) => f,
-            Process::FunctionProcess(_) => return Err("Not a flow definition".to_string()),
-        };
-
-        let output_dir = abs_path.parent().unwrap_or(Path::new(".")).to_path_buf();
-        let mut source_urls = BTreeMap::<String, Url>::new();
-        let tables = flowrclib::compiler::compile::compile(
-            &flow,
-            &output_dir,
-            false,
-            false,
-            &mut source_urls,
-        )
-        .map_err(|e| e.to_string())?;
-
-        let manifest_path = flowrclib::generator::generate::write_flow_manifest(
-            &flow,
-            false,
-            &output_dir,
-            &tables,
-            source_urls,
-        )
-        .map_err(|e| format!("Manifest error: {e}"))?;
-
-        Ok(manifest_path)
-    }
-
-    /// Add a function from the library panel as a new node on the canvas.
-    ///
-    /// Creates a `NodeLayout` at a default position and a `ProcessReference`
-    /// in the flow definition, and records the action in the edit history.
-    fn add_library_function(&mut self, source: &str, func_name: &str) {
-        // Generate a unique alias: if the name already exists, append a number
-        let alias = generate_unique_alias(func_name, &self.nodes);
-
-        // Place the new node at a default position offset from existing nodes
-        let (x, y) = next_node_position(&self.nodes);
-
-        // Resolve port info from the function definition
-        let (inputs, outputs) = resolve_single_function_ports(source, None);
-
-        let node = NodeLayout {
-            alias: alias.clone(),
-            source: source.to_string(),
-            x,
-            y,
-            width: 180.0,
-            height: 120.0,
-            inputs,
-            outputs,
-            initializers: HashMap::new(),
-        };
-
-        let index = self.nodes.len();
-        self.nodes.push(node.clone());
-
-        // Also add to the flow definition
-        let pref = ProcessReference {
-            alias: alias.clone(),
-            source: source.to_string(),
-            initializations: std::collections::BTreeMap::new(),
-            x: Some(x),
-            y: Some(y),
-            width: Some(180.0),
-            height: Some(120.0),
-        };
-        self.flow_definition.process_refs.push(pref);
-
-        self.record_edit(EditAction::DeleteNode {
-            index,
-            node,
-            removed_edges: Vec::new(),
-        });
-        // Note: We record a DeleteNode so that *undo* removes the added node.
-        // This is intentional: undoing an "add" means deleting what was added.
-
-        self.selected_node = Some(index);
-        self.canvas_state.request_redraw();
-        // Trigger auto-fit if enabled so the new node is visible
-        if self.auto_fit_enabled {
-            self.auto_fit_pending = true;
-        }
-        let nc = self.nodes.len();
-        self.status = format!("Added {alias} from library - {nc} nodes");
-    }
-
-    /// Apply an initializer edit to the flow definition and update the node display.
-    fn apply_initializer_edit(&mut self, editor: &InitializerEditor) {
-        let alias = self
-            .nodes
-            .get(editor.node_index)
-            .map(|n| n.alias.clone())
-            .unwrap_or_default();
-
-        // Capture old state for undo
-        let old_init = self
-            .flow_definition
-            .process_refs
-            .iter()
-            .find(|pr| {
-                let pr_alias = if pr.alias.is_empty() {
-                    derive_short_name(&pr.source)
-                } else {
-                    pr.alias.to_string()
-                };
-                pr_alias == alias
-            })
-            .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
-        let old_display = self
-            .nodes
-            .get(editor.node_index)
-            .and_then(|n| n.initializers.get(&editor.port_name).cloned());
-
-        // Compute new initializer and display
-        let (new_init, new_display) = match editor.init_type.as_str() {
-            "none" => (None, None),
-            "once" | "always" => {
-                let value = serde_json::from_str(&editor.value_text)
-                    .unwrap_or_else(|_| serde_json::Value::String(editor.value_text.clone()));
-                let init = if editor.init_type == "once" {
-                    InputInitializer::Once(value)
-                } else {
-                    InputInitializer::Always(value)
-                };
-                let display = format!("{}: {}", editor.init_type, editor.value_text);
-                (Some(init), Some(display))
+        pr_alias == alias
+    }) {
+        match init {
+            Some(i) => {
+                pref.initializations
+                    .insert(port_name.to_string(), i.clone());
             }
-            _ => return,
-        };
-
-        // Apply to model
-        if let Some(pref) = self.flow_definition.process_refs.iter_mut().find(|pr| {
-            let pr_alias = if pr.alias.is_empty() {
-                derive_short_name(&pr.source)
-            } else {
-                pr.alias.to_string()
-            };
-            pr_alias == alias
-        }) {
-            match &new_init {
-                Some(init) => {
-                    pref.initializations
-                        .insert(editor.port_name.clone(), init.clone());
-                }
-                None => {
-                    pref.initializations.remove(&editor.port_name);
-                }
+            None => {
+                pref.initializations.remove(port_name);
             }
-        }
-
-        // Apply to display
-        if let Some(node) = self.nodes.get_mut(editor.node_index) {
-            match &new_display {
-                Some(display) => {
-                    node.initializers
-                        .insert(editor.port_name.clone(), display.clone());
-                }
-                None => {
-                    node.initializers.remove(&editor.port_name);
-                }
-            }
-        }
-
-        self.history.record(EditAction::EditInitializer {
-            node_index: editor.node_index,
-            port_name: editor.port_name.clone(),
-            old_init,
-            old_display,
-            new_init,
-            new_display,
-        });
-        self.unsaved_edits += 1;
-        self.compiled_manifest = None;
-        self.canvas_state.request_redraw();
-        self.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
-    }
-
-    /// Synchronize the in-memory `FlowDefinition` with the current editor state
-    /// so that process references and the flow name are up to date.
-    /// Connections are handled separately via `EdgeLayout` during save.
-    fn sync_flow_definition(&mut self) {
-        // Update or rebuild process_refs from current NodeLayout data
-        let mut new_refs: Vec<ProcessReference> = Vec::with_capacity(self.nodes.len());
-        for node in &self.nodes {
-            // Try to find the original ProcessReference by alias to preserve initializations
-            let original = self
-                .flow_definition
-                .process_refs
-                .iter()
-                .find(|pr| {
-                    let alias = if pr.alias.is_empty() {
-                        derive_short_name(&pr.source)
-                    } else {
-                        pr.alias.to_string()
-                    };
-                    alias == node.alias
-                })
-                .cloned();
-
-            let pref = if let Some(mut orig) = original {
-                orig.x = Some(node.x);
-                orig.y = Some(node.y);
-                orig.width = Some(node.width);
-                orig.height = Some(node.height);
-                orig
-            } else {
-                // New node without an original -- build from scratch
-                ProcessReference {
-                    alias: node.alias.clone(),
-                    source: node.source.clone(),
-                    initializations: std::collections::BTreeMap::new(),
-                    x: Some(node.x),
-                    y: Some(node.y),
-                    width: Some(node.width),
-                    height: Some(node.height),
-                }
-            };
-            new_refs.push(pref);
-        }
-        self.flow_definition.process_refs = new_refs;
-
-        // Update the flow name
-        self.flow_definition.name = self.flow_name.clone();
-    }
-
-    /// Apply a redo action — re-apply the last undone edit.
-    fn apply_redo(&mut self) {
-        if let Some(action) = self.history.redo() {
-            match action {
-                EditAction::MoveNode {
-                    index,
-                    new_x,
-                    new_y,
-                    ..
-                } => {
-                    if let Some(node) = self.nodes.get_mut(index) {
-                        node.x = new_x;
-                        node.y = new_y;
-                    }
-                    self.status = String::from("Redo: move");
-                }
-                EditAction::ResizeNode {
-                    index,
-                    new_x,
-                    new_y,
-                    new_w,
-                    new_h,
-                    ..
-                } => {
-                    if let Some(node) = self.nodes.get_mut(index) {
-                        node.x = new_x;
-                        node.y = new_y;
-                        node.width = new_w;
-                        node.height = new_h;
-                    }
-                    self.status = String::from("Redo: resize");
-                }
-                EditAction::DeleteNode {
-                    index,
-                    removed_edges,
-                    node,
-                    ..
-                } => {
-                    let alias = node.alias.clone();
-                    if index <= self.nodes.len() {
-                        self.nodes.remove(index);
-                    }
-                    for edge in &removed_edges {
-                        self.edges.retain(|e| {
-                            e.from_node != edge.from_node
-                                || e.from_port != edge.from_port
-                                || e.to_node != edge.to_node
-                                || e.to_port != edge.to_port
-                        });
-                    }
-                    let _ = alias; // used for edge cleanup above
-                    self.status = String::from("Redo: delete node");
-                }
-                EditAction::CreateConnection { edge } => {
-                    self.edges.push(edge);
-                    self.status = String::from("Redo: create connection");
-                }
-                EditAction::DeleteConnection { index, .. } => {
-                    if index < self.edges.len() {
-                        self.edges.remove(index);
-                    }
-                    self.status = String::from("Redo: delete connection");
-                }
-                EditAction::EditInitializer {
-                    node_index,
-                    ref port_name,
-                    ref new_init,
-                    ref new_display,
-                    ..
-                } => {
-                    self.apply_initializer_state(
-                        node_index,
-                        port_name,
-                        new_init.as_ref(),
-                        new_display.as_ref(),
-                    );
-                    self.status = String::from("Redo: initializer");
-                }
-            }
-            self.canvas_state.request_redraw();
         }
     }
 
-    /// Apply an initializer state to both the model and display.
-    fn apply_initializer_state(
-        &mut self,
-        node_index: usize,
-        port_name: &str,
-        init: Option<&InputInitializer>,
-        display: Option<&String>,
-    ) {
-        let alias = self
-            .nodes
-            .get(node_index)
-            .map(|n| n.alias.clone())
-            .unwrap_or_default();
-
-        if let Some(pref) = self.flow_definition.process_refs.iter_mut().find(|pr| {
-            let pr_alias = if pr.alias.is_empty() {
-                derive_short_name(&pr.source)
-            } else {
-                pr.alias.to_string()
-            };
-            pr_alias == alias
-        }) {
-            match init {
-                Some(i) => {
-                    pref.initializations
-                        .insert(port_name.to_string(), i.clone());
-                }
-                None => {
-                    pref.initializations.remove(port_name);
-                }
+    if let Some(node) = win.nodes.get_mut(node_index) {
+        match display {
+            Some(d) => {
+                node.initializers.insert(port_name.to_string(), d.clone());
             }
-        }
-
-        if let Some(node) = self.nodes.get_mut(node_index) {
-            match display {
-                Some(d) => {
-                    node.initializers.insert(port_name.to_string(), d.clone());
-                }
-                None => {
-                    node.initializers.remove(port_name);
-                }
+            None => {
+                node.initializers.remove(port_name);
             }
         }
     }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -105,6 +105,16 @@ enum Message {
     NewSubFlow,
     /// Create a new provided implementation and add it to the current flow
     NewFunction,
+    /// Flow name changed
+    FlowNameChanged(window::Id, String),
+    /// Flow version changed
+    FlowVersionChanged(window::Id, String),
+    /// Flow description changed
+    FlowDescriptionChanged(window::Id, String),
+    /// Flow authors changed
+    FlowAuthorsChanged(window::Id, String),
+    /// Toggle metadata editor visibility
+    ToggleMetadataEditor(window::Id),
     /// Add a flow-level input port
     FlowAddInput(window::Id),
     /// Add a flow-level output port
@@ -205,6 +215,8 @@ struct WindowState {
     flow_outputs: Vec<PortInfo>,
     /// Context menu position (screen coords), if showing
     context_menu: Option<(f32, f32)>,
+    /// Whether the metadata editor is visible
+    show_metadata: bool,
 }
 
 /// Top-level application state
@@ -354,6 +366,7 @@ impl FlowEdit {
             flow_inputs: fi,
             flow_outputs: fo,
             context_menu: None,
+            show_metadata: false,
         };
 
         let mut windows = HashMap::new();
@@ -715,8 +728,41 @@ impl FlowEdit {
                     }
                 }
             }
+            Message::FlowNameChanged(win_id, new_name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_name = new_name.clone();
+                    win.flow_definition.name = new_name;
+                    win.unsaved_edits += 1;
+                }
+            }
+            Message::FlowVersionChanged(win_id, version) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_definition.metadata.version = version;
+                    win.unsaved_edits += 1;
+                }
+            }
+            Message::FlowDescriptionChanged(win_id, desc) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_definition.metadata.description = desc;
+                    win.unsaved_edits += 1;
+                }
+            }
+            Message::FlowAuthorsChanged(win_id, authors_str) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.flow_definition.metadata.authors = authors_str
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    win.unsaved_edits += 1;
+                }
+            }
+            Message::ToggleMetadataEditor(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.show_metadata = !win.show_metadata;
+                }
+            }
             Message::NewSubFlow => {
-                // Dismiss any open context menu
                 for win in self.windows.values_mut() {
                     win.context_menu = None;
                 }
@@ -1017,36 +1063,66 @@ impl FlowEdit {
             )
             .map(move |msg| Message::WindowCanvas(window_id, msg));
 
+        let zoom_btn = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
+                    } else {
+                        Color::from_rgb(0.4, 0.4, 0.45)
+                    },
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        };
+        let zoom_btn_active = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
+                    } else {
+                        Color::from_rgb(0.4, 0.5, 0.7)
+                    },
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        };
         let btn_width = 40;
         let zoom_controls = container(
-            container(
-                Column::new()
-                    .spacing(4)
-                    .push(
-                        button(Text::new("+").center())
-                            .on_press(Message::ZoomIn(window_id))
-                            .width(btn_width)
-                            .style(button::secondary),
-                    )
-                    .push(
-                        button(Text::new("\u{2212}").center())
-                            .on_press(Message::ZoomOut(window_id))
-                            .width(btn_width)
-                            .style(button::secondary),
-                    )
-                    .push(
-                        button(Text::new("Fit").center())
-                            .on_press(Message::ToggleAutoFit(window_id))
-                            .width(btn_width)
-                            .style(if win.auto_fit_enabled {
-                                button::primary
-                            } else {
-                                button::secondary
-                            }),
-                    ),
-            )
-            .padding(6)
-            .style(container::rounded_box),
+            Column::new()
+                .spacing(4)
+                .push(
+                    button(Text::new("+").center())
+                        .on_press(Message::ZoomIn(window_id))
+                        .width(btn_width)
+                        .style(zoom_btn),
+                )
+                .push(
+                    button(Text::new("\u{2212}").center())
+                        .on_press(Message::ZoomOut(window_id))
+                        .width(btn_width)
+                        .style(zoom_btn),
+                )
+                .push(
+                    button(Text::new("Fit").center())
+                        .on_press(Message::ToggleAutoFit(window_id))
+                        .width(btn_width)
+                        .style(if win.auto_fit_enabled {
+                            zoom_btn_active
+                        } else {
+                            zoom_btn
+                        }),
+                ),
         )
         .align_right(Fill)
         .align_bottom(Fill)
@@ -1202,39 +1278,83 @@ impl FlowEdit {
             String::from("  |  saved")
         };
 
-        // Build status bar — compile button only for root windows
+        // Build status bar — action buttons only for root windows
+        let btn_pad = [6, 14];
+        let btn_size = 13;
+        let toolbar_btn = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
+                    } else {
+                        Color::from_rgb(0.4, 0.4, 0.45)
+                    },
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        };
+        let toolbar_btn_active = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
+                    } else {
+                        Color::from_rgb(0.4, 0.5, 0.7)
+                    },
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        };
         let status_bar: Row<'_, Message> = if win.is_root {
-            let mut compile_btn = button(Text::new("\u{1F528} Build").size(14).center())
-                .padding([6, 14])
-                .style(if win.nodes.is_empty() {
-                    button::secondary
-                } else {
-                    button::primary
-                });
+            let mut compile_btn = button(Text::new("\u{1F528} Build").size(btn_size).center())
+                .padding(btn_pad)
+                .style(toolbar_btn);
             if !win.nodes.is_empty() {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
-            let new_subflow_btn = button(Text::new("+ Sub-flow").size(12).center())
+            let new_subflow_btn = button(Text::new("+ Sub-flow").size(btn_size).center())
                 .on_press(Message::NewSubFlow)
-                .style(button::secondary)
-                .padding([4, 10]);
+                .style(toolbar_btn)
+                .padding(btn_pad);
 
-            let new_func_btn = button(Text::new("+ Function").size(12).center())
+            let new_func_btn = button(Text::new("+ Function").size(btn_size).center())
                 .on_press(Message::NewFunction)
-                .style(button::secondary)
-                .padding([4, 10]);
+                .style(toolbar_btn)
+                .padding(btn_pad);
+
+            let info_btn = button(Text::new("\u{2139} Info").size(btn_size).center())
+                .on_press(Message::ToggleMetadataEditor(window_id))
+                .style(if win.show_metadata {
+                    toolbar_btn_active
+                } else {
+                    toolbar_btn
+                })
+                .padding(btn_pad);
 
             Row::new()
                 .spacing(8)
+                .padding([4, 8])
                 .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
                 .push(iced::widget::Space::new().width(Fill))
+                .push(info_btn)
                 .push(new_subflow_btn)
                 .push(new_func_btn)
                 .push(compile_btn)
         } else {
             Row::new()
                 .spacing(8)
+                .padding([4, 8])
                 .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
                 .push(iced::widget::Space::new().width(Fill))
         };
@@ -1244,6 +1364,83 @@ impl FlowEdit {
         // Flow I/O editor panel for sub-flow windows
         if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
             layout = layout.push(self.view_flow_io_panel(window_id, win));
+        }
+
+        // Metadata editor panel (toggled by Info button)
+        if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
+            let authors_str = win.flow_definition.metadata.authors.join(", ");
+            let meta_panel = container(
+                Column::new()
+                    .spacing(6)
+                    .padding(12)
+                    .push(
+                        Row::new()
+                            .spacing(8)
+                            .align_y(iced::Alignment::Center)
+                            .push(Text::new("Name:").size(12).width(70))
+                            .push(
+                                text_input("Flow name", &win.flow_name)
+                                    .on_input(move |s| Message::FlowNameChanged(window_id, s))
+                                    .size(13)
+                                    .padding(4)
+                                    .width(250),
+                            ),
+                    )
+                    .push(
+                        Row::new()
+                            .spacing(8)
+                            .align_y(iced::Alignment::Center)
+                            .push(Text::new("Version:").size(12).width(70))
+                            .push(
+                                text_input("0.1.0", &win.flow_definition.metadata.version)
+                                    .on_input(move |s| Message::FlowVersionChanged(window_id, s))
+                                    .size(13)
+                                    .padding(4)
+                                    .width(120),
+                            ),
+                    )
+                    .push(
+                        Row::new()
+                            .spacing(8)
+                            .align_y(iced::Alignment::Center)
+                            .push(Text::new("Description:").size(12).width(70))
+                            .push(
+                                text_input(
+                                    "A short description",
+                                    &win.flow_definition.metadata.description,
+                                )
+                                .on_input(move |s| Message::FlowDescriptionChanged(window_id, s))
+                                .size(13)
+                                .padding(4)
+                                .width(Fill),
+                            ),
+                    )
+                    .push(
+                        Row::new()
+                            .spacing(8)
+                            .align_y(iced::Alignment::Center)
+                            .push(Text::new("Authors:").size(12).width(70))
+                            .push(
+                                text_input("Name <email>, ...", &authors_str)
+                                    .on_input(move |s| Message::FlowAuthorsChanged(window_id, s))
+                                    .size(13)
+                                    .padding(4)
+                                    .width(Fill),
+                            ),
+                    ),
+            )
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.14, 0.14, 0.18))),
+                border: iced::Border {
+                    color: Color::from_rgb(0.3, 0.3, 0.3),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            })
+            .width(Fill);
+
+            layout = layout.push(meta_panel);
         }
 
         layout = layout.push(container(status_bar).width(Fill).padding(5));
@@ -1706,6 +1903,7 @@ impl FlowEdit {
                     flow_inputs: fi,
                     flow_outputs: fo,
                     context_menu: None,
+                    show_metadata: false,
                 };
                 self.windows.insert(new_id, child);
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -1776,6 +1974,7 @@ impl FlowEdit {
             flow_inputs: Vec::new(),
             flow_outputs: Vec::new(),
             context_menu: None,
+            show_metadata: false,
         };
 
         self.windows.insert(new_id, child);
@@ -1903,6 +2102,7 @@ impl FlowEdit {
             flow_inputs: Vec::new(),
             flow_outputs: Vec::new(),
             context_menu: None,
+            show_metadata: false,
         };
 
         self.windows.insert(new_id, child);
@@ -2022,6 +2222,7 @@ impl FlowEdit {
             flow_inputs: Vec::new(),
             flow_outputs: Vec::new(),
             context_menu: None,
+            show_metadata: false,
         };
 
         self.windows.insert(new_id, child);

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -727,6 +727,7 @@ impl FlowEdit {
                     if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
                         viewer.name = new_name;
                     }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionBrowseSource(win_id) => {
@@ -734,56 +735,48 @@ impl FlowEdit {
                 if let Some(selected) = dialog.pick_file() {
                     if let Some(win) = self.windows.get_mut(&win_id) {
                         if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                            // Make path relative to the TOML directory if possible
                             let base = viewer.toml_path.parent().unwrap_or(Path::new("."));
                             let rel = selected
                                 .strip_prefix(base)
                                 .map(|p| p.to_string_lossy().to_string())
                                 .unwrap_or_else(|_| selected.to_string_lossy().to_string());
                             viewer.source_file = rel;
-                            // Reload the source content
                             viewer.rs_content = std::fs::read_to_string(&selected)
                                 .unwrap_or_else(|_| String::from("// Could not read file"));
                         }
+                        win.unsaved_edits += 1;
                     }
                 }
             }
-            Message::FunctionAddInput(win_id) => {
+            Message::FunctionAddInput(win_id)
+            | Message::FunctionAddOutput(win_id)
+            | Message::FunctionDeleteInput(win_id, _)
+            | Message::FunctionDeleteOutput(win_id, _) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        v.inputs.push(PortInfo {
-                            name: format!("input{}", v.inputs.len()),
-                            datatypes: vec![String::from("string")],
-                        });
-                    }
-                }
-            }
-            Message::FunctionAddOutput(win_id) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        v.outputs.push(PortInfo {
-                            name: format!("output{}", v.outputs.len()),
-                            datatypes: vec![String::from("string")],
-                        });
-                    }
-                }
-            }
-            Message::FunctionDeleteInput(win_id, idx) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if idx < v.inputs.len() {
-                            v.inputs.remove(idx);
+                        match message {
+                            Message::FunctionAddInput(_) => v.inputs.push(PortInfo {
+                                name: format!("input{}", v.inputs.len()),
+                                datatypes: vec![String::from("string")],
+                            }),
+                            Message::FunctionAddOutput(_) => v.outputs.push(PortInfo {
+                                name: format!("output{}", v.outputs.len()),
+                                datatypes: vec![String::from("string")],
+                            }),
+                            Message::FunctionDeleteInput(_, idx) => {
+                                if idx < v.inputs.len() {
+                                    v.inputs.remove(idx);
+                                }
+                            }
+                            Message::FunctionDeleteOutput(_, idx) => {
+                                if idx < v.outputs.len() {
+                                    v.outputs.remove(idx);
+                                }
+                            }
+                            _ => {}
                         }
                     }
-                }
-            }
-            Message::FunctionDeleteOutput(win_id, idx) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if idx < v.outputs.len() {
-                            v.outputs.remove(idx);
-                        }
-                    }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionInputNameChanged(win_id, idx, name) => {
@@ -793,6 +786,7 @@ impl FlowEdit {
                             port.name = name;
                         }
                     }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionInputTypeChanged(win_id, idx, dtype) => {
@@ -802,6 +796,7 @@ impl FlowEdit {
                             port.datatypes = vec![dtype];
                         }
                     }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionOutputNameChanged(win_id, idx, name) => {
@@ -811,6 +806,7 @@ impl FlowEdit {
                             port.name = name;
                         }
                     }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionOutputTypeChanged(win_id, idx, dtype) => {
@@ -820,6 +816,7 @@ impl FlowEdit {
                             port.datatypes = vec![dtype];
                         }
                     }
+                    win.unsaved_edits += 1;
                 }
             }
             Message::FunctionSave(win_id) => {
@@ -828,6 +825,7 @@ impl FlowEdit {
                         match save_function_definition(v) {
                             Ok(()) => {
                                 win.status = format!("Saved: {}", v.toml_path.display());
+                                win.unsaved_edits = 0;
                             }
                             Err(e) => {
                                 win.status = format!("Save failed: {e}");

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -77,10 +77,36 @@ enum Message {
     InitializerApply(window::Id),
     /// Cancel the initializer edit, tagged with the originating window ID
     InitializerCancel(window::Id),
+    /// Switch tab in a function viewer window
+    FunctionTabSelected(window::Id, usize),
+    /// Function name edited
+    FunctionNameChanged(window::Id, String),
+    /// Browse for source file
+    FunctionBrowseSource(window::Id),
+    /// Add a new input port to a function
+    FunctionAddInput(window::Id),
+    /// Add a new output port to a function
+    FunctionAddOutput(window::Id),
+    /// Delete an input port from a function
+    FunctionDeleteInput(window::Id, usize),
+    /// Delete an output port from a function
+    FunctionDeleteOutput(window::Id, usize),
+    /// Input port name changed
+    FunctionInputNameChanged(window::Id, usize, String),
+    /// Input port type changed
+    FunctionInputTypeChanged(window::Id, usize, String),
+    /// Output port name changed
+    FunctionOutputNameChanged(window::Id, usize, String),
+    /// Output port type changed
+    FunctionOutputTypeChanged(window::Id, usize, String),
+    /// Save function definition to disk
+    FunctionSave(window::Id),
     /// A window close was requested
     CloseRequested(window::Id),
     /// Close the currently focused window (Cmd+W)
     CloseActiveWindow,
+    /// Quit the entire application (Cmd+Q)
+    QuitAll,
     /// A window received focus
     WindowFocused(window::Id),
 }
@@ -97,8 +123,28 @@ struct InitializerEditor {
     value_text: String,
 }
 
+/// State for a function definition viewer/editor window.
+struct FunctionViewer {
+    name: String,
+    source_file: String,
+    inputs: Vec<PortInfo>,
+    outputs: Vec<PortInfo>,
+    rs_content: String,
+    docs_content: Option<String>,
+    active_tab: usize,
+    toml_path: PathBuf,
+}
+
+/// What kind of content a window displays.
+enum WindowKind {
+    FlowEditor,
+    FunctionViewer(FunctionViewer),
+}
+
 /// Per-window state for the flow editor.
 struct WindowState {
+    /// What this window displays
+    kind: WindowKind,
     /// The name of the flow being viewed
     flow_name: String,
     /// Positioned nodes derived from the flow's process references
@@ -265,6 +311,7 @@ impl FlowEdit {
 
         let (fi, fo) = extract_ports(&flow_definition.inputs, &flow_definition.outputs);
         let win_state = WindowState {
+            kind: WindowKind::FlowEditor,
             flow_name,
             nodes,
             edges,
@@ -668,6 +715,127 @@ impl FlowEdit {
             Message::WindowFocused(id) => {
                 self.focused_window = Some(id);
             }
+            Message::FunctionTabSelected(win_id, tab) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        viewer.active_tab = tab;
+                    }
+                }
+            }
+            Message::FunctionNameChanged(win_id, new_name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        viewer.name = new_name;
+                    }
+                }
+            }
+            Message::FunctionBrowseSource(win_id) => {
+                let dialog = rfd::FileDialog::new().add_filter("Rust", &["rs"]);
+                if let Some(selected) = dialog.pick_file() {
+                    if let Some(win) = self.windows.get_mut(&win_id) {
+                        if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                            // Make path relative to the TOML directory if possible
+                            let base = viewer.toml_path.parent().unwrap_or(Path::new("."));
+                            let rel = selected
+                                .strip_prefix(base)
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_else(|_| selected.to_string_lossy().to_string());
+                            viewer.source_file = rel;
+                            // Reload the source content
+                            viewer.rs_content = std::fs::read_to_string(&selected)
+                                .unwrap_or_else(|_| String::from("// Could not read file"));
+                        }
+                    }
+                }
+            }
+            Message::FunctionAddInput(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        v.inputs.push(PortInfo {
+                            name: format!("input{}", v.inputs.len()),
+                            datatypes: vec![String::from("string")],
+                        });
+                    }
+                }
+            }
+            Message::FunctionAddOutput(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        v.outputs.push(PortInfo {
+                            name: format!("output{}", v.outputs.len()),
+                            datatypes: vec![String::from("string")],
+                        });
+                    }
+                }
+            }
+            Message::FunctionDeleteInput(win_id, idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if idx < v.inputs.len() {
+                            v.inputs.remove(idx);
+                        }
+                    }
+                }
+            }
+            Message::FunctionDeleteOutput(win_id, idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if idx < v.outputs.len() {
+                            v.outputs.remove(idx);
+                        }
+                    }
+                }
+            }
+            Message::FunctionInputNameChanged(win_id, idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(port) = v.inputs.get_mut(idx) {
+                            port.name = name;
+                        }
+                    }
+                }
+            }
+            Message::FunctionInputTypeChanged(win_id, idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(port) = v.inputs.get_mut(idx) {
+                            port.datatypes = vec![dtype];
+                        }
+                    }
+                }
+            }
+            Message::FunctionOutputNameChanged(win_id, idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(port) = v.outputs.get_mut(idx) {
+                            port.name = name;
+                        }
+                    }
+                }
+            }
+            Message::FunctionOutputTypeChanged(win_id, idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(port) = v.outputs.get_mut(idx) {
+                            port.datatypes = vec![dtype];
+                        }
+                    }
+                }
+            }
+            Message::FunctionSave(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        match save_function_definition(v) {
+                            Ok(()) => {
+                                win.status = format!("Saved: {}", v.toml_path.display());
+                            }
+                            Err(e) => {
+                                win.status = format!("Save failed: {e}");
+                            }
+                        }
+                    }
+                }
+            }
             Message::CloseRequested(id) => {
                 self.windows.remove(&id);
                 if self.root_window == Some(id) || self.windows.is_empty() {
@@ -684,15 +852,34 @@ impl FlowEdit {
                     return window::close(id);
                 }
             }
+            Message::QuitAll => {
+                // Check for unsaved edits in any window
+                let has_unsaved = self.windows.values().any(|w| w.unsaved_edits > 0);
+                if has_unsaved {
+                    let dialog = rfd::MessageDialog::new()
+                        .set_title("Unsaved Changes")
+                        .set_description("There are unsaved changes. Quit without saving?")
+                        .set_buttons(rfd::MessageButtons::YesNo)
+                        .set_level(rfd::MessageLevel::Warning);
+                    if dialog.show() != rfd::MessageDialogResult::Yes {
+                        return Task::none();
+                    }
+                }
+                return iced::exit();
+            }
         }
         Task::none()
     }
 
-    /// Build the view: a canvas area with zoom controls overlaid, and a status bar at the bottom.
+    /// Build the view for a window, dispatching based on window kind.
     fn view(&self, window_id: window::Id) -> Element<'_, Message> {
         let Some(win) = self.windows.get(&window_id) else {
             return Text::new("Window not found").into();
         };
+
+        if let WindowKind::FunctionViewer(ref viewer) = win.kind {
+            return self.view_function(window_id, viewer, &win.status);
+        }
 
         let canvas = win
             .canvas_state
@@ -881,6 +1068,229 @@ impl FlowEdit {
         layout.into()
     }
 
+    fn view_function<'a>(
+        &'a self,
+        window_id: window::Id,
+        viewer: &'a FunctionViewer,
+        status: &'a str,
+    ) -> Element<'a, Message> {
+        let content: Element<'_, Message> = match viewer.active_tab {
+            0 => {
+                let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+                let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+
+                // Input ports inside box: semicircle ◗ (flat left), name, type, delete
+                let mut input_col = Column::new().spacing(6);
+                for (i, port) in viewer.inputs.iter().enumerate() {
+                    let dtype = port.datatypes.first().cloned().unwrap_or_default();
+                    let row = Row::new()
+                        .spacing(4)
+                        .align_y(iced::Alignment::Center)
+                        .push(Text::new("\u{25D7}").size(24).color(input_color))
+                        .push(
+                            text_input("name", &port.name)
+                                .on_input(move |s| {
+                                    Message::FunctionInputNameChanged(window_id, i, s)
+                                })
+                                .size(13)
+                                .padding(3)
+                                .width(90),
+                        )
+                        .push(
+                            text_input("type", &dtype)
+                                .on_input(move |s| {
+                                    Message::FunctionInputTypeChanged(window_id, i, s)
+                                })
+                                .size(11)
+                                .padding(3)
+                                .width(75),
+                        )
+                        .push(
+                            button(Text::new("\u{2715}").size(10).center())
+                                .on_press(Message::FunctionDeleteInput(window_id, i))
+                                .style(button::danger)
+                                .padding([2, 5]),
+                        );
+                    input_col = input_col.push(row);
+                }
+                input_col = input_col.push(
+                    button(Text::new("+").size(14).center())
+                        .on_press(Message::FunctionAddInput(window_id))
+                        .style(button::secondary)
+                        .padding([2, 10]),
+                );
+
+                // Output ports inside box: delete, type, name, semicircle ◖ (flat right)
+                let mut output_col = Column::new().spacing(6).align_x(iced::Alignment::End);
+                for (i, port) in viewer.outputs.iter().enumerate() {
+                    let dtype = port.datatypes.first().cloned().unwrap_or_default();
+                    let row = Row::new()
+                        .spacing(4)
+                        .align_y(iced::Alignment::Center)
+                        .push(
+                            button(Text::new("\u{2715}").size(10).center())
+                                .on_press(Message::FunctionDeleteOutput(window_id, i))
+                                .style(button::danger)
+                                .padding([2, 5]),
+                        )
+                        .push(
+                            text_input("type", &dtype)
+                                .on_input(move |s| {
+                                    Message::FunctionOutputTypeChanged(window_id, i, s)
+                                })
+                                .size(11)
+                                .padding(3)
+                                .width(75),
+                        )
+                        .push(
+                            text_input("name", &port.name)
+                                .on_input(move |s| {
+                                    Message::FunctionOutputNameChanged(window_id, i, s)
+                                })
+                                .size(13)
+                                .padding(3)
+                                .width(90),
+                        )
+                        .push(Text::new("\u{25D6}").size(24).color(output_color));
+                    output_col = output_col.push(row);
+                }
+                output_col = output_col.push(
+                    button(Text::new("+").size(14).center())
+                        .on_press(Message::FunctionAddOutput(window_id))
+                        .style(button::secondary)
+                        .padding([2, 10]),
+                );
+
+                let name_input = container(
+                    text_input("Function name", &viewer.name)
+                        .on_input(move |s| Message::FunctionNameChanged(window_id, s))
+                        .size(16)
+                        .padding(6)
+                        .width(250),
+                )
+                .center_x(Fill);
+
+                let mut source_row = Row::new()
+                    .spacing(6)
+                    .align_y(iced::Alignment::Center)
+                    .push(
+                        button(
+                            Text::new(&viewer.source_file)
+                                .size(13)
+                                .color(Color::from_rgb(0.6, 0.8, 1.0)),
+                        )
+                        .on_press(Message::FunctionTabSelected(window_id, 1))
+                        .style(button::text)
+                        .padding(0),
+                    )
+                    .push(
+                        button(Text::new("...").size(12).center())
+                            .on_press(Message::FunctionBrowseSource(window_id))
+                            .style(button::secondary)
+                            .padding([3, 8]),
+                    );
+                if viewer.docs_content.is_some() {
+                    source_row = source_row.push(
+                        button(Text::new("Docs").size(12).center())
+                            .on_press(Message::FunctionTabSelected(window_id, 2))
+                            .style(button::secondary)
+                            .padding([3, 8]),
+                    );
+                }
+
+                let func_box = container(
+                    Column::new()
+                        .spacing(20)
+                        .padding(iced::Padding {
+                            top: 24.0,
+                            bottom: 24.0,
+                            left: 0.0,
+                            right: 0.0,
+                        })
+                        .push(name_input)
+                        .push(
+                            Row::new()
+                                .push(input_col)
+                                .push(iced::widget::Space::new().width(Fill))
+                                .push(output_col),
+                        )
+                        .push(container(source_row).center_x(Fill)),
+                )
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
+                    border: iced::Border {
+                        color: Color::from_rgb(0.5, 0.3, 0.7),
+                        width: 2.0,
+                        radius: 12.0.into(),
+                    },
+                    ..Default::default()
+                })
+                .width(550);
+
+                container(func_box).center(Fill).padding(40).into()
+            }
+            1 => {
+                let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
+                    .on_press(Message::FunctionTabSelected(window_id, 0))
+                    .style(button::secondary)
+                    .padding([6, 14]);
+                Column::new()
+                    .push(container(back_btn).padding([8, 12]))
+                    .push(
+                        container(
+                            iced::widget::scrollable(
+                                Text::new(&viewer.rs_content)
+                                    .size(14)
+                                    .font(iced::Font::MONOSPACE),
+                            )
+                            .width(Fill)
+                            .height(Fill),
+                        )
+                        .width(Fill)
+                        .height(Fill)
+                        .padding(12),
+                    )
+                    .into()
+            }
+            _ => {
+                let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
+                    .on_press(Message::FunctionTabSelected(window_id, 0))
+                    .style(button::secondary)
+                    .padding([6, 14]);
+                let docs = viewer.docs_content.as_deref().unwrap_or("");
+                Column::new()
+                    .push(container(back_btn).padding([8, 12]))
+                    .push(
+                        container(
+                            iced::widget::scrollable(Text::new(docs).size(14))
+                                .width(Fill)
+                                .height(Fill),
+                        )
+                        .width(Fill)
+                        .height(Fill)
+                        .padding(12),
+                    )
+                    .into()
+            }
+        };
+
+        let save_btn = button(Text::new("\u{1F4BE} Save").size(14).center())
+            .on_press(Message::FunctionSave(window_id))
+            .style(button::primary)
+            .padding([6, 14]);
+
+        let status_bar = Row::new()
+            .spacing(8)
+            .push(Text::new(status).size(14))
+            .push(iced::widget::Space::new().width(Fill))
+            .push(save_btn);
+
+        Column::new()
+            .push(container(content).width(Fill).height(Fill))
+            .push(container(status_bar).width(Fill).padding(5))
+            .into()
+    }
+
     fn subscription(&self) -> Subscription<Message> {
         let keyboard_sub = keyboard::listen().filter_map(|event| match event {
             keyboard::Event::KeyPressed {
@@ -896,6 +1306,7 @@ impl FlowEdit {
                 "n" => Some(Message::New),
                 "b" => Some(Message::Compile),
                 "w" => Some(Message::CloseActiveWindow),
+                "q" => Some(Message::QuitAll),
                 _ => None,
             },
             _ => None,
@@ -945,17 +1356,17 @@ impl FlowEdit {
         }
 
         // Check whether the resolved file is a flow or a function
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(url) = Url::from_file_path(&path) {
+        let abs_path = match std::fs::canonicalize(&path) {
+            Ok(p) => p,
+            Err(_) => path.clone(),
+        };
+        if let Ok(contents) = std::fs::read_to_string(&abs_path) {
+            if let Ok(url) = Url::from_file_path(&abs_path) {
                 if let Ok(deserializer) = get::<Process>(&url) {
-                    if let Ok(Process::FunctionProcess(_)) =
+                    if let Ok(Process::FunctionProcess(ref func)) =
                         deserializer.deserialize(&contents, Some(&url))
                     {
-                        if let Some(win) = self.windows.get_mut(&parent_win_id) {
-                            win.status =
-                                format!("'{}' is a function -- viewer not yet implemented", source);
-                        }
-                        return Task::none();
+                        return self.open_function_viewer(parent_win_id, &path, func);
                     }
                 }
             }
@@ -965,19 +1376,15 @@ impl FlowEdit {
         match load_flow(&path) {
             Ok((name, nodes, edges, flow_def)) => {
                 let has_nodes = !nodes.is_empty();
-                let cascade = self.windows.len() as f32;
                 let (new_id, open_task) = window::open(window::Settings {
                     size: iced::Size::new(1024.0, 768.0),
-                    position: window::Position::Specific(iced::Point::new(
-                        80.0 + cascade * 30.0,
-                        60.0 + cascade * 30.0,
-                    )),
                     ..Default::default()
                 });
                 let nc = nodes.len();
                 let ec = edges.len();
                 let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
                 let child = WindowState {
+                    kind: WindowKind::FlowEditor,
                     flow_name: name,
                     nodes,
                     edges,
@@ -1011,6 +1418,68 @@ impl FlowEdit {
                 Task::none()
             }
         }
+    }
+
+    fn open_function_viewer(
+        &mut self,
+        parent_win_id: window::Id,
+        toml_path: &Path,
+        func: &flowcore::model::function_definition::FunctionDefinition,
+    ) -> Task<Message> {
+        let dir = toml_path.parent().unwrap_or(Path::new("."));
+        let func_name = &func.name;
+
+        let rs_path = dir.join(&func.source);
+        let rs_content = std::fs::read_to_string(&rs_path)
+            .unwrap_or_else(|_| String::from("// Source file not found"));
+        let docs_content = std::fs::read_to_string(dir.join(format!("{func_name}.md"))).ok();
+
+        let (inputs, outputs) = extract_ports(&func.inputs, &func.outputs);
+
+        let (new_id, open_task) = window::open(window::Settings {
+            size: iced::Size::new(700.0, 500.0),
+            ..Default::default()
+        });
+
+        let viewer = FunctionViewer {
+            name: func_name.clone(),
+            source_file: func.source.clone(),
+            inputs,
+            outputs,
+            rs_content,
+            docs_content,
+            active_tab: 0,
+            toml_path: toml_path.to_path_buf(),
+        };
+
+        let child = WindowState {
+            kind: WindowKind::FunctionViewer(viewer),
+            flow_name: func_name.clone(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            canvas_state: FlowCanvasState::default(),
+            status: format!("Function: {func_name}"),
+            selected_node: None,
+            selected_connection: None,
+            history: EditHistory::default(),
+            auto_fit_pending: false,
+            auto_fit_enabled: false,
+            unsaved_edits: 0,
+            compiled_manifest: None,
+            file_path: Some(toml_path.to_path_buf()),
+            flow_definition: FlowDefinition::default(),
+            tooltip: None,
+            initializer_editor: None,
+            is_root: false,
+            flow_inputs: Vec::new(),
+            flow_outputs: Vec::new(),
+        };
+
+        self.windows.insert(new_id, child);
+        if let Some(win) = self.windows.get_mut(&parent_win_id) {
+            win.status = format!("Opened function: {func_name}");
+        }
+        open_task.discard()
     }
 }
 
@@ -1938,4 +2407,98 @@ fn format_endpoint(node: &str, port: &str) -> String {
     } else {
         format!("{node}/{port}")
     }
+}
+
+fn save_function_definition(viewer: &FunctionViewer) -> Result<(), String> {
+    let dir = viewer
+        .toml_path
+        .parent()
+        .ok_or_else(|| "Invalid path".to_string())?;
+    std::fs::create_dir_all(dir).map_err(|e| format!("Could not create directory: {e}"))?;
+
+    // 1. Write the function definition TOML
+    let mut toml = format!(
+        "function = \"{}\"\nsource = \"{}\"\ntype = \"rust\"\n",
+        viewer.name, viewer.source_file
+    );
+    for input in &viewer.inputs {
+        let dtype = input.datatypes.first().map_or("", String::as_str);
+        if input.name.is_empty() || input.name == "input" || input.name == "name" {
+            toml.push_str(&format!("\n[[input]]\ntype = \"{dtype}\"\n"));
+        } else {
+            toml.push_str(&format!(
+                "\n[[input]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
+                input.name
+            ));
+        }
+    }
+    for output in &viewer.outputs {
+        let dtype = output.datatypes.first().map_or("", String::as_str);
+        if output.name.is_empty() || output.name == "output" || output.name == "name" {
+            toml.push_str(&format!("\n[[output]]\ntype = \"{dtype}\"\n"));
+        } else {
+            toml.push_str(&format!(
+                "\n[[output]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
+                output.name
+            ));
+        }
+    }
+    std::fs::write(&viewer.toml_path, &toml)
+        .map_err(|e| format!("Could not write {}: {e}", viewer.toml_path.display()))?;
+
+    // 2. Generate skeleton .rs if it doesn't exist
+    let rs_path = dir.join(&viewer.source_file);
+    if !rs_path.exists() {
+        let input_count = viewer.inputs.len();
+        let skeleton = format!(
+            "use flowcore::{{RUN_AGAIN, RunAgain}};\n\
+             use flowcore::errors::*;\n\
+             use flowmacro::flow_function;\n\
+             use serde_json::Value;\n\
+             \n\
+             #[flow_function]\n\
+             fn _{name}(inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {{\n\
+             {input_bindings}\
+             \n    // TODO: implement function logic\n\
+             \n    Ok((None, RUN_AGAIN))\n\
+             }}\n",
+            name = viewer.name,
+            input_bindings = (0..input_count)
+                .map(|i| format!("    let _input{i} = &inputs[{i}];\n"))
+                .collect::<String>(),
+        );
+        std::fs::write(&rs_path, &skeleton)
+            .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))?;
+    }
+
+    // 3. Generate function.toml (Cargo manifest) if it doesn't exist
+    let cargo_path = dir.join("function.toml");
+    if !cargo_path.exists() {
+        let stem = viewer
+            .source_file
+            .strip_suffix(".rs")
+            .unwrap_or(&viewer.source_file);
+        let cargo = format!(
+            "[package]\n\
+             name = \"{name}\"\n\
+             version = \"0.1.0\"\n\
+             edition = \"2021\"\n\
+             \n\
+             [lib]\n\
+             name = \"{name}\"\n\
+             crate-type = [\"cdylib\"]\n\
+             path = \"{source}\"\n\
+             \n\
+             [dependencies]\n\
+             flowcore = {{version = \"0\"}}\n\
+             flowmacro = {{version = \"0\"}}\n\
+             serde_json = {{version = \"1.0\", default-features = false}}\n",
+            name = viewer.name,
+            source = stem,
+        );
+        std::fs::write(&cargo_path, &cargo)
+            .map_err(|e| format!("Could not write {}: {e}", cargo_path.display()))?;
+    }
+
+    Ok(())
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -79,6 +79,8 @@ enum Message {
     InitializerCancel(window::Id),
     /// A window close was requested
     CloseRequested(window::Id),
+    /// Close the currently focused window (Cmd+W)
+    CloseActiveWindow,
     /// A window received focus
     WindowFocused(window::Id),
 }
@@ -131,6 +133,10 @@ struct WindowState {
     initializer_editor: Option<InitializerEditor>,
     /// Whether this is the root (main) window
     is_root: bool,
+    /// Flow-level input ports (for sub-flow display)
+    flow_inputs: Vec<PortInfo>,
+    /// Flow-level output ports (for sub-flow display)
+    flow_outputs: Vec<PortInfo>,
 }
 
 /// Top-level application state
@@ -257,6 +263,7 @@ impl FlowEdit {
             ..Default::default()
         });
 
+        let (fi, fo) = extract_ports(&flow_definition.inputs, &flow_definition.outputs);
         let win_state = WindowState {
             flow_name,
             nodes,
@@ -275,6 +282,8 @@ impl FlowEdit {
             tooltip: None,
             initializer_editor: None,
             is_root: true,
+            flow_inputs: fi,
+            flow_outputs: fo,
         };
 
         let mut windows = HashMap::new();
@@ -475,7 +484,9 @@ impl FlowEdit {
                     }
                     CanvasMessage::AutoFitViewport(viewport) => {
                         if win.auto_fit_enabled || win.auto_fit_pending {
-                            win.canvas_state.auto_fit(&win.nodes, viewport);
+                            let has_flow_io =
+                                !win.flow_inputs.is_empty() || !win.flow_outputs.is_empty();
+                            win.canvas_state.auto_fit(&win.nodes, has_flow_io, viewport);
                             win.auto_fit_pending = false;
                         }
                     }
@@ -658,13 +669,20 @@ impl FlowEdit {
                 self.focused_window = Some(id);
             }
             Message::CloseRequested(id) => {
-                // Check if this is the root window
-                if self.root_window == Some(id) {
+                self.windows.remove(&id);
+                if self.root_window == Some(id) || self.windows.is_empty() {
                     return iced::exit();
                 }
-                // Otherwise, close the child window and remove its state
-                self.windows.remove(&id);
                 return window::close(id);
+            }
+            Message::CloseActiveWindow => {
+                if let Some(id) = self.focused_window.or(self.root_window) {
+                    self.windows.remove(&id);
+                    if self.root_window == Some(id) || self.windows.is_empty() {
+                        return iced::exit();
+                    }
+                    return window::close(id);
+                }
             }
         }
         Task::none()
@@ -681,6 +699,8 @@ impl FlowEdit {
             .view(
                 &win.nodes,
                 &win.edges,
+                &win.flow_inputs,
+                &win.flow_outputs,
                 win.auto_fit_pending,
                 win.auto_fit_enabled,
             )
@@ -832,9 +852,13 @@ impl FlowEdit {
 
         // Build status bar — compile button only for root windows
         let status_bar: Row<'_, Message> = if win.is_root {
-            let mut compile_btn = button(Text::new("Compile").size(12).center())
-                .style(button::secondary)
-                .padding(4);
+            let mut compile_btn = button(Text::new("\u{1F528} Build").size(14).center())
+                .padding([6, 14])
+                .style(if win.nodes.is_empty() {
+                    button::secondary
+                } else {
+                    button::primary
+                });
             if !win.nodes.is_empty() {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
@@ -871,6 +895,7 @@ impl FlowEdit {
                 "o" => Some(Message::Open),
                 "n" => Some(Message::New),
                 "b" => Some(Message::Compile),
+                "w" => Some(Message::CloseActiveWindow),
                 _ => None,
             },
             _ => None,
@@ -912,6 +937,13 @@ impl FlowEdit {
             return Task::none();
         };
 
+        // If a window already has this file open, focus it instead of opening a duplicate
+        for (&win_id, win) in &self.windows {
+            if win.file_path.as_ref() == Some(&path) && win_id != parent_win_id {
+                return window::gain_focus(win_id);
+            }
+        }
+
         // Check whether the resolved file is a flow or a function
         if let Ok(contents) = std::fs::read_to_string(&path) {
             if let Ok(url) = Url::from_file_path(&path) {
@@ -933,12 +965,18 @@ impl FlowEdit {
         match load_flow(&path) {
             Ok((name, nodes, edges, flow_def)) => {
                 let has_nodes = !nodes.is_empty();
+                let cascade = self.windows.len() as f32;
                 let (new_id, open_task) = window::open(window::Settings {
                     size: iced::Size::new(1024.0, 768.0),
+                    position: window::Position::Specific(iced::Point::new(
+                        80.0 + cascade * 30.0,
+                        60.0 + cascade * 30.0,
+                    )),
                     ..Default::default()
                 });
                 let nc = nodes.len();
                 let ec = edges.len();
+                let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
                 let child = WindowState {
                     flow_name: name,
                     nodes,
@@ -957,6 +995,8 @@ impl FlowEdit {
                     tooltip: None,
                     initializer_editor: None,
                     is_root: false,
+                    flow_inputs: fi,
+                    flow_outputs: fo,
                 };
                 self.windows.insert(new_id, child);
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -1093,11 +1133,14 @@ fn perform_open(win: &mut WindowState) {
             Ok((name, node_list, edge_list, flow_def)) => {
                 let nc = node_list.len();
                 let ec = edge_list.len();
+                let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
                 win.flow_name = name;
                 win.nodes = node_list;
                 win.edges = edge_list;
                 win.flow_definition = flow_def;
                 win.file_path = Some(path);
+                win.flow_inputs = fi;
+                win.flow_outputs = fo;
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.history = EditHistory::default();
@@ -1121,6 +1164,8 @@ fn perform_new(win: &mut WindowState) {
     win.edges = Vec::new();
     win.flow_definition = FlowDefinition::default();
     win.file_path = None;
+    win.flow_inputs = Vec::new();
+    win.flow_outputs = Vec::new();
     win.selected_node = None;
     win.selected_connection = None;
     win.history = EditHistory::default();


### PR DESCRIPTION
## Summary
- Refactor from `iced::application` to `iced::daemon` for multi-window support
- Click pencil icon on sub-flow nodes to open them in new in-process windows
- Sub-flow windows show bounding box with flow I/O ports and bezier connections to internal nodes
- Click pencil icon on provided implementations to open graphical function definition editor
- Function editor: editable name, input/output ports (add/edit/delete), source file link, Save generates .toml + skeleton .rs + function.toml
- Cmd+W closes focused window, Cmd+Q quits all with unsaved changes prompt
- Window focus tracking for correct keyboard shortcut routing
- All warnings fixed, zero clippy warnings

## Test plan
- [ ] Open `mandlebrot/root.toml`, click pencil on `generate_pixels` — sub-flow opens with bounding box, I/O ports, connections
- [ ] Click pencil on already-open sub-flow — focuses existing window instead of duplicate
- [ ] Open `reverse-echo/root.toml`, click pencil on `reverse` — function editor opens with inputs/outputs
- [ ] Edit function name, add/delete ports, click Save — files written to disk
- [ ] Cmd+W closes child window, root stays open
- [ ] Cmd+Q prompts for unsaved changes, exits all
- [ ] Close root window exits entire application
- [ ] `fibonacci/root.toml` — lib:// and context:// nodes have no pencil icon
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pencil/open icons to open/edit nested sub-flows and provided functions in separate windows; canvas shows flow-level inputs/outputs, on-node edit icon, and right-click context menu on empty canvas.
  * Multi-window editor and flow-hierarchy navigator with double-click editing/read-only library nodes.
  * CLI options to load/compile/run flows.

* **Documentation**
  * Step-by-step nested flow/function editing, build/compile workflow, multi-window usage, port initializer editing, and keyboard shortcuts.

* **Tests**
  * Automated UI tests and ensured generated implementation skeletons compile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->