### PR TITLE
flowedit: Phase 7 — hierarchy panel, window fixes, polish

### DIFF
--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -421,8 +421,6 @@ correctly. Provided implementation skeletons compile.
   from unnamed output ports). Consider alternative approaches: distance-to-curve
   calculation, wider hit zones, or rendering connections to an off-screen buffer
   for pixel-precise hit testing.
-- Canvas scroll bars: add visible horizontal and vertical scroll bars to the
-  main editing canvas (in addition to the existing mouse-wheel/middle-button pan)
 - Revisit hover tooltip: improve positioning (track cursor more closely), ensure
   text size matches the source label, and extend to show port data types on hover
 - Port inset so semi-circles sit inside the box border without breaking connection

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -448,6 +448,11 @@ correctly. Provided implementation skeletons compile.
   child sub-flows and functions as children, recursively. Double-click to open
   an editing window for that node. For library-defined functions/flows (lib://),
   open a read-only view window similar to the existing editor windows.
+- Library function/flow viewer and editor: right-click (or view icon) on a
+  library function in the Process Library panel to view its definition, source,
+  and docs. Extend to full editing for library authoring — edit function/flow
+  definitions, inputs/outputs, source files, and save changes back to the
+  library directory.
 - Automated UI testing for interactive features described in the user manual
 
 ## 9. Key Design Decisions

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -421,9 +421,6 @@ correctly. Provided implementation skeletons compile.
   from unnamed output ports). Consider alternative approaches: distance-to-curve
   calculation, wider hit zones, or rendering connections to an off-screen buffer
   for pixel-precise hit testing.
-- Root flow background: draw the canvas background as a slightly different color
-  with a rounded border to visually suggest the root flow is itself a process,
-  just the one where we start viewing/editing
 - Canvas scroll bars: add visible horizontal and vertical scroll bars to the
   main editing canvas (in addition to the existing mouse-wheel/middle-button pan)
 - Revisit hover tooltip: improve positioning (track cursor more closely), ensure

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -434,10 +434,6 @@ correctly. Provided implementation skeletons compile.
   optional x, y, width, height fields on the root flow metadata) so the window
   reopens at the same position when editing is resumed
 - Prompt to save on window close (Cmd+Q or close button) when there are unsaved edits
-- Fix alias-vs-connection-route key mismatch: when a ProcessReference has no explicit
-  alias, the display alias is derived from the source URL, but connection routes may
-  use a different name. Need to align alias resolution with flowc's logic so port
-  lookups and connection drawing always match.
 - Add UI dialog to add custom library search paths or specific libraries at runtime
   (the `-L` CLI flag already supports this at startup, but there is no in-app way
   to add paths during an editing session)

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -441,8 +441,6 @@ correctly. Provided implementation skeletons compile.
 - Add UI dialog to add custom library search paths or specific libraries at runtime
   (the `-L` CLI flag already supports this at startup, but there is no in-app way
   to add paths during an editing session)
-- Implement CLI options for loading, compiling and running a flow compatible with
-  flowrgui, to enable using the same automated tests for both editors
 - Flow hierarchy navigator panel: add a collapsible tree view above the Process
   Library panel showing the structure of the loaded flow — root flow at the top,
   child sub-flows and functions as children, recursively. Double-click to open
@@ -454,6 +452,11 @@ correctly. Provided implementation skeletons compile.
   definitions, inputs/outputs, source files, and save changes back to the
   library directory.
 - Automated UI testing for interactive features described in the user manual
+- Implement flow execution (Run button) — requires in-process coordinator
+  and context functions, similar to flowrgui's execution pipeline
+- Implement CLI options for loading, compiling and running a flow compatible
+  with flowrgui, to enable using the same automated tests for both editors
+  (depends on flow execution being implemented first)
 
 ## 9. Key Design Decisions
 

--- a/docs/design/2026-04-17-flowedit-analysis.md
+++ b/docs/design/2026-04-17-flowedit-analysis.md
@@ -432,12 +432,7 @@ correctly. Provided implementation skeletons compile.
 - Add UI dialog to add custom library search paths or specific libraries at runtime
   (the `-L` CLI flag already supports this at startup, but there is no in-app way
   to add paths during an editing session)
-- Flow hierarchy navigator panel: add a collapsible tree view above the Process
-  Library panel showing the structure of the loaded flow — root flow at the top,
-  child sub-flows and functions as children, recursively. Double-click to open
-  an editing window for that node. For library-defined functions/flows (lib://),
-  open a read-only view window similar to the existing editor windows.
-- Library function/flow viewer and editor: right-click (or view icon) on a
+- Library function/flow editor: extend editing for library authoring — edit function/flow
   library function in the Process Library panel to view its definition, source,
   and docs. Extend to full editing for library authoring — edit function/flow
   definitions, inputs/outputs, source files, and save changes back to the

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -1981,8 +1981,8 @@ fn draw_flow_io_ports(
             builder.arc(canvas::path::Arc {
                 center: screen_pos,
                 radius: scaled_r,
-                start_angle: (PI / 2.0).into(),
-                end_angle: (3.0 * PI / 2.0).into(),
+                start_angle: (-PI / 2.0).into(),
+                end_angle: (PI / 2.0).into(),
             });
             builder.close();
         });
@@ -2016,8 +2016,8 @@ fn draw_flow_io_ports(
             builder.arc(canvas::path::Arc {
                 center: screen_pos,
                 radius: scaled_r,
-                start_angle: (-PI / 2.0).into(),
-                end_angle: (PI / 2.0).into(),
+                start_angle: (PI / 2.0).into(),
+                end_angle: (3.0 * PI / 2.0).into(),
             });
             builder.close();
         });

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -624,6 +624,7 @@ impl FlowCanvasState {
         &'a self,
         nodes: &'a [NodeLayout],
         edges: &'a [EdgeLayout],
+        flow_name: &'a str,
         flow_inputs: &'a [PortInfo],
         flow_outputs: &'a [PortInfo],
         is_subflow: bool,
@@ -634,6 +635,7 @@ impl FlowCanvasState {
             state: self,
             nodes,
             edges,
+            flow_name,
             flow_inputs,
             flow_outputs,
             is_subflow,
@@ -756,6 +758,8 @@ struct FlowCanvas<'a> {
     nodes: &'a [NodeLayout],
     /// Edges to render
     edges: &'a [EdgeLayout],
+    /// Flow name (displayed on sub-flow bounding box)
+    flow_name: &'a str,
     /// Flow-level input ports (displayed on left edge for sub-flows)
     flow_inputs: &'a [PortInfo],
     /// Flow-level output ports (displayed on right edge for sub-flows)
@@ -1500,6 +1504,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             draw_nodes(frame, self.nodes, zoom, offset);
             draw_flow_io_ports(
                 frame,
+                self.flow_name,
                 self.flow_inputs,
                 self.flow_outputs,
                 self.nodes,
@@ -1891,6 +1896,7 @@ fn draw_nodes(frame: &mut Frame, nodes: &[NodeLayout], zoom: f32, offset: Point)
 #[allow(clippy::too_many_arguments)]
 fn draw_flow_io_ports(
     frame: &mut Frame,
+    flow_name: &str,
     flow_inputs: &[PortInfo],
     flow_outputs: &[PortInfo],
     nodes: &[NodeLayout],
@@ -1942,6 +1948,19 @@ fn draw_flow_io_ports(
             .with_width(2.0)
             .with_color(Color::from_rgba(0.6, 0.6, 0.6, 0.5)),
     );
+
+    // Draw flow name at top center of the bounding box
+    if !flow_name.is_empty() {
+        let name_pos = transform_point(Point::new(box_x + box_w / 2.0, box_y + 8.0), zoom, offset);
+        frame.fill_text(CanvasText {
+            content: flow_name.to_string(),
+            position: name_pos,
+            color: Color::from_rgb(0.9, 0.6, 0.2),
+            size: (16.0 * zoom).into(),
+            align_x: iced::alignment::Horizontal::Center.into(),
+            ..CanvasText::default()
+        });
+    }
 
     let center_y = (min_y + max_y) / 2.0;
     let input_color = Color::from_rgb(0.4, 0.8, 1.0);

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -1,0 +1,298 @@
+//! Flow hierarchy panel that shows the structure of the loaded flow
+//! as a collapsible tree view. The root flow is at the top, with child
+//! sub-flows and functions as children, recursively.
+
+use std::path::{Path, PathBuf};
+
+use iced::widget::{button, container, scrollable, text, Column, Row};
+use iced::{Color, Element, Length};
+
+use flowcore::deserializers::deserializer::get;
+use flowcore::model::process::Process;
+
+const PANEL_WIDTH: f32 = 220.0;
+
+#[derive(Debug, Clone)]
+pub(crate) enum HierarchyMessage {
+    Toggle(Vec<usize>),
+    Open(String, PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum NodeKind {
+    Flow,
+    Function,
+    Library,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HierarchyNode {
+    pub name: String,
+    pub kind: NodeKind,
+    pub source: String,
+    pub path: Option<PathBuf>,
+    pub children: Vec<HierarchyNode>,
+    pub expanded: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FlowHierarchy {
+    pub root: Option<HierarchyNode>,
+}
+
+impl FlowHierarchy {
+    pub(crate) fn build(flow_path: &Path) -> Self {
+        let root = build_node_from_path(flow_path, 0);
+        Self { root }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self { root: None }
+    }
+
+    pub(crate) fn update(&mut self, msg: &HierarchyMessage) -> Option<(String, PathBuf)> {
+        match msg {
+            HierarchyMessage::Toggle(indices) => {
+                if let Some(ref mut root) = self.root {
+                    toggle_at(root, indices, 0);
+                }
+                None
+            }
+            HierarchyMessage::Open(source, path) => Some((source.clone(), path.clone())),
+        }
+    }
+
+    pub(crate) fn view(&self) -> Element<'_, HierarchyMessage> {
+        let mut col = Column::new().spacing(2).push(
+            container(text("Flow Hierarchy").size(14))
+                .padding([6, 8])
+                .width(Length::Fill),
+        );
+
+        if let Some(ref root) = self.root {
+            col = col.push(view_node(root, &[]));
+        }
+
+        container(scrollable(col).height(Length::Fill))
+            .width(PANEL_WIDTH)
+            .style(|_theme: &iced::Theme| iced::widget::container::Style {
+                border: iced::Border {
+                    color: Color::from_rgb(0.3, 0.3, 0.3),
+                    width: 1.0,
+                    radius: 4.0.into(),
+                },
+                ..Default::default()
+            })
+            .padding(4)
+            .into()
+    }
+}
+
+fn toggle_at(node: &mut HierarchyNode, indices: &[usize], depth: usize) {
+    if depth >= indices.len() {
+        node.expanded = !node.expanded;
+        return;
+    }
+    let Some(&idx) = indices.get(depth) else {
+        return;
+    };
+    if let Some(child) = node.children.get_mut(idx) {
+        if depth + 1 == indices.len() {
+            child.expanded = !child.expanded;
+        } else {
+            toggle_at(child, indices, depth + 1);
+        }
+    }
+}
+
+fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, HierarchyMessage> {
+    let indent = path.len() as f32 * 16.0;
+    let icon = match node.kind {
+        NodeKind::Flow => {
+            if node.expanded {
+                "\u{25BC}"
+            } else {
+                "\u{25B6}"
+            }
+        }
+        NodeKind::Function => "\u{25C6}",
+        NodeKind::Library => "\u{25CB}",
+    };
+
+    let color = match node.kind {
+        NodeKind::Flow => Color::from_rgb(0.9, 0.6, 0.2),
+        NodeKind::Function => Color::from_rgb(0.6, 0.3, 0.8),
+        NodeKind::Library => Color::from_rgb(0.3, 0.5, 0.9),
+    };
+
+    let path_vec: Vec<usize> = path.to_vec();
+    let label = Row::new()
+        .spacing(4)
+        .push(text(icon).size(11).color(color))
+        .push(text(&node.name).size(13).color(color));
+
+    let label_btn = match node.kind {
+        NodeKind::Flow => {
+            // Flows toggle expand/collapse on click
+            button(label)
+                .on_press(HierarchyMessage::Toggle(path_vec))
+                .style(button::text)
+                .padding([2, 4])
+        }
+        NodeKind::Function => {
+            // Functions open in editor on click
+            if let Some(ref p) = node.path {
+                button(label)
+                    .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
+                    .style(button::text)
+                    .padding([2, 4])
+            } else {
+                button(label).style(button::text).padding([2, 4])
+            }
+        }
+        NodeKind::Library => {
+            // Library nodes are non-interactive (no path)
+            button(label).style(button::text).padding([2, 4])
+        }
+    };
+
+    // Add a small open button for flows (except root)
+    let mut row = Row::new().push(container(label_btn).padding(iced::Padding {
+        top: 0.0,
+        bottom: 0.0,
+        left: indent,
+        right: 0.0,
+    }));
+    if matches!(node.kind, NodeKind::Flow) && !path.is_empty() {
+        if let Some(ref p) = node.path {
+            row = row.push(
+                button(text("\u{270E}").size(11).color(color))
+                    .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
+                    .style(button::text)
+                    .padding([2, 4]),
+            );
+        }
+    }
+
+    let mut col = Column::new().push(row);
+
+    if node.expanded {
+        for (i, child) in node.children.iter().enumerate() {
+            let mut child_path = path.to_vec();
+            child_path.push(i);
+            col = col.push(view_node(child, &child_path));
+        }
+    }
+
+    col.into()
+}
+
+fn build_node_from_path(flow_path: &Path, depth: usize) -> Option<HierarchyNode> {
+    if depth > 10 || !flow_path.exists() {
+        return None;
+    }
+
+    let contents = std::fs::read_to_string(flow_path).ok()?;
+    let url = url::Url::from_file_path(std::fs::canonicalize(flow_path).ok()?).ok()?;
+    let deserializer = get::<Process>(&url).ok()?;
+    let process = deserializer.deserialize(&contents, Some(&url)).ok()?;
+
+    let dir = flow_path.parent()?;
+    let name = match &process {
+        Process::FlowProcess(f) => f.name.clone(),
+        Process::FunctionProcess(f) => f.name.clone(),
+    };
+
+    match process {
+        Process::FlowProcess(flow) => {
+            let mut children = Vec::new();
+            for pref in &flow.process_refs {
+                let alias = if pref.alias.is_empty() {
+                    pref.source
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(&pref.source)
+                        .to_string()
+                } else {
+                    pref.alias.clone()
+                };
+
+                if pref.source.starts_with("lib://") || pref.source.starts_with("context://") {
+                    children.push(HierarchyNode {
+                        name: alias,
+                        kind: NodeKind::Library,
+                        source: pref.source.clone(),
+                        path: None,
+                        children: Vec::new(),
+                        expanded: false,
+                    });
+                } else {
+                    // Relative source — resolve to file
+                    let resolved = resolve_source(dir, &pref.source);
+                    if let Some(ref resolved_path) = resolved {
+                        if let Some(child) = build_node_from_path(resolved_path, depth + 1) {
+                            children.push(HierarchyNode {
+                                name: alias,
+                                path: Some(resolved_path.clone()),
+                                ..child
+                            });
+                        } else {
+                            children.push(HierarchyNode {
+                                name: alias,
+                                kind: NodeKind::Function,
+                                source: pref.source.clone(),
+                                path: resolved,
+                                children: Vec::new(),
+                                expanded: false,
+                            });
+                        }
+                    }
+                }
+            }
+
+            Some(HierarchyNode {
+                name,
+                kind: NodeKind::Flow,
+                source: String::new(),
+                path: Some(flow_path.to_path_buf()),
+                children,
+                expanded: true,
+            })
+        }
+        Process::FunctionProcess(_) => Some(HierarchyNode {
+            name,
+            kind: NodeKind::Function,
+            source: String::new(),
+            path: Some(flow_path.to_path_buf()),
+            children: Vec::new(),
+            expanded: false,
+        }),
+    }
+}
+
+fn resolve_source(dir: &Path, source: &str) -> Option<PathBuf> {
+    let candidate = dir.join(source);
+    if candidate.exists() {
+        return Some(std::fs::canonicalize(&candidate).unwrap_or(candidate));
+    }
+    let with_ext = dir.join(format!("{source}.toml"));
+    if with_ext.exists() {
+        return Some(std::fs::canonicalize(&with_ext).unwrap_or(with_ext));
+    }
+    let dir_default = dir.join(source).join("default.toml");
+    if dir_default.exists() {
+        return Some(std::fs::canonicalize(&dir_default).unwrap_or(dir_default));
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_hierarchy() {
+        let h = FlowHierarchy::empty();
+        assert!(h.root.is_none());
+    }
+}

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -246,6 +246,15 @@ fn build_node_from_path(flow_path: &Path, depth: usize) -> Option<HierarchyNode>
                                 expanded: false,
                             });
                         }
+                    } else {
+                        children.push(HierarchyNode {
+                            name: alias,
+                            kind: NodeKind::Function,
+                            source: pref.source.clone(),
+                            path: None,
+                            children: Vec::new(),
+                            expanded: false,
+                        });
                     }
                 }
             }

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -259,6 +259,11 @@ impl LibraryTree {
 
 /// Resolve the library search path directories.
 ///
+/// Get the current library search paths.
+pub(crate) fn get_lib_paths() -> Vec<String> {
+    resolve_lib_path()
+}
+
 /// Reads `FLOW_LIB_PATH` as a comma-separated list and appends `~/.flow/lib`
 /// as a default if it exists.
 fn resolve_lib_path() -> Vec<String> {

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -20,6 +20,16 @@ pub(crate) enum LibraryMessage {
     ToggleCategory(usize, usize),
     /// Add a function to the canvas: (`source_url`, `function_name`).
     AddFunction(String, String),
+    /// View a library function/flow definition.
+    ViewFunction(String, String),
+}
+
+/// Result of a library panel interaction.
+#[derive(Debug, PartialEq)]
+pub(crate) enum LibraryAction {
+    None,
+    Add(String, String),
+    View(String, String),
 }
 
 /// A single function entry in the library tree.
@@ -117,15 +127,14 @@ impl LibraryTree {
 
     /// Handle a library message, updating expansion state.
     ///
-    /// Returns `Some((source, name))` if a function was clicked (for the caller
-    /// to create a node), or `None` if just a toggle.
-    pub(crate) fn update(&mut self, message: &LibraryMessage) -> Option<(String, String)> {
+    /// Result of a library panel interaction.
+    pub(crate) fn update(&mut self, message: &LibraryMessage) -> LibraryAction {
         match message {
             LibraryMessage::ToggleLibrary(lib_idx) => {
                 if let Some(lib) = self.libraries.get_mut(*lib_idx) {
                     lib.expanded = !lib.expanded;
                 }
-                None
+                LibraryAction::None
             }
             LibraryMessage::ToggleCategory(lib_idx, cat_idx) => {
                 if let Some(lib) = self.libraries.get_mut(*lib_idx) {
@@ -133,9 +142,14 @@ impl LibraryTree {
                         cat.expanded = !cat.expanded;
                     }
                 }
-                None
+                LibraryAction::None
             }
-            LibraryMessage::AddFunction(source, name) => Some((source.clone(), name.clone())),
+            LibraryMessage::AddFunction(source, name) => {
+                LibraryAction::Add(source.clone(), name.clone())
+            }
+            LibraryMessage::ViewFunction(source, name) => {
+                LibraryAction::View(source.clone(), name.clone())
+            }
         }
     }
 
@@ -194,20 +208,34 @@ impl LibraryTree {
 
                     if cat.expanded {
                         for func in &cat.functions {
+                            let view_btn = button(text("\u{270E}").size(10))
+                                .on_press(LibraryMessage::ViewFunction(
+                                    func.source.clone(),
+                                    func.name.clone(),
+                                ))
+                                .style(button::text)
+                                .padding([1, 3]);
+
                             let func_btn = button(text(&func.name).size(11))
                                 .on_press(LibraryMessage::AddFunction(
                                     func.source.clone(),
                                     func.name.clone(),
                                 ))
                                 .style(button::text)
-                                .padding(iced::Padding {
-                                    top: 2.0,
-                                    right: 6.0,
-                                    bottom: 2.0,
-                                    left: 28.0,
-                                });
+                                .padding([2, 4]);
 
-                            content = content.push(func_btn);
+                            let row = Row::new()
+                                .spacing(2)
+                                .align_y(iced::Alignment::Center)
+                                .push(view_btn)
+                                .push(func_btn);
+
+                            content = content.push(container(row).padding(iced::Padding {
+                                top: 0.0,
+                                right: 0.0,
+                                bottom: 0.0,
+                                left: 24.0,
+                            }));
                         }
                     }
                 }
@@ -453,7 +481,7 @@ mod test {
             }],
         };
         let result = tree.update(&LibraryMessage::ToggleLibrary(0));
-        assert!(result.is_none());
+        assert_eq!(result, LibraryAction::None);
         assert!(tree.libraries.first().is_some_and(|l| l.expanded));
     }
 
@@ -471,7 +499,7 @@ mod test {
             }],
         };
         let result = tree.update(&LibraryMessage::ToggleCategory(0, 0));
-        assert!(result.is_none());
+        assert_eq!(result, LibraryAction::None);
         assert!(tree
             .libraries
             .first()
@@ -490,7 +518,7 @@ mod test {
         ));
         assert_eq!(
             result,
-            Some(("lib://flowstdlib/math/add".into(), "add".into()))
+            LibraryAction::Add("lib://flowstdlib/math/add".into(), "add".into())
         );
     }
 
@@ -500,8 +528,8 @@ mod test {
             libraries: Vec::new(),
         };
         let result = tree.update(&LibraryMessage::ToggleLibrary(99));
-        assert!(result.is_none());
+        assert_eq!(result, LibraryAction::None);
         let result = tree.update(&LibraryMessage::ToggleCategory(99, 0));
-        assert!(result.is_none());
+        assert_eq!(result, LibraryAction::None);
     }
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -739,9 +739,22 @@ impl FlowEdit {
                             return open_task.discard();
                         }
                         Err(_) => {
-                            // Try as function
-                            if let Some(root_id) = self.root_window {
-                                return self.open_node(root_id, 0);
+                            // Try as function definition
+                            let abs = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                            if let Ok(contents) = std::fs::read_to_string(&abs) {
+                                if let Ok(url) = Url::from_file_path(&abs) {
+                                    if let Ok(deser) = get::<Process>(&url) {
+                                        if let Ok(Process::FunctionProcess(ref func)) =
+                                            deser.deserialize(&contents, Some(&url))
+                                        {
+                                            return self.open_function_viewer(
+                                                hier_win_id,
+                                                &path,
+                                                func,
+                                            );
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -817,8 +830,16 @@ impl FlowEdit {
                 }
             }
             Message::Open => {
-                if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
-                    perform_open(win);
+                if let Some(root_id) = self.root_window {
+                    if let Some(win) = self.windows.get_mut(&root_id) {
+                        perform_open(win);
+                        self.root_flow_path = win.file_path.clone();
+                        win.flow_hierarchy = win
+                            .file_path
+                            .as_ref()
+                            .map(|p| FlowHierarchy::build(p))
+                            .unwrap_or_else(FlowHierarchy::empty);
+                    }
                 }
             }
             Message::New => {
@@ -1138,6 +1159,9 @@ impl FlowEdit {
             }
             Message::WindowClosed(id) => {
                 self.windows.remove(&id);
+                if self.focused_window == Some(id) {
+                    self.focused_window = self.root_window;
+                }
                 if self.root_window == Some(id) || self.windows.is_empty() {
                     return iced::exit();
                 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -33,12 +33,14 @@ use flowcore::model::name::HasName;
 use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 mod canvas_view;
+mod hierarchy_panel;
 mod history;
 mod library_panel;
 use canvas_view::{
     build_edge_layouts, build_node_layouts, derive_short_name, CanvasMessage, EdgeLayout,
     FlowCanvasState, NodeLayout, PortInfo,
 };
+use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
 use history::{EditAction, EditHistory};
 use library_panel::{LibraryMessage, LibraryTree};
 
@@ -49,6 +51,8 @@ enum Message {
     WindowCanvas(window::Id, CanvasMessage),
     /// A message from the library side panel, tagged with the originating window ID
     Library(window::Id, LibraryMessage),
+    /// A message from the flow hierarchy panel, tagged with window ID
+    Hierarchy(window::Id, HierarchyMessage),
     /// Zoom in by one step, tagged with the originating window ID
     ZoomIn(window::Id),
     /// Zoom out by one step, tagged with the originating window ID
@@ -217,6 +221,8 @@ struct WindowState {
     context_menu: Option<(f32, f32)>,
     /// Whether the metadata editor is visible
     show_metadata: bool,
+    /// Flow hierarchy tree for this window's navigation panel
+    flow_hierarchy: FlowHierarchy,
 }
 
 /// Top-level application state
@@ -229,6 +235,8 @@ struct FlowEdit {
     focused_window: Option<window::Id>,
     /// Library panel tree for process discovery
     library_tree: LibraryTree,
+    /// Path to the root flow file (for rebuilding hierarchy)
+    root_flow_path: Option<PathBuf>,
 }
 
 /// Main entry point for the flowedit binary.
@@ -343,6 +351,12 @@ impl FlowEdit {
             ..Default::default()
         });
 
+        let root_flow_path = file_path.clone();
+        let flow_hierarchy = file_path
+            .as_ref()
+            .map(|p| FlowHierarchy::build(p))
+            .unwrap_or_else(FlowHierarchy::empty);
+
         let (fi, fo) = extract_ports(&flow_definition.inputs, &flow_definition.outputs);
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
@@ -354,7 +368,7 @@ impl FlowEdit {
             selected_node: None,
             selected_connection: None,
             auto_fit_pending: has_nodes,
-            auto_fit_enabled: true, // Start in auto-fit mode
+            auto_fit_enabled: true,
             history: EditHistory::default(),
             unsaved_edits: 0,
             compiled_manifest: None,
@@ -367,6 +381,7 @@ impl FlowEdit {
             flow_outputs: fo,
             context_menu: None,
             show_metadata: false,
+            flow_hierarchy,
         };
 
         let mut windows = HashMap::new();
@@ -377,6 +392,7 @@ impl FlowEdit {
             root_window: Some(root_id),
             focused_window: Some(root_id),
             library_tree,
+            root_flow_path,
         };
 
         (app, open_task.discard())
@@ -632,6 +648,64 @@ impl FlowEdit {
                     CanvasMessage::ContextMenu(x, y) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             win.context_menu = Some((x, y));
+                        }
+                    }
+                }
+            }
+            Message::Hierarchy(hier_win_id, ref hier_msg) => {
+                let open_result = self
+                    .windows
+                    .get_mut(&hier_win_id)
+                    .and_then(|win| win.flow_hierarchy.update(hier_msg));
+                if let Some((_source, path)) = open_result {
+                    // Check if already open
+                    for (&win_id, win) in &self.windows {
+                        if win.file_path.as_ref() == Some(&path) {
+                            return window::gain_focus(win_id);
+                        }
+                    }
+                    // Open the flow or function
+                    match load_flow(&path) {
+                        Ok((name, nodes, edges, flow_def)) => {
+                            let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
+                            let (new_id, open_task) =
+                                window::open(self.child_window_settings(1024.0, 768.0));
+                            let has_nodes = !nodes.is_empty();
+                            let nc = nodes.len();
+                            let ec = edges.len();
+                            let child = WindowState {
+                                kind: WindowKind::FlowEditor,
+                                flow_name: name,
+                                nodes,
+                                edges,
+                                canvas_state: FlowCanvasState::default(),
+                                status: format!("Ready - {nc} nodes, {ec} connections"),
+                                selected_node: None,
+                                selected_connection: None,
+                                history: EditHistory::default(),
+                                auto_fit_pending: has_nodes,
+                                auto_fit_enabled: true,
+                                unsaved_edits: 0,
+                                compiled_manifest: None,
+                                file_path: Some(path),
+                                flow_definition: flow_def,
+                                tooltip: None,
+                                initializer_editor: None,
+                                is_root: false,
+                                flow_inputs: fi,
+                                flow_outputs: fo,
+                                context_menu: None,
+                                show_metadata: false,
+                                flow_hierarchy: self.build_hierarchy(),
+                            };
+                            self.windows.insert(new_id, child);
+                            return open_task.discard();
+                        }
+                        Err(_) => {
+                            // Try as function
+                            if let Some(root_id) = self.root_window {
+                                return self.open_node(root_id, 0);
+                            }
                         }
                     }
                 }
@@ -1055,6 +1129,7 @@ impl FlowEdit {
             .view(
                 &win.nodes,
                 &win.edges,
+                &win.flow_name,
                 &win.flow_inputs,
                 &win.flow_outputs,
                 !win.is_root,
@@ -1263,14 +1338,23 @@ impl FlowEdit {
 
         let canvas_with_controls = stack(canvas_stack);
 
+        let hierarchy_panel = win
+            .flow_hierarchy
+            .view()
+            .map(move |msg| Message::Hierarchy(window_id, msg));
+
         let library_panel = self
             .library_tree
             .view()
             .map(move |msg| Message::Library(window_id, msg));
 
-        let main_content = Row::new()
+        let left_panel = Column::new()
+            .push(hierarchy_panel)
             .push(library_panel)
-            .push(container(canvas_with_controls).width(Fill).height(Fill));
+            .height(Fill);
+
+        let mut right_col: Column<'_, Message> =
+            Column::new().push(container(canvas_with_controls).width(Fill).height(Fill));
 
         let edit_indicator = if win.unsaved_edits > 0 {
             format!("  |  {} unsaved edit(s)", win.unsaved_edits)
@@ -1359,11 +1443,9 @@ impl FlowEdit {
                 .push(iced::widget::Space::new().width(Fill))
         };
 
-        let mut layout = Column::new().push(container(main_content).width(Fill).height(Fill));
-
         // Flow I/O editor panel for sub-flow windows
         if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
-            layout = layout.push(self.view_flow_io_panel(window_id, win));
+            right_col = right_col.push(self.view_flow_io_panel(window_id, win));
         }
 
         // Metadata editor panel (toggled by Info button)
@@ -1440,10 +1522,12 @@ impl FlowEdit {
             })
             .width(Fill);
 
-            layout = layout.push(meta_panel);
+            right_col = right_col.push(meta_panel);
         }
 
-        layout = layout.push(container(status_bar).width(Fill).padding(5));
+        right_col = right_col.push(container(status_bar).width(Fill).padding(5));
+
+        let layout = Row::new().push(left_panel).push(right_col.width(Fill));
         layout.into()
     }
 
@@ -1527,23 +1611,15 @@ impl FlowEdit {
                 .padding([2, 8]),
         );
 
-        let flow_name_label = container(
-            Text::new(&win.flow_name)
-                .size(14)
-                .color(Color::from_rgb(0.9, 0.6, 0.2)),
-        )
-        .center_x(Fill);
-
         let io_box = container(
             Column::new()
                 .spacing(12)
                 .padding(iced::Padding {
-                    top: 12.0,
-                    bottom: 12.0,
+                    top: 8.0,
+                    bottom: 8.0,
                     left: 0.0,
                     right: 0.0,
                 })
-                .push(flow_name_label)
                 .push(
                     Row::new()
                         .push(input_col)
@@ -1823,6 +1899,25 @@ impl FlowEdit {
         Subscription::batch(vec![keyboard_sub, close_sub, focus_sub])
     }
 
+    fn build_hierarchy(&self) -> FlowHierarchy {
+        self.root_flow_path
+            .as_ref()
+            .map(|p| FlowHierarchy::build(p))
+            .unwrap_or_else(FlowHierarchy::empty)
+    }
+
+    fn child_window_settings(&self, width: f32, height: f32) -> window::Settings {
+        let n = self.windows.len() as f32;
+        window::Settings {
+            size: iced::Size::new(width, height),
+            position: window::Position::Specific(iced::Point::new(
+                200.0 + n * 30.0,
+                150.0 + n * 30.0,
+            )),
+            ..Default::default()
+        }
+    }
+
     /// Open a sub-flow in a new in-process window, or show a status message
     /// if the node resolves to a function rather than a flow.
     fn open_node(&mut self, parent_win_id: window::Id, idx: usize) -> Task<Message> {
@@ -1874,10 +1969,7 @@ impl FlowEdit {
         match load_flow(&path) {
             Ok((name, nodes, edges, flow_def)) => {
                 let has_nodes = !nodes.is_empty();
-                let (new_id, open_task) = window::open(window::Settings {
-                    size: iced::Size::new(1024.0, 768.0),
-                    ..Default::default()
-                });
+                let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
                 let nc = nodes.len();
                 let ec = edges.len();
                 let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
@@ -1904,6 +1996,7 @@ impl FlowEdit {
                     flow_outputs: fo,
                     context_menu: None,
                     show_metadata: false,
+                    flow_hierarchy: self.build_hierarchy(),
                 };
                 self.windows.insert(new_id, child);
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -1936,10 +2029,7 @@ impl FlowEdit {
 
         let (inputs, outputs) = extract_ports(&func.inputs, &func.outputs);
 
-        let (new_id, open_task) = window::open(window::Settings {
-            size: iced::Size::new(700.0, 500.0),
-            ..Default::default()
-        });
+        let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
 
         let viewer = FunctionViewer {
             name: func_name.clone(),
@@ -1975,6 +2065,7 @@ impl FlowEdit {
             flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
+            flow_hierarchy: self.build_hierarchy(),
         };
 
         self.windows.insert(new_id, child);
@@ -2075,10 +2166,7 @@ impl FlowEdit {
         }
 
         // Open the new sub-flow in a child window
-        let (new_id, open_task) = window::open(window::Settings {
-            size: iced::Size::new(1024.0, 768.0),
-            ..Default::default()
-        });
+        let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
 
         let child = WindowState {
             kind: WindowKind::FlowEditor,
@@ -2103,6 +2191,7 @@ impl FlowEdit {
             flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
+            flow_hierarchy: self.build_hierarchy(),
         };
 
         self.windows.insert(new_id, child);
@@ -2184,10 +2273,7 @@ impl FlowEdit {
         }
 
         // Open the function viewer window
-        let (new_id, open_task) = window::open(window::Settings {
-            size: iced::Size::new(700.0, 500.0),
-            ..Default::default()
-        });
+        let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
 
         let viewer = FunctionViewer {
             name: func_name.clone(),
@@ -2223,6 +2309,7 @@ impl FlowEdit {
             flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
+            flow_hierarchy: self.build_hierarchy(),
         };
 
         self.windows.insert(new_id, child);

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -145,6 +145,10 @@ enum Message {
     QuitAll,
     /// A window received focus
     WindowFocused(window::Id),
+    /// Window was resized — track the new size
+    WindowResized(window::Id, iced::Size),
+    /// Window was moved — track the new position
+    WindowMoved(window::Id, iced::Point),
 }
 
 /// State for the initializer editing dialog.
@@ -225,6 +229,10 @@ struct WindowState {
     show_metadata: bool,
     /// Flow hierarchy tree for this window's navigation panel
     flow_hierarchy: FlowHierarchy,
+    /// Last known window size (tracked via resize events)
+    last_size: Option<iced::Size>,
+    /// Last known window position (tracked via move events)
+    last_position: Option<iced::Point>,
 }
 
 /// Top-level application state
@@ -348,8 +356,21 @@ impl FlowEdit {
         let library_tree = LibraryTree::scan();
 
         // Open the root window via daemon API
+        let saved_prefs = file_path.as_ref().and_then(|p| load_editor_prefs(p));
+        let saved_size = saved_prefs
+            .as_ref()
+            .map(|p| iced::Size::new(p.width, p.height))
+            .unwrap_or_else(|| iced::Size::new(1024.0, 768.0));
+        let saved_position = saved_prefs
+            .as_ref()
+            .and_then(|p| match (p.x, p.y) {
+                (Some(x), Some(y)) => Some(window::Position::Specific(iced::Point::new(x, y))),
+                _ => None,
+            })
+            .unwrap_or(window::Position::Default);
         let (root_id, open_task) = window::open(window::Settings {
-            size: iced::Size::new(1024.0, 768.0),
+            size: saved_size,
+            position: saved_position,
             ..Default::default()
         });
 
@@ -384,6 +405,8 @@ impl FlowEdit {
             context_menu: None,
             show_metadata: false,
             flow_hierarchy,
+            last_size: None,
+            last_position: None,
         };
 
         let mut windows = HashMap::new();
@@ -699,6 +722,8 @@ impl FlowEdit {
                                 context_menu: None,
                                 show_metadata: false,
                                 flow_hierarchy: self.build_hierarchy(),
+                                last_size: None,
+                                last_position: None,
                             };
                             self.windows.insert(new_id, child);
                             return open_task.discard();
@@ -878,6 +903,16 @@ impl FlowEdit {
             }
             Message::WindowFocused(id) => {
                 self.focused_window = Some(id);
+            }
+            Message::WindowResized(id, size) => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.last_size = Some(size);
+                }
+            }
+            Message::WindowMoved(id, pos) => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.last_position = Some(pos);
+                }
             }
             Message::FunctionTabSelected(win_id, tab) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1900,6 +1935,12 @@ impl FlowEdit {
             }
             iced::Event::Window(iced::window::Event::Closed) => Some(Message::WindowClosed(id)),
             iced::Event::Window(iced::window::Event::Focused) => Some(Message::WindowFocused(id)),
+            iced::Event::Window(iced::window::Event::Resized(size)) => {
+                Some(Message::WindowResized(id, size))
+            }
+            iced::Event::Window(iced::window::Event::Moved(pos)) => {
+                Some(Message::WindowMoved(id, pos))
+            }
             _ => None,
         });
 
@@ -2004,6 +2045,8 @@ impl FlowEdit {
                     context_menu: None,
                     show_metadata: false,
                     flow_hierarchy: self.build_hierarchy(),
+                    last_size: None,
+                    last_position: None,
                 };
                 self.windows.insert(new_id, child);
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -2073,6 +2116,8 @@ impl FlowEdit {
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),
+            last_size: None,
+            last_position: None,
         };
 
         self.windows.insert(new_id, child);
@@ -2199,6 +2244,8 @@ impl FlowEdit {
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),
+            last_size: None,
+            last_position: None,
         };
 
         self.windows.insert(new_id, child);
@@ -2317,6 +2364,8 @@ impl FlowEdit {
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),
+            last_size: None,
+            last_position: None,
         };
 
         self.windows.insert(new_id, child);
@@ -2413,6 +2462,7 @@ fn perform_save(win: &mut WindowState, path: &PathBuf) {
         Ok(()) => {
             win.unsaved_edits = 0;
             win.file_path = Some(path.clone());
+            save_editor_prefs(path, win.last_size, win.last_position);
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 win.status = format!("Saved to {name}");
             } else {
@@ -3342,4 +3392,52 @@ fn save_function_definition(viewer: &FunctionViewer) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn editor_prefs_path(flow_path: &Path) -> PathBuf {
+    let mut p = flow_path.to_path_buf();
+    let name = p
+        .file_name()
+        .map(|n| format!(".{}.flowedit", n.to_string_lossy()))
+        .unwrap_or_else(|| ".flowedit".to_string());
+    p.set_file_name(name);
+    p
+}
+
+fn save_editor_prefs(flow_path: &Path, size: Option<iced::Size>, position: Option<iced::Point>) {
+    let prefs_path = editor_prefs_path(flow_path);
+    let mut map = serde_json::Map::new();
+    if let Some(s) = size {
+        map.insert("width".into(), serde_json::json!(s.width));
+        map.insert("height".into(), serde_json::json!(s.height));
+    }
+    if let Some(p) = position {
+        map.insert("x".into(), serde_json::json!(p.x));
+        map.insert("y".into(), serde_json::json!(p.y));
+    }
+    let json = serde_json::Value::Object(map).to_string();
+    let _ = std::fs::write(prefs_path, json);
+}
+
+struct EditorPrefs {
+    width: f32,
+    height: f32,
+    x: Option<f32>,
+    y: Option<f32>,
+}
+
+fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
+    let prefs_path = editor_prefs_path(flow_path);
+    let content = std::fs::read_to_string(prefs_path).ok()?;
+    let val: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let w = val.get("width")?.as_f64()? as f32;
+    let h = val.get("height")?.as_f64()? as f32;
+    let x = val.get("x").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let y = val.get("y").and_then(|v| v.as_f64()).map(|v| v as f32);
+    Some(EditorPrefs {
+        width: w,
+        height: h,
+        x,
+        y,
+    })
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -149,6 +149,12 @@ enum Message {
     WindowResized(window::Id, iced::Size),
     /// Window was moved — track the new position
     WindowMoved(window::Id, iced::Point),
+    /// Add a library search path via file dialog
+    AddLibraryPath,
+    /// Remove a library search path by index
+    RemoveLibraryPath(usize),
+    /// Toggle the library paths editor
+    ToggleLibPaths,
 }
 
 /// State for the initializer editing dialog.
@@ -247,6 +253,8 @@ struct FlowEdit {
     library_tree: LibraryTree,
     /// Path to the root flow file (for rebuilding hierarchy)
     root_flow_path: Option<PathBuf>,
+    show_lib_paths: bool,
+    lib_paths: Vec<String>,
 }
 
 /// Main entry point for the flowedit binary.
@@ -418,6 +426,8 @@ impl FlowEdit {
             focused_window: Some(root_id),
             library_tree,
             root_flow_path,
+            show_lib_paths: false,
+            lib_paths: library_panel::get_lib_paths(),
         };
 
         (app, open_task.discard())
@@ -917,6 +927,25 @@ impl FlowEdit {
                 if let Some(win) = self.windows.get_mut(&id) {
                     win.last_position = Some(pos);
                 }
+            }
+            Message::AddLibraryPath => {
+                let dialog = rfd::FileDialog::new();
+                if let Some(dir) = dialog.pick_folder() {
+                    let path_str = dir.to_string_lossy().to_string();
+                    if !self.lib_paths.contains(&path_str) {
+                        self.lib_paths.push(path_str);
+                        self.update_lib_paths();
+                    }
+                }
+            }
+            Message::RemoveLibraryPath(idx) => {
+                if idx < self.lib_paths.len() {
+                    self.lib_paths.remove(idx);
+                    self.update_lib_paths();
+                }
+            }
+            Message::ToggleLibPaths => {
+                self.show_lib_paths = !self.show_lib_paths;
             }
             Message::FunctionTabSelected(win_id, tab) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1479,6 +1508,16 @@ impl FlowEdit {
                 .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
                 .push(iced::widget::Space::new().width(Fill))
                 .push(info_btn)
+                .push(
+                    button(Text::new("\u{1F4C1} Libs").size(btn_size).center())
+                        .on_press(Message::ToggleLibPaths)
+                        .style(if self.show_lib_paths {
+                            toolbar_btn_active
+                        } else {
+                            toolbar_btn
+                        })
+                        .padding(btn_pad),
+                )
                 .push(new_subflow_btn)
                 .push(new_func_btn)
                 .push(compile_btn)
@@ -1570,6 +1609,47 @@ impl FlowEdit {
             .width(Fill);
 
             right_col = right_col.push(meta_panel);
+        }
+
+        // Library paths panel (toggled by Libs button)
+        if self.show_lib_paths {
+            let mut paths_col = Column::new().spacing(4).padding(12);
+            paths_col = paths_col.push(Text::new("Library Search Paths").size(14));
+
+            for (i, p) in self.lib_paths.iter().enumerate() {
+                let row = Row::new()
+                    .spacing(6)
+                    .align_y(iced::Alignment::Center)
+                    .push(Text::new(p).size(12))
+                    .push(iced::widget::Space::new().width(Fill))
+                    .push(
+                        button(Text::new("\u{2715}").size(10).center())
+                            .on_press(Message::RemoveLibraryPath(i))
+                            .style(button::danger)
+                            .padding([2, 5]),
+                    );
+                paths_col = paths_col.push(row);
+            }
+            paths_col = paths_col.push(
+                button(Text::new("+ Add Path...").size(12).center())
+                    .on_press(Message::AddLibraryPath)
+                    .style(button::secondary)
+                    .padding([4, 10]),
+            );
+
+            let lib_panel = container(paths_col)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Background::Color(Color::from_rgb(0.14, 0.14, 0.18))),
+                    border: iced::Border {
+                        color: Color::from_rgb(0.3, 0.3, 0.3),
+                        width: 1.0,
+                        radius: 0.0.into(),
+                    },
+                    ..Default::default()
+                })
+                .width(Fill);
+
+            right_col = right_col.push(lib_panel);
         }
 
         right_col = right_col.push(container(status_bar).width(Fill).padding(5));
@@ -2039,6 +2119,12 @@ impl FlowEdit {
             },
             Err(_) => Task::none(),
         }
+    }
+
+    fn update_lib_paths(&mut self) {
+        let path_str = self.lib_paths.join(",");
+        std::env::set_var("FLOW_LIB_PATH", &path_str);
+        self.library_tree = LibraryTree::scan();
     }
 
     fn build_hierarchy(&self) -> FlowHierarchy {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -42,7 +42,7 @@ use canvas_view::{
 };
 use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
 use history::{EditAction, EditHistory};
-use library_panel::{LibraryMessage, LibraryTree};
+use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
 
 /// Messages handled by the flowedit application
 #[derive(Debug, Clone)]
@@ -737,13 +737,17 @@ impl FlowEdit {
                     }
                 }
             }
-            Message::Library(win_id, ref lib_msg) => {
-                if let Some((source, func_name)) = self.library_tree.update(lib_msg) {
+            Message::Library(win_id, ref lib_msg) => match self.library_tree.update(lib_msg) {
+                LibraryAction::Add(source, func_name) => {
                     if let Some(win) = self.windows.get_mut(&win_id) {
                         add_library_function(win, &source, &func_name);
                     }
                 }
-            }
+                LibraryAction::View(source, _name) => {
+                    return self.open_library_function(&source);
+                }
+                LibraryAction::None => {}
+            },
             Message::ZoomIn(win_id) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     win.auto_fit_enabled = false;
@@ -1945,6 +1949,96 @@ impl FlowEdit {
         });
 
         Subscription::batch(vec![keyboard_sub, window_events])
+    }
+
+    fn open_library_function(&mut self, source: &str) -> Task<Message> {
+        use flowcore::provider::Provider;
+
+        let provider = build_meta_provider();
+        let source_url = match Url::parse(source) {
+            Ok(u) => u,
+            Err(_) => return Task::none(),
+        };
+        let (resolved_url, _) = match provider.resolve_url(&source_url, "default", &["toml"]) {
+            Ok(r) => r,
+            Err(_) => return Task::none(),
+        };
+        let path = match resolved_url.to_file_path() {
+            Ok(p) => p,
+            Err(()) => return Task::none(),
+        };
+
+        // Check if already open
+        for (&win_id, win) in &self.windows {
+            if win.file_path.as_ref() == Some(&path) {
+                return window::gain_focus(win_id);
+            }
+        }
+
+        // Read and parse
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => return Task::none(),
+        };
+        let url = match Url::from_file_path(&path) {
+            Ok(u) => u,
+            Err(()) => return Task::none(),
+        };
+        let deserializer = match get::<Process>(&url) {
+            Ok(d) => d,
+            Err(_) => return Task::none(),
+        };
+
+        match deserializer.deserialize(&contents, Some(&url)) {
+            Ok(Process::FunctionProcess(ref func)) => {
+                let parent = match self.root_window {
+                    Some(id) => id,
+                    None => return Task::none(),
+                };
+                self.open_function_viewer(parent, &path, func)
+            }
+            Ok(Process::FlowProcess(_)) => match load_flow(&path) {
+                Ok((name, nodes, edges, flow_def)) => {
+                    let (fi, fo) = extract_ports(&flow_def.inputs, &flow_def.outputs);
+                    let has_nodes = !nodes.is_empty();
+                    let nc = nodes.len();
+                    let ec = edges.len();
+                    let (new_id, open_task) =
+                        window::open(self.child_window_settings(1024.0, 768.0));
+                    let child = WindowState {
+                        kind: WindowKind::FlowEditor,
+                        flow_name: name,
+                        nodes,
+                        edges,
+                        canvas_state: FlowCanvasState::default(),
+                        status: format!("Library flow - {nc} nodes, {ec} connections"),
+                        selected_node: None,
+                        selected_connection: None,
+                        history: EditHistory::default(),
+                        auto_fit_pending: has_nodes,
+                        auto_fit_enabled: true,
+                        unsaved_edits: 0,
+                        compiled_manifest: None,
+                        file_path: Some(path),
+                        flow_definition: flow_def,
+                        tooltip: None,
+                        initializer_editor: None,
+                        is_root: false,
+                        flow_inputs: fi,
+                        flow_outputs: fo,
+                        context_menu: None,
+                        show_metadata: false,
+                        flow_hierarchy: self.build_hierarchy(),
+                        last_size: None,
+                        last_position: None,
+                    };
+                    self.windows.insert(new_id, child);
+                    open_task.discard()
+                }
+                Err(_) => Task::none(),
+            },
+            Err(_) => Task::none(),
+        }
     }
 
     fn build_hierarchy(&self) -> FlowHierarchy {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -137,6 +137,8 @@ enum Message {
     FlowOutputTypeChanged(window::Id, usize, String),
     /// A window close was requested
     CloseRequested(window::Id),
+    /// A window was actually closed (cleanup stale state)
+    WindowClosed(window::Id),
     /// Close the currently focused window (Cmd+W)
     CloseActiveWindow,
     /// Quit the entire application (Cmd+Q)
@@ -1066,6 +1068,12 @@ impl FlowEdit {
                     win.canvas_state.request_redraw();
                 }
             }
+            Message::WindowClosed(id) => {
+                self.windows.remove(&id);
+                if self.root_window == Some(id) || self.windows.is_empty() {
+                    return iced::exit();
+                }
+            }
             Message::CloseRequested(_) | Message::CloseActiveWindow => {
                 let target = match message {
                     Message::CloseRequested(win_id) => Some(win_id),
@@ -1886,17 +1894,16 @@ impl FlowEdit {
             _ => None,
         });
 
-        let close_sub = window::close_requests().map(Message::CloseRequested);
-
-        let focus_sub = iced::event::listen_with(|event, _status, id| {
-            if let iced::Event::Window(iced::window::Event::Focused) = event {
-                Some(Message::WindowFocused(id))
-            } else {
-                None
+        let window_events = iced::event::listen_with(|event, _status, id| match event {
+            iced::Event::Window(iced::window::Event::CloseRequested) => {
+                Some(Message::CloseRequested(id))
             }
+            iced::Event::Window(iced::window::Event::Closed) => Some(Message::WindowClosed(id)),
+            iced::Event::Window(iced::window::Event::Focused) => Some(Message::WindowFocused(id)),
+            _ => None,
         });
 
-        Subscription::batch(vec![keyboard_sub, close_sub, focus_sub])
+        Subscription::batch(vec![keyboard_sub, window_events])
     }
 
     fn build_hierarchy(&self) -> FlowHierarchy {


### PR DESCRIPTION
## Summary
- Flow hierarchy navigator panel showing recursive flow structure above Process Library
- Color-coded nodes: orange (flows), purple (functions), blue (library/context)
- Click to expand/collapse flows, pencil to open sub-flows, click to open functions
- Per-window hierarchy state (expand/collapse independent per window)
- Fix window re-open after close via window decoration (subscribe to Window::Closed event)
- Fix flow I/O port semicircle orientation on bounding box
- Flow name drawn on canvas bounding box
- Left panels span full window height
- Consistent child window cascade positioning
- Library function/flow editing added to backlog
- Plan cleanup: removed completed/non-issue items

## Test plan
- [ ] Open `mandlebrot/root.toml` — hierarchy panel shows flow structure
- [ ] Click flow names to expand/collapse in hierarchy
- [ ] Click pencil on sub-flows to open in new window
- [ ] Click function names to open function viewer
- [ ] Close window with red X, re-open same flow — works correctly
- [ ] Each window has independent expand/collapse state in hierarchy
- [ ] Sub-flow I/O ports have correct semicircle orientation
- [ ] `make test` passes (pre-existing flaky test excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a collapsible Flow Hierarchy panel displaying currently loaded flows as an interactive tree structure
  * Enabled navigation to and opening of flows directly from the hierarchy panel
  * Added visual flow name labels to the canvas for improved clarity

* **Documentation**
  * Updated design documentation to reflect expanded library inspection and editing capabilities, plus flow execution requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->