### PR TITLE
Add optional description field to function definitions (#2573)

### DIFF
--- a/flowc/tests/test-functions/test/test.toml
+++ b/flowc/tests/test-functions/test/test.toml
@@ -1,4 +1,5 @@
 function = "test"
+description = "A test function used in compiler tests"
 source = "test.rs"
 type = "rust"
 impure = true

--- a/flowcore/src/model/function_definition.rs
+++ b/flowcore/src/model/function_definition.rs
@@ -33,6 +33,9 @@ pub struct FunctionDefinition {
     /// Name of any docs file associated with this Function
     #[serde(default)]
     pub docs: String,
+    /// Optional description of what this function does
+    #[serde(default)]
+    pub description: String,
     /// Type of build used to compile Function's implementation to WASM from source
     #[serde(default, rename = "type")]
     pub build_type: String,
@@ -79,6 +82,7 @@ impl Default for FunctionDefinition {
             impure: false,
             source: String::new(),
             docs: String::new(),
+            description: String::new(),
             build_type: String::new(),
             inputs: vec![],
             outputs: vec![],
@@ -153,6 +157,7 @@ impl FunctionDefinition {
             function_id: id,
             flow_id,
             build_type: String::default(),
+            description: String::default(),
         }
     }
 

--- a/flowedit_log.txt
+++ b/flowedit_log.txt
@@ -1,4 +1,0 @@
-    Finished `dev` profile [optimized + debuginfo] target(s) in 0.52s
-warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
-note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
-     Running `target/debug/flowedit /tmp/flowedit-test/root.toml`

--- a/flowedit_log.txt
+++ b/flowedit_log.txt
@@ -1,0 +1,4 @@
+    Finished `dev` profile [optimized + debuginfo] target(s) in 0.52s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
+     Running `target/debug/flowedit /tmp/flowedit-test/root.toml`

--- a/flowr/examples/mandlebrot/escapes/escapes.toml
+++ b/flowr/examples/mandlebrot/escapes/escapes.toml
@@ -1,4 +1,5 @@
 function = "escapes"
+description = "Calculate the escape value for a point in the Mandelbrot set"
 source = "escapes.rs"
 docs = "escapes.md"
 type = "rust"

--- a/flowr/examples/mandlebrot/pixel_to_point/pixel_to_point.toml
+++ b/flowr/examples/mandlebrot/pixel_to_point/pixel_to_point.toml
@@ -1,4 +1,5 @@
 function = "pixel_to_point"
+description = "Convert a pixel coordinate to a point in the complex plane"
 source = "pixel_to_point.rs"
 docs = "pixel_to_point.md"
 type = "rust"

--- a/flowr/examples/reverse-echo/reverse/reverse.toml
+++ b/flowr/examples/reverse-echo/reverse/reverse.toml
@@ -1,4 +1,5 @@
 function = "reverse"
+description = "Reverse the characters in a string"
 source = "reverse.rs"
 type = "rust"
 

--- a/flowr/src/bin/flowrcli/context/args/get.toml
+++ b/flowr/src/bin/flowrcli/context/args/get.toml
@@ -1,4 +1,5 @@
 function = "get"
+description = "Get command line arguments"
 source = "get.rs"
 docs = "get.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/file/file_read.toml
+++ b/flowr/src/bin/flowrcli/context/file/file_read.toml
@@ -1,4 +1,5 @@
 function = "file_read"
+description = "Read the contents of a file"
 source = "file_read.rs"
 docs = "file_read.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/file/file_write.toml
+++ b/flowr/src/bin/flowrcli/context/file/file_write.toml
@@ -1,4 +1,5 @@
 function = "file_write"
+description = "Write content to a file"
 source = "file_write.rs"
 docs = "file_write.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/image/image_buffer.toml
+++ b/flowr/src/bin/flowrcli/context/image/image_buffer.toml
@@ -1,4 +1,5 @@
 function = "image_buffer"
+description = "Create an image buffer and write pixels to it"
 source = "image_buffer.rs"
 docs = "image_buffer.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/stdio/readline.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/readline.toml
@@ -1,4 +1,5 @@
 function = "readline"
+description = "Read a line of text with an optional prompt"
 source = "readline.rs"
 docs = "readline.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.toml
@@ -1,4 +1,5 @@
 function = "stderr"
+description = "Write a value to standard error"
 source = "stderr.rs"
 docs = "stderr.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/stdio/stdin.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/stdin.toml
@@ -1,4 +1,5 @@
 function = "stdin"
+description = "Read a line of text from standard input"
 source = "stdin.rs"
 docs = "stdin.md"
 impure = true

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.toml
@@ -1,4 +1,5 @@
 function = "stdout"
+description = "Write a value to standard output"
 source = "stdout.rs"
 docs = "stdout.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/args/get.toml
+++ b/flowr/src/bin/flowrgui/context/args/get.toml
@@ -1,4 +1,5 @@
 function = "get"
+description = "Get command line arguments"
 source = "get.rs"
 docs = "get.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/file/file_write.toml
+++ b/flowr/src/bin/flowrgui/context/file/file_write.toml
@@ -1,4 +1,5 @@
 function = "file_write"
+description = "Write content to a file"
 source = "file_write.rs"
 docs = "file_write.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/image/image_buffer.toml
+++ b/flowr/src/bin/flowrgui/context/image/image_buffer.toml
@@ -1,4 +1,5 @@
 function = "image_buffer"
+description = "Create an image buffer and write pixels to it"
 source = "image_buffer.rs"
 docs = "image_buffer.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/stdio/readline.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/readline.toml
@@ -1,4 +1,5 @@
 function = "readline"
+description = "Read a line of text with an optional prompt"
 source = "readline.rs"
 docs = "readline.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.toml
@@ -1,4 +1,5 @@
 function = "stderr"
+description = "Write a value to standard error"
 source = "stderr.rs"
 docs = "stderr.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/stdio/stdin.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/stdin.toml
@@ -1,4 +1,5 @@
 function = "stdin"
+description = "Read a line of text from standard input"
 source = "stdin.rs"
 docs = "stdin.md"
 impure = true

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.toml
@@ -1,4 +1,5 @@
 function = "stdout"
+description = "Write a value to standard output"
 source = "stdout.rs"
 docs = "stdout.md"
 impure = true

--- a/flowstdlib/src/control/compare_switch/compare_switch.toml
+++ b/flowstdlib/src/control/compare_switch/compare_switch.toml
@@ -1,5 +1,5 @@
 function = "compare_switch"
-description = "Compares two input values and outputs the right hand and left hand values on different outputs, "
+description = "Compares two input values and routes the left-hand and right-hand values to outputs based on the comparison"
 source = "compare_switch.rs"
 docs = "compare_switch.md"
 type = "rust"

--- a/flowstdlib/src/control/compare_switch/compare_switch.toml
+++ b/flowstdlib/src/control/compare_switch/compare_switch.toml
@@ -1,4 +1,5 @@
 function = "compare_switch"
+description = "Compares two input values and outputs the right hand and left hand values on different outputs, "
 source = "compare_switch.rs"
 docs = "compare_switch.md"
 type = "rust"

--- a/flowstdlib/src/control/index/index.toml
+++ b/flowstdlib/src/control/index/index.toml
@@ -1,4 +1,5 @@
 function = "index"
+description = "Pass thru a value based on the index of an item in the stream of values"
 source = "index.rs"
 docs = "index.md"
 type = "rust"

--- a/flowstdlib/src/control/index/index.toml
+++ b/flowstdlib/src/control/index/index.toml
@@ -1,5 +1,5 @@
 function = "index"
-description = "Pass thru a value based on the index of an item in the stream of values"
+description = "Pass through a value based on its index in the stream"
 source = "index.rs"
 docs = "index.md"
 type = "rust"

--- a/flowstdlib/src/control/join/join.toml
+++ b/flowstdlib/src/control/join/join.toml
@@ -1,4 +1,5 @@
 function = "join"
+description = "Control the flow of a piece of data by waiting for a second value to be available"
 source = "join.rs"
 docs = "join.md"
 type = "rust"

--- a/flowstdlib/src/control/route/route.toml
+++ b/flowstdlib/src/control/route/route.toml
@@ -1,4 +1,5 @@
 function = "route"
+description = "Route data to one or another based on a boolean control value."
 source = "route.rs"
 docs = "route.md"
 type = "rust"

--- a/flowstdlib/src/control/select/select.toml
+++ b/flowstdlib/src/control/select/select.toml
@@ -1,4 +1,5 @@
 function = "select"
+description = "Select which data to output, based on a boolean control value."
 source = "select.rs"
 docs = "select.md"
 type = "rust"

--- a/flowstdlib/src/control/tap/tap.toml
+++ b/flowstdlib/src/control/tap/tap.toml
@@ -1,4 +1,5 @@
 function = "tap"
+description = "Control the flow of data (flow it through this function, or have it disappear) based on a boolean control value."
 source = "tap.rs"
 docs = "tap.md"
 type = "rust"

--- a/flowstdlib/src/data/accumulate/accumulate.toml
+++ b/flowstdlib/src/data/accumulate/accumulate.toml
@@ -1,4 +1,5 @@
 function = "accumulate"
+description = "Accumulate input values into an array upto the limit specified"
 source = "accumulate.rs"
 docs = "accumulate.md"
 type = "rust"

--- a/flowstdlib/src/data/accumulate/accumulate.toml
+++ b/flowstdlib/src/data/accumulate/accumulate.toml
@@ -1,5 +1,5 @@
 function = "accumulate"
-description = "Accumulate input values into an array upto the limit specified"
+description = "Accumulate input values into an array up to the specified limit"
 source = "accumulate.rs"
 docs = "accumulate.md"
 type = "rust"

--- a/flowstdlib/src/data/append/append.toml
+++ b/flowstdlib/src/data/append/append.toml
@@ -1,4 +1,5 @@
 function = "append"
+description = "Append two strings"
 source = "append.rs"
 docs = "append.md"
 type = "rust"

--- a/flowstdlib/src/data/count/count.toml
+++ b/flowstdlib/src/data/count/count.toml
@@ -1,4 +1,5 @@
 function = "count"
+description = "Takes a value on it's input and sends the same value on it's output and adds one to the count"
 source = "count.rs"
 docs = "count.md"
 type = "rust"

--- a/flowstdlib/src/data/count/count.toml
+++ b/flowstdlib/src/data/count/count.toml
@@ -1,5 +1,5 @@
 function = "count"
-description = "Takes a value on it's input and sends the same value on it's output and adds one to the count"
+description = "Takes a value on its input, sends it on its output, and increments the count"
 source = "count.rs"
 docs = "count.md"
 type = "rust"

--- a/flowstdlib/src/data/duplicate/duplicate.toml
+++ b/flowstdlib/src/data/duplicate/duplicate.toml
@@ -1,4 +1,5 @@
 function = "duplicate"
+description = "Takes a value on it's input and sends the same value `factor` times in an array output"
 source = "duplicate.rs"
 docs = "duplicate.md"
 type = "rust"

--- a/flowstdlib/src/data/duplicate/duplicate.toml
+++ b/flowstdlib/src/data/duplicate/duplicate.toml
@@ -1,5 +1,5 @@
 function = "duplicate"
-description = "Takes a value on it's input and sends the same value `factor` times in an array output"
+description = "Takes a value on its input and sends the same value `factor` times in an array output"
 source = "duplicate.rs"
 docs = "duplicate.md"
 type = "rust"

--- a/flowstdlib/src/data/enumerate/enumerate.toml
+++ b/flowstdlib/src/data/enumerate/enumerate.toml
@@ -1,4 +1,5 @@
 function = "enumerate"
+description = "Enumerate the elements of an array"
 source = "enumerate.rs"
 docs = "enumerate.md"
 type = "rust"

--- a/flowstdlib/src/data/info/info.toml
+++ b/flowstdlib/src/data/info/info.toml
@@ -1,4 +1,5 @@
 function = "info"
+description = "Output info about the input value"
 source = "info.rs"
 docs = "info.md"
 type = "rust"

--- a/flowstdlib/src/data/ordered_split/ordered_split.toml
+++ b/flowstdlib/src/data/ordered_split/ordered_split.toml
@@ -1,4 +1,5 @@
 function = "ordered_split"
+description = "Split a string into (possibly) its constituent parts based on a separator."
 source = "ordered_split.rs"
 docs = "ordered_split.md"
 type = "rust"

--- a/flowstdlib/src/data/remove/remove.toml
+++ b/flowstdlib/src/data/remove/remove.toml
@@ -1,5 +1,5 @@
 function = "remove"
-description = "Remove a value from a vector of values"
+description = "Remove a value from an array of values"
 source = "remove.rs"
 docs = "remove.md"
 type = "rust"

--- a/flowstdlib/src/data/remove/remove.toml
+++ b/flowstdlib/src/data/remove/remove.toml
@@ -1,4 +1,5 @@
 function = "remove"
+description = "Remove a value from a vector of values"
 source = "remove.rs"
 docs = "remove.md"
 type = "rust"

--- a/flowstdlib/src/data/sort/sort.toml
+++ b/flowstdlib/src/data/sort/sort.toml
@@ -1,4 +1,5 @@
 function = "sort"
+description = "Sort an array of numbers"
 source = "sort.rs"
 docs = "sort.md"
 type = "rust"

--- a/flowstdlib/src/data/split/split.toml
+++ b/flowstdlib/src/data/split/split.toml
@@ -1,4 +1,5 @@
 function = "split"
+description = "Split a string into (possibly) two parts and a possible token, based on a separator."
 source = "split.rs"
 docs = "split.md"
 type = "rust"

--- a/flowstdlib/src/data/zip/zip.toml
+++ b/flowstdlib/src/data/zip/zip.toml
@@ -1,4 +1,5 @@
 function = "zip"
+description = "Takes two arrays of values and produce an array of tuples of pairs of values from each input array."
 source = "zip.rs"
 docs = "zip.md"
 type = "rust"

--- a/flowstdlib/src/fmt/reverse/reverse.toml
+++ b/flowstdlib/src/fmt/reverse/reverse.toml
@@ -1,4 +1,5 @@
 function = "reverse"
+description = "Reverse a String"
 source = "reverse.rs"
 docs = "reverse.md"
 type = "rust"

--- a/flowstdlib/src/fmt/to_json/to_json.toml
+++ b/flowstdlib/src/fmt/to_json/to_json.toml
@@ -1,4 +1,5 @@
 function = "to_json"
+description = "Convert a String to Json"
 source = "to_json.rs"
 docs = "to_json.md"
 type = "rust"

--- a/flowstdlib/src/fmt/to_string/to_string.toml
+++ b/flowstdlib/src/fmt/to_string/to_string.toml
@@ -1,4 +1,5 @@
 function = "to_string"
+description = "Convert an input type to a String"
 source = "to_string.rs"
 docs = "to_string.md"
 type = "rust"

--- a/flowstdlib/src/math/add/add.toml
+++ b/flowstdlib/src/math/add/add.toml
@@ -1,4 +1,5 @@
 function = "add"
+description = "Add two inputs to produce a new output"
 source = "add.rs"
 docs = "add.md"
 type = "rust"

--- a/flowstdlib/src/math/compare/compare.toml
+++ b/flowstdlib/src/math/compare/compare.toml
@@ -1,4 +1,5 @@
 function = "compare"
+description = "Compare two input values and output different boolean values depending on if the comparison"
 source = "compare.rs"
 docs = "compare.md"
 type = "rust"

--- a/flowstdlib/src/math/compare/compare.toml
+++ b/flowstdlib/src/math/compare/compare.toml
@@ -1,5 +1,5 @@
 function = "compare"
-description = "Compare two input values and output different boolean values depending on if the comparison"
+description = "Compare two input values and emit boolean outputs for equality and ordering relations"
 source = "compare.rs"
 docs = "compare.md"
 type = "rust"

--- a/flowstdlib/src/math/divide/divide.toml
+++ b/flowstdlib/src/math/divide/divide.toml
@@ -1,5 +1,5 @@
 function = "divide"
-description = "Divide one input by another, producing outputs for the dividend, divisor, result and the remainder "
+description = "Divide one input by another, producing the quotient and remainder"
 source = "divide.rs"
 docs = "divide.md"
 type = "rust"

--- a/flowstdlib/src/math/divide/divide.toml
+++ b/flowstdlib/src/math/divide/divide.toml
@@ -1,4 +1,5 @@
 function = "divide"
+description = "Divide one input by another, producing outputs for the dividend, divisor, result and the remainder "
 source = "divide.rs"
 docs = "divide.md"
 type = "rust"

--- a/flowstdlib/src/math/multiply/multiply.toml
+++ b/flowstdlib/src/math/multiply/multiply.toml
@@ -1,4 +1,5 @@
 function = "multiply"
+description = "Multiply one input by another"
 source = "multiply.rs"
 docs = "multiply.md"
 type = "rust"

--- a/flowstdlib/src/math/range_split/range_split.toml
+++ b/flowstdlib/src/math/range_split/range_split.toml
@@ -1,4 +1,5 @@
 function = "range_split"
+description = "Split a range of numbers into two sub-ranges, or output the number if they are the same"
 source = "range_split.rs"
 docs = "range_split.md"
 type = "rust"

--- a/flowstdlib/src/math/sqrt/sqrt.toml
+++ b/flowstdlib/src/math/sqrt/sqrt.toml
@@ -1,4 +1,5 @@
 function = "sqrt"
+description = "Calculate the square root of a number"
 source = "sqrt.rs"
 docs = "sqrt.md"
 type = "rust"

--- a/flowstdlib/src/math/subtract/subtract.toml
+++ b/flowstdlib/src/math/subtract/subtract.toml
@@ -1,4 +1,5 @@
 function = "subtract"
+description = "Subtract one input from another to produce a new output"
 source = "subtract.rs"
 docs = "subtract.md"
 type = "rust"

--- a/flowstdlib/src/matrix/compose_matrix/compose_matrix.toml
+++ b/flowstdlib/src/matrix/compose_matrix/compose_matrix.toml
@@ -1,4 +1,5 @@
 function = "compose_matrix"
+description = "Compose a matrix from a set of matrix elements"
 source = "compose_matrix.rs"
 docs = "compose_matrix.md"
 type = "rust"

--- a/flowstdlib/src/matrix/duplicate_rows/duplicate_rows.toml
+++ b/flowstdlib/src/matrix/duplicate_rows/duplicate_rows.toml
@@ -1,4 +1,5 @@
 function = "duplicate_rows"
+description = "Duplicate the rows of a matrix"
 source = "duplicate_rows.rs"
 docs = "duplicate_rows.md"
 type = "rust"

--- a/flowstdlib/src/matrix/multiply_row/multiply_row.toml
+++ b/flowstdlib/src/matrix/multiply_row/multiply_row.toml
@@ -1,4 +1,5 @@
 function = "multiply_row"
+description = "Multiply two matrix rows to a product"
 source = "multiply_row.rs"
 docs = "multiply_row.md"
 type = "rust"

--- a/flowstdlib/src/matrix/transpose/transpose.toml
+++ b/flowstdlib/src/matrix/transpose/transpose.toml
@@ -1,4 +1,5 @@
 function = "transpose"
+description = "Transpose a matrix's rows and columns"
 source = "transpose.rs"
 docs = "transpose.md"
 type = "rust"


### PR DESCRIPTION
Closes #2573

## Summary
- Add `description: String` field to `FunctionDefinition` in flowcore (optional, defaults to empty)
- Populate descriptions for all 50 existing function definitions:
  - 31 flowstdlib functions (extracted from existing .md documentation)
  - 15 context functions across flowrcli and flowrgui (stdin, stdout, stderr, readline, args/get, file read/write, image_buffer)
  - 3 example functions (reverse, escapes, pixel_to_point)
  - 1 test function

## Test plan
- [ ] `make test` passes (pre-existing flaky test excluded)
- [ ] All function TOML files parse correctly with the new field
- [ ] Existing flows compile and run without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptions to core functions and operations across control flow, data manipulation, formatting, mathematics, and matrix operations, providing quick reference information about what each function does.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->