### PR TITLE
flowedit: Unify library and context definition caches (#2593)

### DIFF
--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -25,16 +25,11 @@ use crate::WindowState;
 /// URL in `context_references`, parses the context function definition.
 pub(crate) fn load_library_catalogs(
     lib_references: &BTreeSet<Url>,
-) -> (
-    HashMap<Url, LibraryManifest>,
-    HashMap<Url, Process>,
-    HashMap<Url, Process>,
-) {
+) -> (HashMap<Url, LibraryManifest>, HashMap<Url, Process>) {
     let provider = flow_io::build_meta_provider();
     let arc_provider: Arc<dyn Provider> = Arc::new(provider);
     let mut library_cache = HashMap::new();
-    let mut lib_definitions = HashMap::new();
-    let mut context_definitions = HashMap::new();
+    let mut all_definitions = HashMap::new();
 
     // Extract unique library root URLs from lib_references
     // e.g., "lib://flowstdlib/math/add" -> "lib://flowstdlib"
@@ -62,7 +57,7 @@ pub(crate) fn load_library_catalogs(
                 for locator_url in manifest.locators.keys() {
                     match flowrclib::compiler::parser::parse(locator_url, &meta_provider) {
                         Ok(process) => {
-                            lib_definitions.insert(locator_url.clone(), process);
+                            all_definitions.insert(locator_url.clone(), process);
                         }
                         Err(e) => {
                             warn!(
@@ -112,13 +107,13 @@ pub(crate) fn load_library_catalogs(
                             if !func_name.is_empty() {
                                 let ctx_url_str = format!("context://{cat_name}/{func_name}");
                                 if let Ok(ctx_url) = Url::parse(&ctx_url_str) {
-                                    if !context_definitions.contains_key(&ctx_url) {
+                                    if !all_definitions.contains_key(&ctx_url) {
                                         match flowrclib::compiler::parser::parse(
                                             &ctx_url,
                                             &ctx_provider,
                                         ) {
                                             Ok(process) => {
-                                                context_definitions.insert(ctx_url, process);
+                                                all_definitions.insert(ctx_url, process);
                                             }
                                             Err(e) => {
                                                 warn!(
@@ -137,7 +132,7 @@ pub(crate) fn load_library_catalogs(
         }
     }
 
-    (library_cache, lib_definitions, context_definitions)
+    (library_cache, all_definitions)
 }
 
 /// Add a function from the library panel as a new node on the canvas.

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -513,6 +513,96 @@ mod test {
     }
 
     #[test]
+    fn from_cache_mixed_lib_and_context() {
+        use flowcore::model::lib_manifest::ImplementationLocator;
+        use flowcore::model::metadata::MetaData;
+
+        let mut all_defs = HashMap::new();
+
+        // Add a context function
+        let ctx_url = Url::parse("context://stdio/stdout").expect("valid url");
+        all_defs.insert(
+            ctx_url,
+            Process::FunctionProcess(
+                flowcore::model::function_definition::FunctionDefinition::default(),
+            ),
+        );
+
+        // Add a lib function definition
+        let lib_url = Url::parse("lib://testlib/math/add").expect("valid url");
+        all_defs.insert(
+            lib_url.clone(),
+            Process::FunctionProcess(
+                flowcore::model::function_definition::FunctionDefinition::default(),
+            ),
+        );
+
+        // Create a library manifest with one locator
+        let mut locators = BTreeMap::new();
+        locators.insert(
+            lib_url,
+            ImplementationLocator::RelativePath("math/add.wasm".into()),
+        );
+        let manifest = LibraryManifest::new(
+            Url::parse("lib://testlib").expect("valid url"),
+            MetaData {
+                name: "testlib".into(),
+                version: "1.0.0".into(),
+                description: String::new(),
+                authors: Vec::new(),
+            },
+        );
+        let mut cache = HashMap::new();
+        let mut m = manifest;
+        m.locators = locators;
+        cache.insert(Url::parse("lib://testlib").expect("valid url"), m);
+
+        let tree = LibraryTree::from_cache(&cache, &all_defs);
+        // Should have Context + testlib
+        assert_eq!(tree.libraries.len(), 2);
+        assert_eq!(tree.libraries[0].name, "Context");
+        assert_eq!(tree.libraries[1].name, "testlib");
+    }
+
+    #[test]
+    fn from_cache_lib_only_no_context() {
+        use flowcore::model::lib_manifest::ImplementationLocator;
+        use flowcore::model::metadata::MetaData;
+
+        let mut all_defs = HashMap::new();
+        let lib_url = Url::parse("lib://testlib/math/add").expect("valid url");
+        all_defs.insert(
+            lib_url.clone(),
+            Process::FunctionProcess(
+                flowcore::model::function_definition::FunctionDefinition::default(),
+            ),
+        );
+
+        let mut locators = BTreeMap::new();
+        locators.insert(
+            lib_url,
+            ImplementationLocator::RelativePath("math/add.wasm".into()),
+        );
+        let mut manifest = LibraryManifest::new(
+            Url::parse("lib://testlib").expect("valid url"),
+            MetaData {
+                name: "testlib".into(),
+                version: "1.0.0".into(),
+                description: String::new(),
+                authors: Vec::new(),
+            },
+        );
+        manifest.locators = locators;
+        let mut cache = HashMap::new();
+        cache.insert(Url::parse("lib://testlib").expect("valid url"), manifest);
+
+        let tree = LibraryTree::from_cache(&cache, &all_defs);
+        // Should have only testlib, no Context (sorting starts at index 0)
+        assert_eq!(tree.libraries.len(), 1);
+        assert_eq!(tree.libraries[0].name, "testlib");
+    }
+
+    #[test]
     fn build_categories_from_locators() {
         let mut locators = BTreeMap::new();
         locators.insert(

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -90,15 +90,14 @@ impl LibraryTree {
     /// "Context" library entry, derived from the parsed context definitions.
     pub(crate) fn from_cache(
         library_cache: &HashMap<Url, LibraryManifest>,
-        lib_definitions: &HashMap<Url, Process>,
-        context_definitions: &HashMap<Url, Process>,
+        all_definitions: &HashMap<Url, Process>,
     ) -> Self {
         let mut libraries = Vec::new();
 
         // Build tree entries from library manifests
         for manifest in library_cache.values() {
             let lib_name = manifest.lib_url.host_str().unwrap_or("unknown").to_string();
-            let categories = build_categories_from_manifest(&manifest.locators, lib_definitions);
+            let categories = build_categories_from_manifest(&manifest.locators, all_definitions);
 
             if !categories.is_empty() {
                 libraries.push(LibraryEntry {
@@ -109,8 +108,12 @@ impl LibraryTree {
             }
         }
 
-        // Build context functions entry from parsed context definitions
-        let context_entry = build_context_entry(context_definitions);
+        // Build context functions entry from context:// definitions in the unified map
+        let context_defs: HashMap<&Url, &Process> = all_definitions
+            .iter()
+            .filter(|(url, _)| url.scheme() == "context")
+            .collect();
+        let context_entry = build_context_entry(&context_defs);
         let has_context = !context_entry.categories.is_empty();
         if has_context {
             libraries.insert(0, context_entry);
@@ -295,7 +298,7 @@ impl LibraryTree {
 /// We extract category and function names from the URL path segments.
 fn build_categories_from_manifest(
     locators: &BTreeMap<Url, flowcore::model::lib_manifest::ImplementationLocator>,
-    lib_definitions: &HashMap<Url, Process>,
+    all_definitions: &HashMap<Url, Process>,
 ) -> Vec<CategoryEntry> {
     // Group functions by category
     let mut category_map: BTreeMap<String, Vec<FunctionEntry>> = BTreeMap::new();
@@ -316,7 +319,7 @@ fn build_categories_from_manifest(
         }
 
         // Extract description from definition if available
-        let description = lib_definitions
+        let description = all_definitions
             .get(url)
             .map(|process| match process {
                 Process::FlowProcess(flow_def) => flow_def.description.clone(),
@@ -353,7 +356,7 @@ fn build_categories_from_manifest(
 /// Build a "Context" library entry from parsed context definitions.
 ///
 /// Context URLs have the form `context://category/function`.
-fn build_context_entry(context_definitions: &HashMap<Url, Process>) -> LibraryEntry {
+fn build_context_entry(context_definitions: &HashMap<&Url, &Process>) -> LibraryEntry {
     let mut category_map: BTreeMap<String, Vec<FunctionEntry>> = BTreeMap::new();
 
     for (url, process) in context_definitions {
@@ -486,21 +489,21 @@ mod test {
 
     #[test]
     fn from_cache_empty() {
-        let tree = LibraryTree::from_cache(&HashMap::new(), &HashMap::new(), &HashMap::new());
+        let tree = LibraryTree::from_cache(&HashMap::new(), &HashMap::new());
         assert!(tree.libraries.is_empty());
     }
 
     #[test]
     fn from_cache_with_context_only() {
-        let mut context_defs = HashMap::new();
+        let mut all_defs = HashMap::new();
         let url = Url::parse("context://stdio/stdout").expect("valid url");
-        context_defs.insert(
+        all_defs.insert(
             url,
             Process::FunctionProcess(
                 flowcore::model::function_definition::FunctionDefinition::default(),
             ),
         );
-        let tree = LibraryTree::from_cache(&HashMap::new(), &HashMap::new(), &context_defs);
+        let tree = LibraryTree::from_cache(&HashMap::new(), &all_defs);
         assert_eq!(tree.libraries.len(), 1);
         assert_eq!(tree.libraries[0].name, "Context");
         assert_eq!(tree.libraries[0].categories.len(), 1);

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -198,10 +198,8 @@ struct FlowEdit {
     lib_paths: Vec<String>,
     /// Cached library manifests, keyed by library root URL (e.g., `lib://flowstdlib`)
     library_cache: HashMap<Url, LibraryManifest>,
-    /// Cached parsed definitions for library functions/flows, keyed by lib:// URL
-    lib_definitions: HashMap<Url, Process>,
-    /// Cached parsed definitions for context functions, keyed by context:// URL
-    context_definitions: HashMap<Url, Process>,
+    /// Cached parsed definitions for all library and context functions/flows
+    all_definitions: HashMap<Url, Process>,
 }
 
 impl Default for FlowEdit {
@@ -215,8 +213,7 @@ impl Default for FlowEdit {
             show_lib_paths: false,
             lib_paths: Vec::new(),
             library_cache: HashMap::new(),
-            lib_definitions: HashMap::new(),
-            context_definitions: HashMap::new(),
+            all_definitions: HashMap::new(),
         }
     }
 }
@@ -330,10 +327,8 @@ impl FlowEdit {
         let has_nodes = !nodes.is_empty();
 
         // Load full library catalogs from manifests and parse all definitions
-        let (library_cache, lib_definitions, context_definitions) =
-            library_mgmt::load_library_catalogs(&lib_refs);
-        let library_tree =
-            LibraryTree::from_cache(&library_cache, &lib_definitions, &context_definitions);
+        let (library_cache, all_definitions) = library_mgmt::load_library_catalogs(&lib_refs);
+        let library_tree = LibraryTree::from_cache(&library_cache, &all_definitions);
 
         // Open the root window via daemon API
         let saved_prefs = file_path
@@ -404,8 +399,7 @@ impl FlowEdit {
             show_lib_paths: false,
             lib_paths,
             library_cache,
-            lib_definitions,
-            context_definitions,
+            all_definitions,
         };
 
         (app, open_task.discard())
@@ -590,7 +584,7 @@ impl FlowEdit {
                                                     &meta_provider,
                                                 ) {
                                                     Ok(process) => {
-                                                        self.lib_definitions
+                                                        self.all_definitions
                                                             .insert(locator_url.clone(), process);
                                                     }
                                                     Err(e) => {
@@ -616,8 +610,7 @@ impl FlowEdit {
                                             // Rebuild the library tree
                                             self.library_tree = LibraryTree::from_cache(
                                                 &self.library_cache,
-                                                &self.lib_definitions,
-                                                &self.context_definitions,
+                                                &self.all_definitions,
                                             );
 
                                             if let Some(win) = self.windows.get_mut(&win_id) {
@@ -695,15 +688,11 @@ impl FlowEdit {
                                 .unwrap_or_else(FlowHierarchy::empty);
 
                             // Rebuild library cache with new flow's references
-                            let (lc, ld, cd) = library_mgmt::load_library_catalogs(&lib_refs);
+                            let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
                             self.library_cache = lc;
-                            self.lib_definitions = ld;
-                            self.context_definitions = cd;
-                            self.library_tree = LibraryTree::from_cache(
-                                &self.library_cache,
-                                &self.lib_definitions,
-                                &self.context_definitions,
-                            );
+                            self.all_definitions = ad;
+                            self.library_tree =
+                                LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
                         }
                     }
                 }
@@ -713,13 +702,9 @@ impl FlowEdit {
                     flow_io::perform_new(win);
                     // Clear the library cache for a new (empty) flow
                     self.library_cache.clear();
-                    self.lib_definitions.clear();
-                    self.context_definitions.clear();
-                    self.library_tree = LibraryTree::from_cache(
-                        &self.library_cache,
-                        &self.lib_definitions,
-                        &self.context_definitions,
-                    );
+                    self.all_definitions.clear();
+                    self.library_tree =
+                        LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
                 }
             }
             Message::Compile => {
@@ -1989,15 +1974,10 @@ impl FlowEdit {
             .and_then(|id| self.windows.get(&id))
             .map(|win| win.flow_definition.lib_references.clone())
             .unwrap_or_default();
-        let (lc, ld, cd) = library_mgmt::load_library_catalogs(&lib_refs);
+        let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
         self.library_cache = lc;
-        self.lib_definitions = ld;
-        self.context_definitions = cd;
-        self.library_tree = LibraryTree::from_cache(
-            &self.library_cache,
-            &self.lib_definitions,
-            &self.context_definitions,
-        );
+        self.all_definitions = ad;
+        self.library_tree = LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
     }
 
     fn build_hierarchy(&self) -> FlowHierarchy {


### PR DESCRIPTION
## Summary

Sub-project 4 of #2593. Merge `lib_definitions` and `context_definitions` into a single `all_definitions: HashMap<Url, Process>` on `FlowEdit`.

- 3 cache fields → 2 (library_cache + all_definitions)
- `load_library_catalogs()` returns 2-tuple instead of 3
- `LibraryTree::from_cache()` takes 2 args, filters context:// by URL scheme internally
- No flowcore/flowclib changes

Pure refactor — no behavior changes. All 193 tests pass.

Part of #2593

## Test plan

- [x] `cargo test -p flowedit` — 193 tests pass
- [x] `make clippy` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated and streamlined internal data management infrastructure by unifying separate definition storage and caching mechanisms into cohesive structures across library manifest parsing, catalog retrieval, and process definition handling components, thereby reducing code complexity, eliminating redundant logic, and improving overall system maintainability and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->