### PR TITLE
flowedit: Remove duplicate state, use FlowDefinition directly (#2593)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-eliminate-edgelayout.md
+++ b/docs/superpowers/plans/2026-04-22-eliminate-edgelayout.md
@@ -1,0 +1,346 @@
+# Eliminate EdgeLayout — Use Connection Directly
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `EdgeLayout` and `WindowState.edges`, using `flow_definition.connections: Vec<Connection>` directly for rendering, editing, and serialization.
+
+**Architecture:** `EdgeLayout` is a flat `(from_node, from_port, to_node, to_port, name)` extracted from `Connection`'s Route-based format. We eliminate it by having the canvas parse `Connection.from()`/`Connection.to()` routes on the fly via `split_route()`. History stores `Connection` instead of `EdgeLayout`. `save_flow_toml` serializes from `flow_definition.connections` directly. Note: `Connection.to` is `Vec<Route>` (fan-out), but the editor creates 1:1 connections — each Connection has exactly one to-route.
+
+**Tech Stack:** Rust, flowcore (Connection, Route), iced (canvas rendering)
+
+**Important:** Any edits proposed outside of `flowedit/` must be shown to the user before being made. `flowcore/src/model/connection.rs` already has getters/setters added in prior commit.
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `flowedit/src/window_state.rs` | Remove `edges: Vec<EdgeLayout>` field |
+| `flowedit/src/canvas_view.rs` | Change all functions taking `&[EdgeLayout]` to take `&[Connection]`; remove `EdgeLayout` struct, `build_edge_layouts()`, `EdgeLayout::new()`, `EdgeLayout::references_node()`; add `connection_references_node()` helper |
+| `flowedit/src/history.rs` | Change `CreateConnection { edge: EdgeLayout }` and `DeleteConnection { index, edge: EdgeLayout }` to use `Connection`; update `apply_undo`/`apply_redo` |
+| `flowedit/src/main.rs` | Replace all `win.edges` with `win.flow_definition.connections`; update connection creation to build `Connection` objects; update edge-related FlowEditMessage handlers |
+| `flowedit/src/flow_io.rs` | Remove `edges` parameter from `save_flow_toml()`, serialize from `flow_definition.connections`; remove `build_edge_layouts()` calls from `load_flow()`; remove `edges` from `LoadedFlow` |
+| `flowedit/src/initializer.rs` | No changes needed (doesn't reference edges) |
+| `flowedit/src/ui_test.rs` | Update tests that create/assert on `EdgeLayout` to use `Connection` |
+| `flowedit/src/library_mgmt.rs` | Minor — remove EdgeLayout import if present |
+
+---
+
+## Task 1: Add `connection_references_node` helper and update `split_route` visibility
+
+**Files:**
+- Modify: `flowedit/src/canvas_view.rs`
+
+This helper replaces `EdgeLayout::references_node()`. It checks whether a `Connection`'s from or to routes reference a given node alias.
+
+- [ ] **Step 1: Add the helper function**
+
+```rust
+/// Check whether a Connection references a node by alias in its from or to routes.
+pub(crate) fn connection_references_node(conn: &Connection, alias: &str) -> bool {
+    let (from_node, _) = split_route(&conn.from().to_string());
+    if from_node == alias {
+        return true;
+    }
+    for to_route in conn.to() {
+        let (to_node, _) = split_route(&to_route.to_string());
+        if to_node == alias {
+            return true;
+        }
+    }
+    false
+}
+```
+
+Add `use flowcore::model::connection::Connection;` to canvas_view.rs imports if not present. Make `split_route` `pub(crate)` so other modules can use it.
+
+- [ ] **Step 2: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Task 2: Update EditAction to use Connection instead of EdgeLayout
+
+**Files:**
+- Modify: `flowedit/src/history.rs`
+
+- [ ] **Step 1: Change EditAction variants**
+
+Replace:
+```rust
+CreateConnection { edge: EdgeLayout },
+DeleteConnection { index: usize, edge: EdgeLayout },
+```
+With:
+```rust
+CreateConnection { connection: Connection },
+DeleteConnection { index: usize, connection: Connection },
+```
+
+Update imports: add `use flowcore::model::connection::Connection;`, remove `EdgeLayout` import.
+
+- [ ] **Step 2: Update apply_undo**
+
+In `apply_undo` for `CreateConnection`: instead of matching on edge fields, use `connection_references_node` or route comparison to find and remove the connection:
+```rust
+EditAction::CreateConnection { connection } => {
+    let from_str = connection.from().to_string();
+    let to_strs: Vec<String> = connection.to().iter().map(ToString::to_string).collect();
+    win.flow_definition.connections.retain(|c| {
+        c.from().to_string() != from_str
+            || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
+    });
+    win.status = String::from("Undo: create connection");
+}
+```
+
+For `DeleteConnection`: insert the connection back:
+```rust
+EditAction::DeleteConnection { index, connection } => {
+    let idx = index.min(win.flow_definition.connections.len());
+    win.flow_definition.connections.insert(idx, connection);
+    win.status = String::from("Undo: delete connection");
+}
+```
+
+- [ ] **Step 3: Update apply_redo**
+
+Mirror the undo logic:
+- `CreateConnection`: push the connection
+- `DeleteConnection`: remove at index
+
+- [ ] **Step 4: Update history tests**
+
+Change test helpers that create `EdgeLayout::new(...)` to create `Connection::new("from_node/from_port", "to_node/to_port")` (or `Connection::new("from_node", "to_node")` for portless connections). Update assertions.
+
+- [ ] **Step 5: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 6: Commit**
+
+---
+
+## Task 3: Remove `edges` from WindowState and LoadedFlow
+
+**Files:**
+- Modify: `flowedit/src/window_state.rs`
+- Modify: `flowedit/src/flow_io.rs`
+
+- [ ] **Step 1: Remove `edges` from WindowState**
+
+Remove `pub(crate) edges: Vec<EdgeLayout>` from the struct and `edges: Vec::new()` from `Default::default()`. Remove the `EdgeLayout` import if no longer needed (keep other imports from canvas_view).
+
+- [ ] **Step 2: Remove `edges` from LoadedFlow**
+
+In `flow_io.rs`, remove `pub(crate) edges: Vec<EdgeLayout>` from `LoadedFlow`. Remove the `build_edge_layouts` call in `load_flow()`. The connections are already in `loaded.flow_def.connections`.
+
+- [ ] **Step 3: Update all WindowState struct literals**
+
+In `main.rs`: remove `edges: loaded.edges` / `edges: Vec::new()` from every WindowState construction. There are ~8 locations (new(), hierarchy open, open_node flows, create_new_subflow, create_new_function, etc.).
+
+In `flow_io.rs` tests: remove `edges` from `test_win_state()`.
+
+In `library_mgmt.rs` tests: remove `edges` from `test_win_state()`.
+
+- [ ] **Step 4: Build (expect errors in canvas_view.rs, history.rs, main.rs)**
+
+The build will fail because code still references `win.edges`. That's expected — the next tasks fix those references.
+
+- [ ] **Step 5: Commit (WIP — will not build yet)**
+
+---
+
+## Task 4: Update canvas_view.rs to use Connection
+
+**Files:**
+- Modify: `flowedit/src/canvas_view.rs`
+
+This is the largest task. Every function that takes `&[EdgeLayout]` or references `win.edges` must use `&[Connection]` / `win.flow_definition.connections`.
+
+- [ ] **Step 1: Update FlowCanvas struct and FlowCanvasState::view()**
+
+Change `edges: &'a [EdgeLayout]` to `connections: &'a [Connection]` in both the `FlowCanvas` struct and the `view()` method signature. Update the Canvas::new construction.
+
+- [ ] **Step 2: Update draw_edges()**
+
+Change signature from `edges: &[EdgeLayout]` to `connections: &[Connection]`. Inside the function, for each connection parse the routes:
+
+```rust
+for conn_idx in draw_order {
+    let Some(conn) = connections.get(conn_idx) else { continue };
+    let (from_node_str, from_port_str) = split_route(&conn.from().to_string());
+    // Handle fan-out: iterate conn.to()
+    for to_route in conn.to() {
+        let (to_node_str, to_port_str) = split_route(&to_route.to_string());
+        // ... rest of rendering logic using from_node_str, from_port_str, to_node_str, to_port_str
+        // ... conn.name() for label
+    }
+}
+```
+
+- [ ] **Step 3: Update hit_test_connection()**
+
+Change `edges` parameter to `connections: &[Connection]`. Same route-splitting approach inside the iteration.
+
+- [ ] **Step 4: Update draw_flow_io_ports() edge iteration**
+
+The section that draws bezier connections from flow I/O ports: change from `edges.iter()` to `connections.iter()`, parse routes with `split_route()`. Check `from_node == "input"` and `to_node == "output"` on the parsed strings.
+
+- [ ] **Step 5: Update view_canvas_area()**
+
+Where `FlowCanvas` / `FlowCanvasState::view()` is called: pass `&win.flow_definition.connections` instead of `&win.edges`.
+
+- [ ] **Step 6: Update CanvasMessage handlers**
+
+In `handle_canvas_message()`:
+- `CanvasMessage::Deleted`: replace `win.edges.iter().filter(|e| e.references_node(...))` with `win.flow_definition.connections.iter().filter(|c| connection_references_node(c, ...))` and `.retain()` similarly
+- `CanvasMessage::ConnectionCreated`: build `Connection::new(from_route, to_route)` where from_route = `format!("{from_node}/{from_port}")` (or just `from_node` if port is empty). Push to `win.flow_definition.connections`
+- `CanvasMessage::ConnectionSelected`: index into `win.flow_definition.connections`, parse routes for status display
+- `CanvasMessage::ConnectionDeleted`: remove from `win.flow_definition.connections`
+- Status messages: use `win.flow_definition.connections.len()` for edge count
+
+- [ ] **Step 7: Remove EdgeLayout struct, build_edge_layouts(), related methods**
+
+Remove:
+- `struct EdgeLayout` and its `impl` block (`new()`, `references_node()`)
+- `fn build_edge_layouts()`
+- Keep `split_route()` (still needed)
+
+- [ ] **Step 8: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 9: Commit**
+
+---
+
+## Task 5: Update main.rs edge references
+
+**Files:**
+- Modify: `flowedit/src/main.rs`
+
+- [ ] **Step 1: Update FlowEditMessage handlers**
+
+`DeleteInput`/`DeleteOutput`: replace `win.edges.retain(...)` with `win.flow_definition.connections.retain(...)`, checking parsed routes:
+```rust
+win.flow_definition.connections.retain(|c| {
+    let (from_node, _) = split_route(&c.from().to_string());
+    !(from_node == "input" && /* port match */)
+});
+```
+
+`InputNameChanged`/`OutputNameChanged`: update connection routes instead of edge strings. For each connection whose from/to references the old port name, use `conn.set_from()` or `conn.set_to()` with the updated route.
+
+- [ ] **Step 2: Update open_node and window creation**
+
+Remove `edges: loaded.edges` and similar from WindowState construction (if not already done in Task 3).
+
+- [ ] **Step 3: Remove EdgeLayout import**
+
+Remove `EdgeLayout` from the `use canvas_view::{...}` import in main.rs.
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 6: Update save_flow_toml to serialize from Connection
+
+**Files:**
+- Modify: `flowedit/src/flow_io.rs`
+
+- [ ] **Step 1: Remove `edges` parameter from save_flow_toml()**
+
+Change signature from `save_flow_toml(flow, edges, path)` to `save_flow_toml(flow, path)`. Serialize connections from `flow.connections`:
+
+```rust
+for conn in &flow.connections {
+    let _ = writeln!(out, "\n[[connection]]");
+    if !conn.name().is_empty() {
+        let _ = writeln!(out, "name = \"{}\"", conn.name());
+    }
+    let _ = writeln!(out, "from = \"{}\"", conn.from());
+    // Connection.to is Vec<Route>; write single or array
+    if conn.to().len() == 1 {
+        let _ = writeln!(out, "to = \"{}\"", conn.to()[0]);
+    } else {
+        let to_strs: Vec<String> = conn.to().iter().map(|r| format!("\"{r}\"")).collect();
+        let _ = writeln!(out, "to = [{}]", to_strs.join(", "));
+    }
+}
+```
+
+- [ ] **Step 2: Update perform_save() call**
+
+Change `save_flow_toml(&win.flow_definition, &win.edges, path)` to `save_flow_toml(&win.flow_definition, path)`.
+
+- [ ] **Step 3: Remove format_endpoint() if only used for edge display**
+
+Check if `format_endpoint()` is still needed. If it was only used by EdgeLayout status messages, remove it.
+
+- [ ] **Step 4: Remove build_edge_layouts import and EdgeLayout from flow_io imports**
+
+- [ ] **Step 5: Update tests**
+
+Update `save_flow_toml` tests to not pass edges. Update assertions to verify connections serialize correctly.
+
+- [ ] **Step 6: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 7: Commit**
+
+---
+
+## Task 7: Update ui_test.rs
+
+**Files:**
+- Modify: `flowedit/src/ui_test.rs`
+
+- [ ] **Step 1: Replace EdgeLayout usage with Connection**
+
+Every test that creates `EdgeLayout::new(...)` should create `Connection::new("from/port", "to/port")` instead.
+
+Every test that pushes to `win.edges` should push to `win.flow_definition.connections`.
+
+Every assertion on `win.edges.len()` should assert on `win.flow_definition.connections.len()`.
+
+Import `Connection` from flowcore.
+
+- [ ] **Step 2: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Task 8: Final cleanup and full test
+
+- [ ] **Step 1: Remove any remaining EdgeLayout references**
+
+```bash
+grep -rn 'EdgeLayout' flowedit/src/
+```
+
+Should return zero results. If any remain, fix them.
+
+- [ ] **Step 2: cargo fmt**
+
+- [ ] **Step 3: make clippy**
+
+Fix any new warnings.
+
+- [ ] **Step 4: make test**
+
+All tests must pass.
+
+- [ ] **Step 5: Final commit if needed**

--- a/docs/superpowers/plans/2026-04-22-eliminate-nodelayout.md
+++ b/docs/superpowers/plans/2026-04-22-eliminate-nodelayout.md
@@ -1,0 +1,169 @@
+# Eliminate NodeLayout — Use ProcessReference + subprocesses Directly
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove `NodeLayout` and `WindowState.nodes`, rendering the canvas directly from `flow_definition.process_refs` (for layout) and `flow_definition.subprocesses` (for ports, description).
+
+**Architecture:** `NodeLayout` duplicates data from `ProcessReference` (alias, source, x, y, width, height, initializations) and resolved subprocess definitions (inputs, outputs, description). We eliminate it by having the canvas read `ProcessReference` fields directly and look up port/description info from `FlowDefinition.subprocesses`. Mutations (drag, resize, add, delete) modify `process_refs` directly. `selected_node` indexes into `process_refs`. History `DeleteNode` stores `ProcessReference` + removed subprocess + removed connections.
+
+**Key types:**
+
+`ProcessReference` fields: `alias: Name`, `source: String`, `initializations: BTreeMap<String, InputInitializer>`, `x: Option<f32>`, `y: Option<f32>`, `width: Option<f32>`, `height: Option<f32>`
+
+`FlowDefinition.subprocesses: BTreeMap<Name, Process>` — resolved definitions for each subprocess, keyed by alias. `Process` is either `FunctionProcess(FunctionDefinition)` or `FlowProcess(FlowDefinition)`, both of which have `inputs: IOSet`, `outputs: IOSet`, `description: String`.
+
+**Rendering approach:** Create free functions that compute rendering properties from `ProcessReference` + subprocess lookup, replacing `NodeLayout` methods. For example, `node_fill_color(source: &str)`, `node_port_position(pref, port_index, is_input, subprocesses)`, etc.
+
+---
+
+## Task 1: Add rendering helper functions
+
+**Files:** `flowedit/src/canvas_view.rs`
+
+Add free functions that provide the same rendering info that NodeLayout methods did, but reading from ProcessReference + subprocesses:
+
+```rust
+fn node_x(pref: &ProcessReference) -> f32 { pref.x.unwrap_or(100.0) }
+fn node_y(pref: &ProcessReference) -> f32 { pref.y.unwrap_or(100.0) }
+fn node_width(pref: &ProcessReference) -> f32 { pref.width.unwrap_or(DEFAULT_WIDTH) }
+fn node_height(pref: &ProcessReference, subprocesses: &BTreeMap<Name, Process>) -> f32 {
+    let (inputs, outputs) = subprocess_ports(pref, subprocesses);
+    let min_ports = inputs.len().max(outputs.len());
+    let min_height = PORT_START_Y + (min_ports as f32 + 1.0) * PORT_SPACING;
+    pref.height.unwrap_or(DEFAULT_HEIGHT.max(min_height))
+}
+
+fn node_alias(pref: &ProcessReference) -> &str {
+    if pref.alias.is_empty() { derive_short_name(&pref.source) } // note: returns String, need to handle
+    else { &pref.alias }
+}
+
+fn node_fill_color(source: &str) -> Color { /* same logic as NodeLayout::fill_color */ }
+fn node_is_openable(source: &str) -> bool { !source.starts_with("lib://") && !source.starts_with("context://") }
+
+fn subprocess_ports(pref: &ProcessReference, subprocesses: &BTreeMap<Name, Process>) -> (Vec<PortInfo>, Vec<PortInfo>) {
+    let alias = if pref.alias.is_empty() { derive_short_name(&pref.source) } else { pref.alias.clone() };
+    subprocesses.get(&alias).map(|proc| match proc {
+        Process::FunctionProcess(f) => extract_ports(&f.inputs, &f.outputs),
+        Process::FlowProcess(f) => extract_ports(&f.inputs, &f.outputs),
+    }).unwrap_or_default()
+}
+
+fn subprocess_description(pref: &ProcessReference, subprocesses: &BTreeMap<Name, Process>) -> String {
+    let alias = if pref.alias.is_empty() { derive_short_name(&pref.source) } else { pref.alias.clone() };
+    subprocesses.get(&alias).map(|proc| match proc {
+        Process::FunctionProcess(f) => f.description.clone(),
+        Process::FlowProcess(f) => f.description.clone(),
+    }).unwrap_or_default()
+}
+
+fn initializer_display(init: &InputInitializer) -> String {
+    match init {
+        InputInitializer::Once(v) => format!("once: {}", format_value(v)),
+        InputInitializer::Always(v) => format!("always: {}", format_value(v)),
+    }
+}
+
+fn node_output_port_position(pref: &ProcessReference, port_index: usize) -> Point {
+    Point::new(
+        node_x(pref) + node_width(pref),
+        node_y(pref) + PORT_START_Y + port_index as f32 * PORT_SPACING,
+    )
+}
+
+fn node_input_port_position(pref: &ProcessReference, port_index: usize) -> Point {
+    Point::new(
+        node_x(pref),
+        node_y(pref) + PORT_START_Y + port_index as f32 * PORT_SPACING,
+    )
+}
+```
+
+These are additive — existing code continues to work.
+
+## Task 2: Update canvas rendering to use ProcessReference
+
+**Files:** `flowedit/src/canvas_view.rs`
+
+Change `FlowCanvas` struct: replace `nodes: &'a [NodeLayout]` with `process_refs: &'a [ProcessReference]` and `subprocesses: &'a BTreeMap<Name, Process>`.
+
+Update `FlowCanvasState::view()` to accept `process_refs` + `subprocesses` instead of `nodes`.
+
+Update `draw_nodes()`, `draw_node()`, `draw_port()`, `draw_edges()`, `draw_flow_io_ports()`, `hit_test_node()`, `hit_test_port()`, `hit_test_connection()`, `hit_test_resize_handle()`, `hit_test_open_icon()`, `is_in_source_text_zone()`, `auto_fit()`, `compute_flow_io_positions()`, and all other functions that take `&[NodeLayout]` to use `&[ProcessReference]` + `&BTreeMap<Name, Process>`.
+
+Replace `node.alias` with `node_alias(pref)`, `node.x` with `node_x(pref)`, `node.inputs` with `subprocess_ports(pref, subprocesses).0`, etc.
+
+Update `view_canvas_area()` to pass `&win.flow_definition.process_refs` and `&win.flow_definition.subprocesses`.
+
+## Task 3: Update CanvasMessage handlers
+
+**Files:** `flowedit/src/canvas_view.rs`
+
+In `handle_canvas_message()`:
+- `Moved(idx, x, y)`: set `win.flow_definition.process_refs[idx].x = Some(x)` and `.y = Some(y)` directly
+- `Resized(idx, x, y, w, h)`: set x/y/width/height on process_refs[idx] directly
+- `MoveCompleted`: same, record history
+- `Deleted(idx)`: remove from `win.flow_definition.process_refs`, also remove from `win.flow_definition.subprocesses`, remove connected connections
+- `ConnectionCreated/Selected/Deleted`: already uses connections (from EdgeLayout elimination)
+
+## Task 4: Update history to use ProcessReference
+
+**Files:** `flowedit/src/history.rs`
+
+Change `EditAction::DeleteNode`:
+```rust
+DeleteNode {
+    index: usize,
+    process_ref: ProcessReference,
+    subprocess: Option<(Name, Process)>,
+    removed_connections: Vec<Connection>,
+}
+```
+
+`MoveNode` and `ResizeNode` stay the same (they store coordinates, not NodeLayout).
+
+Update `apply_undo`/`apply_redo` for DeleteNode to insert/remove from `process_refs` and `subprocesses`.
+
+## Task 5: Update main.rs — remove win.nodes
+
+**Files:** `flowedit/src/main.rs`
+
+- Remove `nodes` from all WindowState construction
+- Node creation (NewSubFlow, NewFunction, add_library_function): add `ProcessReference` to `flow_definition.process_refs` and add the resolved `Process` to `flow_definition.subprocesses`
+- `generate_unique_alias`: take `&[ProcessReference]` instead of `&[NodeLayout]`
+- `next_node_position`: take `&[ProcessReference]` instead of `&[NodeLayout]`
+- open_node: use process_refs index to find source
+
+## Task 6: Update flow_io.rs — remove LoadedFlow.nodes
+
+**Files:** `flowedit/src/flow_io.rs`
+
+- Remove `nodes: Vec<NodeLayout>` from `LoadedFlow`
+- Remove `build_node_layouts()` call from `load_flow()` — process_refs and subprocesses are already in the FlowDefinition
+- Remove `build_node_layouts()` function
+- Update `perform_open`: remove `win.nodes = loaded.nodes`
+- Update `perform_new`: remove `win.nodes = Vec::new()`
+- `generate_unique_alias`: take `&[ProcessReference]`
+- `next_node_position`: take `&[ProcessReference]`
+
+## Task 7: Update remaining files
+
+**Files:** `flowedit/src/initializer.rs`, `flowedit/src/library_mgmt.rs`
+
+- `sync_flow_definition()`: this function syncs NodeLayout positions back to ProcessReference — it becomes unnecessary since we write to ProcessReference directly. Remove it.
+- `apply_initializer_state()`: modify `flow_definition.process_refs` directly (already does this for the model side; remove the NodeLayout display side)
+- `add_library_function()`: add ProcessReference + resolved Process to subprocesses, no NodeLayout
+
+## Task 8: Remove NodeLayout struct and update WindowState
+
+**Files:** `flowedit/src/window_state.rs`, `flowedit/src/canvas_view.rs`
+
+- Remove `nodes: Vec<NodeLayout>` from WindowState
+- Remove `NodeLayout` struct, `Default` impl, `build_node_layouts()`
+- Remove `PortInfo` if no longer used (check FunctionViewer first — that's Sub-plan C)
+
+## Task 9: Update ui_test.rs
+
+Update all tests: replace `win.nodes` with `win.flow_definition.process_refs`, replace NodeLayout construction with ProcessReference construction, update assertions.
+
+## Task 10: Final cleanup, fmt, clippy, test

--- a/docs/superpowers/plans/2026-04-22-remove-duplicate-state-tier1.md
+++ b/docs/superpowers/plans/2026-04-22-remove-duplicate-state-tier1.md
@@ -1,0 +1,409 @@
+# Remove Duplicate State — Tier 1 (Quick Wins) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove three redundant fields from flowedit that duplicate data already in `FlowDefinition`: `WindowState.file_path`, `WindowState.flow_inputs`/`flow_outputs`, and `FlowEdit.root_flow_path`.
+
+**Architecture:** Each field is replaced by reading from / writing to the canonical `FlowDefinition` stored in `WindowState.flow_definition`. `file_path` maps to `flow_definition.source_url` (a `Url`). `flow_inputs`/`flow_outputs` (Vec<PortInfo>) map to `flow_definition.inputs`/`flow_definition.outputs` (Vec<IO>). `root_flow_path` is derived from the root window's `source_url`. This also fixes a bug where flow I/O edits (AddInput, DeleteInput, etc.) were never synced to the FlowDefinition and would be lost on save.
+
+**Tech Stack:** Rust, flowcore (model types), iced (GUI framework)
+
+**Important:** Any edits proposed outside of `flowedit/` must be shown to the user before being made.
+
+---
+
+### Task 1: Add `set_name` method to `IO` in flowcore
+
+The `IO` struct's `name` field is private, accessed via the `HasName` trait which only provides `fn name(&self) -> &Name`. flowedit needs to rename ports, so we need a setter.
+
+**Files:**
+- Modify: `flowcore/src/model/io.rs:70` (impl IO block)
+
+**IMPORTANT: Show this edit to the user before making it — it is outside flowedit.**
+
+- [ ] **Step 1: Add `set_name` method to IO**
+
+Add this method inside the `impl IO` block (after `new_named`, around line 93):
+
+```rust
+/// Set the name of this IO
+pub fn set_name(&mut self, name: Name) {
+    self.name = name;
+}
+```
+
+- [ ] **Step 2: Verify flowcore builds**
+
+Run: `cargo build -p flowcore`
+Expected: SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flowcore/src/model/io.rs
+git commit -m "flowcore: Add set_name method to IO for editor support (#2593)"
+```
+
+---
+
+### Task 2: Remove `WindowState.file_path` — use `flow_definition.source_url`
+
+Replace `file_path: Option<PathBuf>` with reads/writes to `flow_definition.source_url: Url`. The mapping:
+- `file_path = None` → `source_url == FlowDefinition::default_url()` (which is `"file://"`)
+- `file_path = Some(path)` → `source_url = Url::from_file_path(path)`
+- Reading: `source_url.to_file_path().ok()` → `Option<PathBuf>`
+
+Add a helper method on `WindowState` to avoid repeating the conversion.
+
+**Files:**
+- Modify: `flowedit/src/window_state.rs` — remove `file_path` field, add `file_path()` helper method
+- Modify: `flowedit/src/main.rs` — update all `win.file_path` reads/writes
+- Modify: `flowedit/src/flow_io.rs` — update `perform_save`, `handle_save`, `perform_open`, `perform_new`, `perform_compile`
+- Modify: `flowedit/src/library_mgmt.rs` — update `resolve_node_source`
+- Modify: `flowedit/src/ui_test.rs` — update test that sets `win.file_path`
+
+- [ ] **Step 1: Add `file_path()` and `set_file_path()` helpers to WindowState**
+
+In `flowedit/src/window_state.rs`, add to the `impl WindowState` block:
+
+```rust
+/// Get the file path from the flow definition's source URL.
+/// Returns None if no file has been saved/loaded yet.
+pub(crate) fn file_path(&self) -> Option<PathBuf> {
+    self.flow_definition.source_url.to_file_path().ok()
+}
+
+/// Set the file path by updating the flow definition's source URL.
+pub(crate) fn set_file_path(&mut self, path: &Path) {
+    if let Ok(url) = Url::from_file_path(path) {
+        self.flow_definition.source_url = url;
+    }
+}
+
+/// Clear the file path by resetting the source URL to the default.
+pub(crate) fn clear_file_path(&mut self) {
+    self.flow_definition.source_url = FlowDefinition::default_url();
+}
+```
+
+Add `use std::path::Path;` and `use url::Url;` to the imports.
+
+- [ ] **Step 2: Remove `file_path` field from WindowState**
+
+Remove the `file_path: Option<PathBuf>` field from the struct and from `Default::default()`.
+
+- [ ] **Step 3: Update flow_io.rs**
+
+Replace all `win.file_path` reads with `win.file_path()` and all `win.file_path = Some(path)` writes with `win.set_file_path(&path)`. In `perform_new`, replace `win.file_path = None` with `win.clear_file_path()`.
+
+Key changes:
+- `perform_save`: `win.file_path = Some(path.clone())` → `win.set_file_path(path)`
+- `handle_save`: `win.file_path.clone()` → `win.file_path()`
+- `perform_open`: `win.file_path = Some(path)` → `win.set_file_path(&path)`
+- `perform_new`: `win.file_path = None` → `win.clear_file_path()`
+- `perform_compile`: `win.file_path.is_none()` → `win.file_path().is_none()`, `win.file_path.clone()` → `win.file_path()`
+
+- [ ] **Step 4: Update main.rs**
+
+Replace all `file_path` field accesses on WindowState:
+- In `new()` (init): set `flow_definition.source_url` before constructing WindowState, remove `file_path` from struct literal
+- In `Message::Open`: `win.file_path.clone()` → `win.file_path()`, `self.root_flow_path = win.file_path.clone()` → derive from source_url
+- In node-opening code: `win.file_path.as_ref()` → `win.file_path()`
+- In window creation: remove `file_path` field from WindowState literals, set source_url on flow_definition instead
+- In `compile` button handler: `win.file_path.as_ref()` → `win.file_path()`
+
+- [ ] **Step 5: Update library_mgmt.rs**
+
+`resolve_node_source`: `win.file_path.as_ref()?.parent()?` → `win.file_path()?.parent()?.to_path_buf()` (adjust as needed for the borrow)
+
+- [ ] **Step 6: Update ui_test.rs**
+
+Replace `win.file_path = Some(path.clone())` with `win.set_file_path(&path)`.
+
+- [ ] **Step 7: Update test WindowState literals in flow_io.rs, library_mgmt.rs, history.rs**
+
+Remove `file_path: None` / `file_path: Some(...)` from all test WindowState struct literals. For tests that need a file path, use `win.set_file_path(&path)` after construction.
+
+- [ ] **Step 8: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+Expected: All tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add flowedit/src/window_state.rs flowedit/src/main.rs flowedit/src/flow_io.rs flowedit/src/library_mgmt.rs flowedit/src/ui_test.rs flowedit/src/history.rs
+git commit -m "flowedit: Remove WindowState.file_path, use flow_definition.source_url (#2593)"
+```
+
+---
+
+### Task 3: Remove `WindowState.flow_inputs`/`flow_outputs` — use `flow_definition.inputs`/`outputs`
+
+Replace `flow_inputs: Vec<PortInfo>` and `flow_outputs: Vec<PortInfo>` with direct reads/writes to `flow_definition.inputs: Vec<IO>` and `flow_definition.outputs: Vec<IO>`.
+
+This also fixes a bug: the `AddInput`, `DeleteInput`, `InputNameChanged`, `InputTypeChanged` (and output equivalents) message handlers currently only modify the `PortInfo` vecs, never updating `flow_definition.inputs`/`outputs`. Since `save_flow_toml` serializes from `flow_definition.inputs`/`outputs`, flow I/O edits are silently lost on save.
+
+The `PortInfo` struct is still used by `NodeLayout` for subprocess ports — it is NOT removed in this task (that happens in Tier 2 when NodeLayout is eliminated).
+
+**Files:**
+- Modify: `flowedit/src/window_state.rs` — remove `flow_inputs`/`flow_outputs` fields
+- Modify: `flowedit/src/main.rs` — update all FlowEditMessage handlers and view code to use `flow_definition.inputs`/`outputs`
+- Modify: `flowedit/src/flow_io.rs` — remove `extract_ports` calls for flow-level I/O, remove `flow_inputs`/`flow_outputs` from `perform_open`/`perform_new`
+- Modify: `flowedit/src/canvas_view.rs` — change functions that take `&[PortInfo]` for flow I/O to take `&[IO]`
+- Modify: `flowedit/src/ui_test.rs` — update assertions to check `flow_definition.inputs`/`outputs` instead of `flow_inputs`/`flow_outputs`
+
+- [ ] **Step 1: Update canvas_view.rs rendering functions to accept `&[IO]`**
+
+Change these function signatures to use `&[IO]` instead of `&[PortInfo]`:
+- `compute_flow_io_positions(nodes, flow_inputs, flow_outputs)` — change params to `&[IO]`, access name via `io.name()` (returns `&str`)
+- `draw_flow_io_ports(...)` — change flow_inputs/flow_outputs params to `&[IO]`
+- `draw_flow_io_beziers(...)` — change flow_inputs/flow_outputs params to `&[IO]`
+- `FlowCanvasData` struct — change `flow_inputs`/`flow_outputs` fields to `&'a [IO]`
+
+In all these functions, `input.name.clone()` becomes `input.name().to_string()` and `input.name` becomes `input.name()`.
+
+Add `use flowcore::model::io::IO;` to canvas_view.rs imports. Add `use flowcore::model::name::HasName;` for the `name()` trait method.
+
+- [ ] **Step 2: Update canvas_view.rs callers**
+
+Where `FlowCanvasData` is constructed (in `view_canvas_area` or similar), pass `&win.flow_definition.inputs` and `&win.flow_definition.outputs` instead of `&win.flow_inputs` and `&win.flow_outputs`.
+
+The `has_flow_io` check: `!win.flow_inputs.is_empty() || !win.flow_outputs.is_empty()` becomes `!win.flow_definition.inputs.is_empty() || !win.flow_definition.outputs.is_empty()`.
+
+- [ ] **Step 3: Update main.rs FlowEditMessage handlers**
+
+Replace all `win.flow_inputs` / `win.flow_outputs` usage with `win.flow_definition.inputs` / `win.flow_definition.outputs`:
+
+`AddInput`:
+```rust
+FlowEditMessage::AddInput => {
+    let name = format!("input{}", win.flow_definition.inputs.len());
+    let io = IO::new_named(
+        vec![DataType::from("string")],
+        Route::default(),
+        name,
+    );
+    win.flow_definition.inputs.push(io);
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+`AddOutput`:
+```rust
+FlowEditMessage::AddOutput => {
+    let name = format!("output{}", win.flow_definition.outputs.len());
+    let io = IO::new_named(
+        vec![DataType::from("string")],
+        Route::default(),
+        name,
+    );
+    win.flow_definition.outputs.push(io);
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+`DeleteInput(idx)`:
+```rust
+FlowEditMessage::DeleteInput(idx) => {
+    if idx < win.flow_definition.inputs.len() {
+        let name = win.flow_definition.inputs[idx].name().to_string();
+        win.flow_definition.inputs.remove(idx);
+        win.edges.retain(|e| !(e.from_node == "input" && e.from_port == name));
+        win.unsaved_edits += 1;
+        win.canvas_state.request_redraw();
+    }
+}
+```
+
+`DeleteOutput(idx)`:
+```rust
+FlowEditMessage::DeleteOutput(idx) => {
+    if idx < win.flow_definition.outputs.len() {
+        let name = win.flow_definition.outputs[idx].name().to_string();
+        win.flow_definition.outputs.remove(idx);
+        win.edges.retain(|e| !(e.to_node == "output" && e.to_port == name));
+        win.unsaved_edits += 1;
+        win.canvas_state.request_redraw();
+    }
+}
+```
+
+`InputNameChanged(idx, name)`:
+```rust
+FlowEditMessage::InputNameChanged(idx, name) => {
+    if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+        let old_name = io.name().to_string();
+        io.set_name(name.clone());
+        for edge in &mut win.edges {
+            if edge.from_node == "input" && edge.from_port == old_name {
+                edge.from_port = name.clone();
+            }
+        }
+    }
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+`InputTypeChanged(idx, dtype)`:
+```rust
+FlowEditMessage::InputTypeChanged(idx, dtype) => {
+    if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+        io.set_datatypes(&[DataType::from(dtype)]);
+    }
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+`OutputNameChanged(idx, name)`:
+```rust
+FlowEditMessage::OutputNameChanged(idx, name) => {
+    if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+        let old_name = io.name().to_string();
+        io.set_name(name.clone());
+        for edge in &mut win.edges {
+            if edge.to_node == "output" && edge.to_port == old_name {
+                edge.to_port = name.clone();
+            }
+        }
+    }
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+`OutputTypeChanged(idx, dtype)`:
+```rust
+FlowEditMessage::OutputTypeChanged(idx, dtype) => {
+    if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+        io.set_datatypes(&[DataType::from(dtype)]);
+    }
+    win.unsaved_edits += 1;
+    win.canvas_state.request_redraw();
+}
+```
+
+Add imports: `use flowcore::model::io::IO;`, `use flowcore::model::datatype::DataType;`, `use flowcore::model::route::Route;`, `use flowcore::model::name::HasName;`.
+
+- [ ] **Step 4: Update main.rs view_flow_io_panel**
+
+Change `win.flow_inputs.iter()` to `win.flow_definition.inputs.iter()` and `win.flow_outputs.iter()` to `win.flow_definition.outputs.iter()`.
+
+For each `port` (now an `&IO`):
+- `port.name` → `port.name().to_string()` (for display) or `port.name()` (for &str comparison)
+- `port.datatypes.first().cloned().unwrap_or_default()` → `port.datatypes().first().map(|dt| dt.to_string()).unwrap_or_default()`
+
+- [ ] **Step 5: Update flow_io.rs**
+
+- Remove `extract_ports` calls for flow-level I/O in `perform_open` and throughout
+- In `perform_open`: remove `win.flow_inputs = fi; win.flow_outputs = fo;`
+- In `perform_new`: remove `win.flow_inputs = Vec::new(); win.flow_outputs = Vec::new();`
+- `extract_ports` function itself stays (still used by `build_node_layouts` for subprocess ports) but the calls for flow-level I/O are removed
+- Remove `flow_inputs`/`flow_outputs` from test WindowState literals
+
+- [ ] **Step 6: Update main.rs init and window creation**
+
+Remove `flow_inputs: fi, flow_outputs: fo` from all WindowState struct literals. Remove the `extract_ports` call for flow-level I/O in `new()`. The flow_definition already has the correct `inputs`/`outputs` from deserialization.
+
+For window creation in `open_node`, `create_new_subflow`, `create_new_function`, etc.: remove `flow_inputs`/`flow_outputs` from the WindowState literals.
+
+- [ ] **Step 7: Remove fields from WindowState**
+
+In `window_state.rs`:
+- Remove `flow_inputs: Vec<PortInfo>` and `flow_outputs: Vec<PortInfo>` fields
+- Remove them from `Default::default()`
+- Remove the `PortInfo` import if it's no longer used here (it's still used by `FunctionViewer`)
+
+- [ ] **Step 8: Update ui_test.rs**
+
+Change all test assertions:
+- `w.flow_inputs.len()` → `w.flow_definition.inputs.len()`
+- `w.flow_outputs.len()` → `w.flow_definition.outputs.len()`
+- `w.flow_inputs.first().map(|p| p.name.as_str())` → `w.flow_definition.inputs.first().map(|io| io.name().as_str())`  (add `use flowcore::model::name::HasName;`)
+- `w.flow_inputs.first().and_then(|p| p.datatypes.first()).map(|s| s.as_str())` → `w.flow_definition.inputs.first().and_then(|io| io.datatypes().first()).map(|dt| dt.to_string())` — note: this changes the comparison type from `&str` to `String`, so adjust `assert_eq!` accordingly
+
+- [ ] **Step 9: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+Expected: All tests pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add flowedit/src/window_state.rs flowedit/src/main.rs flowedit/src/flow_io.rs flowedit/src/canvas_view.rs flowedit/src/ui_test.rs
+git commit -m "flowedit: Remove flow_inputs/flow_outputs, use flow_definition.inputs/outputs directly (#2593)
+
+Fixes bug where flow I/O edits (add/delete/rename ports) were lost on save
+because only the PortInfo duplicates were updated, not flow_definition."
+```
+
+---
+
+### Task 4: Remove `FlowEdit.root_flow_path` — derive from root window
+
+Replace `root_flow_path: Option<PathBuf>` with a helper method that reads from the root window's `flow_definition.source_url`.
+
+**Files:**
+- Modify: `flowedit/src/main.rs` — remove field, add helper, update all usages
+
+- [ ] **Step 1: Add helper method to FlowEdit**
+
+```rust
+fn root_flow_path(&self) -> Option<PathBuf> {
+    self.root_window
+        .and_then(|id| self.windows.get(&id))
+        .and_then(|win| win.file_path())
+}
+```
+
+- [ ] **Step 2: Remove `root_flow_path` field**
+
+Remove from the struct definition and from `Default::default()`.
+
+- [ ] **Step 3: Update all usages**
+
+- In `new()`: remove `let root_flow_path = file_path.clone();` and `root_flow_path,` from struct literal
+- In `Message::Open`: remove `self.root_flow_path = win.file_path.clone();` (no longer needed — it's derived)
+- In `build_hierarchy()`: change `self.root_flow_path.as_ref()` to `self.root_flow_path()` (the new helper returns `Option<PathBuf>`, so adjust `.map(|p| ...)` to `.as_ref().map(|p| ...)` or use `as_deref()`)
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build -p flowedit && cargo test -p flowedit`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flowedit/src/main.rs
+git commit -m "flowedit: Remove FlowEdit.root_flow_path, derive from root window (#2593)"
+```
+
+---
+
+### Task 5: Run full test suite and lint
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt`
+
+- [ ] **Step 2: Clippy**
+
+Run: `make clippy`
+Expected: Clean
+
+- [ ] **Step 3: Full test suite**
+
+Run: `make test`
+Expected: All tests pass
+
+- [ ] **Step 4: Fix any issues found**
+
+If clippy or tests fail, fix the issues and re-run.
+
+- [ ] **Step 5: Final commit if needed**
+
+Only if formatting or clippy fixes were needed.

--- a/docs/superpowers/plans/2026-04-22-single-flowdefinition-owner.md
+++ b/docs/superpowers/plans/2026-04-22-single-flowdefinition-owner.md
@@ -1,0 +1,88 @@
+# Single FlowDefinition Owner Architecture
+
+## Status: Planned (not yet started)
+
+## Problem
+
+After the state deduplication work in #2593, each window still owns its own `FlowDefinition`. The `FunctionViewer` clones its `FunctionDefinition` from the parent flow's `subprocesses`, meaning edits are not immediately reflected in the canonical tree. The `propagate_function_ports()` function manually syncs changes back, but this is fragile and creates a window where the data is inconsistent.
+
+Similarly, when a sub-flow is opened in a child window, it gets its own `FlowDefinition` loaded independently, not a reference into the parent's `subprocesses`.
+
+## Proposed Architecture
+
+**`FlowEdit` owns the single canonical `FlowDefinition`:**
+
+```
+FlowEdit {
+    flow_definition: FlowDefinition,       // THE source of truth
+    compiled_manifest: Option<PathBuf>,     // one per app, not per window
+    windows: HashMap<window::Id, WindowState>,
+    ...
+}
+```
+
+**Each `WindowState` knows what it's editing but doesn't own the data:**
+
+```
+enum EditTarget {
+    RootFlow,                              // editing flow_definition itself
+    SubFlow { alias: Name },               // editing flow_definition.subprocesses[alias]
+    Function { alias: Name },              // editing a FunctionDefinition within subprocesses
+}
+
+struct WindowState {
+    target: EditTarget,                    // what part of the tree this window edits
+    canvas_state: FlowCanvasState,
+    selected_node: Option<usize>,
+    selected_connection: Option<usize>,
+    // ... UI-only state
+}
+```
+
+**`view()` and `update()` resolve the target:**
+
+In iced's `update(&mut self, message)`, `self` is `&mut FlowEdit`. Both the canonical `flow_definition` and all `WindowState`s are accessible. The update method looks up the target:
+
+```rust
+fn get_flow_for_window(&self, win: &WindowState) -> &FlowDefinition {
+    match &win.target {
+        EditTarget::RootFlow => &self.flow_definition,
+        EditTarget::SubFlow { alias } => {
+            // walk subprocesses to find the nested FlowDefinition
+        }
+        EditTarget::Function { alias } => { /* not a flow */ }
+    }
+}
+```
+
+**Benefits:**
+- No cloning or syncing — all edits go to the canonical tree
+- `is_root` field removed — derived from `EditTarget::RootFlow`
+- `compiled_manifest` moves to `FlowEdit` (one per app)
+- `file_path()` derived from the root flow's `source_url`
+- Hierarchy panel walks the canonical `subprocesses` tree directly
+- Child windows are thin views, not independent copies
+
+**Challenges:**
+- Iced's `view()` takes `&self` — need to resolve target and pass the right `&FlowDefinition` or `&FunctionDefinition` to the view methods
+- History undo/redo needs to modify the canonical tree, not a per-window copy
+- Opening a sub-flow that isn't yet in `subprocesses` requires loading it via flowclib first
+
+## Relationship to Other Work
+
+This architecture change would also enable:
+- **Hierarchy panel as a view onto FlowDefinition** (#2593) — walk `subprocesses` directly
+- **Component encapsulation** (#2597) — each component's `view()` takes a reference to the relevant part of the canonical tree
+- **Proper save** — serialize the single canonical `FlowDefinition` via serde
+
+## Tasks
+
+1. Move `flow_definition` from `WindowState` to `FlowEdit`
+2. Add `EditTarget` enum to `WindowState`
+3. Move `compiled_manifest` to `FlowEdit`
+4. Remove `is_root` from `WindowState`
+5. Update all `update()` handlers to resolve target from `FlowEdit.flow_definition`
+6. Update all `view()` methods to receive the resolved `&FlowDefinition` or `&FunctionDefinition`
+7. Remove `propagate_function_ports()` — edits go directly to the canonical tree
+8. Update hierarchy panel to walk `FlowEdit.flow_definition.subprocesses`
+9. Update history to operate on the canonical tree

--- a/flowcore/src/model/connection.rs
+++ b/flowcore/src/model/connection.rs
@@ -94,11 +94,51 @@ impl Connection {
         }
     }
 
+    /// Create a new named Connection
+    pub fn new_named<N, R>(name: N, from_route: R, to_route: R) -> Self
+    where
+        N: Into<Name>,
+        R: Into<Route>,
+    {
+        Connection {
+            name: name.into(),
+            from: from_route.into(),
+            to: vec![to_route.into()],
+            ..Default::default()
+        }
+    }
+
     /// Return the name
-    #[cfg(feature = "debugger")]
     #[must_use]
     pub fn name(&self) -> &Name {
         &self.name
+    }
+
+    /// Set the connection name
+    pub fn set_name(&mut self, name: Name) {
+        self.name = name;
+    }
+
+    /// Return the `from` Route
+    #[must_use]
+    pub fn from(&self) -> &Route {
+        &self.from
+    }
+
+    /// Set the `from` Route
+    pub fn set_from<R: Into<Route>>(&mut self, from: R) {
+        self.from = from.into();
+    }
+
+    /// Return the `to` Routes
+    #[must_use]
+    pub fn to(&self) -> &Vec<Route> {
+        &self.to
+    }
+
+    /// Set the `to` Routes
+    pub fn set_to(&mut self, to: Vec<Route>) {
+        self.to = to;
     }
 
     /// Connect the `from_io` to the `to_io` inside a flow at level `level`, if they are compatible
@@ -138,12 +178,6 @@ impl Connection {
         Ok(())
     }
 
-    /// Return the `from` Route specified in this connection
-    #[must_use]
-    pub fn from(&self) -> &Route {
-        &self.from
-    }
-
     /// Return a reference to the `from_io`
     #[must_use]
     pub fn from_io(&self) -> &IO {
@@ -153,12 +187,6 @@ impl Connection {
     /// Return a mutable reference to the `from_io`
     pub fn from_io_mut(&mut self) -> &mut IO {
         &mut self.from_io
-    }
-
-    /// Return the `to` Route specified in this connection
-    #[must_use]
-    pub fn to(&self) -> &Vec<Route> {
-        &self.to
     }
 
     /// Return a reference to the `to_io`

--- a/flowcore/src/model/io.rs
+++ b/flowcore/src/model/io.rs
@@ -91,6 +91,11 @@ impl IO {
         }
     }
 
+    /// Set the name of this IO
+    pub fn set_name(&mut self, name: Name) {
+        self.name = name;
+    }
+
     /// Is this IO an input or an output of a Flow?
     #[must_use]
     pub fn flow_io(&self) -> bool {

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -136,27 +136,30 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                     return CanvasAction::None;
                 };
                 let alias = node.alias.clone();
-                let removed_edges: Vec<EdgeLayout> = win
-                    .edges
+                let removed_connections: Vec<Connection> = win
+                    .flow_definition
+                    .connections
                     .iter()
-                    .filter(|e| e.references_node(&alias))
+                    .filter(|c| connection_references_node(c, &alias))
                     .cloned()
                     .collect();
                 win.nodes.remove(idx);
-                win.edges.retain(|e| !e.references_node(&alias));
+                win.flow_definition
+                    .connections
+                    .retain(|c| !connection_references_node(c, &alias));
                 history::record_edit(
                     win,
                     EditAction::DeleteNode {
                         index: idx,
                         node,
-                        removed_edges,
+                        removed_connections,
                     },
                 );
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
                 let nc = win.nodes.len();
-                let ec = win.edges.len();
+                let ec = win.flow_definition.connections.len();
                 win.status = format!("Node deleted - {nc} nodes, {ec} connections");
                 if win.auto_fit_enabled {
                     win.auto_fit_pending = true;
@@ -169,17 +172,27 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             to_node,
             to_port,
         } => {
-            let edge = EdgeLayout::new(
-                from_node.clone(),
-                from_port.clone(),
-                to_node.clone(),
-                to_port.clone(),
+            let from_route = if from_port.is_empty() {
+                from_node.clone()
+            } else {
+                format!("{from_node}/{from_port}")
+            };
+            let to_route = if to_port.is_empty() {
+                to_node.clone()
+            } else {
+                format!("{to_node}/{to_port}")
+            };
+            let connection = Connection::new(from_route, to_route);
+            history::record_edit(
+                win,
+                EditAction::CreateConnection {
+                    connection: connection.clone(),
+                },
             );
-            history::record_edit(win, EditAction::CreateConnection { edge: edge.clone() });
-            win.edges.push(edge);
+            win.flow_definition.connections.push(connection);
             win.canvas_state.request_redraw();
             let nc = win.nodes.len();
-            let ec = win.edges.len();
+            let ec = win.flow_definition.connections.len();
             win.status = format!(
                 "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
             );
@@ -189,11 +202,17 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             win.selected_node = None;
             win.canvas_state.request_redraw();
             if let Some(i) = idx {
-                if let Some(edge) = win.edges.get(i) {
+                if let Some(conn) = win.flow_definition.connections.get(i) {
+                    let (from_node, from_port) = split_route(conn.from().as_ref());
+                    let to_str = conn
+                        .to()
+                        .first()
+                        .map_or_else(String::new, ToString::to_string);
+                    let (to_node, to_port) = split_route(&to_str);
                     win.status = format!(
                         "Connection: {} -> {}",
-                        flow_io::format_endpoint(&edge.from_node, &edge.from_port),
-                        flow_io::format_endpoint(&edge.to_node, &edge.to_port),
+                        flow_io::format_endpoint(&from_node, &from_port),
+                        flow_io::format_endpoint(&to_node, &to_port),
                     );
                 }
             } else {
@@ -201,13 +220,19 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             }
         }
         CanvasMessage::ConnectionDeleted(idx) => {
-            if idx < win.edges.len() {
-                let edge = win.edges.remove(idx);
-                history::record_edit(win, EditAction::DeleteConnection { index: idx, edge });
+            if idx < win.flow_definition.connections.len() {
+                let connection = win.flow_definition.connections.remove(idx);
+                history::record_edit(
+                    win,
+                    EditAction::DeleteConnection {
+                        index: idx,
+                        connection,
+                    },
+                );
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
                 let nc = win.nodes.len();
-                let ec = win.edges.len();
+                let ec = win.flow_definition.connections.len();
                 win.status = format!("Connection deleted - {nc} nodes, {ec} connections");
             }
         }
@@ -650,21 +675,6 @@ impl NodeLayout {
     }
 }
 
-/// A connection edge to render between two nodes
-#[derive(Debug, Clone)]
-pub(crate) struct EdgeLayout {
-    /// Source node alias
-    pub(crate) from_node: String,
-    /// Source port name (may be empty for whole-node output)
-    pub(crate) from_port: String,
-    /// Destination node alias
-    pub(crate) to_node: String,
-    /// Destination port name
-    pub(crate) to_port: String,
-    /// Optional connection name for display on the line
-    pub(crate) name: String,
-}
-
 /// Build a list of [`NodeLayout`] from process references and connections.
 ///
 /// Ports and descriptions are taken from the resolved definitions loaded for each subprocess.
@@ -748,29 +758,6 @@ pub(crate) fn build_node_layouts(
     }
 
     nodes
-}
-
-impl EdgeLayout {
-    /// Create a new edge layout with the given source and destination.
-    pub(crate) fn new(
-        from_node: String,
-        from_port: String,
-        to_node: String,
-        to_port: String,
-    ) -> Self {
-        Self {
-            from_node,
-            from_port,
-            to_node,
-            to_port,
-            name: String::new(),
-        }
-    }
-
-    /// Check whether this edge references the given node alias as source or destination.
-    pub(crate) fn references_node(&self, alias: &str) -> bool {
-        self.from_node == alias || self.to_node == alias
-    }
 }
 
 /// Compute topology-based positions for nodes without saved layout.
@@ -874,30 +861,6 @@ fn compute_topological_layout(
     positions
 }
 
-/// Build edge layouts from flow connections
-pub(crate) fn build_edge_layouts(connections: &[Connection]) -> Vec<EdgeLayout> {
-    let mut edges = Vec::new();
-
-    for conn in connections {
-        let from_route = conn.from().to_string();
-        let (from_node, from_port) = split_route(&from_route);
-
-        for to_route in conn.to() {
-            let to_str = to_route.to_string();
-            let (to_node, to_port) = split_route(&to_str);
-            edges.push(EdgeLayout {
-                from_node: from_node.clone(),
-                from_port: from_port.clone(),
-                to_node,
-                to_port,
-                name: conn.name().clone(),
-            });
-        }
-    }
-
-    edges
-}
-
 /// Format a [`serde_json::Value`] for compact display
 fn format_value(v: &serde_json::Value) -> String {
     match v {
@@ -973,12 +936,12 @@ impl Default for FlowCanvasState {
 }
 
 impl FlowCanvasState {
-    /// Create the canvas [`Element`] for displaying the given nodes and edges.
+    /// Create the canvas [`Element`] for displaying the given nodes and connections.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn view<'a>(
         &'a self,
         nodes: &'a [NodeLayout],
-        edges: &'a [EdgeLayout],
+        connections: &'a [Connection],
         flow_name: &'a str,
         flow_inputs: &'a [IO],
         flow_outputs: &'a [IO],
@@ -989,7 +952,7 @@ impl FlowCanvasState {
         Canvas::new(FlowCanvas {
             state: self,
             nodes,
-            edges,
+            connections,
             flow_name,
             flow_inputs,
             flow_outputs,
@@ -1111,8 +1074,8 @@ struct FlowCanvas<'a> {
     state: &'a FlowCanvasState,
     /// Nodes to render
     nodes: &'a [NodeLayout],
-    /// Edges to render
-    edges: &'a [EdgeLayout],
+    /// Connections to render
+    connections: &'a [Connection],
     /// Flow name (displayed on sub-flow bounding box)
     flow_name: &'a str,
     /// Flow-level input ports (displayed on left edge for sub-flows)
@@ -1362,13 +1325,13 @@ fn cubic_bezier(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> Point {
     )
 }
 
-/// Hit test connections by sampling points along each edge's bezier curve.
+/// Hit test connections by sampling points along each connection's bezier curve.
 ///
-/// Returns the edge index if the cursor is within [`CONNECTION_HIT_DISTANCE`]
+/// Returns the connection index if the cursor is within [`CONNECTION_HIT_DISTANCE`]
 /// screen pixels of any sample point on the curve.
 #[allow(clippy::too_many_arguments)]
 fn hit_test_connection(
-    edges: &[EdgeLayout],
+    connections: &[Connection],
     nodes: &[NodeLayout],
     flow_inputs: &[IO],
     flow_outputs: &[IO],
@@ -1385,105 +1348,110 @@ fn hit_test_connection(
 
     let threshold_sq = CONNECTION_HIT_DISTANCE * CONNECTION_HIT_DISTANCE;
 
-    for (edge_idx, edge) in edges.iter().enumerate() {
-        // Resolve from_point
-        let from_point = if edge.from_node == "input" {
-            let input_name = base_port_name(&edge.from_port);
-            flow_io_positions.0.get(input_name).copied()
-        } else {
-            node_map
-                .get(edge.from_node.as_str())
-                .map(|n| find_node_output_pos_inline(n, &edge.from_port))
-        };
+    for (conn_idx, conn) in connections.iter().enumerate() {
+        let (from_node_str, from_port_str) = split_route(conn.from().as_ref());
+        for to_route in conn.to() {
+            let (to_node_str, to_port_str) = split_route(to_route.as_ref());
 
-        let to_point = if edge.to_node == "output" {
-            let output_name = base_port_name(&edge.to_port);
-            flow_io_positions.1.get(output_name).copied()
-        } else {
-            node_map
-                .get(edge.to_node.as_str())
-                .map(|n| find_node_input_pos_inline(n, &edge.to_port))
-        };
-
-        if let (Some(from_point), Some(to_point)) = (from_point, to_point) {
-            let from_s = transform_point(from_point, zoom, offset);
-            let to_s = transform_point(to_point, zoom, offset);
-
-            let is_self = edge.from_node == edge.to_node;
-
-            // Build sample points along the actual drawn path
-            let sample_points: Vec<Point> = if is_self {
-                let from_node_ref = node_map.get(edge.from_node.as_str());
-                let Some(from_n) = from_node_ref else {
-                    continue;
-                };
-                let (box_right, box_bottom, box_left, mid_x) = loopback_waypoints(
-                    from_n.x,
-                    from_n.y,
-                    from_n.width,
-                    from_n.height,
-                    zoom,
-                    offset,
-                );
-
-                // Sample the path: from -> right -> curve down -> bottom -> curve up -> to
-                let mut pts = Vec::with_capacity(BEZIER_SAMPLES + 1);
-                let segments = BEZIER_SAMPLES / 5;
-                // Segment 1: from -> right
-                for i in 0..=segments {
-                    let t = i as f32 / segments as f32;
-                    pts.push(Point::new(from_s.x + (box_right - from_s.x) * t, from_s.y));
-                }
-                // Segment 2: curve right -> bottom
-                for i in 0..=segments {
-                    let t = i as f32 / segments as f32;
-                    let p = quadratic_bezier_pt(
-                        Point::new(box_right, from_s.y),
-                        Point::new(box_right, box_bottom),
-                        Point::new(mid_x, box_bottom),
-                        t,
-                    );
-                    pts.push(p);
-                }
-                // Segment 3: curve bottom -> left
-                for i in 0..=segments {
-                    let t = i as f32 / segments as f32;
-                    let p = quadratic_bezier_pt(
-                        Point::new(mid_x, box_bottom),
-                        Point::new(box_left, box_bottom),
-                        Point::new(box_left, to_s.y),
-                        t,
-                    );
-                    pts.push(p);
-                }
-                // Segment 4: left -> to
-                for i in 0..=segments {
-                    let t = i as f32 / segments as f32;
-                    pts.push(Point::new(box_left + (to_s.x - box_left) * t, to_s.y));
-                }
-                pts
+            // Resolve from_point
+            let from_point = if from_node_str == "input" {
+                let input_name = base_port_name(&from_port_str);
+                flow_io_positions.0.get(input_name).copied()
             } else {
-                // Use matching control points for flow I/O vs normal connections
-                let is_flow_io = edge.from_node == "input" || edge.to_node == "output";
-                let dx_ctrl = if is_flow_io {
-                    (to_s.x - from_s.x).abs().max(40.0 * zoom) * 0.4
-                } else {
-                    (to_s.x - from_s.x).abs().max(60.0 * zoom) * 0.5
-                };
-                let control1 = Point::new(from_s.x + dx_ctrl, from_s.y);
-                let control2 = Point::new(to_s.x - dx_ctrl, to_s.y);
-                (0..=BEZIER_SAMPLES)
-                    .map(|i| {
-                        let t = i as f32 / BEZIER_SAMPLES as f32;
-                        cubic_bezier(from_s, control1, control2, to_s, t)
-                    })
-                    .collect()
+                node_map
+                    .get(from_node_str.as_str())
+                    .map(|n| find_node_output_pos_inline(n, &from_port_str))
             };
 
-            for pair in sample_points.windows(2) {
-                if let [a, b] = *pair {
-                    if distance_to_segment_sq(screen_pos, a, b) <= threshold_sq {
-                        return Some(edge_idx);
+            let to_point = if to_node_str == "output" {
+                let output_name = base_port_name(&to_port_str);
+                flow_io_positions.1.get(output_name).copied()
+            } else {
+                node_map
+                    .get(to_node_str.as_str())
+                    .map(|n| find_node_input_pos_inline(n, &to_port_str))
+            };
+
+            if let (Some(from_point), Some(to_point)) = (from_point, to_point) {
+                let from_s = transform_point(from_point, zoom, offset);
+                let to_s = transform_point(to_point, zoom, offset);
+
+                let is_self = from_node_str == to_node_str;
+
+                // Build sample points along the actual drawn path
+                let sample_points: Vec<Point> = if is_self {
+                    let from_node_ref = node_map.get(from_node_str.as_str());
+                    let Some(from_n) = from_node_ref else {
+                        continue;
+                    };
+                    let (box_right, box_bottom, box_left, mid_x) = loopback_waypoints(
+                        from_n.x,
+                        from_n.y,
+                        from_n.width,
+                        from_n.height,
+                        zoom,
+                        offset,
+                    );
+
+                    // Sample the path: from -> right -> curve down -> bottom -> curve up -> to
+                    let mut pts = Vec::with_capacity(BEZIER_SAMPLES + 1);
+                    let segments = BEZIER_SAMPLES / 5;
+                    // Segment 1: from -> right
+                    for i in 0..=segments {
+                        let t = i as f32 / segments as f32;
+                        pts.push(Point::new(from_s.x + (box_right - from_s.x) * t, from_s.y));
+                    }
+                    // Segment 2: curve right -> bottom
+                    for i in 0..=segments {
+                        let t = i as f32 / segments as f32;
+                        let p = quadratic_bezier_pt(
+                            Point::new(box_right, from_s.y),
+                            Point::new(box_right, box_bottom),
+                            Point::new(mid_x, box_bottom),
+                            t,
+                        );
+                        pts.push(p);
+                    }
+                    // Segment 3: curve bottom -> left
+                    for i in 0..=segments {
+                        let t = i as f32 / segments as f32;
+                        let p = quadratic_bezier_pt(
+                            Point::new(mid_x, box_bottom),
+                            Point::new(box_left, box_bottom),
+                            Point::new(box_left, to_s.y),
+                            t,
+                        );
+                        pts.push(p);
+                    }
+                    // Segment 4: left -> to
+                    for i in 0..=segments {
+                        let t = i as f32 / segments as f32;
+                        pts.push(Point::new(box_left + (to_s.x - box_left) * t, to_s.y));
+                    }
+                    pts
+                } else {
+                    // Use matching control points for flow I/O vs normal connections
+                    let is_flow_io = from_node_str == "input" || to_node_str == "output";
+                    let dx_ctrl = if is_flow_io {
+                        (to_s.x - from_s.x).abs().max(40.0 * zoom) * 0.4
+                    } else {
+                        (to_s.x - from_s.x).abs().max(60.0 * zoom) * 0.5
+                    };
+                    let control1 = Point::new(from_s.x + dx_ctrl, from_s.y);
+                    let control2 = Point::new(to_s.x - dx_ctrl, to_s.y);
+                    (0..=BEZIER_SAMPLES)
+                        .map(|i| {
+                            let t = i as f32 / BEZIER_SAMPLES as f32;
+                            cubic_bezier(from_s, control1, control2, to_s, t)
+                        })
+                        .collect()
+                };
+
+                for pair in sample_points.windows(2) {
+                    if let [a, b] = *pair {
+                        if distance_to_segment_sq(screen_pos, a, b) <= threshold_sq {
+                            return Some(conn_idx);
+                        }
                     }
                 }
             }
@@ -1600,8 +1568,8 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 // 2. Check if cursor is near a connection line (but NOT on a port) — select it
                 let on_a_port = hit_test_port(self.nodes, cursor_position, zoom, offset).is_some();
                 if !on_a_port {
-                    if let Some(edge_idx) = hit_test_connection(
-                        self.edges,
+                    if let Some(conn_idx) = hit_test_connection(
+                        self.connections,
                         self.nodes,
                         self.flow_inputs,
                         self.flow_outputs,
@@ -1609,12 +1577,12 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         zoom,
                         offset,
                     ) {
-                        state.selected_connection = Some(edge_idx);
+                        state.selected_connection = Some(conn_idx);
                         state.selected_node = None;
                         state.dragging = None;
                         return Some(
                             canvas::Action::publish(CanvasMessage::ConnectionSelected(Some(
-                                edge_idx,
+                                conn_idx,
                             )))
                             .and_capture(),
                         );
@@ -1997,7 +1965,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         let zoom = self.state.zoom;
         let offset = self.state.scroll_offset;
 
-        // Draw the main cached content (edges, nodes, and flow I/O ports)
+        // Draw the main cached content (connections, nodes, and flow I/O ports)
         let content = self.state.cache.draw(renderer, bounds.size(), |frame| {
             draw_nodes(frame, self.nodes, zoom, offset);
             draw_flow_io_ports(
@@ -2006,7 +1974,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 self.flow_inputs,
                 self.flow_outputs,
                 self.nodes,
-                self.edges,
+                self.connections,
                 self.is_subflow,
                 state.selected_connection,
                 zoom,
@@ -2014,7 +1982,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             );
             draw_edges(
                 frame,
-                self.edges,
+                self.connections,
                 self.nodes,
                 zoom,
                 offset,
@@ -2196,7 +2164,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
 /// Draw all connection edges as bezier curves.
 fn draw_edges(
     frame: &mut Frame,
-    edges: &[EdgeLayout],
+    connections: &[Connection],
     nodes: &[NodeLayout],
     zoom: f32,
     offset: Point,
@@ -2207,81 +2175,90 @@ fn draw_edges(
         nodes.iter().map(|n| (n.alias.as_str(), n)).collect();
 
     // Draw selected connection last so it renders on top of crossing connections
-    let draw_order: Vec<usize> = (0..edges.len())
+    let draw_order: Vec<usize> = (0..connections.len())
         .filter(|i| selected != Some(*i))
-        .chain(selected.filter(|i| *i < edges.len()))
+        .chain(selected.filter(|i| *i < connections.len()))
         .collect();
 
-    for edge_idx in draw_order {
-        let Some(edge) = edges.get(edge_idx) else {
+    for conn_idx in draw_order {
+        let Some(conn) = connections.get(conn_idx) else {
             continue;
         };
-        let from_node = node_map.get(edge.from_node.as_str());
-        let to_node = node_map.get(edge.to_node.as_str());
+        let (from_node_str, from_port_str) = split_route(conn.from().as_ref());
+        for to_route in conn.to() {
+            let (to_node_str, to_port_str) = split_route(to_route.as_ref());
+            let from_node = node_map.get(from_node_str.as_str());
+            let to_node = node_map.get(to_node_str.as_str());
 
-        if let (Some(from), Some(to)) = (from_node, to_node) {
-            // Find port positions (in world space)
-            let from_point = if edge.from_port.is_empty() {
-                from.output_port_position(0)
-            } else {
-                let base = base_port_name(&edge.from_port);
-                let port_idx = from
-                    .outputs
-                    .iter()
-                    .position(|p| p.name == base)
-                    .unwrap_or(0);
-                from.output_port_position(port_idx)
-            };
-
-            let to_point = if edge.to_port.is_empty() {
-                to.input_port_position(0)
-            } else {
-                let base = base_port_name(&edge.to_port);
-                let port_idx = to.inputs.iter().position(|p| p.name == base).unwrap_or(0);
-                to.input_port_position(port_idx)
-            };
-
-            let is_self_connection = edge.from_node == edge.to_node;
-            let node_bounds = if is_self_connection {
-                Some((from.x, from.y, from.width, from.height))
-            } else {
-                None
-            };
-            let is_selected = selected == Some(edge_idx);
-            draw_bezier_connection(
-                frame,
-                from_point,
-                to_point,
-                zoom,
-                offset,
-                node_bounds,
-                is_selected,
-            );
-
-            // Draw connection name along the path if present
-            if !edge.name.is_empty() {
-                let from_s = transform_point(from_point, zoom, offset);
-                let to_s = transform_point(to_point, zoom, offset);
-                let mid = if is_self_connection {
-                    // For loopback: place label at the bottom of the curve, outside the box
-                    let (_, box_bottom, box_left, mid_x) =
-                        loopback_waypoints(from.x, from.y, from.width, from.height, zoom, offset);
-                    let _ = box_left;
-                    Point::new(mid_x, box_bottom)
+            if let (Some(from), Some(to)) = (from_node, to_node) {
+                // Find port positions (in world space)
+                let from_point = if from_port_str.is_empty() {
+                    from.output_port_position(0)
                 } else {
-                    // For normal connections: midpoint, above the line
-                    Point::new(from_s.x.midpoint(to_s.x), from_s.y.midpoint(to_s.y))
+                    let base = base_port_name(&from_port_str);
+                    let port_idx = from
+                        .outputs
+                        .iter()
+                        .position(|p| p.name == base)
+                        .unwrap_or(0);
+                    from.output_port_position(port_idx)
                 };
-                let name_label = CanvasText {
-                    content: edge.name.clone(),
-                    position: mid,
-                    color: Color::from_rgb(0.7, 0.7, 0.7),
-                    size: (PORT_FONT_SIZE * zoom).into(),
-                    align_x: iced::alignment::Horizontal::Center.into(),
-                    align_y: iced::alignment::Vertical::Bottom,
-                    ..CanvasText::default()
+
+                let to_point = if to_port_str.is_empty() {
+                    to.input_port_position(0)
+                } else {
+                    let base = base_port_name(&to_port_str);
+                    let port_idx = to.inputs.iter().position(|p| p.name == base).unwrap_or(0);
+                    to.input_port_position(port_idx)
                 };
-                frame.fill_text(name_label);
+
+                let is_self_connection = from_node_str == to_node_str;
+                let node_bounds = if is_self_connection {
+                    Some((from.x, from.y, from.width, from.height))
+                } else {
+                    None
+                };
+                let is_selected = selected == Some(conn_idx);
+                draw_bezier_connection(
+                    frame,
+                    from_point,
+                    to_point,
+                    zoom,
+                    offset,
+                    node_bounds,
+                    is_selected,
+                );
+
+                // Draw connection name along the path if present
+                let conn_name = conn.name();
+                if !conn_name.is_empty() {
+                    let from_s = transform_point(from_point, zoom, offset);
+                    let to_s = transform_point(to_point, zoom, offset);
+                    let mid = if is_self_connection {
+                        let (_, box_bottom, box_left, mid_x) = loopback_waypoints(
+                            from.x,
+                            from.y,
+                            from.width,
+                            from.height,
+                            zoom,
+                            offset,
+                        );
+                        let _ = box_left;
+                        Point::new(mid_x, box_bottom)
+                    } else {
+                        Point::new(from_s.x.midpoint(to_s.x), from_s.y.midpoint(to_s.y))
+                    };
+                    let name_label = CanvasText {
+                        content: conn_name.clone(),
+                        position: mid,
+                        color: Color::from_rgb(0.7, 0.7, 0.7),
+                        size: (PORT_FONT_SIZE * zoom).into(),
+                        align_x: iced::alignment::Horizontal::Center.into(),
+                        align_y: iced::alignment::Vertical::Bottom,
+                        ..CanvasText::default()
+                    };
+                    frame.fill_text(name_label);
+                }
             }
         }
     }
@@ -2394,7 +2371,7 @@ fn draw_flow_io_ports(
     flow_inputs: &[IO],
     flow_outputs: &[IO],
     nodes: &[NodeLayout],
-    edges: &[EdgeLayout],
+    connections: &[Connection],
     is_subflow: bool,
     selected_connection: Option<usize>,
     zoom: f32,
@@ -2530,25 +2507,33 @@ fn draw_flow_io_ports(
     // Draw bezier connections from flow inputs/outputs to internal node ports
     let conn_color = Color::from_rgba(0.7, 0.7, 0.7, 0.6);
     let sel_color = Color::from_rgb(1.0, 0.85, 0.0);
-    for (edge_idx, edge) in edges.iter().enumerate() {
-        let is_selected = selected_connection == Some(edge_idx);
+    for (conn_idx, conn) in connections.iter().enumerate() {
+        let is_selected = selected_connection == Some(conn_idx);
         let color = if is_selected { sel_color } else { conn_color };
         let width = if is_selected { 3.0 } else { 1.5 };
-        if edge.from_node == "input" {
-            let input_name = base_port_name(&edge.from_port);
-            if let Some(&from_world) = input_positions.get(input_name) {
-                if let Some(to_world) = find_node_input_pos(nodes, &edge.to_node, &edge.to_port) {
-                    draw_flow_io_bezier(frame, from_world, to_world, zoom, offset, color, width);
+        let (from_node_str, from_port_str) = split_route(conn.from().as_ref());
+        for to_route in conn.to() {
+            let (to_node_str, to_port_str) = split_route(to_route.as_ref());
+            if from_node_str == "input" {
+                let input_name = base_port_name(&from_port_str);
+                if let Some(&from_world) = input_positions.get(input_name) {
+                    if let Some(to_world) = find_node_input_pos(nodes, &to_node_str, &to_port_str) {
+                        draw_flow_io_bezier(
+                            frame, from_world, to_world, zoom, offset, color, width,
+                        );
+                    }
                 }
             }
-        }
-        if edge.to_node == "output" {
-            let output_name = base_port_name(&edge.to_port);
-            if let Some(&to_world) = output_positions.get(output_name) {
-                if let Some(from_world) =
-                    find_node_output_pos(nodes, &edge.from_node, &edge.from_port)
-                {
-                    draw_flow_io_bezier(frame, from_world, to_world, zoom, offset, color, width);
+            if to_node_str == "output" {
+                let output_name = base_port_name(&to_port_str);
+                if let Some(&to_world) = output_positions.get(output_name) {
+                    if let Some(from_world) =
+                        find_node_output_pos(nodes, &from_node_str, &from_port_str)
+                    {
+                        draw_flow_io_bezier(
+                            frame, from_world, to_world, zoom, offset, color, width,
+                        );
+                    }
                 }
             }
         }
@@ -2923,7 +2908,7 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
         .canvas_state
         .view(
             &win.nodes,
-            &win.edges,
+            &win.flow_definition.connections,
             &win.flow_definition.name,
             &win.flow_definition.inputs,
             &win.flow_definition.outputs,
@@ -3296,32 +3281,12 @@ mod test {
     }
 
     #[test]
-    fn build_edge_layouts_single() {
+    fn connection_references_node_check() {
         use flowcore::model::connection::Connection;
-        let conn = Connection::new("sequence/number", "add1/i1");
-        let edges = build_edge_layouts(&[conn]);
-        assert_eq!(edges.len(), 1);
-        assert_eq!(
-            edges.first().map(|e| e.from_node.as_str()),
-            Some("sequence")
-        );
-        assert_eq!(edges.first().map(|e| e.from_port.as_str()), Some("number"));
-        assert_eq!(edges.first().map(|e| e.to_node.as_str()), Some("add1"));
-        assert_eq!(edges.first().map(|e| e.to_port.as_str()), Some("i1"));
-    }
-
-    #[test]
-    fn edge_references_node() {
-        let edge = EdgeLayout {
-            from_node: "a".into(),
-            from_port: "out".into(),
-            to_node: "b".into(),
-            to_port: "in".into(),
-            name: String::new(),
-        };
-        assert!(edge.references_node("a"));
-        assert!(edge.references_node("b"));
-        assert!(!edge.references_node("c"));
+        let conn = Connection::new("a/out", "b/in");
+        assert!(connection_references_node(&conn, "a"));
+        assert!(connection_references_node(&conn, "b"));
+        assert!(!connection_references_node(&conn, "c"));
     }
 
     #[test]

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -57,26 +57,31 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                 win.canvas_state.request_redraw();
             }
             if let Some(i) = idx {
-                if let Some(node) = win.nodes.get(i) {
-                    win.status = format!("Selected: {}", node.alias);
+                if let Some(pref) = win.flow_definition.process_refs.get(i) {
+                    let alias = if pref.alias.is_empty() {
+                        derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    win.status = format!("Selected: {alias}");
                 }
             } else {
                 win.status = String::from("Ready");
             }
         }
         CanvasMessage::Moved(idx, x, y) => {
-            if let Some(node) = win.nodes.get_mut(idx) {
-                node.x = x;
-                node.y = y;
+            if let Some(pref) = win.flow_definition.process_refs.get_mut(idx) {
+                pref.x = Some(x);
+                pref.y = Some(y);
                 win.canvas_state.request_redraw();
             }
         }
         CanvasMessage::Resized(idx, x, y, w, h) => {
-            if let Some(node) = win.nodes.get_mut(idx) {
-                node.x = x;
-                node.y = y;
-                node.width = w;
-                node.height = h;
+            if let Some(pref) = win.flow_definition.process_refs.get_mut(idx) {
+                pref.x = Some(x);
+                pref.y = Some(y);
+                pref.width = Some(w);
+                pref.height = Some(h);
                 win.canvas_state.request_redraw();
             }
         }
@@ -129,13 +134,15 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             }
         }
         CanvasMessage::Deleted(idx) => {
-            if idx < win.nodes.len() {
-                let node = if let Some(node) = win.nodes.get(idx) {
-                    node.clone()
-                } else {
+            if idx < win.flow_definition.process_refs.len() {
+                let Some(pref) = win.flow_definition.process_refs.get(idx).cloned() else {
                     return CanvasAction::None;
                 };
-                let alias = node.alias.clone();
+                let alias = if pref.alias.is_empty() {
+                    derive_short_name(&pref.source)
+                } else {
+                    pref.alias.clone()
+                };
                 let removed_connections: Vec<Connection> = win
                     .flow_definition
                     .connections
@@ -143,7 +150,8 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                     .filter(|c| connection_references_node(c, &alias))
                     .cloned()
                     .collect();
-                win.nodes.remove(idx);
+                let removed_pref = win.flow_definition.process_refs.remove(idx);
+                let removed_subprocess = win.flow_definition.subprocesses.remove(&alias);
                 win.flow_definition
                     .connections
                     .retain(|c| !connection_references_node(c, &alias));
@@ -151,14 +159,15 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                     win,
                     EditAction::DeleteNode {
                         index: idx,
-                        node,
+                        process_ref: removed_pref,
+                        subprocess: removed_subprocess.map(|p| (alias, p)),
                         removed_connections,
                     },
                 );
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
-                let nc = win.nodes.len();
+                let nc = win.flow_definition.process_refs.len();
                 let ec = win.flow_definition.connections.len();
                 win.status = format!("Node deleted - {nc} nodes, {ec} connections");
                 if win.auto_fit_enabled {
@@ -191,7 +200,7 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             );
             win.flow_definition.connections.push(connection);
             win.canvas_state.request_redraw();
-            let nc = win.nodes.len();
+            let nc = win.flow_definition.process_refs.len();
             let ec = win.flow_definition.connections.len();
             win.status = format!(
                 "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
@@ -231,7 +240,7 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                 );
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
-                let nc = win.nodes.len();
+                let nc = win.flow_definition.process_refs.len();
                 let ec = win.flow_definition.connections.len();
                 win.status = format!("Connection deleted - {nc} nodes, {ec} connections");
             }
@@ -243,7 +252,9 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
             if win.auto_fit_enabled || win.auto_fit_pending {
                 let has_flow_io = !win.flow_definition.inputs.is_empty()
                     || !win.flow_definition.outputs.is_empty();
-                win.canvas_state.auto_fit(&win.nodes, has_flow_io, viewport);
+                let render_nodes = build_render_nodes(&win.flow_definition);
+                win.canvas_state
+                    .auto_fit(&render_nodes, has_flow_io, viewport);
                 win.auto_fit_pending = false;
             }
         }
@@ -264,23 +275,10 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
         }
         CanvasMessage::InitializerEdit(node_idx, port_name) => {
             // Look up current initializer from the model (flow definition)
-            let alias = win
-                .nodes
-                .get(node_idx)
-                .map(|n| n.alias.clone())
-                .unwrap_or_default();
             let (init_type, value_text) = win
                 .flow_definition
                 .process_refs
-                .iter()
-                .find(|pr| {
-                    let pr_alias = if pr.alias.is_empty() {
-                        derive_short_name(&pr.source)
-                    } else {
-                        pr.alias.clone()
-                    };
-                    pr_alias == alias
-                })
+                .get(node_idx)
                 .and_then(|pr| pr.initializations.get(&port_name))
                 .map_or_else(
                     || ("none".to_string(), String::new()),
@@ -675,34 +673,39 @@ impl NodeLayout {
     }
 }
 
-/// Build a list of [`NodeLayout`] from process references and connections.
+/// Build render-only [`NodeLayout`] list directly from a [`FlowDefinition`].
 ///
-/// Ports and descriptions are taken from the resolved definitions loaded for each subprocess.
-/// Layout uses the optional `x`, `y`, `width`, `height` fields from `ProcessReference`,
-/// falling back to auto-grid positioning.
-pub(crate) fn build_node_layouts(
-    process_refs: &[ProcessReference],
-    connections: &[Connection],
-    resolved_ports: &HashMap<String, (Vec<PortInfo>, Vec<PortInfo>)>,
-    subprocesses: &std::collections::BTreeMap<String, flowcore::model::process::Process>,
+/// This is the single entry point for converting process references and their
+/// resolved subprocess definitions into the rendering representation.
+/// The returned layouts are ephemeral and must not be stored in persistent state.
+pub(crate) fn build_render_nodes(
+    flow_def: &flowcore::model::flow_definition::FlowDefinition,
 ) -> Vec<NodeLayout> {
-    let topo_positions = compute_topological_layout(process_refs, connections);
+    use flowcore::model::process::Process;
 
-    let mut nodes = Vec::with_capacity(process_refs.len());
+    let topo_positions = compute_topological_layout(&flow_def.process_refs, &flow_def.connections);
 
-    for (i, pref) in process_refs.iter().enumerate() {
+    let mut nodes = Vec::with_capacity(flow_def.process_refs.len());
+
+    for (i, pref) in flow_def.process_refs.iter().enumerate() {
         let alias = if pref.alias.is_empty() {
             derive_short_name(&pref.source)
         } else {
             pref.alias.clone()
         };
 
-        let (inputs, outputs) = resolved_ports.get(&alias).cloned().unwrap_or_default();
+        let (inputs, outputs) = flow_def
+            .subprocesses
+            .get(&alias)
+            .map(|proc| match proc {
+                Process::FunctionProcess(f) => crate::flow_io::extract_ports(&f.inputs, &f.outputs),
+                Process::FlowProcess(f) => crate::flow_io::extract_ports(&f.inputs, &f.outputs),
+            })
+            .unwrap_or_default();
 
         let min_ports = inputs.len().max(outputs.len());
         let min_height = PORT_START_Y + (min_ports as f32 + 1.0) * PORT_SPACING;
 
-        // Use saved position, then topology position, then grid fallback
         let (default_x, default_y) = if let Some((tx, ty)) = topo_positions.get(&alias) {
             (*tx, *ty)
         } else {
@@ -718,7 +721,6 @@ pub(crate) fn build_node_layouts(
         let width = pref.width.unwrap_or(DEFAULT_WIDTH);
         let height = pref.height.unwrap_or(DEFAULT_HEIGHT.max(min_height));
 
-        // Build initializer display strings
         let mut initializers = HashMap::new();
         for (port_name, init) in &pref.initializations {
             let display = match init {
@@ -732,14 +734,12 @@ pub(crate) fn build_node_layouts(
             initializers.insert(port_name.clone(), display);
         }
 
-        // Extract description from the resolved subprocess definition
-        let description = subprocesses
+        let description = flow_def
+            .subprocesses
             .get(&alias)
             .map(|proc| match proc {
-                flowcore::model::process::Process::FunctionProcess(func) => {
-                    func.description.clone()
-                }
-                flowcore::model::process::Process::FlowProcess(flow) => flow.description.clone(),
+                Process::FunctionProcess(func) => func.description.clone(),
+                Process::FlowProcess(flow) => flow.description.clone(),
             })
             .unwrap_or_default();
 
@@ -936,11 +936,15 @@ impl Default for FlowCanvasState {
 }
 
 impl FlowCanvasState {
-    /// Create the canvas [`Element`] for displaying the given nodes and connections.
+    /// Create the canvas [`Element`] for displaying the given flow definition.
+    ///
+    /// Builds render nodes from the flow definition's process references and
+    /// subprocess definitions. The `FlowCanvas` owns these render nodes for the
+    /// duration of the frame.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn view<'a>(
         &'a self,
-        nodes: &'a [NodeLayout],
+        flow_def: &flowcore::model::flow_definition::FlowDefinition,
         connections: &'a [Connection],
         flow_name: &'a str,
         flow_inputs: &'a [IO],
@@ -949,6 +953,7 @@ impl FlowCanvasState {
         auto_fit_pending: bool,
         auto_fit_enabled: bool,
     ) -> Element<'a, CanvasMessage> {
+        let nodes = build_render_nodes(flow_def);
         Canvas::new(FlowCanvas {
             state: self,
             nodes,
@@ -1072,8 +1077,8 @@ fn screen_to_world(screen: Point, zoom: f32, offset: Point) -> Point {
 struct FlowCanvas<'a> {
     /// Reference to the persistent canvas state (zoom, offset, cache)
     state: &'a FlowCanvasState,
-    /// Nodes to render
-    nodes: &'a [NodeLayout],
+    /// Render nodes built from `process_refs` (owned, rebuilt each frame)
+    nodes: Vec<NodeLayout>,
     /// Connections to render
     connections: &'a [Connection],
     /// Flow name (displayed on sub-flow bounding box)
@@ -1566,11 +1571,11 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 }
 
                 // 2. Check if cursor is near a connection line (but NOT on a port) — select it
-                let on_a_port = hit_test_port(self.nodes, cursor_position, zoom, offset).is_some();
+                let on_a_port = hit_test_port(&self.nodes, cursor_position, zoom, offset).is_some();
                 if !on_a_port {
                     if let Some(conn_idx) = hit_test_connection(
                         self.connections,
-                        self.nodes,
+                        &self.nodes,
                         self.flow_inputs,
                         self.flow_outputs,
                         cursor_position,
@@ -1591,7 +1596,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
 
                 // 3. Check if cursor is on a port — start connection drag
                 if let Some((node_idx, port_name, is_output)) =
-                    hit_test_port(self.nodes, cursor_position, zoom, offset)
+                    hit_test_port(&self.nodes, cursor_position, zoom, offset)
                 {
                     if let Some(node) = self.nodes.get(node_idx) {
                         let port_world_pos = if is_output {
@@ -1621,14 +1626,14 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 }
 
                 // 4. Check if cursor is on an openable node's open icon
-                if let Some(idx) = hit_test_open_icon(self.nodes, world_pos) {
+                if let Some(idx) = hit_test_open_icon(&self.nodes, world_pos) {
                     return Some(
                         canvas::Action::publish(CanvasMessage::OpenNode(idx)).and_capture(),
                     );
                 }
 
                 // 6. Check if cursor is on a node — select/drag it
-                if let Some(idx) = hit_test_node(self.nodes, world_pos) {
+                if let Some(idx) = hit_test_node(&self.nodes, world_pos) {
                     let node = self.nodes.get(idx)?;
                     state.selected_node = Some(idx);
                     state.selected_connection = None;
@@ -1652,7 +1657,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             // Right mouse button pressed — edit initializer on input port, or context menu
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
                 if let Some((node_idx, port_name, is_output)) =
-                    hit_test_port(self.nodes, cursor_position, zoom, offset)
+                    hit_test_port(&self.nodes, cursor_position, zoom, offset)
                 {
                     if !is_output {
                         return Some(
@@ -1664,7 +1669,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     }
                 }
                 // Right-click on empty canvas — show context menu
-                if hit_test_node(self.nodes, world_pos).is_none() {
+                if hit_test_node(&self.nodes, world_pos).is_none() {
                     return Some(
                         canvas::Action::publish(CanvasMessage::ContextMenu(
                             cursor_position.x,
@@ -1765,7 +1770,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 } else {
                     // Check port hover for type tooltip
                     if let Some((node_idx, port_name, is_output)) =
-                        hit_test_port(self.nodes, cursor_position, zoom, offset)
+                        hit_test_port(&self.nodes, cursor_position, zoom, offset)
                     {
                         if let Some(node) = self.nodes.get(node_idx) {
                             let ports = if is_output {
@@ -1791,7 +1796,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     }
 
                     // Track hover for two-zone node tooltip
-                    let new_hover = hit_test_node(self.nodes, world_pos);
+                    let new_hover = hit_test_node(&self.nodes, world_pos);
                     if new_hover != state.hover_node || new_hover.is_some() {
                         state.hover_node = new_hover;
                         let tooltip_data =
@@ -1822,7 +1827,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 if let Some(connecting) = state.connecting.take() {
                     // Check if cursor is on a compatible port
                     if let Some((target_idx, target_port, target_is_output)) =
-                        hit_test_port(self.nodes, cursor_position, zoom, offset)
+                        hit_test_port(&self.nodes, cursor_position, zoom, offset)
                     {
                         // Must connect output→input or input→output
                         if connecting.from_output != target_is_output {
@@ -1967,13 +1972,13 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
 
         // Draw the main cached content (connections, nodes, and flow I/O ports)
         let content = self.state.cache.draw(renderer, bounds.size(), |frame| {
-            draw_nodes(frame, self.nodes, zoom, offset);
+            draw_nodes(frame, &self.nodes, zoom, offset);
             draw_flow_io_ports(
                 frame,
                 self.flow_name,
                 self.flow_inputs,
                 self.flow_outputs,
-                self.nodes,
+                &self.nodes,
                 self.connections,
                 self.is_subflow,
                 state.selected_connection,
@@ -1983,7 +1988,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             draw_edges(
                 frame,
                 self.connections,
-                self.nodes,
+                &self.nodes,
                 zoom,
                 offset,
                 state.selected_connection,
@@ -2067,7 +2072,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
 
                 // Highlight the target port if hovering over a compatible one
                 if let Some((target_idx, target_port, target_is_output)) =
-                    hit_test_port(self.nodes, end_screen, zoom, offset)
+                    hit_test_port(&self.nodes, end_screen, zoom, offset)
                 {
                     if connecting.from_output != target_is_output {
                         if let Some(target_node) = self.nodes.get(target_idx) {
@@ -2142,17 +2147,18 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             }
 
             // Check if hovering over a port
-            if hit_test_port(self.nodes, pos, self.state.zoom, self.state.scroll_offset).is_some() {
+            if hit_test_port(&self.nodes, pos, self.state.zoom, self.state.scroll_offset).is_some()
+            {
                 return mouse::Interaction::Crosshair;
             }
 
             let world_pos = screen_to_world(pos, self.state.zoom, self.state.scroll_offset);
 
-            if hit_test_open_icon(self.nodes, world_pos).is_some() {
+            if hit_test_open_icon(&self.nodes, world_pos).is_some() {
                 return mouse::Interaction::Pointer;
             }
 
-            if hit_test_node(self.nodes, world_pos).is_some() {
+            if hit_test_node(&self.nodes, world_pos).is_some() {
                 return mouse::Interaction::Grab;
             }
         }
@@ -2907,7 +2913,7 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
     let canvas = win
         .canvas_state
         .view(
-            &win.nodes,
+            &win.flow_definition,
             &win.flow_definition.connections,
             &win.flow_definition.name,
             &win.flow_definition.inputs,
@@ -3010,8 +3016,14 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
 
     // Initializer editor dialog overlay
     if let Some(ref editor) = win.initializer_editor {
-        let port_label = if let Some(node) = win.nodes.get(editor.node_index) {
-            format!("{}/{}", node.alias, editor.port_name)
+        let port_label = if let Some(pref) = win.flow_definition.process_refs.get(editor.node_index)
+        {
+            let alias = if pref.alias.is_empty() {
+                derive_short_name(&pref.source)
+            } else {
+                pref.alias.clone()
+            };
+            format!("{}/{}", alias, editor.port_name)
         } else {
             editor.port_name.clone()
         };

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -928,13 +928,28 @@ pub(crate) fn derive_short_name(source: &str) -> String {
 
 /// Split a route string like "sequence/number" into ("sequence", "number")
 /// or "add1" into ("add1", "")
-fn split_route(route: &str) -> (String, String) {
+pub(crate) fn split_route(route: &str) -> (String, String) {
     let route = route.trim_start_matches('/');
     if let Some(pos) = route.find('/') {
         (route[..pos].to_string(), route[pos + 1..].to_string())
     } else {
         (route.to_string(), String::new())
     }
+}
+
+/// Check whether a Connection references a node by alias in its from or to routes.
+pub(crate) fn connection_references_node(conn: &Connection, alias: &str) -> bool {
+    let (from_node, _) = split_route(conn.from().as_ref());
+    if from_node == alias {
+        return true;
+    }
+    for to_route in conn.to() {
+        let (to_node, _) = split_route(to_route.as_ref());
+        if to_node == alias {
+            return true;
+        }
+    }
+    false
 }
 
 /// Persistent canvas state that caches the rendered geometry.

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -24,6 +24,8 @@ use iced::{Color, Element, Fill, Point, Rectangle, Renderer, Size, Theme};
 use log::info;
 
 use flowcore::model::input::InputInitializer;
+use flowcore::model::io::IO;
+use flowcore::model::name::HasName;
 
 use crate::flow_io;
 use crate::history;
@@ -214,7 +216,8 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
         }
         CanvasMessage::AutoFitViewport(viewport) => {
             if win.auto_fit_enabled || win.auto_fit_pending {
-                let has_flow_io = !win.flow_inputs.is_empty() || !win.flow_outputs.is_empty();
+                let has_flow_io = !win.flow_definition.inputs.is_empty()
+                    || !win.flow_definition.outputs.is_empty();
                 win.canvas_state.auto_fit(&win.nodes, has_flow_io, viewport);
                 win.auto_fit_pending = false;
             }
@@ -962,8 +965,8 @@ impl FlowCanvasState {
         nodes: &'a [NodeLayout],
         edges: &'a [EdgeLayout],
         flow_name: &'a str,
-        flow_inputs: &'a [PortInfo],
-        flow_outputs: &'a [PortInfo],
+        flow_inputs: &'a [IO],
+        flow_outputs: &'a [IO],
         is_subflow: bool,
         auto_fit_pending: bool,
         auto_fit_enabled: bool,
@@ -1098,9 +1101,9 @@ struct FlowCanvas<'a> {
     /// Flow name (displayed on sub-flow bounding box)
     flow_name: &'a str,
     /// Flow-level input ports (displayed on left edge for sub-flows)
-    flow_inputs: &'a [PortInfo],
+    flow_inputs: &'a [IO],
     /// Flow-level output ports (displayed on right edge for sub-flows)
-    flow_outputs: &'a [PortInfo],
+    flow_outputs: &'a [IO],
     /// Whether this is a sub-flow (always draws bounding box)
     is_subflow: bool,
     /// Whether an auto-fit should be triggered on the next event
@@ -1230,8 +1233,8 @@ fn quadratic_bezier_pt(p0: Point, p1: Point, p2: Point, t: f32) -> Point {
 /// Compute flow I/O port world positions (same layout as `draw_flow_io_ports`).
 fn compute_flow_io_positions(
     nodes: &[NodeLayout],
-    flow_inputs: &[PortInfo],
-    flow_outputs: &[PortInfo],
+    flow_inputs: &[IO],
+    flow_outputs: &[IO],
 ) -> (HashMap<String, Point>, HashMap<String, Point>) {
     use std::collections::HashMap;
 
@@ -1266,14 +1269,14 @@ fn compute_flow_io_positions(
     let input_start_y = center_y - (flow_inputs.len() as f32 - 1.0) * spacing / 2.0;
     for (i, input) in flow_inputs.iter().enumerate() {
         let y = input_start_y + i as f32 * spacing;
-        input_positions.insert(input.name.clone(), Point::new(box_x, y));
+        input_positions.insert(input.name().clone(), Point::new(box_x, y));
     }
 
     let right_x = box_x + box_w;
     let output_start_y = center_y - (flow_outputs.len() as f32 - 1.0) * spacing / 2.0;
     for (i, output) in flow_outputs.iter().enumerate() {
         let y = output_start_y + i as f32 * spacing;
-        output_positions.insert(output.name.clone(), Point::new(right_x, y));
+        output_positions.insert(output.name().clone(), Point::new(right_x, y));
     }
 
     (input_positions, output_positions)
@@ -1352,8 +1355,8 @@ fn cubic_bezier(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> Point {
 fn hit_test_connection(
     edges: &[EdgeLayout],
     nodes: &[NodeLayout],
-    flow_inputs: &[PortInfo],
-    flow_outputs: &[PortInfo],
+    flow_inputs: &[IO],
+    flow_outputs: &[IO],
     screen_pos: Point,
     zoom: f32,
     offset: Point,
@@ -2373,8 +2376,8 @@ fn draw_nodes(frame: &mut Frame, nodes: &[NodeLayout], zoom: f32, offset: Point)
 fn draw_flow_io_ports(
     frame: &mut Frame,
     flow_name: &str,
-    flow_inputs: &[PortInfo],
-    flow_outputs: &[PortInfo],
+    flow_inputs: &[IO],
+    flow_outputs: &[IO],
     nodes: &[NodeLayout],
     edges: &[EdgeLayout],
     is_subflow: bool,
@@ -2451,7 +2454,7 @@ fn draw_flow_io_ports(
     for (i, input) in flow_inputs.iter().enumerate() {
         let world_y = input_start_y + i as f32 * spacing;
         let world_pos = Point::new(box_x, world_y);
-        input_positions.insert(input.name.clone(), world_pos);
+        input_positions.insert(input.name().clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
         let semi = Path::new(|builder| {
@@ -2467,7 +2470,7 @@ fn draw_flow_io_ports(
 
         let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
         frame.fill_text(CanvasText {
-            content: input.name.clone(),
+            content: input.name().clone(),
             position: label_pos,
             color: input_color,
             size: (font_size * zoom).into(),
@@ -2484,7 +2487,7 @@ fn draw_flow_io_ports(
     for (i, output) in flow_outputs.iter().enumerate() {
         let world_y = output_start_y + i as f32 * spacing;
         let world_pos = Point::new(right_x, world_y);
-        output_positions.insert(output.name.clone(), world_pos);
+        output_positions.insert(output.name().clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
         let semi = Path::new(|builder| {
@@ -2500,7 +2503,7 @@ fn draw_flow_io_ports(
 
         let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
         frame.fill_text(CanvasText {
-            content: output.name.clone(),
+            content: output.name().clone(),
             position: label_pos,
             color: output_color,
             size: (font_size * zoom).into(),
@@ -2907,8 +2910,8 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
             &win.nodes,
             &win.edges,
             &win.flow_definition.name,
-            &win.flow_inputs,
-            &win.flow_outputs,
+            &win.flow_definition.inputs,
+            &win.flow_definition.outputs,
             !win.is_root,
             win.auto_fit_pending,
             win.auto_fit_enabled,
@@ -3610,18 +3613,13 @@ mod test {
 
     #[test]
     fn compute_flow_io_positions_with_nodes() {
+        use flowcore::model::route::Route;
         let nodes = vec![NodeLayout {
             alias: "n".into(),
             ..Default::default()
         }];
-        let inputs = vec![PortInfo {
-            name: "data".into(),
-            datatypes: vec![],
-        }];
-        let outputs = vec![PortInfo {
-            name: "result".into(),
-            datatypes: vec![],
-        }];
+        let inputs = vec![IO::new_named(vec![], Route::default(), "data")];
+        let outputs = vec![IO::new_named(vec![], Route::default(), "result")];
         let (inp, outp) = compute_flow_io_positions(&nodes, &inputs, &outputs);
         assert!(inp.contains_key("data"));
         assert!(outp.contains_key("result"));
@@ -3633,14 +3631,9 @@ mod test {
 
     #[test]
     fn compute_flow_io_positions_empty_nodes() {
-        let inputs = vec![PortInfo {
-            name: "in".into(),
-            datatypes: vec![],
-        }];
-        let outputs = vec![PortInfo {
-            name: "out".into(),
-            datatypes: vec![],
-        }];
+        use flowcore::model::route::Route;
+        let inputs = vec![IO::new_named(vec![], Route::default(), "in")];
+        let outputs = vec![IO::new_named(vec![], Route::default(), "out")];
         let (inp, outp) = compute_flow_io_positions(&[], &inputs, &outputs);
         assert!(inp.contains_key("in"));
         assert!(outp.contains_key("out"));

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -5,6 +5,12 @@
 //! blue for `lib://`, green for `context://`, purple for provided implementations,
 //! and orange for nested flows.
 
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
 use std::collections::HashMap;
 
 use iced::keyboard;
@@ -243,22 +249,24 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                     let pr_alias = if pr.alias.is_empty() {
                         derive_short_name(&pr.source)
                     } else {
-                        pr.alias.to_string()
+                        pr.alias.clone()
                     };
                     pr_alias == alias
                 })
                 .and_then(|pr| pr.initializations.get(&port_name))
-                .map(|init| match init {
-                    InputInitializer::Once(v) => (
-                        "once".to_string(),
-                        serde_json::to_string(v).unwrap_or_default(),
-                    ),
-                    InputInitializer::Always(v) => (
-                        "always".to_string(),
-                        serde_json::to_string(v).unwrap_or_default(),
-                    ),
-                })
-                .unwrap_or_else(|| ("none".to_string(), String::new()));
+                .map_or_else(
+                    || ("none".to_string(), String::new()),
+                    |init| match init {
+                        InputInitializer::Once(v) => (
+                            "once".to_string(),
+                            serde_json::to_string(v).unwrap_or_default(),
+                        ),
+                        InputInitializer::Always(v) => (
+                            "always".to_string(),
+                            serde_json::to_string(v).unwrap_or_default(),
+                        ),
+                    },
+                );
 
             win.initializer_editor = Some(InitializerEditor {
                 node_index: node_idx,
@@ -343,9 +351,9 @@ pub(crate) enum CanvasMessage {
     Selected(Option<usize>),
     /// A node was moved to a new position (continuous during drag).
     Moved(usize, f32, f32),
-    /// A node move completed (old_x, old_y, new_x, new_y) — for undo history.
+    /// A node move completed (`old_x`, `old_y`, `new_x`, `new_y`) — for undo history.
     MoveCompleted(usize, f32, f32, f32, f32),
-    /// A node was resized (index, new_x, new_y, new_width, new_height) — continuous during drag.
+    /// A node was resized (index, `new_x`, `new_y`, `new_width`, `new_height`) — continuous during drag.
     Resized(usize, f32, f32, f32, f32),
     /// A node resize completed — for undo history.
     ResizeCompleted(usize, f32, f32, f32, f32, f32, f32, f32, f32),
@@ -367,7 +375,7 @@ pub(crate) enum CanvasMessage {
     /// A connection should be deleted.
     ConnectionDeleted(usize),
     /// Right-click on an input port to edit its initializer.
-    /// (node_index, port_name)
+    /// (`node_index`, `port_name`)
     InitializerEdit(usize, String),
     /// Open a sub-flow or provided implementation in a new editor.
     OpenNode(usize),
@@ -451,7 +459,7 @@ pub(crate) struct CanvasInteractionState {
     dragging: Option<DragState>,
     /// Active resize operation, if any
     resizing: Option<ResizeState>,
-    /// Current keyboard modifier state (tracked via ModifiersChanged events)
+    /// Current keyboard modifier state (tracked via `ModifiersChanged` events)
     modifiers: keyboard::Modifiers,
     /// Active middle-mouse-button pan operation
     panning: Option<PanState>,
@@ -587,7 +595,10 @@ impl NodeLayout {
             Color::from_rgb(0.3, 0.5, 0.9) // Blue for library
         } else if self.source.starts_with("context://") {
             Color::from_rgb(0.3, 0.75, 0.45) // Green for context
-        } else if self.source.ends_with(".rs") || self.source.ends_with(".wasm") {
+        } else if std::path::Path::new(&self.source)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("rs") || ext.eq_ignore_ascii_case("wasm"))
+        {
             Color::from_rgb(0.6, 0.3, 0.8) // Purple for provided implementations
         } else {
             Color::from_rgb(0.9, 0.6, 0.2) // Orange for nested flows
@@ -617,7 +628,7 @@ impl NodeLayout {
 
     /// Return the 8 resize handle positions in world coordinates.
     ///
-    /// Order: TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+    /// Order: `TopLeft`, Top, `TopRight`, Left, Right, `BottomLeft`, Bottom, `BottomRight`.
     fn resize_handle_positions(&self) -> [(ResizeHandle, Point); 8] {
         let mid_x = self.x + self.width / 2.0;
         let mid_y = self.y + self.height / 2.0;
@@ -670,7 +681,7 @@ pub(crate) fn build_node_layouts(
         let alias = if pref.alias.is_empty() {
             derive_short_name(&pref.source)
         } else {
-            pref.alias.to_string()
+            pref.alias.clone()
         };
 
         let (inputs, outputs) = resolved_ports.get(&alias).cloned().unwrap_or_default();
@@ -774,7 +785,7 @@ fn compute_topological_layout(
             if p.alias.is_empty() {
                 derive_short_name(&p.source)
             } else {
-                p.alias.to_string()
+                p.alias.clone()
             }
         })
         .collect();
@@ -876,7 +887,7 @@ pub(crate) fn build_edge_layouts(connections: &[Connection]) -> Vec<EdgeLayout> 
                 from_port: from_port.clone(),
                 to_node,
                 to_port,
-                name: conn.name().to_string(),
+                name: conn.name().clone(),
             });
         }
     }
@@ -884,7 +895,7 @@ pub(crate) fn build_edge_layouts(connections: &[Connection]) -> Vec<EdgeLayout> 
     edges
 }
 
-/// Format a serde_json::Value for compact display
+/// Format a [`serde_json::Value`] for compact display
 fn format_value(v: &serde_json::Value) -> String {
     match v {
         serde_json::Value::String(s) => format!("\"{s}\""),
@@ -1016,7 +1027,7 @@ impl FlowCanvasState {
                 let max_len = node
                     .initializers
                     .values()
-                    .map(|s| s.len())
+                    .map(String::len)
                     .max()
                     .unwrap_or(0);
                 max_len as f32 * 8.0
@@ -1053,8 +1064,8 @@ impl FlowCanvasState {
         // Set offset so that the content is centered
         // screen_x = (world_x + offset_x) * zoom
         // We want the center of the content to map to the center of the viewport
-        let content_center_x = (min_x + max_x) / 2.0;
-        let content_center_y = (min_y + max_y) / 2.0;
+        let content_center_x = min_x.midpoint(max_x);
+        let content_center_y = min_y.midpoint(max_y);
         let viewport_center_x = viewport.width / 2.0 / self.zoom;
         let viewport_center_y = viewport.height / 2.0 / self.zoom;
 
@@ -1216,7 +1227,7 @@ fn quadratic_bezier_pt(p0: Point, p1: Point, p2: Point, t: f32) -> Point {
 }
 
 /// Evaluate a cubic bezier curve at parameter `t` (0.0..=1.0).
-/// Compute flow I/O port world positions (same layout as draw_flow_io_ports).
+/// Compute flow I/O port world positions (same layout as `draw_flow_io_ports`).
 fn compute_flow_io_positions(
     nodes: &[NodeLayout],
     flow_inputs: &[PortInfo],
@@ -1250,7 +1261,7 @@ fn compute_flow_io_positions(
     };
     let box_x = min_x - padding;
     let box_w = (max_x - min_x) + 2.0 * padding;
-    let center_y = (min_y + max_y) / 2.0;
+    let center_y = min_y.midpoint(max_y);
 
     let input_start_y = center_y - (flow_inputs.len() as f32 - 1.0) * spacing / 2.0;
     for (i, input) in flow_inputs.iter().enumerate() {
@@ -1302,17 +1313,18 @@ fn find_node_input_pos_inline(node: &NodeLayout, port: &str) -> Point {
     }
 }
 
-/// Squared distance from point `p` to the line segment `a`–`b`.
+/// Squared distance from point `p` to the line segment `a`--`b`.
+#[allow(clippy::similar_names)]
 fn distance_to_segment_sq(p: Point, a: Point, b: Point) -> f32 {
     let ab_x = b.x - a.x;
     let ab_y = b.y - a.y;
     let ap_x = p.x - a.x;
     let ap_y = p.y - a.y;
-    let ab_len_sq = ab_x * ab_x + ab_y * ab_y;
-    if ab_len_sq < 0.001 {
+    let seg_len_sq = ab_x * ab_x + ab_y * ab_y;
+    if seg_len_sq < 0.001 {
         return ap_x * ap_x + ap_y * ap_y;
     }
-    let t = ((ap_x * ab_x + ap_y * ab_y) / ab_len_sq).clamp(0.0, 1.0);
+    let t = ((ap_x * ab_x + ap_y * ab_y) / seg_len_sq).clamp(0.0, 1.0);
     let proj_x = a.x + t * ab_x;
     let proj_y = a.y + t * ab_y;
     let dx = p.x - proj_x;
@@ -1463,7 +1475,7 @@ fn hit_test_connection(
 }
 
 /// Compute the appropriate mouse cursor for a given [`ResizeHandle`].
-fn resize_cursor(handle: &ResizeHandle) -> mouse::Interaction {
+fn resize_cursor(handle: ResizeHandle) -> mouse::Interaction {
     match handle {
         ResizeHandle::TopLeft | ResizeHandle::BottomRight => {
             mouse::Interaction::ResizingDiagonallyDown
@@ -1775,17 +1787,16 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                             } else {
                                 &node.inputs
                             };
-                            let type_text = ports
-                                .iter()
-                                .find(|p| p.name == port_name)
-                                .map(|p| {
+                            let type_text = ports.iter().find(|p| p.name == port_name).map_or_else(
+                                || port_name.clone(),
+                                |p| {
                                     if p.datatypes.is_empty() {
                                         format!("{port_name}: (any)")
                                     } else {
                                         format!("{port_name}: {}", p.datatypes.join(", "))
                                     }
-                                })
-                                .unwrap_or_else(|| port_name.clone());
+                                },
+                            );
                             state.hover_node = None;
                             return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
                                 Some((type_text, cursor_position.x, cursor_position.y - 20.0)),
@@ -1947,9 +1958,9 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     }
                 } else {
                     // Pan
-                    let pan_dx = dx / zoom;
-                    let pan_dy = dy / zoom;
-                    Some(canvas::Action::publish(CanvasMessage::Pan(pan_dx, pan_dy)).and_capture())
+                    let pan_x = dx / zoom;
+                    let pan_y = dy / zoom;
+                    Some(canvas::Action::publish(CanvasMessage::Pan(pan_x, pan_y)).and_capture())
                 }
             }
 
@@ -2117,7 +2128,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         }
 
         if let Some(ref resize) = state.resizing {
-            return resize_cursor(&resize.handle);
+            return resize_cursor(resize.handle);
         }
 
         if state.connecting.is_some() {
@@ -2139,7 +2150,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         self.state.zoom,
                         self.state.scroll_offset,
                     ) {
-                        return resize_cursor(&handle);
+                        return resize_cursor(handle);
                     }
                 }
             }
@@ -2184,9 +2195,7 @@ fn draw_edges(
         .collect();
 
     for edge_idx in draw_order {
-        let edge = if let Some(e) = edges.get(edge_idx) {
-            e
-        } else {
+        let Some(edge) = edges.get(edge_idx) else {
             continue;
         };
         let from_node = node_map.get(edge.from_node.as_str());
@@ -2243,7 +2252,7 @@ fn draw_edges(
                     Point::new(mid_x, box_bottom)
                 } else {
                     // For normal connections: midpoint, above the line
-                    Point::new((from_s.x + to_s.x) / 2.0, (from_s.y + to_s.y) / 2.0)
+                    Point::new(from_s.x.midpoint(to_s.x), from_s.y.midpoint(to_s.y))
                 };
                 let name_label = CanvasText {
                     content: edge.name.clone(),
@@ -2276,7 +2285,7 @@ fn loopback_waypoints(
     let box_right = (nx + nw + offset.x) * zoom + margin;
     let box_bottom = (ny + nh + offset.y) * zoom + margin;
     let box_left = (nx + offset.x) * zoom - margin;
-    let mid_x = (box_right + box_left) / 2.0;
+    let mid_x = box_right.midpoint(box_left);
     (box_right, box_bottom, box_left, mid_x)
 }
 
@@ -2316,7 +2325,7 @@ fn draw_bezier_connection(
             // Curve down to below the box
             builder.quadratic_curve_to(
                 Point::new(box_right, box_bottom),
-                Point::new((box_right + box_left) / 2.0, box_bottom),
+                Point::new(box_right.midpoint(box_left), box_bottom),
             );
             // Curve up to left of the box
             builder.quadratic_curve_to(
@@ -2373,6 +2382,8 @@ fn draw_flow_io_ports(
     zoom: f32,
     offset: Point,
 ) {
+    use std::f32::consts::PI;
+
     if !is_subflow {
         return;
     }
@@ -2430,7 +2441,7 @@ fn draw_flow_io_ports(
         });
     }
 
-    let center_y = (min_y + max_y) / 2.0;
+    let center_y = min_y.midpoint(max_y);
     let input_color = Color::from_rgb(0.4, 0.8, 1.0);
     let output_color = Color::from_rgb(1.0, 0.6, 0.3);
 
@@ -2443,8 +2454,6 @@ fn draw_flow_io_ports(
         input_positions.insert(input.name.clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
-
-        use std::f32::consts::PI;
         let semi = Path::new(|builder| {
             builder.arc(canvas::path::Arc {
                 center: screen_pos,
@@ -2478,8 +2487,6 @@ fn draw_flow_io_ports(
         output_positions.insert(output.name.clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
-
-        use std::f32::consts::PI;
         let semi = Path::new(|builder| {
             builder.arc(canvas::path::Arc {
                 center: screen_pos,
@@ -2689,6 +2696,8 @@ fn draw_port(
     zoom: f32,
     offset: Point,
 ) {
+    use std::f32::consts::PI;
+
     let screen_center = transform_point(center, zoom, offset);
     let scaled_radius = PORT_RADIUS * zoom;
 
@@ -2700,7 +2709,6 @@ fn draw_port(
     };
 
     // Draw semi-circle: curved side faces inside the box, flat edge on the box boundary
-    use std::f32::consts::PI;
     let semi = Path::new(|builder| {
         let (start_angle, end_angle) = if is_input {
             (-PI / 2.0, PI / 2.0) // Right-facing (inside the box)
@@ -2781,21 +2789,30 @@ fn draw_port(
 
 /// Build a rounded rectangle path using quadratic bezier curves at corners.
 fn rounded_rect(builder: &mut canvas::path::Builder, top_left: Point, size: Size, radius: f32) {
-    let r = radius.min(size.width / 2.0).min(size.height / 2.0);
-    let x = top_left.x;
-    let y = top_left.y;
-    let w = size.width;
-    let h = size.height;
+    let cr = radius.min(size.width / 2.0).min(size.height / 2.0);
+    let left = top_left.x;
+    let top = top_left.y;
+    let width = size.width;
+    let height = size.height;
 
-    builder.move_to(Point::new(x + r, y));
-    builder.line_to(Point::new(x + w - r, y));
-    builder.quadratic_curve_to(Point::new(x + w, y), Point::new(x + w, y + r));
-    builder.line_to(Point::new(x + w, y + h - r));
-    builder.quadratic_curve_to(Point::new(x + w, y + h), Point::new(x + w - r, y + h));
-    builder.line_to(Point::new(x + r, y + h));
-    builder.quadratic_curve_to(Point::new(x, y + h), Point::new(x, y + h - r));
-    builder.line_to(Point::new(x, y + r));
-    builder.quadratic_curve_to(Point::new(x, y), Point::new(x + r, y));
+    builder.move_to(Point::new(left + cr, top));
+    builder.line_to(Point::new(left + width - cr, top));
+    builder.quadratic_curve_to(
+        Point::new(left + width, top),
+        Point::new(left + width, top + cr),
+    );
+    builder.line_to(Point::new(left + width, top + height - cr));
+    builder.quadratic_curve_to(
+        Point::new(left + width, top + height),
+        Point::new(left + width - cr, top + height),
+    );
+    builder.line_to(Point::new(left + cr, top + height));
+    builder.quadratic_curve_to(
+        Point::new(left, top + height),
+        Point::new(left, top + height - cr),
+    );
+    builder.line_to(Point::new(left, top + cr));
+    builder.quadratic_curve_to(Point::new(left, top), Point::new(left + cr, top));
     builder.close();
 }
 
@@ -2857,9 +2874,9 @@ fn check_port_type_compatibility(
             // If either has no type info (empty list or only empty strings),
             // allow the connection — untyped ports accept anything
             let src_untyped =
-                src.datatypes.is_empty() || src.datatypes.iter().all(|t| t.is_empty());
+                src.datatypes.is_empty() || src.datatypes.iter().all(String::is_empty);
             let tgt_untyped =
-                tgt.datatypes.is_empty() || tgt.datatypes.iter().all(|t| t.is_empty());
+                tgt.datatypes.is_empty() || tgt.datatypes.iter().all(String::is_empty);
             if src_untyped || tgt_untyped {
                 return true;
             }
@@ -2883,16 +2900,13 @@ fn check_port_type_compatibility(
 /// Build the complete canvas area for a flow-editor window, including the
 /// interactive canvas, zoom controls, tooltip overlay, initializer editor
 /// dialog, and right-click context menu.
-pub(crate) fn view_canvas_area<'a>(
-    win: &'a WindowState,
-    window_id: window::Id,
-) -> Element<'a, Message> {
+pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Element<'_, Message> {
     let canvas = win
         .canvas_state
         .view(
             &win.nodes,
             &win.edges,
-            &win.flow_name,
+            &win.flow_definition.name,
             &win.flow_inputs,
             &win.flow_outputs,
             !win.is_root,
@@ -3417,7 +3431,7 @@ mod test {
             ..Default::default()
         };
         assert_eq!(
-            hit_test_node(&[node.clone()], Point::new(150.0, 150.0)),
+            hit_test_node(std::slice::from_ref(&node), Point::new(150.0, 150.0)),
             Some(0)
         );
         assert_eq!(hit_test_node(&[node], Point::new(50.0, 50.0)), None);
@@ -3494,7 +3508,7 @@ mod test {
 
     #[test]
     fn check_type_compat_same_type() {
-        let nodes = vec![
+        let nodes = [
             NodeLayout {
                 alias: "a".into(),
                 x: 0.0,
@@ -3528,7 +3542,7 @@ mod test {
 
     #[test]
     fn check_type_compat_different_type() {
-        let nodes = vec![
+        let nodes = [
             NodeLayout {
                 alias: "a".into(),
                 x: 0.0,
@@ -3562,7 +3576,7 @@ mod test {
 
     #[test]
     fn check_type_compat_untyped_allows_any() {
-        let nodes = vec![
+        let nodes = [
             NodeLayout {
                 alias: "a".into(),
                 x: 0.0,

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -1,6 +1,7 @@
 //! Flow file operations: loading, saving, compiling, and editor preferences.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
 use log::info;
@@ -22,7 +23,6 @@ use flowcore::model::process::Process;
 
 /// Result of loading a flow definition file.
 pub(crate) struct LoadedFlow {
-    pub(crate) name: String,
     pub(crate) nodes: Vec<NodeLayout>,
     pub(crate) edges: Vec<EdgeLayout>,
     pub(crate) flow_def: FlowDefinition,
@@ -62,7 +62,7 @@ pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
 pub(crate) fn perform_save_as(win: &mut WindowState) {
     let dialog = rfd::FileDialog::new()
         .add_filter("Flow", &["toml"])
-        .set_file_name(format!("{}.toml", win.flow_name));
+        .set_file_name(format!("{}.toml", win.flow_definition.name));
     if let Some(path) = dialog.save_file() {
         perform_save(win, &path);
     }
@@ -93,7 +93,6 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
                 let nc = loaded.nodes.len();
                 let ec = loaded.edges.len();
                 let (fi, fo) = extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
-                win.flow_name = loaded.name;
                 win.nodes = loaded.nodes;
                 win.edges = loaded.edges;
                 win.flow_definition = loaded.flow_def;
@@ -120,10 +119,10 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
 
 /// Clear the canvas and reset to an empty flow state.
 pub(crate) fn perform_new(win: &mut WindowState) {
-    win.flow_name = String::from("(new flow)");
     win.nodes = Vec::new();
     win.edges = Vec::new();
     win.flow_definition = FlowDefinition::default();
+    win.flow_definition.name = String::from("(new flow)");
     win.file_path = None;
     win.flow_inputs = Vec::new();
     win.flow_outputs = Vec::new();
@@ -211,14 +210,15 @@ pub(crate) fn build_meta_provider() -> MetaProvider {
             }
         }
     }
-    let context_root = std::env::var("HOME")
-        .map(|h| {
+    let context_root = std::env::var("HOME").map_or_else(
+        |_| PathBuf::from("/"),
+        |h| {
             PathBuf::from(h)
                 .join(".flow")
                 .join("runner")
                 .join("flowrcli")
-        })
-        .unwrap_or_else(|_| PathBuf::from("/"));
+        },
+    );
     MetaProvider::new(lib_search_path, context_root)
 }
 
@@ -254,15 +254,15 @@ pub(crate) fn extract_ports(
     let input_ports = inputs
         .iter()
         .map(|io| PortInfo {
-            name: io.name().to_string(),
-            datatypes: io.datatypes().iter().map(|dt| dt.to_string()).collect(),
+            name: io.name().clone(),
+            datatypes: io.datatypes().iter().map(ToString::to_string).collect(),
         })
         .collect();
     let output_ports = outputs
         .iter()
         .map(|io| PortInfo {
-            name: io.name().to_string(),
-            datatypes: io.datatypes().iter().map(|dt| dt.to_string()).collect(),
+            name: io.name().clone(),
+            datatypes: io.datatypes().iter().map(ToString::to_string).collect(),
         })
         .collect();
     (input_ports, output_ports)
@@ -279,8 +279,8 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
             .join(path)
     };
 
-    let url =
-        Url::from_file_path(&abs_path).map_err(|()| format!("Invalid file path: {abs_path:?}"))?;
+    let url = Url::from_file_path(&abs_path)
+        .map_err(|()| format!("Invalid file path: {}", abs_path.display()))?;
 
     let provider = build_meta_provider();
     let process = flowrclib::compiler::parser::parse(&url, &provider)
@@ -305,7 +305,7 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
                     inputs.len(),
                     outputs.len()
                 );
-                resolved_ports.insert(alias.to_string(), (inputs, outputs));
+                resolved_ports.insert(alias.clone(), (inputs, outputs));
             }
 
             let edges = build_edge_layouts(&flow.connections);
@@ -315,11 +315,9 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
                 &resolved_ports,
                 &flow.subprocesses,
             );
-            let name = flow.name.clone();
             let lib_references = flow.lib_references.clone();
             let context_references = flow.context_references.clone();
             Ok(LoadedFlow {
-                name,
                 nodes,
                 edges,
                 flow_def: flow,
@@ -401,19 +399,20 @@ pub(crate) fn save_flow_toml(
     let mut out = String::new();
 
     // Flow name
-    out.push_str(&format!("flow = \"{}\"\n", escape_toml_string(&flow.name)));
+    let _ = writeln!(out, "flow = \"{}\"", escape_toml_string(&flow.name));
 
     // Description
     if !flow.description.is_empty() {
-        out.push_str(&format!(
-            "description = \"{}\"\n",
+        let _ = writeln!(
+            out,
+            "description = \"{}\"",
             escape_toml_string(&flow.description)
-        ));
+        );
     }
 
     // Docs
     if !flow.docs.is_empty() {
-        out.push_str(&format!("docs = \"{}\"\n", escape_toml_string(&flow.docs)));
+        let _ = writeln!(out, "docs = \"{}\"", escape_toml_string(&flow.docs));
     }
 
     // Metadata (only if any field is non-empty)
@@ -421,16 +420,14 @@ pub(crate) fn save_flow_toml(
     if !md.version.is_empty() || !md.description.is_empty() || !md.authors.is_empty() {
         out.push_str("\n[metadata]\n");
         if !md.version.is_empty() {
-            out.push_str(&format!(
-                "version = \"{}\"\n",
-                escape_toml_string(&md.version)
-            ));
+            let _ = writeln!(out, "version = \"{}\"", escape_toml_string(&md.version));
         }
         if !md.description.is_empty() {
-            out.push_str(&format!(
-                "description = \"{}\"\n",
+            let _ = writeln!(
+                out,
+                "description = \"{}\"",
                 escape_toml_string(&md.description)
-            ));
+            );
         }
         if !md.authors.is_empty() {
             let authors: Vec<String> = md
@@ -438,7 +435,7 @@ pub(crate) fn save_flow_toml(
                 .iter()
                 .map(|a| format!("\"{}\"", escape_toml_string(a)))
                 .collect();
-            out.push_str(&format!("authors = [{}]\n", authors.join(", ")));
+            let _ = writeln!(out, "authors = [{}]", authors.join(", "));
         }
     }
 
@@ -447,16 +444,16 @@ pub(crate) fn save_flow_toml(
         out.push_str("\n[[input]]\n");
         let name = input.name();
         if !name.is_empty() {
-            out.push_str(&format!("name = \"{name}\"\n"));
+            let _ = writeln!(out, "name = \"{name}\"");
         }
         let types = input.datatypes();
         if types.len() == 1 {
             if let Some(t) = types.first() {
-                out.push_str(&format!("type = \"{t}\"\n"));
+                let _ = writeln!(out, "type = \"{t}\"");
             }
         } else if types.len() > 1 {
             let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
-            out.push_str(&format!("type = [{}]\n", ts.join(", ")));
+            let _ = writeln!(out, "type = [{}]", ts.join(", "));
         }
     }
 
@@ -465,16 +462,16 @@ pub(crate) fn save_flow_toml(
         out.push_str("\n[[output]]\n");
         let name = output.name();
         if !name.is_empty() {
-            out.push_str(&format!("name = \"{name}\"\n"));
+            let _ = writeln!(out, "name = \"{name}\"");
         }
         let types = output.datatypes();
         if types.len() == 1 {
             if let Some(t) = types.first() {
-                out.push_str(&format!("type = \"{t}\"\n"));
+                let _ = writeln!(out, "type = \"{t}\"");
             }
         } else if types.len() > 1 {
             let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
-            out.push_str(&format!("type = [{}]\n", ts.join(", ")));
+            let _ = writeln!(out, "type = [{}]", ts.join(", "));
         }
     }
 
@@ -482,30 +479,27 @@ pub(crate) fn save_flow_toml(
     for pref in &flow.process_refs {
         out.push_str("\n[[process]]\n");
         if !pref.alias.is_empty() {
-            out.push_str(&format!("alias = \"{}\"\n", pref.alias));
+            let _ = writeln!(out, "alias = \"{}\"", pref.alias);
         }
-        out.push_str(&format!("source = \"{}\"\n", pref.source));
+        let _ = writeln!(out, "source = \"{}\"", pref.source);
 
         // Layout positions
         if let Some(x) = pref.x {
-            out.push_str(&format!("x = {x}\n"));
+            let _ = writeln!(out, "x = {x}");
         }
         if let Some(y) = pref.y {
-            out.push_str(&format!("y = {y}\n"));
+            let _ = writeln!(out, "y = {y}");
         }
         if let Some(w) = pref.width {
-            out.push_str(&format!("width = {w}\n"));
+            let _ = writeln!(out, "width = {w}");
         }
         if let Some(h) = pref.height {
-            out.push_str(&format!("height = {h}\n"));
+            let _ = writeln!(out, "height = {h}");
         }
 
         // Initializations
         for (port_name, init) in &pref.initializations {
-            out.push_str(&format!(
-                "input.{port_name} = {}\n",
-                initializer_to_toml(init)
-            ));
+            let _ = writeln!(out, "input.{port_name} = {}", initializer_to_toml(init));
         }
     }
 
@@ -513,20 +507,20 @@ pub(crate) fn save_flow_toml(
     for edge in edges {
         out.push_str("\n[[connection]]\n");
         if !edge.name.is_empty() {
-            out.push_str(&format!("name = \"{}\"\n", edge.name));
+            let _ = writeln!(out, "name = \"{}\"", edge.name);
         }
         let from = if edge.from_port.is_empty() {
             edge.from_node.clone()
         } else {
             format!("{}/{}", edge.from_node, edge.from_port)
         };
-        out.push_str(&format!("from = \"{from}\"\n"));
+        let _ = writeln!(out, "from = \"{from}\"");
         let to = if edge.to_port.is_empty() {
             edge.to_node.clone()
         } else {
             format!("{}/{}", edge.to_node, edge.to_port)
         };
-        out.push_str(&format!("to = \"{to}\"\n"));
+        let _ = writeln!(out, "to = \"{to}\"");
     }
 
     std::fs::write(path, out).map_err(|e| format!("Could not write file: {e}"))
@@ -582,31 +576,34 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
         escape_toml_string(&viewer.source_file)
     );
     if !viewer.description.is_empty() {
-        toml.push_str(&format!(
-            "description = \"{}\"\n",
+        let _ = writeln!(
+            toml,
+            "description = \"{}\"",
             escape_toml_string(&viewer.description)
-        ));
+        );
     }
     for input in &viewer.inputs {
         let dtype = input.datatypes.first().map_or("", String::as_str);
         if input.name.is_empty() || input.name == "input" || input.name == "name" {
-            toml.push_str(&format!("\n[[input]]\ntype = \"{dtype}\"\n"));
+            let _ = write!(toml, "\n[[input]]\ntype = \"{dtype}\"\n");
         } else {
-            toml.push_str(&format!(
+            let _ = write!(
+                toml,
                 "\n[[input]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
                 input.name
-            ));
+            );
         }
     }
     for output in &viewer.outputs {
         let dtype = output.datatypes.first().map_or("", String::as_str);
         if output.name.is_empty() || output.name == "output" || output.name == "name" {
-            toml.push_str(&format!("\n[[output]]\ntype = \"{dtype}\"\n"));
+            let _ = write!(toml, "\n[[output]]\ntype = \"{dtype}\"\n");
         } else {
-            toml.push_str(&format!(
+            let _ = write!(
+                toml,
                 "\n[[output]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
                 output.name
-            ));
+            );
         }
     }
     std::fs::write(&viewer.toml_path, &toml)
@@ -616,6 +613,11 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
     let rs_path = dir.join(&viewer.source_file);
     if !rs_path.exists() {
         let input_count = viewer.inputs.len();
+        let input_bindings = (0..input_count).fold(String::new(), |mut acc, i| {
+            use std::fmt::Write;
+            let _ = writeln!(acc, "    let _input{i} = &inputs[{i}];");
+            acc
+        });
         let skeleton = format!(
             "use flowcore::{{RUN_AGAIN, RunAgain}};\n\
              use flowcore::errors::*;\n\
@@ -629,9 +631,6 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
              \n    Ok((None, RUN_AGAIN))\n\
              }}\n",
             name = viewer.name,
-            input_bindings = (0..input_count)
-                .map(|i| format!("    let _input{i} = &inputs[{i}];\n"))
-                .collect::<String>(),
         );
         std::fs::write(&rs_path, &skeleton)
             .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))?;
@@ -672,10 +671,10 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
 /// Compute the path for the editor preferences file alongside the flow file.
 pub(crate) fn editor_prefs_path(flow_path: &Path) -> PathBuf {
     let mut p = flow_path.to_path_buf();
-    let name = p
-        .file_name()
-        .map(|n| format!(".{}.flowedit", n.to_string_lossy()))
-        .unwrap_or_else(|| ".flowedit".to_string());
+    let name = p.file_name().map_or_else(
+        || ".flowedit".to_string(),
+        |n| format!(".{}.flowedit", n.to_string_lossy()),
+    );
     p.set_file_name(name);
     p
 }
@@ -701,14 +700,21 @@ pub(crate) fn save_editor_prefs(
 }
 
 /// Load editor preferences from the prefs file alongside the flow file.
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
     let prefs_path = editor_prefs_path(flow_path);
     let content = std::fs::read_to_string(prefs_path).ok()?;
     let val: serde_json::Value = serde_json::from_str(&content).ok()?;
     let w = val.get("width")?.as_f64()? as f32;
     let h = val.get("height")?.as_f64()? as f32;
-    let x = val.get("x").and_then(|v| v.as_f64()).map(|v| v as f32);
-    let y = val.get("y").and_then(|v| v.as_f64()).map(|v| v as f32);
+    let x = val
+        .get("x")
+        .and_then(serde_json::Value::as_f64)
+        .map(|v| v as f32);
+    let y = val
+        .get("y")
+        .and_then(serde_json::Value::as_f64)
+        .map(|v| v as f32);
     Some(EditorPrefs {
         width: w,
         height: h,
@@ -892,8 +898,10 @@ mod test {
         let dir = temp_dir("save_load");
         let path = dir.join("test.toml");
 
-        let mut flow = FlowDefinition::default();
-        flow.name = "roundtrip_test".into();
+        let mut flow = FlowDefinition {
+            name: "roundtrip_test".into(),
+            ..FlowDefinition::default()
+        };
         flow.metadata.version = "1.0.0".into();
         flow.metadata.authors = vec!["Test Author".into()];
         flow.process_refs.push(ProcessReference {
@@ -908,7 +916,7 @@ mod test {
 
         let edges = vec![EdgeLayout::new(
             "add1".into(),
-            "".into(),
+            String::new(),
             "add1".into(),
             "i1".into(),
         )];
@@ -922,7 +930,7 @@ mod test {
         assert!(contents.contains("lib://flowstdlib/math/add"));
 
         let loaded = load_flow(&path).expect("load failed");
-        assert_eq!(loaded.name, "roundtrip_test");
+        assert_eq!(loaded.flow_def.name, "roundtrip_test");
         assert_eq!(loaded.nodes.len(), 1);
         assert_eq!(loaded.edges.len(), 1);
         assert_eq!(loaded.flow_def.metadata.version, "1.0.0");
@@ -935,8 +943,10 @@ mod test {
         let dir = temp_dir("metadata");
         let path = dir.join("meta.toml");
 
-        let mut flow = FlowDefinition::default();
-        flow.name = "meta_flow".into();
+        let mut flow = FlowDefinition {
+            name: "meta_flow".into(),
+            ..FlowDefinition::default()
+        };
         flow.metadata.description = "A test description".into();
 
         save_flow_toml(&flow, &[], &path).expect("save failed");
@@ -951,9 +961,11 @@ mod test {
         let dir = temp_dir("description");
         let path = dir.join("test_flow.toml");
 
-        let mut flow = FlowDefinition::default();
-        flow.name = "described_flow".into();
-        flow.description = "A test flow that does something".into();
+        let flow = FlowDefinition {
+            name: "described_flow".into(),
+            description: "A test flow that does something".into(),
+            ..FlowDefinition::default()
+        };
 
         save_flow_toml(&flow, &[], &path).expect("Could not save flow");
 
@@ -968,8 +980,10 @@ mod test {
         let dir = temp_dir("initializers");
         let path = dir.join("init.toml");
 
-        let mut flow = FlowDefinition::default();
-        flow.name = "init_flow".into();
+        let mut flow = FlowDefinition {
+            name: "init_flow".into(),
+            ..FlowDefinition::default()
+        };
         let mut inits = std::collections::BTreeMap::new();
         inits.insert(
             "start".to_string(),
@@ -998,8 +1012,10 @@ mod test {
         let dir = temp_dir("connections");
         let path = dir.join("conn.toml");
 
-        let mut flow = FlowDefinition::default();
-        flow.name = "conn_flow".into();
+        let mut flow = FlowDefinition {
+            name: "conn_flow".into(),
+            ..FlowDefinition::default()
+        };
         flow.process_refs.push(ProcessReference {
             alias: "a".into(),
             source: "lib://test/a".into(),
@@ -1138,9 +1154,12 @@ mod test {
     }
 
     fn test_win_state() -> WindowState {
+        let flow_def = FlowDefinition {
+            name: String::from("test"),
+            ..FlowDefinition::default()
+        };
         WindowState {
             kind: WindowKind::FlowEditor,
-            flow_name: String::from("test"),
             nodes: vec![
                 test_node("add", "lib://flowstdlib/math/add"),
                 test_node("stdout", "context://stdio/stdout"),
@@ -1156,7 +1175,7 @@ mod test {
             unsaved_edits: 0,
             compiled_manifest: None,
             file_path: None,
-            flow_definition: FlowDefinition::default(),
+            flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
             is_root: true,
@@ -1177,7 +1196,7 @@ mod test {
 
         let mut win = test_win_state();
         win.unsaved_edits = 5;
-        win.flow_name = "saved_flow".into();
+        win.flow_definition.name = "saved_flow".into();
 
         perform_save(&mut win, &path);
         assert_eq!(win.unsaved_edits, 0);

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -92,13 +92,10 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
             Ok(loaded) => {
                 let nc = loaded.nodes.len();
                 let ec = loaded.edges.len();
-                let (fi, fo) = extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
                 win.nodes = loaded.nodes;
                 win.edges = loaded.edges;
                 win.flow_definition = loaded.flow_def;
                 win.set_file_path(&path);
-                win.flow_inputs = fi;
-                win.flow_outputs = fo;
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.history = EditHistory::default();
@@ -124,8 +121,6 @@ pub(crate) fn perform_new(win: &mut WindowState) {
     win.flow_definition = FlowDefinition::default();
     win.flow_definition.name = String::from("(new flow)");
     win.clear_file_path();
-    win.flow_inputs = Vec::new();
-    win.flow_outputs = Vec::new();
     win.selected_node = None;
     win.selected_connection = None;
     win.history = EditHistory::default();
@@ -1178,8 +1173,6 @@ mod test {
             tooltip: None,
             initializer_editor: None,
             is_root: true,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: FlowHierarchy::empty(),

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -1,17 +1,14 @@
 //! Flow file operations: loading, saving, compiling, and editor preferences.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
-use log::info;
 use simpath::Simpath;
 use url::Url;
 
-use crate::canvas_view::FlowCanvasState;
-use crate::canvas_view::{build_node_layouts, NodeLayout, PortInfo};
+use crate::canvas_view::{derive_short_name, FlowCanvasState, PortInfo};
 use crate::history::EditHistory;
-use crate::initializer;
 use crate::{FunctionViewer, WindowState};
 use flowcore::meta_provider::MetaProvider;
 use flowcore::model::flow_definition::FlowDefinition;
@@ -21,7 +18,6 @@ use flowcore::model::process::Process;
 
 /// Result of loading a flow definition file.
 pub(crate) struct LoadedFlow {
-    pub(crate) nodes: Vec<NodeLayout>,
     pub(crate) flow_def: FlowDefinition,
     pub(crate) lib_references: BTreeSet<Url>,
     pub(crate) context_references: BTreeSet<Url>,
@@ -37,7 +33,6 @@ pub(crate) struct EditorPrefs {
 
 /// Save the current flow to the given path.
 pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
-    initializer::sync_flow_definition(win);
     match save_flow_toml(&win.flow_definition, path) {
         Ok(()) => {
             win.unsaved_edits = 0;
@@ -87,9 +82,8 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
     if let Some(path) = dialog.pick_file() {
         match load_flow(&path) {
             Ok(loaded) => {
-                let nc = loaded.nodes.len();
+                let nc = loaded.flow_def.process_refs.len();
                 let ec = loaded.flow_def.connections.len();
-                win.nodes = loaded.nodes;
                 win.flow_definition = loaded.flow_def;
                 win.set_file_path(&path);
                 win.selected_node = None;
@@ -112,7 +106,6 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
 
 /// Clear the canvas and reset to an empty flow state.
 pub(crate) fn perform_new(win: &mut WindowState) {
-    win.nodes = Vec::new();
     win.flow_definition = FlowDefinition::default();
     win.flow_definition.name = String::from("(new flow)");
     win.clear_file_path();
@@ -277,37 +270,13 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
         .map_err(|e| format!("Could not parse flow definition: {e}"))?;
 
     match process {
-        Process::FlowProcess(flow) => {
-            // Extract port definitions from the fully-resolved subprocesses
-            let mut resolved_ports = HashMap::new();
-            for (alias, subprocess) in &flow.subprocesses {
-                let (inputs, outputs) = match subprocess {
-                    Process::FunctionProcess(func) => {
-                        extract_ports(&func.inputs, &func.outputs)
-                    }
-                    Process::FlowProcess(sub_flow) => {
-                        extract_ports(&sub_flow.inputs, &sub_flow.outputs)
-                    }
-                };
-                info!(
-                    "Resolved '{}': {} inputs, {} outputs",
-                    alias,
-                    inputs.len(),
-                    outputs.len()
-                );
-                resolved_ports.insert(alias.clone(), (inputs, outputs));
-            }
+        Process::FlowProcess(mut flow) => {
+            // Assign default positions to nodes that don't have saved x/y
+            assign_default_positions(&mut flow);
 
-            let nodes = build_node_layouts(
-                &flow.process_refs,
-                &flow.connections,
-                &resolved_ports,
-                &flow.subprocesses,
-            );
             let lib_references = flow.lib_references.clone();
             let context_references = flow.context_references.clone();
             Ok(LoadedFlow {
-                nodes,
                 flow_def: flow,
                 lib_references,
                 context_references,
@@ -504,15 +473,27 @@ pub(crate) fn save_flow_toml(flow: &FlowDefinition, path: &PathBuf) -> Result<()
 }
 
 /// Generate a unique alias for a new node, appending a numeric suffix if needed.
-pub(crate) fn generate_unique_alias(base_name: &str, nodes: &[NodeLayout]) -> String {
-    let existing: Vec<&str> = nodes.iter().map(|n| n.alias.as_str()).collect();
-    if !existing.contains(&base_name) {
+pub(crate) fn generate_unique_alias(
+    base_name: &str,
+    process_refs: &[flowcore::model::process_reference::ProcessReference],
+) -> String {
+    let existing: Vec<String> = process_refs
+        .iter()
+        .map(|pr| {
+            if pr.alias.is_empty() {
+                derive_short_name(&pr.source)
+            } else {
+                pr.alias.clone()
+            }
+        })
+        .collect();
+    if !existing.contains(&base_name.to_string()) {
         return base_name.to_string();
     }
     let mut counter = 2u32;
     loop {
         let candidate = format!("{base_name}_{counter}");
-        if !existing.iter().any(|a| *a == candidate) {
+        if !existing.contains(&candidate) {
             return candidate;
         }
         counter = counter.saturating_add(1);
@@ -520,13 +501,44 @@ pub(crate) fn generate_unique_alias(base_name: &str, nodes: &[NodeLayout]) -> St
 }
 
 /// Compute a default position for a new node, offset from the last node or at a default origin.
-pub(crate) fn next_node_position(nodes: &[NodeLayout]) -> (f32, f32) {
-    if nodes.is_empty() {
+pub(crate) fn next_node_position(
+    process_refs: &[flowcore::model::process_reference::ProcessReference],
+) -> (f32, f32) {
+    if process_refs.is_empty() {
         return (100.0, 100.0);
     }
     // Find the rightmost node and place the new one to its right
-    let max_right = nodes.iter().map(|n| n.x + n.width).fold(0.0_f32, f32::max);
+    let max_right = process_refs
+        .iter()
+        .map(|pr| pr.x.unwrap_or(100.0) + pr.width.unwrap_or(180.0))
+        .fold(0.0_f32, f32::max);
     (max_right + 50.0, 100.0)
+}
+
+/// Assign default positions to process references that don't have saved x/y coordinates.
+///
+/// Uses topological layout based on connections to determine column placement.
+fn assign_default_positions(flow: &mut FlowDefinition) {
+    use crate::canvas_view;
+
+    let needs_layout = flow
+        .process_refs
+        .iter()
+        .any(|pr| pr.x.is_none() || pr.y.is_none());
+    if !needs_layout {
+        return;
+    }
+
+    // Build render nodes (which computes topo positions) and copy back positions
+    let render_nodes = canvas_view::build_render_nodes(flow);
+    for (pref, node) in flow.process_refs.iter_mut().zip(render_nodes.iter()) {
+        if pref.x.is_none() {
+            pref.x = Some(node.x);
+        }
+        if pref.y.is_none() {
+            pref.y = Some(node.y);
+        }
+    }
 }
 
 /// Format a connection endpoint for display, omitting "default" or empty port names.
@@ -704,7 +716,6 @@ pub(crate) fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
 #[allow(clippy::indexing_slicing)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
 
     use flowcore::model::process_reference::ProcessReference;
 
@@ -713,18 +724,15 @@ mod test {
     use crate::history::EditHistory;
     use crate::WindowKind;
 
-    fn test_node(alias: &str, source: &str) -> NodeLayout {
-        NodeLayout {
+    fn test_pref(alias: &str, source: &str) -> ProcessReference {
+        ProcessReference {
             alias: alias.into(),
             source: source.into(),
-            description: String::new(),
-            x: 100.0,
-            y: 100.0,
-            width: 180.0,
-            height: 120.0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            initializers: HashMap::new(),
+            initializations: std::collections::BTreeMap::new(),
+            x: Some(100.0),
+            y: Some(100.0),
+            width: Some(180.0),
+            height: Some(120.0),
         }
     }
 
@@ -736,36 +744,37 @@ mod test {
 
     #[test]
     fn unique_alias_no_conflict() {
-        let nodes = vec![test_node("add", "lib://test")];
-        assert_eq!(generate_unique_alias("subtract", &nodes), "subtract");
+        let prefs = vec![test_pref("add", "lib://test")];
+        assert_eq!(generate_unique_alias("subtract", &prefs), "subtract");
     }
 
     #[test]
     fn unique_alias_with_conflict() {
-        let nodes = vec![test_node("add", "lib://test")];
-        assert_eq!(generate_unique_alias("add", &nodes), "add_2");
+        let prefs = vec![test_pref("add", "lib://test")];
+        assert_eq!(generate_unique_alias("add", &prefs), "add_2");
     }
 
     #[test]
     fn unique_alias_multiple_conflicts() {
-        let nodes = vec![
-            test_node("add", "lib://test"),
-            test_node("add_2", "lib://test"),
+        let prefs = vec![
+            test_pref("add", "lib://test"),
+            test_pref("add_2", "lib://test"),
         ];
-        assert_eq!(generate_unique_alias("add", &nodes), "add_3");
+        assert_eq!(generate_unique_alias("add", &prefs), "add_3");
     }
 
     #[test]
     fn next_position_empty() {
-        let (x, y) = next_node_position(&[]);
-        assert!((x - 100.0).abs() < 0.01);
-        assert!((y - 100.0).abs() < 0.01);
+        let prefs: Vec<ProcessReference> = vec![];
+        let (x, y) = next_node_position(&prefs);
+        assert!((x - 100.0_f32).abs() < 0.01);
+        assert!((y - 100.0_f32).abs() < 0.01);
     }
 
     #[test]
     fn next_position_after_nodes() {
-        let nodes = vec![test_node("a", "lib://test")];
-        let (x, _y) = next_node_position(&nodes);
+        let prefs = vec![test_pref("a", "lib://test")];
+        let (x, _y) = next_node_position(&prefs);
         assert!(x > 280.0); // right of existing node + gap
     }
 
@@ -904,7 +913,7 @@ mod test {
 
         let loaded = load_flow(&path).expect("load failed");
         assert_eq!(loaded.flow_def.name, "roundtrip_test");
-        assert_eq!(loaded.nodes.len(), 1);
+        assert_eq!(loaded.flow_def.process_refs.len(), 1);
         assert_eq!(loaded.flow_def.connections.len(), 1);
         assert_eq!(loaded.flow_def.metadata.version, "1.0.0");
 
@@ -1126,14 +1135,14 @@ mod test {
     fn test_win_state() -> WindowState {
         let flow_def = FlowDefinition {
             name: String::from("test"),
+            process_refs: vec![
+                test_pref("add", "lib://flowstdlib/math/add"),
+                test_pref("stdout", "context://stdio/stdout"),
+            ],
             ..FlowDefinition::default()
         };
         WindowState {
             kind: WindowKind::FlowEditor,
-            nodes: vec![
-                test_node("add", "lib://flowstdlib/math/add"),
-                test_node("stdout", "context://stdio/stdout"),
-            ],
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -1192,7 +1192,8 @@ mod test {
 
         perform_save(&mut win, &path);
         assert_eq!(win.unsaved_edits, 0);
-        assert_eq!(win.file_path(), Some(path.clone()));
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+        assert_eq!(win.file_path(), Some(canonical));
 
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("flow = \"saved_flow\""));

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -9,9 +9,7 @@ use simpath::Simpath;
 use url::Url;
 
 use crate::canvas_view::FlowCanvasState;
-use crate::canvas_view::{
-    build_edge_layouts, build_node_layouts, EdgeLayout, NodeLayout, PortInfo,
-};
+use crate::canvas_view::{build_node_layouts, NodeLayout, PortInfo};
 use crate::history::EditHistory;
 use crate::initializer;
 use crate::{FunctionViewer, WindowState};
@@ -24,7 +22,6 @@ use flowcore::model::process::Process;
 /// Result of loading a flow definition file.
 pub(crate) struct LoadedFlow {
     pub(crate) nodes: Vec<NodeLayout>,
-    pub(crate) edges: Vec<EdgeLayout>,
     pub(crate) flow_def: FlowDefinition,
     pub(crate) lib_references: BTreeSet<Url>,
     pub(crate) context_references: BTreeSet<Url>,
@@ -41,7 +38,7 @@ pub(crate) struct EditorPrefs {
 /// Save the current flow to the given path.
 pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
     initializer::sync_flow_definition(win);
-    match save_flow_toml(&win.flow_definition, &win.edges, path) {
+    match save_flow_toml(&win.flow_definition, path) {
         Ok(()) => {
             win.unsaved_edits = 0;
             win.set_file_path(path);
@@ -91,9 +88,8 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
         match load_flow(&path) {
             Ok(loaded) => {
                 let nc = loaded.nodes.len();
-                let ec = loaded.edges.len();
+                let ec = loaded.flow_def.connections.len();
                 win.nodes = loaded.nodes;
-                win.edges = loaded.edges;
                 win.flow_definition = loaded.flow_def;
                 win.set_file_path(&path);
                 win.selected_node = None;
@@ -117,7 +113,6 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
 /// Clear the canvas and reset to an empty flow state.
 pub(crate) fn perform_new(win: &mut WindowState) {
     win.nodes = Vec::new();
-    win.edges = Vec::new();
     win.flow_definition = FlowDefinition::default();
     win.flow_definition.name = String::from("(new flow)");
     win.clear_file_path();
@@ -303,7 +298,6 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
                 resolved_ports.insert(alias.clone(), (inputs, outputs));
             }
 
-            let edges = build_edge_layouts(&flow.connections);
             let nodes = build_node_layouts(
                 &flow.process_refs,
                 &flow.connections,
@@ -314,7 +308,6 @@ pub(crate) fn load_flow(path: &PathBuf) -> Result<LoadedFlow, String> {
             let context_references = flow.context_references.clone();
             Ok(LoadedFlow {
                 nodes,
-                edges,
                 flow_def: flow,
                 lib_references,
                 context_references,
@@ -384,13 +377,7 @@ fn initializer_to_toml(init: &InputInitializer) -> String {
 /// Builds the TOML text manually to match the expected flow format
 /// (the derived `Serialize` on some flowcore types produces struct-style
 /// output that is not compatible with the flow deserializer).
-/// Connections are written from `edges` to preserve names that would be lost
-/// when roundtripping through `Connection::new`.
-pub(crate) fn save_flow_toml(
-    flow: &FlowDefinition,
-    edges: &[EdgeLayout],
-    path: &PathBuf,
-) -> Result<(), String> {
+pub(crate) fn save_flow_toml(flow: &FlowDefinition, path: &PathBuf) -> Result<(), String> {
     let mut out = String::new();
 
     // Flow name
@@ -498,24 +485,19 @@ pub(crate) fn save_flow_toml(
         }
     }
 
-    // Connections (from EdgeLayout to preserve names)
-    for edge in edges {
-        out.push_str("\n[[connection]]\n");
-        if !edge.name.is_empty() {
-            let _ = writeln!(out, "name = \"{}\"", edge.name);
+    // Connections
+    for conn in &flow.connections {
+        let _ = writeln!(out, "\n[[connection]]");
+        if !conn.name().is_empty() {
+            let _ = writeln!(out, "name = \"{}\"", conn.name());
         }
-        let from = if edge.from_port.is_empty() {
-            edge.from_node.clone()
+        let _ = writeln!(out, "from = \"{}\"", conn.from());
+        if let [single] = conn.to().as_slice() {
+            let _ = writeln!(out, "to = \"{single}\"");
         } else {
-            format!("{}/{}", edge.from_node, edge.from_port)
-        };
-        let _ = writeln!(out, "from = \"{from}\"");
-        let to = if edge.to_port.is_empty() {
-            edge.to_node.clone()
-        } else {
-            format!("{}/{}", edge.to_node, edge.to_port)
-        };
-        let _ = writeln!(out, "to = \"{to}\"");
+            let to_strs: Vec<String> = conn.to().iter().map(|r| format!("\"{r}\"")).collect();
+            let _ = writeln!(out, "to = [{}]", to_strs.join(", "));
+        }
     }
 
     std::fs::write(path, out).map_err(|e| format!("Could not write file: {e}"))
@@ -890,6 +872,8 @@ mod test {
 
     #[test]
     fn save_and_load_flow_roundtrip() {
+        use flowcore::model::connection::Connection;
+
         let dir = temp_dir("save_load");
         let path = dir.join("test.toml");
 
@@ -908,15 +892,9 @@ mod test {
             width: Some(180.0),
             height: Some(120.0),
         });
+        flow.connections.push(Connection::new("add1", "add1/i1"));
 
-        let edges = vec![EdgeLayout::new(
-            "add1".into(),
-            String::new(),
-            "add1".into(),
-            "i1".into(),
-        )];
-
-        save_flow_toml(&flow, &edges, &path).expect("save failed");
+        save_flow_toml(&flow, &path).expect("save failed");
 
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("flow = \"roundtrip_test\""));
@@ -927,7 +905,7 @@ mod test {
         let loaded = load_flow(&path).expect("load failed");
         assert_eq!(loaded.flow_def.name, "roundtrip_test");
         assert_eq!(loaded.nodes.len(), 1);
-        assert_eq!(loaded.edges.len(), 1);
+        assert_eq!(loaded.flow_def.connections.len(), 1);
         assert_eq!(loaded.flow_def.metadata.version, "1.0.0");
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -944,7 +922,7 @@ mod test {
         };
         flow.metadata.description = "A test description".into();
 
-        save_flow_toml(&flow, &[], &path).expect("save failed");
+        save_flow_toml(&flow, &path).expect("save failed");
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("description = \"A test description\""));
 
@@ -962,7 +940,7 @@ mod test {
             ..FlowDefinition::default()
         };
 
-        save_flow_toml(&flow, &[], &path).expect("Could not save flow");
+        save_flow_toml(&flow, &path).expect("Could not save flow");
 
         let content = std::fs::read_to_string(&path).expect("Could not read saved file");
         assert!(content.contains("description = \"A test flow that does something\""));
@@ -994,7 +972,7 @@ mod test {
             height: Some(120.0),
         });
 
-        save_flow_toml(&flow, &[], &path).expect("save failed");
+        save_flow_toml(&flow, &path).expect("save failed");
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("input.start"));
         assert!(contents.contains("once"));
@@ -1004,6 +982,8 @@ mod test {
 
     #[test]
     fn save_flow_with_connections() {
+        use flowcore::model::connection::Connection;
+
         let dir = temp_dir("connections");
         let path = dir.join("conn.toml");
 
@@ -1030,14 +1010,9 @@ mod test {
             height: None,
         });
 
-        let edges = vec![EdgeLayout::new(
-            "a".into(),
-            "out".into(),
-            "b".into(),
-            "in".into(),
-        )];
+        flow.connections.push(Connection::new("a/out", "b/in"));
 
-        save_flow_toml(&flow, &edges, &path).expect("save failed");
+        save_flow_toml(&flow, &path).expect("save failed");
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("from = \"a/out\""));
         assert!(contents.contains("to = \"b/in\""));
@@ -1159,7 +1134,6 @@ mod test {
                 test_node("add", "lib://flowstdlib/math/add"),
                 test_node("stdout", "context://stdio/stdout"),
             ],
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -552,56 +552,65 @@ pub(crate) fn format_endpoint(node: &str, port: &str) -> String {
 
 /// Save a function definition to disk (TOML, skeleton .rs, and function.toml).
 pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), String> {
-    let dir = viewer
-        .toml_path
+    let toml_path = viewer
+        .toml_path()
+        .ok_or_else(|| "Invalid source URL".to_string())?;
+    let dir = toml_path
         .parent()
         .ok_or_else(|| "Invalid path".to_string())?;
     std::fs::create_dir_all(dir).map_err(|e| format!("Could not create directory: {e}"))?;
 
+    let func = &viewer.func_def;
+
     // 1. Write the function definition TOML
     let mut toml = format!(
         "function = \"{}\"\nsource = \"{}\"\ntype = \"rust\"\n",
-        escape_toml_string(&viewer.name),
-        escape_toml_string(&viewer.source_file)
+        escape_toml_string(&func.name),
+        escape_toml_string(&func.source)
     );
-    if !viewer.description.is_empty() {
+    if !func.description.is_empty() {
         let _ = writeln!(
             toml,
             "description = \"{}\"",
-            escape_toml_string(&viewer.description)
+            escape_toml_string(&func.description)
         );
     }
-    for input in &viewer.inputs {
-        let dtype = input.datatypes.first().map_or("", String::as_str);
-        if input.name.is_empty() || input.name == "input" || input.name == "name" {
+    for input in &func.inputs {
+        let dtype = input
+            .datatypes()
+            .first()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let name = input.name();
+        if name.is_empty() || name == "input" || name == "name" {
             let _ = write!(toml, "\n[[input]]\ntype = \"{dtype}\"\n");
         } else {
-            let _ = write!(
-                toml,
-                "\n[[input]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
-                input.name
-            );
+            let _ = write!(toml, "\n[[input]]\nname = \"{name}\"\ntype = \"{dtype}\"\n");
         }
     }
-    for output in &viewer.outputs {
-        let dtype = output.datatypes.first().map_or("", String::as_str);
-        if output.name.is_empty() || output.name == "output" || output.name == "name" {
+    for output in &func.outputs {
+        let dtype = output
+            .datatypes()
+            .first()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let name = output.name();
+        if name.is_empty() || name == "output" || name == "name" {
             let _ = write!(toml, "\n[[output]]\ntype = \"{dtype}\"\n");
         } else {
             let _ = write!(
                 toml,
-                "\n[[output]]\nname = \"{}\"\ntype = \"{dtype}\"\n",
-                output.name
+                "\n[[output]]\nname = \"{name}\"\ntype = \"{dtype}\"\n"
             );
         }
     }
-    std::fs::write(&viewer.toml_path, &toml)
-        .map_err(|e| format!("Could not write {}: {e}", viewer.toml_path.display()))?;
+    std::fs::write(&toml_path, &toml)
+        .map_err(|e| format!("Could not write {}: {e}", toml_path.display()))?;
 
     // 2. Generate skeleton .rs if it doesn't exist
-    let rs_path = dir.join(&viewer.source_file);
+    let rs_path = dir.join(&func.source);
     if !rs_path.exists() {
-        let input_count = viewer.inputs.len();
+        let input_count = func.inputs.len();
         let input_bindings = (0..input_count).fold(String::new(), |mut acc, i| {
             use std::fmt::Write;
             let _ = writeln!(acc, "    let _input{i} = &inputs[{i}];");
@@ -619,7 +628,7 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
              \n    // TODO: implement function logic\n\
              \n    Ok((None, RUN_AGAIN))\n\
              }}\n",
-            name = viewer.name,
+            name = func.name,
         );
         std::fs::write(&rs_path, &skeleton)
             .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))?;
@@ -628,10 +637,7 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
     // 3. Generate function.toml (Cargo manifest) if it doesn't exist
     let cargo_path = dir.join("function.toml");
     if !cargo_path.exists() {
-        let stem = viewer
-            .source_file
-            .strip_suffix(".rs")
-            .unwrap_or(&viewer.source_file);
+        let stem = func.source.strip_suffix(".rs").unwrap_or(&func.source);
         let cargo = format!(
             "[package]\n\
              name = \"{name}\"\n\
@@ -647,7 +653,7 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
              flowcore = {{version = \"0\"}}\n\
              flowmacro = {{version = \"0\"}}\n\
              serde_json = {{version = \"1.0\", default-features = false}}\n",
-            name = escape_toml_string(&viewer.name),
+            name = escape_toml_string(&func.name),
             source = escape_toml_string(stem),
         );
         std::fs::write(&cargo_path, &cargo)
@@ -717,7 +723,11 @@ pub(crate) fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
 mod test {
     use super::*;
 
+    use flowcore::model::datatype::DataType;
+    use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::io::IO;
     use flowcore::model::process_reference::ProcessReference;
+    use flowcore::model::route::Route;
 
     use crate::canvas_view::FlowCanvasState;
     use crate::hierarchy_panel::FlowHierarchy;
@@ -1050,22 +1060,28 @@ mod test {
         let dir = temp_dir("func_def");
         let toml_path = dir.join("myfunc.toml");
 
+        let mut func_def = FunctionDefinition::default();
+        func_def.name = "myfunc".into();
+        func_def.source = "myfunc.rs".into();
+        func_def.inputs.push(IO::new_named(
+            vec![DataType::from("string")],
+            Route::default(),
+            "data",
+        ));
+        func_def.outputs.push(IO::new_named(
+            vec![DataType::from("number")],
+            Route::default(),
+            "result",
+        ));
+        if let Ok(url) = url::Url::from_file_path(&toml_path) {
+            func_def.source_url = url;
+        }
+
         let viewer = FunctionViewer {
-            name: "myfunc".into(),
-            description: String::new(),
-            source_file: "myfunc.rs".into(),
-            inputs: vec![PortInfo {
-                name: "data".into(),
-                datatypes: vec!["string".into()],
-            }],
-            outputs: vec![PortInfo {
-                name: "result".into(),
-                datatypes: vec!["number".into()],
-            }],
+            func_def,
             rs_content: String::new(),
             docs_content: None,
             active_tab: 0,
-            toml_path: toml_path.clone(),
             parent_window: None,
             node_source: String::new(),
             read_only: false,
@@ -1108,16 +1124,18 @@ mod test {
         // Create existing .rs
         std::fs::write(&rs_path, "// existing code").expect("write rs");
 
+        let mut func_def = FunctionDefinition::default();
+        func_def.name = "existing".into();
+        func_def.source = "existing.rs".into();
+        if let Ok(url) = url::Url::from_file_path(&toml_path) {
+            func_def.source_url = url;
+        }
+
         let viewer = FunctionViewer {
-            name: "existing".into(),
-            description: String::new(),
-            source_file: "existing.rs".into(),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
+            func_def,
             rs_content: String::new(),
             docs_content: None,
             active_tab: 0,
-            toml_path,
             parent_window: None,
             node_source: String::new(),
             read_only: false,

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -44,7 +44,7 @@ pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
     match save_flow_toml(&win.flow_definition, &win.edges, path) {
         Ok(()) => {
             win.unsaved_edits = 0;
-            win.file_path = Some(path.clone());
+            win.set_file_path(path);
             save_editor_prefs(path, win.last_size, win.last_position);
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 win.status = format!("Saved to {name}");
@@ -70,7 +70,7 @@ pub(crate) fn perform_save_as(win: &mut WindowState) {
 
 /// Handle save message -- saves to existing path or prompts with save dialog.
 pub(crate) fn handle_save(win: &mut WindowState) {
-    if let Some(path) = win.file_path.clone() {
+    if let Some(path) = win.file_path() {
         perform_save(win, &path);
     } else {
         perform_save_as(win);
@@ -96,7 +96,7 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
                 win.nodes = loaded.nodes;
                 win.edges = loaded.edges;
                 win.flow_definition = loaded.flow_def;
-                win.file_path = Some(path);
+                win.set_file_path(&path);
                 win.flow_inputs = fi;
                 win.flow_outputs = fo;
                 win.selected_node = None;
@@ -123,7 +123,7 @@ pub(crate) fn perform_new(win: &mut WindowState) {
     win.edges = Vec::new();
     win.flow_definition = FlowDefinition::default();
     win.flow_definition.name = String::from("(new flow)");
-    win.file_path = None;
+    win.clear_file_path();
     win.flow_inputs = Vec::new();
     win.flow_outputs = Vec::new();
     win.selected_node = None;
@@ -145,10 +145,10 @@ pub(crate) fn perform_new(win: &mut WindowState) {
 /// error message on failure.
 pub(crate) fn perform_compile(win: &mut WindowState) -> Result<PathBuf, String> {
     // New flows must be saved first so the compiler has a real file path
-    if win.file_path.is_none() {
+    if win.file_path().is_none() {
         perform_save_as(win);
     }
-    let Some(flow_path) = win.file_path.clone() else {
+    let Some(flow_path) = win.file_path() else {
         return Err("Flow must be saved before compiling".to_string());
     };
 
@@ -1174,7 +1174,6 @@ mod test {
             auto_fit_enabled: false,
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path: None,
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -1200,7 +1199,7 @@ mod test {
 
         perform_save(&mut win, &path);
         assert_eq!(win.unsaved_edits, 0);
-        assert_eq!(win.file_path, Some(path.clone()));
+        assert_eq!(win.file_path(), Some(path.clone()));
 
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("flow = \"saved_flow\""));

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -105,6 +105,7 @@ fn toggle_at(node: &mut HierarchyNode, indices: &[usize], depth: usize) {
     }
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, HierarchyMessage> {
     let indent = path.len() as f32 * 16.0;
     let icon = match node.kind {

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -4,9 +4,10 @@
 //! information to both undo and redo the operation. The history is lost
 //! when the application exits.
 
+use flowcore::model::connection::Connection;
 use flowcore::model::input::InputInitializer;
 
-use crate::canvas_view::{EdgeLayout, NodeLayout};
+use crate::canvas_view::NodeLayout;
 use crate::initializer;
 use crate::WindowState;
 
@@ -47,26 +48,26 @@ pub(crate) enum EditAction {
         /// New geometry
         new_h: f32,
     },
-    /// A node was deleted. Stores the node and its connected edges for restoration.
+    /// A node was deleted. Stores the node and its connected connections for restoration.
     DeleteNode {
         /// Index where the node was
         index: usize,
         /// The deleted node
         node: NodeLayout,
-        /// Edges that were removed with the node
-        removed_edges: Vec<EdgeLayout>,
+        /// Connections that were removed with the node
+        removed_connections: Vec<Connection>,
     },
     /// A connection was created.
     CreateConnection {
-        /// The new edge
-        edge: EdgeLayout,
+        /// The new connection
+        connection: Connection,
     },
     /// A connection was deleted.
     DeleteConnection {
-        /// Index where the edge was
+        /// Index where the connection was
         index: usize,
-        /// The deleted edge
-        edge: EdgeLayout,
+        /// The deleted connection
+        connection: Connection,
     },
     /// An input initializer was changed.
     EditInitializer {
@@ -168,23 +169,24 @@ fn apply_undo(win: &mut WindowState) {
             EditAction::DeleteNode {
                 index,
                 node,
-                removed_edges,
+                removed_connections,
             } => {
                 win.nodes.insert(index, node);
-                win.edges.extend(removed_edges);
+                win.flow_definition.connections.extend(removed_connections);
                 win.status = String::from("Undo: delete node");
             }
-            EditAction::CreateConnection { edge } => {
-                win.edges.retain(|e| {
-                    e.from_node != edge.from_node
-                        || e.from_port != edge.from_port
-                        || e.to_node != edge.to_node
-                        || e.to_port != edge.to_port
+            EditAction::CreateConnection { connection } => {
+                let from_str = connection.from().to_string();
+                let to_strs: Vec<String> =
+                    connection.to().iter().map(ToString::to_string).collect();
+                win.flow_definition.connections.retain(|c| {
+                    c.from().to_string() != from_str
+                        || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
                 });
                 win.status = String::from("Undo: create connection");
             }
-            EditAction::DeleteConnection { index, edge } => {
-                win.edges.insert(index, edge);
+            EditAction::DeleteConnection { index, connection } => {
+                win.flow_definition.connections.insert(index, connection);
                 win.status = String::from("Undo: delete connection");
             }
             EditAction::EditInitializer {
@@ -242,29 +244,29 @@ fn apply_redo(win: &mut WindowState) {
             }
             EditAction::DeleteNode {
                 index,
-                removed_edges,
+                removed_connections,
                 ..
             } => {
                 if index < win.nodes.len() {
                     win.nodes.remove(index);
                 }
-                for edge in &removed_edges {
-                    win.edges.retain(|e| {
-                        e.from_node != edge.from_node
-                            || e.from_port != edge.from_port
-                            || e.to_node != edge.to_node
-                            || e.to_port != edge.to_port
+                for conn in &removed_connections {
+                    let from_str = conn.from().to_string();
+                    let to_strs: Vec<String> = conn.to().iter().map(ToString::to_string).collect();
+                    win.flow_definition.connections.retain(|c| {
+                        c.from().to_string() != from_str
+                            || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
                     });
                 }
                 win.status = String::from("Redo: delete node");
             }
-            EditAction::CreateConnection { edge } => {
-                win.edges.push(edge);
+            EditAction::CreateConnection { connection } => {
+                win.flow_definition.connections.push(connection);
                 win.status = String::from("Redo: create connection");
             }
             EditAction::DeleteConnection { index, .. } => {
-                if index < win.edges.len() {
-                    win.edges.remove(index);
+                if index < win.flow_definition.connections.len() {
+                    win.flow_definition.connections.remove(index);
                 }
                 win.status = String::from("Redo: delete connection");
             }
@@ -403,7 +405,7 @@ mod test {
         history.record(EditAction::DeleteNode {
             index: 0,
             node: node.clone(),
-            removed_edges: vec![],
+            removed_connections: vec![],
         });
         let action = history.undo().expect("Should have action");
         match action {
@@ -417,14 +419,20 @@ mod test {
 
     #[test]
     fn create_connection_roundtrip() {
+        use crate::canvas_view::split_route;
         let mut history = EditHistory::default();
-        let edge = EdgeLayout::new("a".into(), "out".into(), "b".into(), "in".into());
-        history.record(EditAction::CreateConnection { edge: edge.clone() });
+        let connection = Connection::new("a/out", "b/in");
+        history.record(EditAction::CreateConnection {
+            connection: connection.clone(),
+        });
         let action = history.undo().expect("Should have action");
         match action {
-            EditAction::CreateConnection { edge: e } => {
-                assert_eq!(e.from_node, "a");
-                assert_eq!(e.to_node, "b");
+            EditAction::CreateConnection { connection: c } => {
+                let (from_node, _) = split_route(c.from().as_ref());
+                let (to_node, _) =
+                    split_route(c.to().first().expect("should have to route").as_ref());
+                assert_eq!(from_node, "a");
+                assert_eq!(to_node, "b");
             }
             _ => panic!("Expected CreateConnection"),
         }
@@ -487,7 +495,6 @@ mod test {
 
         WindowState {
             nodes,
-            edges: Vec::new(),
             flow_definition: flow,
             is_root: true,
             ..Default::default()
@@ -603,7 +610,7 @@ mod test {
             EditAction::DeleteNode {
                 index: 0,
                 node: removed_node,
-                removed_edges: Vec::new(),
+                removed_connections: Vec::new(),
             },
         );
         assert_eq!(win.nodes.len(), 1);
@@ -620,46 +627,43 @@ mod test {
     #[test]
     fn undo_redo_create_connection() {
         let mut win = test_win_state();
-        let edge = EdgeLayout::new("add".into(), "out".into(), "stdout".into(), "in".into());
-        win.edges.push(edge.clone());
-        record_edit(&mut win, EditAction::CreateConnection { edge });
-        assert_eq!(win.edges.len(), 1);
+        let connection = Connection::new("add/out", "stdout/in");
+        win.flow_definition.connections.push(connection.clone());
+        record_edit(&mut win, EditAction::CreateConnection { connection });
+        assert_eq!(win.flow_definition.connections.len(), 1);
 
         // Undo removes
         handle_undo(&mut win);
-        assert_eq!(win.edges.len(), 0);
+        assert_eq!(win.flow_definition.connections.len(), 0);
 
         // Redo re-adds
         handle_redo(&mut win);
-        assert_eq!(win.edges.len(), 1);
+        assert_eq!(win.flow_definition.connections.len(), 1);
     }
 
     #[test]
     fn undo_redo_delete_connection() {
         let mut win = test_win_state();
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            "out".into(),
-            "stdout".into(),
-            "in".into(),
-        ));
-        let removed_edge = win.edges.remove(0);
+        win.flow_definition
+            .connections
+            .push(Connection::new("add/out", "stdout/in"));
+        let removed_conn = win.flow_definition.connections.remove(0);
         record_edit(
             &mut win,
             EditAction::DeleteConnection {
                 index: 0,
-                edge: removed_edge,
+                connection: removed_conn,
             },
         );
-        assert_eq!(win.edges.len(), 0);
+        assert_eq!(win.flow_definition.connections.len(), 0);
 
         // Undo restores
         handle_undo(&mut win);
-        assert_eq!(win.edges.len(), 1);
+        assert_eq!(win.flow_definition.connections.len(), 1);
 
         // Redo removes again
         handle_redo(&mut win);
-        assert_eq!(win.edges.len(), 0);
+        assert_eq!(win.flow_definition.connections.len(), 0);
     }
 
     #[test]

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -13,7 +13,7 @@ use crate::WindowState;
 /// An editing action that can be undone and redone.
 #[derive(Debug, Clone)]
 pub(crate) enum EditAction {
-    /// A node was moved from (old_x, old_y) to (new_x, new_y).
+    /// A node was moved from (`old_x`, `old_y`) to (`new_x`, `new_y`).
     MoveNode {
         /// Node index
         index: usize,
@@ -486,7 +486,6 @@ mod test {
             .collect();
 
         WindowState {
-            flow_name: flow.name.clone(),
             nodes,
             edges: Vec::new(),
             flow_definition: flow,
@@ -497,9 +496,13 @@ mod test {
 
     #[test]
     fn record_and_undo_edit() {
+        let flow_def = flowcore::model::flow_definition::FlowDefinition {
+            name: String::from("test"),
+            ..flowcore::model::flow_definition::FlowDefinition::default()
+        };
         let mut win = WindowState {
-            flow_name: String::from("test"),
             nodes: vec![test_win_node("a", "lib://test")],
+            flow_definition: flow_def,
             is_root: true,
             ..Default::default()
         };

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -6,8 +6,10 @@
 
 use flowcore::model::connection::Connection;
 use flowcore::model::input::InputInitializer;
+use flowcore::model::name::Name;
+use flowcore::model::process::Process;
+use flowcore::model::process_reference::ProcessReference;
 
-use crate::canvas_view::NodeLayout;
 use crate::initializer;
 use crate::WindowState;
 
@@ -48,12 +50,14 @@ pub(crate) enum EditAction {
         /// New geometry
         new_h: f32,
     },
-    /// A node was deleted. Stores the node and its connected connections for restoration.
+    /// A node was deleted. Stores the process reference and subprocess for restoration.
     DeleteNode {
         /// Index where the node was
         index: usize,
-        /// The deleted node
-        node: NodeLayout,
+        /// The deleted process reference
+        process_ref: ProcessReference,
+        /// The removed subprocess definition, if any
+        subprocess: Option<(Name, Process)>,
         /// Connections that were removed with the node
         removed_connections: Vec<Connection>,
     },
@@ -77,12 +81,8 @@ pub(crate) enum EditAction {
         port_name: String,
         /// Previous initializer (None if there was none)
         old_init: Option<InputInitializer>,
-        /// Previous display string (None if there was none)
-        old_display: Option<String>,
         /// New initializer (None if removed)
         new_init: Option<InputInitializer>,
-        /// New display string (None if removed)
-        new_display: Option<String>,
     },
 }
 
@@ -144,9 +144,9 @@ fn apply_undo(win: &mut WindowState) {
                 old_y,
                 ..
             } => {
-                if let Some(node) = win.nodes.get_mut(index) {
-                    node.x = old_x;
-                    node.y = old_y;
+                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
+                    pref.x = Some(old_x);
+                    pref.y = Some(old_y);
                 }
                 win.status = String::from("Undo: move");
             }
@@ -158,20 +158,24 @@ fn apply_undo(win: &mut WindowState) {
                 old_h,
                 ..
             } => {
-                if let Some(node) = win.nodes.get_mut(index) {
-                    node.x = old_x;
-                    node.y = old_y;
-                    node.width = old_w;
-                    node.height = old_h;
+                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
+                    pref.x = Some(old_x);
+                    pref.y = Some(old_y);
+                    pref.width = Some(old_w);
+                    pref.height = Some(old_h);
                 }
                 win.status = String::from("Undo: resize");
             }
             EditAction::DeleteNode {
                 index,
-                node,
+                process_ref,
+                subprocess,
                 removed_connections,
             } => {
-                win.nodes.insert(index, node);
+                win.flow_definition.process_refs.insert(index, process_ref);
+                if let Some((name, proc)) = subprocess {
+                    win.flow_definition.subprocesses.insert(name, proc);
+                }
                 win.flow_definition.connections.extend(removed_connections);
                 win.status = String::from("Undo: delete node");
             }
@@ -193,16 +197,9 @@ fn apply_undo(win: &mut WindowState) {
                 node_index,
                 ref port_name,
                 ref old_init,
-                ref old_display,
                 ..
             } => {
-                initializer::apply_initializer_state(
-                    win,
-                    node_index,
-                    port_name,
-                    old_init.as_ref(),
-                    old_display.as_ref(),
-                );
+                initializer::apply_initializer_state(win, node_index, port_name, old_init.as_ref());
                 win.status = String::from("Undo: initializer");
             }
         }
@@ -220,9 +217,9 @@ fn apply_redo(win: &mut WindowState) {
                 new_y,
                 ..
             } => {
-                if let Some(node) = win.nodes.get_mut(index) {
-                    node.x = new_x;
-                    node.y = new_y;
+                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
+                    pref.x = Some(new_x);
+                    pref.y = Some(new_y);
                 }
                 win.status = String::from("Redo: move");
             }
@@ -234,21 +231,32 @@ fn apply_redo(win: &mut WindowState) {
                 new_h,
                 ..
             } => {
-                if let Some(node) = win.nodes.get_mut(index) {
-                    node.x = new_x;
-                    node.y = new_y;
-                    node.width = new_w;
-                    node.height = new_h;
+                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
+                    pref.x = Some(new_x);
+                    pref.y = Some(new_y);
+                    pref.width = Some(new_w);
+                    pref.height = Some(new_h);
                 }
                 win.status = String::from("Redo: resize");
             }
             EditAction::DeleteNode {
                 index,
+                subprocess,
                 removed_connections,
                 ..
             } => {
-                if index < win.nodes.len() {
-                    win.nodes.remove(index);
+                if index < win.flow_definition.process_refs.len() {
+                    let removed = win.flow_definition.process_refs.remove(index);
+                    let alias = if removed.alias.is_empty() {
+                        crate::canvas_view::derive_short_name(&removed.source)
+                    } else {
+                        removed.alias.clone()
+                    };
+                    win.flow_definition.subprocesses.remove(&alias);
+                }
+                // Also remove re-inserted subprocess if it was restored during undo
+                if let Some((ref name, _)) = subprocess {
+                    win.flow_definition.subprocesses.remove(name);
                 }
                 for conn in &removed_connections {
                     let from_str = conn.from().to_string();
@@ -274,16 +282,9 @@ fn apply_redo(win: &mut WindowState) {
                 node_index,
                 ref port_name,
                 ref new_init,
-                ref new_display,
                 ..
             } => {
-                initializer::apply_initializer_state(
-                    win,
-                    node_index,
-                    port_name,
-                    new_init.as_ref(),
-                    new_display.as_ref(),
-                );
+                initializer::apply_initializer_state(win, node_index, port_name, new_init.as_ref());
                 win.status = String::from("Redo: initializer");
             }
         }
@@ -310,20 +311,17 @@ pub(crate) fn handle_redo(win: &mut WindowState) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
-    fn test_node() -> NodeLayout {
-        NodeLayout {
+    fn test_pref() -> ProcessReference {
+        ProcessReference {
             alias: "test".into(),
             source: "lib://test".into(),
-            description: String::new(),
-            x: 100.0,
-            y: 100.0,
-            width: 180.0,
-            height: 120.0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            initializers: HashMap::new(),
+            initializations: BTreeMap::new(),
+            x: Some(100.0),
+            y: Some(100.0),
+            width: Some(180.0),
+            height: Some(120.0),
         }
     }
 
@@ -401,17 +399,22 @@ mod test {
     #[test]
     fn delete_node_roundtrip() {
         let mut history = EditHistory::default();
-        let node = test_node();
+        let pref = test_pref();
         history.record(EditAction::DeleteNode {
             index: 0,
-            node: node.clone(),
+            process_ref: pref.clone(),
+            subprocess: None,
             removed_connections: vec![],
         });
         let action = history.undo().expect("Should have action");
         match action {
-            EditAction::DeleteNode { index, node: n, .. } => {
+            EditAction::DeleteNode {
+                index,
+                process_ref: pr,
+                ..
+            } => {
                 assert_eq!(index, 0);
-                assert_eq!(n.alias, node.alias);
+                assert_eq!(pr.alias, pref.alias);
             }
             _ => panic!("Expected DeleteNode"),
         }
@@ -440,19 +443,9 @@ mod test {
 
     // --- Tests moved from ui_test.rs (direct function calls, no message routing) ---
 
-    fn test_win_node(alias: &str, source: &str) -> NodeLayout {
-        NodeLayout {
-            alias: alias.into(),
-            source: source.into(),
-            ..Default::default()
-        }
-    }
-
     fn test_win_state() -> WindowState {
         use flowcore::model::flow_definition::FlowDefinition;
         use flowcore::model::name::Name;
-        use flowcore::model::process_reference::ProcessReference;
-        use std::collections::BTreeMap;
 
         let flow = FlowDefinition {
             name: Name::from("test"),
@@ -479,22 +472,7 @@ mod test {
             ..FlowDefinition::default()
         };
 
-        let nodes: Vec<NodeLayout> = flow
-            .process_refs
-            .iter()
-            .map(|pref| NodeLayout {
-                alias: pref.alias.clone(),
-                source: pref.source.clone(),
-                x: pref.x.unwrap_or(0.0),
-                y: pref.y.unwrap_or(0.0),
-                width: pref.width.unwrap_or(180.0),
-                height: pref.height.unwrap_or(120.0),
-                ..Default::default()
-            })
-            .collect();
-
         WindowState {
-            nodes,
             flow_definition: flow,
             is_root: true,
             ..Default::default()
@@ -503,21 +481,29 @@ mod test {
 
     #[test]
     fn record_and_undo_edit() {
-        let flow_def = flowcore::model::flow_definition::FlowDefinition {
+        let mut flow_def = flowcore::model::flow_definition::FlowDefinition {
             name: String::from("test"),
             ..flowcore::model::flow_definition::FlowDefinition::default()
         };
+        flow_def.process_refs.push(ProcessReference {
+            alias: "a".into(),
+            source: "lib://test".into(),
+            initializations: BTreeMap::new(),
+            x: Some(100.0),
+            y: Some(100.0),
+            width: Some(180.0),
+            height: Some(120.0),
+        });
         let mut win = WindowState {
-            nodes: vec![test_win_node("a", "lib://test")],
             flow_definition: flow_def,
             is_root: true,
             ..Default::default()
         };
 
         // Move node
-        if let Some(n) = win.nodes.first_mut() {
-            n.x = 200.0;
-            n.y = 300.0;
+        if let Some(pref) = win.flow_definition.process_refs.first_mut() {
+            pref.x = Some(200.0);
+            pref.y = Some(300.0);
         }
         record_edit(
             &mut win,
@@ -533,34 +519,24 @@ mod test {
 
         // Undo
         handle_undo(&mut win);
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.x - 100.0).abs() < 0.01));
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.y - 100.0).abs() < 0.01));
+        let pref = win.flow_definition.process_refs.first();
+        assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 100.0).abs() < 0.01));
+        assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 100.0).abs() < 0.01));
 
         // Redo
         handle_redo(&mut win);
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.x - 200.0).abs() < 0.01));
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.y - 300.0).abs() < 0.01));
+        let pref = win.flow_definition.process_refs.first();
+        assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 200.0).abs() < 0.01));
+        assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 300.0).abs() < 0.01));
     }
 
     #[test]
     fn undo_redo_resize_node() {
         let mut win = test_win_state();
         // Simulate resize
-        if let Some(n) = win.nodes.first_mut() {
-            n.width = 250.0;
-            n.height = 180.0;
+        if let Some(pref) = win.flow_definition.process_refs.first_mut() {
+            pref.width = Some(250.0);
+            pref.height = Some(180.0);
         }
         record_edit(
             &mut win,
@@ -579,49 +555,40 @@ mod test {
 
         // Undo
         handle_undo(&mut win);
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.width - 180.0).abs() < 0.01));
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.height - 120.0).abs() < 0.01));
+        let pref = win.flow_definition.process_refs.first();
+        assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 180.0).abs() < 0.01));
+        assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 120.0).abs() < 0.01));
 
         // Redo
         handle_redo(&mut win);
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.width - 250.0).abs() < 0.01));
-        assert!(win
-            .nodes
-            .first()
-            .is_some_and(|n| (n.height - 180.0).abs() < 0.01));
+        let pref = win.flow_definition.process_refs.first();
+        assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 250.0).abs() < 0.01));
+        assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 180.0).abs() < 0.01));
     }
 
     #[test]
     fn undo_redo_delete_node() {
         let mut win = test_win_state();
-        assert_eq!(win.nodes.len(), 2);
-        let removed_node = win.nodes.remove(0);
+        assert_eq!(win.flow_definition.process_refs.len(), 2);
+        let removed_pref = win.flow_definition.process_refs.remove(0);
         record_edit(
             &mut win,
             EditAction::DeleteNode {
                 index: 0,
-                node: removed_node,
+                process_ref: removed_pref,
+                subprocess: None,
                 removed_connections: Vec::new(),
             },
         );
-        assert_eq!(win.nodes.len(), 1);
+        assert_eq!(win.flow_definition.process_refs.len(), 1);
 
         // Undo restores
         handle_undo(&mut win);
-        assert_eq!(win.nodes.len(), 2);
+        assert_eq!(win.flow_definition.process_refs.len(), 2);
 
         // Redo removes again
         handle_redo(&mut win);
-        assert_eq!(win.nodes.len(), 1);
+        assert_eq!(win.flow_definition.process_refs.len(), 1);
     }
 
     #[test]
@@ -678,9 +645,7 @@ mod test {
                 node_index: 0,
                 port_name: "input".into(),
                 old_init: None,
-                old_display: None,
                 new_init: Some(InputInitializer::Once(serde_json::json!(42))),
-                new_display: Some("once: 42".into()),
             },
         );
 
@@ -690,28 +655,30 @@ mod test {
             0,
             "input",
             Some(&InputInitializer::Once(serde_json::json!(42))),
-            Some(&"once: 42".to_string()),
         );
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
+            .and_then(|p| p.initializations.get("input"))
             .is_some());
 
         // Undo
         handle_undo(&mut win);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
+            .and_then(|p| p.initializations.get("input"))
             .is_none());
 
         // Redo
         handle_redo(&mut win);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
+            .and_then(|p| p.initializations.get("input"))
             .is_some());
     }
 }

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -1,42 +1,36 @@
 //! Initializer editor logic for applying and syncing initializer edits.
 
 use flowcore::model::input::InputInitializer;
-use flowcore::model::process_reference::ProcessReference;
 
 use crate::canvas_view::derive_short_name;
 use crate::history::EditAction;
 use crate::{InitializerEditor, WindowState};
 
-/// Apply an initializer edit to the flow definition and update the node display.
+/// Apply an initializer edit to the flow definition.
 pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &InitializerEditor) {
     let alias = win
-        .nodes
+        .flow_definition
+        .process_refs
         .get(editor.node_index)
-        .map(|n| n.alias.clone())
+        .map(|pr| {
+            if pr.alias.is_empty() {
+                derive_short_name(&pr.source)
+            } else {
+                pr.alias.clone()
+            }
+        })
         .unwrap_or_default();
 
     // Capture old state for undo
     let old_init = win
         .flow_definition
         .process_refs
-        .iter()
-        .find(|pr| {
-            let pr_alias = if pr.alias.is_empty() {
-                derive_short_name(&pr.source)
-            } else {
-                pr.alias.clone()
-            };
-            pr_alias == alias
-        })
-        .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
-    let old_display = win
-        .nodes
         .get(editor.node_index)
-        .and_then(|n| n.initializers.get(&editor.port_name).cloned());
+        .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
 
-    // Compute new initializer and display
-    let (new_init, new_display) = match editor.init_type.as_str() {
-        "none" => (None, None),
+    // Compute new initializer
+    let new_init = match editor.init_type.as_str() {
+        "none" => None,
         "once" | "always" => {
             let value = serde_json::from_str(&editor.value_text)
                 .unwrap_or_else(|_| serde_json::Value::String(editor.value_text.clone()));
@@ -45,21 +39,13 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
             } else {
                 InputInitializer::Always(value)
             };
-            let display = format!("{}: {}", editor.init_type, editor.value_text);
-            (Some(init), Some(display))
+            Some(init)
         }
         _ => return,
     };
 
     // Apply to model
-    if let Some(pref) = win.flow_definition.process_refs.iter_mut().find(|pr| {
-        let pr_alias = if pr.alias.is_empty() {
-            derive_short_name(&pr.source)
-        } else {
-            pr.alias.clone()
-        };
-        pr_alias == alias
-    }) {
+    if let Some(pref) = win.flow_definition.process_refs.get_mut(editor.node_index) {
         match &new_init {
             Some(init) => {
                 pref.initializations
@@ -71,26 +57,11 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
         }
     }
 
-    // Apply to display
-    if let Some(node) = win.nodes.get_mut(editor.node_index) {
-        match &new_display {
-            Some(display) => {
-                node.initializers
-                    .insert(editor.port_name.clone(), display.clone());
-            }
-            None => {
-                node.initializers.remove(&editor.port_name);
-            }
-        }
-    }
-
     win.history.record(EditAction::EditInitializer {
         node_index: editor.node_index,
         port_name: editor.port_name.clone(),
         old_init,
-        old_display,
         new_init,
-        new_display,
     });
     win.unsaved_edits += 1;
     win.compiled_manifest = None;
@@ -98,73 +69,14 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
     win.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
 }
 
-/// Synchronize the in-memory `FlowDefinition` with the current editor state
-/// so that process references and the flow name are up to date.
-/// Connections are stored in `flow_definition.connections` and serialized during save.
-pub(crate) fn sync_flow_definition(win: &mut WindowState) {
-    // Update or rebuild process_refs from current NodeLayout data
-    let mut new_refs: Vec<ProcessReference> = Vec::with_capacity(win.nodes.len());
-    for node in &win.nodes {
-        // Try to find the original ProcessReference by alias to preserve initializations
-        let original = win
-            .flow_definition
-            .process_refs
-            .iter()
-            .find(|pr| {
-                let alias = if pr.alias.is_empty() {
-                    derive_short_name(&pr.source)
-                } else {
-                    pr.alias.clone()
-                };
-                alias == node.alias
-            })
-            .cloned();
-
-        let pref = if let Some(mut orig) = original {
-            orig.x = Some(node.x);
-            orig.y = Some(node.y);
-            orig.width = Some(node.width);
-            orig.height = Some(node.height);
-            orig
-        } else {
-            // New node without an original -- build from scratch
-            ProcessReference {
-                alias: node.alias.clone(),
-                source: node.source.clone(),
-                initializations: std::collections::BTreeMap::new(),
-                x: Some(node.x),
-                y: Some(node.y),
-                width: Some(node.width),
-                height: Some(node.height),
-            }
-        };
-        new_refs.push(pref);
-    }
-    win.flow_definition.process_refs = new_refs;
-}
-
-/// Apply an initializer state to both the model and display.
+/// Apply an initializer state to the model (`process_refs`).
 pub(crate) fn apply_initializer_state(
     win: &mut WindowState,
     node_index: usize,
     port_name: &str,
     init: Option<&InputInitializer>,
-    display: Option<&String>,
 ) {
-    let alias = win
-        .nodes
-        .get(node_index)
-        .map(|n| n.alias.clone())
-        .unwrap_or_default();
-
-    if let Some(pref) = win.flow_definition.process_refs.iter_mut().find(|pr| {
-        let pr_alias = if pr.alias.is_empty() {
-            derive_short_name(&pr.source)
-        } else {
-            pr.alias.clone()
-        };
-        pr_alias == alias
-    }) {
+    if let Some(pref) = win.flow_definition.process_refs.get_mut(node_index) {
         match init {
             Some(i) => {
                 pref.initializations
@@ -172,17 +84,6 @@ pub(crate) fn apply_initializer_state(
             }
             None => {
                 pref.initializations.remove(port_name);
-            }
-        }
-    }
-
-    if let Some(node) = win.nodes.get_mut(node_index) {
-        match display {
-            Some(d) => {
-                node.initializers.insert(port_name.to_string(), d.clone());
-            }
-            None => {
-                node.initializers.remove(port_name);
             }
         }
     }
@@ -219,23 +120,10 @@ mod test {
     use super::*;
     use flowcore::model::flow_definition::FlowDefinition;
     use flowcore::model::name::Name;
-
-    use crate::canvas_view::NodeLayout;
-
-    fn test_node(alias: &str, source: &str) -> NodeLayout {
-        NodeLayout {
-            alias: alias.into(),
-            source: source.into(),
-            ..Default::default()
-        }
-    }
+    use flowcore::model::process_reference::ProcessReference;
+    use std::collections::BTreeMap;
 
     fn test_win_state() -> WindowState {
-        use flowcore::model::flow_definition::FlowDefinition;
-        use flowcore::model::name::Name;
-        use flowcore::model::process_reference::ProcessReference;
-        use std::collections::BTreeMap;
-
         let flow = FlowDefinition {
             name: Name::from("test"),
             process_refs: vec![
@@ -261,47 +149,11 @@ mod test {
             ..FlowDefinition::default()
         };
 
-        let nodes: Vec<NodeLayout> = flow
-            .process_refs
-            .iter()
-            .map(|pref| NodeLayout {
-                alias: pref.alias.clone(),
-                source: pref.source.clone(),
-                x: pref.x.unwrap_or(0.0),
-                y: pref.y.unwrap_or(0.0),
-                width: pref.width.unwrap_or(180.0),
-                height: pref.height.unwrap_or(120.0),
-                ..Default::default()
-            })
-            .collect();
-
         WindowState {
-            nodes,
             flow_definition: flow,
             is_root: true,
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn sync_flow_definition_preserves_nodes() {
-        let flow_def = FlowDefinition {
-            name: Name::from("test"),
-            ..FlowDefinition::default()
-        };
-        let mut win = WindowState {
-            nodes: vec![
-                test_node("add", "lib://flowstdlib/math/add"),
-                test_node("stdout", "context://stdio/stdout"),
-            ],
-            flow_definition: flow_def,
-            is_root: true,
-            ..Default::default()
-        };
-
-        sync_flow_definition(&mut win);
-        assert_eq!(win.flow_definition.process_refs.len(), 2);
-        assert_eq!(win.flow_definition.name, "test");
     }
 
     #[test]
@@ -315,12 +167,13 @@ mod test {
         };
         apply_initializer_edit(&mut win, &editor);
         assert!(win.unsaved_edits > 0);
-        // Check display was updated
+        // Check model was updated
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
-            .is_some_and(|d| d.contains("once")));
+            .and_then(|p| p.initializations.get("input"))
+            .is_some());
     }
 
     #[test]
@@ -334,10 +187,11 @@ mod test {
         };
         apply_initializer_edit(&mut win, &editor);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
-            .is_some_and(|d| d.contains("always")));
+            .and_then(|p| p.initializations.get("input"))
+            .is_some());
     }
 
     #[test]
@@ -352,9 +206,10 @@ mod test {
         };
         apply_initializer_edit(&mut win, &editor);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
+            .and_then(|p| p.initializations.get("input"))
             .is_some());
 
         // Then remove it
@@ -366,9 +221,10 @@ mod test {
         };
         apply_initializer_edit(&mut win, &editor);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("input"))
+            .and_then(|p| p.initializations.get("input"))
             .is_none());
     }
 
@@ -376,20 +232,21 @@ mod test {
     fn initializer_apply_state_set_and_remove() {
         let mut win = test_win_state();
         let init = InputInitializer::Once(serde_json::json!(99));
-        let display = "once: 99".to_string();
-        apply_initializer_state(&mut win, 0, "port", Some(&init), Some(&display));
+        apply_initializer_state(&mut win, 0, "port", Some(&init));
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("port"))
+            .and_then(|p| p.initializations.get("port"))
             .is_some());
 
         // Remove
-        apply_initializer_state(&mut win, 0, "port", None, None);
+        apply_initializer_state(&mut win, 0, "port", None);
         assert!(win
-            .nodes
+            .flow_definition
+            .process_refs
             .first()
-            .and_then(|n| n.initializers.get("port"))
+            .and_then(|p| p.initializations.get("port"))
             .is_none());
     }
 

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -100,7 +100,7 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
 
 /// Synchronize the in-memory `FlowDefinition` with the current editor state
 /// so that process references and the flow name are up to date.
-/// Connections are handled separately via `EdgeLayout` during save.
+/// Connections are stored in `flow_definition.connections` and serialized during save.
 pub(crate) fn sync_flow_definition(win: &mut WindowState) {
     // Update or rebuild process_refs from current NodeLayout data
     let mut new_refs: Vec<ProcessReference> = Vec::with_capacity(win.nodes.len());
@@ -277,7 +277,6 @@ mod test {
 
         WindowState {
             nodes,
-            edges: Vec::new(),
             flow_definition: flow,
             is_root: true,
             ..Default::default()

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -24,7 +24,7 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
             let pr_alias = if pr.alias.is_empty() {
                 derive_short_name(&pr.source)
             } else {
-                pr.alias.to_string()
+                pr.alias.clone()
             };
             pr_alias == alias
         })
@@ -56,7 +56,7 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
         let pr_alias = if pr.alias.is_empty() {
             derive_short_name(&pr.source)
         } else {
-            pr.alias.to_string()
+            pr.alias.clone()
         };
         pr_alias == alias
     }) {
@@ -114,7 +114,7 @@ pub(crate) fn sync_flow_definition(win: &mut WindowState) {
                 let alias = if pr.alias.is_empty() {
                     derive_short_name(&pr.source)
                 } else {
-                    pr.alias.to_string()
+                    pr.alias.clone()
                 };
                 alias == node.alias
             })
@@ -141,9 +141,6 @@ pub(crate) fn sync_flow_definition(win: &mut WindowState) {
         new_refs.push(pref);
     }
     win.flow_definition.process_refs = new_refs;
-
-    // Update the flow name
-    win.flow_definition.name = win.flow_name.clone();
 }
 
 /// Apply an initializer state to both the model and display.
@@ -164,7 +161,7 @@ pub(crate) fn apply_initializer_state(
         let pr_alias = if pr.alias.is_empty() {
             derive_short_name(&pr.source)
         } else {
-            pr.alias.to_string()
+            pr.alias.clone()
         };
         pr_alias == alias
     }) {
@@ -220,6 +217,9 @@ pub(crate) fn handle_cancel(win: &mut WindowState) {
 #[cfg(test)]
 mod test {
     use super::*;
+    use flowcore::model::flow_definition::FlowDefinition;
+    use flowcore::model::name::Name;
+
     use crate::canvas_view::NodeLayout;
 
     fn test_node(alias: &str, source: &str) -> NodeLayout {
@@ -276,7 +276,6 @@ mod test {
             .collect();
 
         WindowState {
-            flow_name: flow.name.clone(),
             nodes,
             edges: Vec::new(),
             flow_definition: flow,
@@ -287,12 +286,16 @@ mod test {
 
     #[test]
     fn sync_flow_definition_preserves_nodes() {
+        let flow_def = FlowDefinition {
+            name: Name::from("test"),
+            ..FlowDefinition::default()
+        };
         let mut win = WindowState {
-            flow_name: String::from("test"),
             nodes: vec![
                 test_node("add", "lib://flowstdlib/math/add"),
                 test_node("stdout", "context://stdio/stdout"),
             ],
+            flow_definition: flow_def,
             is_root: true,
             ..Default::default()
         };

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -202,7 +202,7 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
         EditAction::DeleteNode {
             index,
             node,
-            removed_edges: Vec::new(),
+            removed_connections: Vec::new(),
         },
     );
     // Note: We record a DeleteNode so that *undo* removes the added node.
@@ -275,7 +275,6 @@ mod test {
                 test_node("add", "lib://flowstdlib/math/add"),
                 test_node("stdout", "context://stdio/stdout"),
             ],
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -220,7 +220,8 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
 
 /// Resolve a node's source path relative to the current flow file.
 pub(crate) fn resolve_node_source(win: &WindowState, source: &str) -> Option<PathBuf> {
-    let base_dir = win.file_path.as_ref()?.parent()?;
+    let base_dir = win.file_path()?.parent()?.to_path_buf();
+    let base_dir = &base_dir;
     let canonicalize = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
     let candidate = base_dir.join(source);
     if candidate.exists() {
@@ -240,6 +241,8 @@ pub(crate) fn resolve_node_source(win: &WindowState, source: &str) -> Option<Pat
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod test {
+    use std::path::Path;
+
     use super::*;
     use crate::canvas_view::FlowCanvasState;
     use crate::hierarchy_panel::FlowHierarchy;
@@ -282,7 +285,6 @@ mod test {
             auto_fit_enabled: false,
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path: None,
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -311,10 +313,8 @@ mod test {
         let sub_path = dir.join("sub.toml");
         std::fs::write(&sub_path, "flow = \"sub\"").expect("write");
 
-        let win = WindowState {
-            file_path: Some(flow_path),
-            ..test_win_state()
-        };
+        let mut win = test_win_state();
+        win.set_file_path(&flow_path);
 
         let resolved = resolve_node_source(&win, "sub");
         assert!(resolved.is_some());
@@ -324,10 +324,8 @@ mod test {
 
     #[test]
     fn resolve_node_source_not_found() {
-        let win = WindowState {
-            file_path: Some(PathBuf::from("/tmp/flowedit_tests/nonexistent/root.toml")),
-            ..test_win_state()
-        };
+        let mut win = test_win_state();
+        win.set_file_path(Path::new("/tmp/flowedit_tests/nonexistent/root.toml"));
         let resolved = resolve_node_source(&win, "missing");
         assert!(resolved.is_none());
     }

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -289,8 +289,6 @@ mod test {
             tooltip: None,
             initializer_editor: None,
             is_root: true,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: FlowHierarchy::empty(),

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -60,10 +60,7 @@ pub(crate) fn load_library_catalogs(
                             all_definitions.insert(locator_url.clone(), process);
                         }
                         Err(e) => {
-                            warn!(
-                                "Could not parse library definition '{}': {}",
-                                locator_url, e
-                            );
+                            warn!("Could not parse library definition '{locator_url}': {e}");
                         }
                     }
                 }
@@ -71,7 +68,7 @@ pub(crate) fn load_library_catalogs(
                 library_cache.insert(lib_root.clone(), manifest);
             }
             Err(e) => {
-                warn!("Could not load library manifest for '{}': {}", lib_root, e);
+                warn!("Could not load library manifest for '{lib_root}': {e}");
             }
         }
     }
@@ -107,18 +104,19 @@ pub(crate) fn load_library_catalogs(
                             if !func_name.is_empty() {
                                 let ctx_url_str = format!("context://{cat_name}/{func_name}");
                                 if let Ok(ctx_url) = Url::parse(&ctx_url_str) {
-                                    if !all_definitions.contains_key(&ctx_url) {
+                                    if let std::collections::hash_map::Entry::Vacant(entry) =
+                                        all_definitions.entry(ctx_url)
+                                    {
                                         match flowrclib::compiler::parser::parse(
-                                            &ctx_url,
+                                            entry.key(),
                                             &ctx_provider,
                                         ) {
                                             Ok(process) => {
-                                                all_definitions.insert(ctx_url, process);
+                                                entry.insert(process);
                                             }
                                             Err(e) => {
                                                 warn!(
-                                                    "Could not parse context function '{}': {}",
-                                                    ctx_url_str, e
+                                                    "Could not parse context function '{ctx_url_str}': {e}"
                                                 );
                                             }
                                         }
@@ -243,7 +241,7 @@ pub(crate) fn resolve_node_source(win: &WindowState, source: &str) -> Option<Pat
 #[allow(clippy::indexing_slicing)]
 mod test {
     use super::*;
-    use crate::canvas_view::{FlowCanvasState, PortInfo};
+    use crate::canvas_view::FlowCanvasState;
     use crate::hierarchy_panel::FlowHierarchy;
     use crate::history::EditHistory;
     use crate::WindowKind;
@@ -264,9 +262,12 @@ mod test {
     }
 
     fn test_win_state() -> WindowState {
+        let flow_def = flowcore::model::flow_definition::FlowDefinition {
+            name: String::from("test"),
+            ..flowcore::model::flow_definition::FlowDefinition::default()
+        };
         WindowState {
             kind: WindowKind::FlowEditor,
-            flow_name: String::from("test"),
             nodes: vec![
                 test_node("add", "lib://flowstdlib/math/add"),
                 test_node("stdout", "context://stdio/stdout"),
@@ -282,7 +283,7 @@ mod test {
             unsaved_edits: 0,
             compiled_manifest: None,
             file_path: None,
-            flow_definition: flowcore::model::flow_definition::FlowDefinition::default(),
+            flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
             is_root: true,

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -12,7 +12,6 @@ use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 use flowcore::provider::Provider;
 
-use crate::canvas_view::NodeLayout;
 use crate::flow_io;
 use crate::history;
 use crate::history::EditAction;
@@ -139,53 +138,29 @@ pub(crate) fn load_library_catalogs(
 /// in the flow definition, and records the action in the edit history.
 pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_name: &str) {
     // Generate a unique alias: if the name already exists, append a number
-    let alias = flow_io::generate_unique_alias(func_name, &win.nodes);
+    let alias = flow_io::generate_unique_alias(func_name, &win.flow_definition.process_refs);
 
     // Place the new node at a default position offset from existing nodes
-    let (x, y) = flow_io::next_node_position(&win.nodes);
+    let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
 
-    // Resolve port info and description by parsing the function/flow definition
-    let (inputs, outputs, description) = match Url::parse(source) {
+    // Resolve the subprocess definition by parsing the function/flow
+    let resolved_process = match Url::parse(source) {
         Ok(url) => {
             let provider = flow_io::build_meta_provider();
             match flowrclib::compiler::parser::parse(&url, &provider) {
-                Ok(Process::FunctionProcess(func)) => {
-                    let ports = flow_io::extract_ports(&func.inputs, &func.outputs);
-                    (ports.0, ports.1, func.description.clone())
-                }
-                Ok(Process::FlowProcess(flow)) => {
-                    let ports = flow_io::extract_ports(&flow.inputs, &flow.outputs);
-                    (ports.0, ports.1, flow.description.clone())
-                }
+                Ok(proc) => Some(proc),
                 Err(e) => {
                     info!("add_library_function: could not parse '{source}': {e}");
-                    (Vec::new(), Vec::new(), String::new())
+                    None
                 }
             }
         }
         Err(e) => {
             info!("add_library_function: could not parse URL '{source}': {e}");
-            (Vec::new(), Vec::new(), String::new())
+            None
         }
     };
 
-    let node = NodeLayout {
-        alias: alias.clone(),
-        source: source.to_string(),
-        description,
-        x,
-        y,
-        width: 180.0,
-        height: 120.0,
-        inputs,
-        outputs,
-        initializers: HashMap::new(),
-    };
-
-    let index = win.nodes.len();
-    win.nodes.push(node.clone());
-
-    // Also add to the flow definition
     let pref = ProcessReference {
         alias: alias.clone(),
         source: source.to_string(),
@@ -195,13 +170,25 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
         width: Some(180.0),
         height: Some(120.0),
     };
-    win.flow_definition.process_refs.push(pref);
+
+    let index = win.flow_definition.process_refs.len();
+    win.flow_definition.process_refs.push(pref.clone());
+
+    // Add the resolved subprocess definition if we have one
+    if let Some(proc) = resolved_process {
+        win.flow_definition.subprocesses.insert(alias.clone(), proc);
+    }
 
     history::record_edit(
         win,
         EditAction::DeleteNode {
             index,
-            node,
+            process_ref: pref,
+            subprocess: win
+                .flow_definition
+                .subprocesses
+                .get(&alias)
+                .map(|p| (alias.clone(), p.clone())),
             removed_connections: Vec::new(),
         },
     );
@@ -214,7 +201,7 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
     if win.auto_fit_enabled {
         win.auto_fit_pending = true;
     }
-    let nc = win.nodes.len();
+    let nc = win.flow_definition.process_refs.len();
     win.status = format!("Added {alias} from library - {nc} nodes");
 }
 
@@ -249,32 +236,36 @@ mod test {
     use crate::history::EditHistory;
     use crate::WindowKind;
 
-    fn test_node(alias: &str, source: &str) -> NodeLayout {
-        NodeLayout {
-            alias: alias.into(),
-            source: source.into(),
-            description: String::new(),
-            x: 100.0,
-            y: 100.0,
-            width: 180.0,
-            height: 120.0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            initializers: HashMap::new(),
-        }
-    }
-
     fn test_win_state() -> WindowState {
+        use flowcore::model::process_reference::ProcessReference;
+        use std::collections::BTreeMap;
+
         let flow_def = flowcore::model::flow_definition::FlowDefinition {
             name: String::from("test"),
+            process_refs: vec![
+                ProcessReference {
+                    alias: "add".into(),
+                    source: "lib://flowstdlib/math/add".into(),
+                    initializations: BTreeMap::new(),
+                    x: Some(100.0),
+                    y: Some(100.0),
+                    width: Some(180.0),
+                    height: Some(120.0),
+                },
+                ProcessReference {
+                    alias: "stdout".into(),
+                    source: "context://stdio/stdout".into(),
+                    initializations: BTreeMap::new(),
+                    x: Some(100.0),
+                    y: Some(100.0),
+                    width: Some(180.0),
+                    height: Some(120.0),
+                },
+            ],
             ..flowcore::model::flow_definition::FlowDefinition::default()
         };
         WindowState {
             kind: WindowKind::FlowEditor,
-            nodes: vec![
-                test_node("add", "lib://flowstdlib/math/add"),
-                test_node("stdout", "context://stdio/stdout"),
-            ],
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -121,7 +121,7 @@ impl LibraryTree {
 
         // Sort non-context libraries by name for consistent display.
         // Skip index 0 only if we actually inserted a Context entry there.
-        let sort_start = if has_context { 1 } else { 0 };
+        let sort_start = usize::from(has_context);
         if let Some(rest) = libraries.get_mut(sort_start..) {
             rest.sort_by(|a, b| a.name.cmp(&b.name));
         }
@@ -366,7 +366,7 @@ fn build_context_entry(context_definitions: &HashMap<&Url, &Process>) -> Library
             .path()
             .trim_start_matches('/')
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("")
             .to_string();
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -196,8 +196,6 @@ struct FlowEdit {
     focused_window: Option<window::Id>,
     /// Library panel tree for process discovery
     library_tree: LibraryTree,
-    /// Path to the root flow file (for rebuilding hierarchy)
-    root_flow_path: Option<PathBuf>,
     show_lib_paths: bool,
     lib_paths: Vec<String>,
     /// Cached library manifests, keyed by library root URL (e.g., `lib://flowstdlib`)
@@ -213,7 +211,6 @@ impl Default for FlowEdit {
             root_window: None,
             focused_window: None,
             library_tree: LibraryTree { libraries: vec![] },
-            root_flow_path: None,
             show_lib_paths: false,
             lib_paths: Vec::new(),
             library_cache: HashMap::new(),
@@ -364,8 +361,7 @@ impl FlowEdit {
             ..Default::default()
         });
 
-        let root_flow_path = file_path;
-        let flow_hierarchy = root_flow_path
+        let flow_hierarchy = file_path
             .as_ref()
             .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
@@ -402,7 +398,6 @@ impl FlowEdit {
             root_window: Some(root_id),
             focused_window: Some(root_id),
             library_tree,
-            root_flow_path,
             show_lib_paths: false,
             lib_paths,
             library_cache,
@@ -680,7 +675,6 @@ impl FlowEdit {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
                         if let Some((lib_refs, _ctx_refs)) = flow_io::perform_open(win) {
-                            self.root_flow_path = win.file_path();
                             win.flow_hierarchy = win
                                 .file_path()
                                 .as_ref()
@@ -1975,8 +1969,14 @@ impl FlowEdit {
         self.library_tree = LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
     }
 
+    fn root_flow_path(&self) -> Option<PathBuf> {
+        self.root_window
+            .and_then(|id| self.windows.get(&id))
+            .and_then(WindowState::file_path)
+    }
+
     fn build_hierarchy(&self) -> FlowHierarchy {
-        self.root_flow_path
+        self.root_flow_path()
             .as_ref()
             .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p))
     }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -297,20 +297,19 @@ impl FlowEdit {
             }
         }
 
-        let (nodes, edges, status, flow_definition, lib_refs) =
+        let (nodes, status, flow_definition, lib_refs) =
             if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
                 let flow_path = PathBuf::from(flow_path_str);
                 match flow_io::load_flow(&flow_path) {
                     Ok(loaded) => {
                         let nc = loaded.nodes.len();
-                        let ec = loaded.edges.len();
+                        let ec = loaded.flow_def.connections.len();
                         let mut fd = loaded.flow_def;
                         if let Ok(url) = Url::from_file_path(&flow_path) {
                             fd.source_url = url;
                         }
                         (
                             loaded.nodes,
-                            loaded.edges,
                             format!("Ready - {nc} nodes, {ec} connections"),
                             fd,
                             loaded.lib_references,
@@ -323,7 +322,6 @@ impl FlowEdit {
                         };
                         (
                             Vec::new(),
-                            Vec::new(),
                             format!("Error loading flow: {e}"),
                             fd,
                             BTreeSet::new(),
@@ -335,13 +333,7 @@ impl FlowEdit {
                     name: String::from("(new flow)"),
                     ..FlowDefinition::default()
                 };
-                (
-                    Vec::new(),
-                    Vec::new(),
-                    String::from("Ready"),
-                    fd,
-                    BTreeSet::new(),
-                )
+                (Vec::new(), String::from("Ready"), fd, BTreeSet::new())
             };
 
         let has_nodes = !nodes.is_empty();
@@ -379,7 +371,6 @@ impl FlowEdit {
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
             nodes,
-            edges,
             canvas_state: FlowCanvasState::default(),
             status,
             selected_node: None,
@@ -469,7 +460,7 @@ impl FlowEdit {
                             window::open(self.child_window_settings(1024.0, 768.0));
                         let has_nodes = !loaded.nodes.is_empty();
                         let nc = loaded.nodes.len();
-                        let ec = loaded.edges.len();
+                        let ec = loaded.flow_def.connections.len();
                         let mut flow_def = loaded.flow_def;
                         if let Ok(url) = Url::from_file_path(&path) {
                             flow_def.source_url = url;
@@ -477,7 +468,6 @@ impl FlowEdit {
                         let child = WindowState {
                             kind: WindowKind::FlowEditor,
                             nodes: loaded.nodes,
-                            edges: loaded.edges,
                             canvas_state: FlowCanvasState::default(),
                             status: format!("Ready - {nc} nodes, {ec} connections"),
                             selected_node: None,
@@ -782,9 +772,12 @@ impl FlowEdit {
                             if let Some(io) = win.flow_definition.inputs.get(idx) {
                                 let name = io.name().clone();
                                 win.flow_definition.inputs.remove(idx);
-                                // Remove edges referencing this flow input
-                                win.edges
-                                    .retain(|e| !(e.from_node == "input" && e.from_port == name));
+                                // Remove connections referencing this flow input
+                                win.flow_definition.connections.retain(|c| {
+                                    let (from_node, from_port) =
+                                        canvas_view::split_route(c.from().as_ref());
+                                    !(from_node == "input" && from_port == name)
+                                });
                                 win.unsaved_edits += 1;
                                 win.canvas_state.request_redraw();
                             }
@@ -793,9 +786,17 @@ impl FlowEdit {
                             if let Some(io) = win.flow_definition.outputs.get(idx) {
                                 let name = io.name().clone();
                                 win.flow_definition.outputs.remove(idx);
-                                // Remove edges referencing this flow output
-                                win.edges
-                                    .retain(|e| !(e.to_node == "output" && e.to_port == name));
+                                // Remove connections referencing this flow output
+                                win.flow_definition.connections.retain(|c| {
+                                    for to_route in c.to() {
+                                        let (to_node, to_port) =
+                                            canvas_view::split_route(to_route.as_ref());
+                                        if to_node == "output" && to_port == name {
+                                            return false;
+                                        }
+                                    }
+                                    true
+                                });
                                 win.unsaved_edits += 1;
                                 win.canvas_state.request_redraw();
                             }
@@ -811,9 +812,11 @@ impl FlowEdit {
                                 if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
                                     let old_name = io.name().clone();
                                     io.set_name(name.clone());
-                                    for edge in &mut win.edges {
-                                        if edge.from_node == "input" && edge.from_port == old_name {
-                                            edge.from_port.clone_from(&name);
+                                    let old_route = format!("input/{old_name}");
+                                    let new_route = format!("input/{name}");
+                                    for conn in &mut win.flow_definition.connections {
+                                        if conn.from().to_string() == old_route {
+                                            conn.set_from(Route::from(new_route.as_str()));
                                         }
                                     }
                                 }
@@ -839,10 +842,21 @@ impl FlowEdit {
                                 if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
                                     let old_name = io.name().clone();
                                     io.set_name(name.clone());
-                                    for edge in &mut win.edges {
-                                        if edge.to_node == "output" && edge.to_port == old_name {
-                                            edge.to_port.clone_from(&name);
-                                        }
+                                    let old_route_str = format!("output/{old_name}");
+                                    let new_route_str = format!("output/{name}");
+                                    for conn in &mut win.flow_definition.connections {
+                                        let new_to: Vec<Route> = conn
+                                            .to()
+                                            .iter()
+                                            .map(|r| {
+                                                if r.to_string() == old_route_str {
+                                                    Route::from(new_route_str.as_str())
+                                                } else {
+                                                    r.clone()
+                                                }
+                                            })
+                                            .collect();
+                                        conn.set_to(new_to);
                                     }
                                 }
                                 win.unsaved_edits += 1;
@@ -1942,7 +1956,7 @@ impl FlowEdit {
                 Ok(loaded) => {
                     let has_nodes = !loaded.nodes.is_empty();
                     let nc = loaded.nodes.len();
-                    let ec = loaded.edges.len();
+                    let ec = loaded.flow_def.connections.len();
                     let (new_id, open_task) =
                         window::open(self.child_window_settings(1024.0, 768.0));
                     let mut flow_def = loaded.flow_def;
@@ -1952,7 +1966,6 @@ impl FlowEdit {
                     let child = WindowState {
                         kind: WindowKind::FlowEditor,
                         nodes: loaded.nodes,
-                        edges: loaded.edges,
                         canvas_state: FlowCanvasState::default(),
                         status: format!("Library flow - {nc} nodes, {ec} connections"),
                         selected_node: None,
@@ -2076,7 +2089,7 @@ impl FlowEdit {
                 let has_nodes = !loaded.nodes.is_empty();
                 let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
                 let nc = loaded.nodes.len();
-                let ec = loaded.edges.len();
+                let ec = loaded.flow_def.connections.len();
                 let mut flow_def = loaded.flow_def;
                 if let Ok(url) = Url::from_file_path(&path) {
                     flow_def.source_url = url;
@@ -2084,7 +2097,6 @@ impl FlowEdit {
                 let child = WindowState {
                     kind: WindowKind::FlowEditor,
                     nodes: loaded.nodes,
-                    edges: loaded.edges,
                     canvas_state: FlowCanvasState::default(),
                     status: format!("Ready - {nc} nodes, {ec} connections"),
                     selected_node: None,
@@ -2164,7 +2176,6 @@ impl FlowEdit {
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
             nodes: Vec::new(),
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: format!("Function: {func_name}"),
             selected_node: None,
@@ -2298,7 +2309,6 @@ impl FlowEdit {
         let child = WindowState {
             kind: WindowKind::FlowEditor,
             nodes: Vec::new(),
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: format!("New sub-flow: {flow_name}"),
             selected_node: None,
@@ -2432,7 +2442,6 @@ impl FlowEdit {
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
             nodes: Vec::new(),
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: String::from("New function — add ports and Save"),
             selected_node: None,

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -38,7 +38,7 @@ use flowcore::model::process_reference::ProcessReference;
 use flowcore::model::route::Route;
 use flowcore::provider::Provider;
 
-use canvas_view::{CanvasMessage, FlowCanvasState, NodeLayout, PortInfo};
+use canvas_view::{CanvasMessage, FlowCanvasState, PortInfo};
 use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
 use history::EditHistory;
 use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
@@ -297,19 +297,18 @@ impl FlowEdit {
             }
         }
 
-        let (nodes, status, flow_definition, lib_refs) =
+        let (status, flow_definition, lib_refs) =
             if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
                 let flow_path = PathBuf::from(flow_path_str);
                 match flow_io::load_flow(&flow_path) {
                     Ok(loaded) => {
-                        let nc = loaded.nodes.len();
+                        let nc = loaded.flow_def.process_refs.len();
                         let ec = loaded.flow_def.connections.len();
                         let mut fd = loaded.flow_def;
                         if let Ok(url) = Url::from_file_path(&flow_path) {
                             fd.source_url = url;
                         }
                         (
-                            loaded.nodes,
                             format!("Ready - {nc} nodes, {ec} connections"),
                             fd,
                             loaded.lib_references,
@@ -320,12 +319,7 @@ impl FlowEdit {
                             name: String::from("(error)"),
                             ..FlowDefinition::default()
                         };
-                        (
-                            Vec::new(),
-                            format!("Error loading flow: {e}"),
-                            fd,
-                            BTreeSet::new(),
-                        )
+                        (format!("Error loading flow: {e}"), fd, BTreeSet::new())
                     }
                 }
             } else {
@@ -333,10 +327,10 @@ impl FlowEdit {
                     name: String::from("(new flow)"),
                     ..FlowDefinition::default()
                 };
-                (Vec::new(), String::from("Ready"), fd, BTreeSet::new())
+                (String::from("Ready"), fd, BTreeSet::new())
             };
 
-        let has_nodes = !nodes.is_empty();
+        let has_nodes = !flow_definition.process_refs.is_empty();
 
         // Load full library catalogs from manifests and parse all definitions
         let (library_cache, all_definitions) = library_mgmt::load_library_catalogs(&lib_refs);
@@ -370,7 +364,6 @@ impl FlowEdit {
 
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
-            nodes,
             canvas_state: FlowCanvasState::default(),
             status,
             selected_node: None,
@@ -458,8 +451,8 @@ impl FlowEdit {
                     if let Ok(loaded) = flow_io::load_flow(&path) {
                         let (new_id, open_task) =
                             window::open(self.child_window_settings(1024.0, 768.0));
-                        let has_nodes = !loaded.nodes.is_empty();
-                        let nc = loaded.nodes.len();
+                        let has_nodes = !loaded.flow_def.process_refs.is_empty();
+                        let nc = loaded.flow_def.process_refs.len();
                         let ec = loaded.flow_def.connections.len();
                         let mut flow_def = loaded.flow_def;
                         if let Ok(url) = Url::from_file_path(&path) {
@@ -467,7 +460,7 @@ impl FlowEdit {
                         }
                         let child = WindowState {
                             kind: WindowKind::FlowEditor,
-                            nodes: loaded.nodes,
+
                             canvas_state: FlowCanvasState::default(),
                             status: format!("Ready - {nc} nodes, {ec} connections"),
                             selected_node: None,
@@ -704,7 +697,7 @@ impl FlowEdit {
             Message::Compile => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    if !win.nodes.is_empty() {
+                    if !win.flow_definition.process_refs.is_empty() {
                         match flow_io::perform_compile(win) {
                             Ok(path) => {
                                 win.compiled_manifest = Some(path.clone());
@@ -971,13 +964,29 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        // Propagate to the parent window's NodeLayout for ALL nodes
-                        // with the same source (multiple nodes may reference it)
+                        // Propagate description to the parent window's subprocess definitions
                         if let Some((parent_id, node_source)) = parent_info {
                             if let Some(parent_win) = self.windows.get_mut(&parent_id) {
-                                for node in &mut parent_win.nodes {
-                                    if node.source == node_source {
-                                        node.description.clone_from(&new_desc);
+                                // Update subprocess definitions with matching source
+                                for pref in &parent_win.flow_definition.process_refs {
+                                    if pref.source == node_source {
+                                        let alias = if pref.alias.is_empty() {
+                                            canvas_view::derive_short_name(&pref.source)
+                                        } else {
+                                            pref.alias.clone()
+                                        };
+                                        if let Some(proc) =
+                                            parent_win.flow_definition.subprocesses.get_mut(&alias)
+                                        {
+                                            match proc {
+                                                Process::FunctionProcess(ref mut f) => {
+                                                    f.description.clone_from(&new_desc);
+                                                }
+                                                Process::FlowProcess(ref mut f) => {
+                                                    f.description.clone_from(&new_desc);
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                                 parent_win.canvas_state.request_redraw();
@@ -1270,7 +1279,7 @@ impl FlowEdit {
             let mut compile_btn = button(Text::new("\u{1F528} Build").size(btn_size).center())
                 .padding(btn_pad)
                 .style(toolbar_btn);
-            if !win.nodes.is_empty() {
+            if !win.flow_definition.process_refs.is_empty() {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
@@ -1954,8 +1963,8 @@ impl FlowEdit {
             }
             Ok(Process::FlowProcess(_)) => match flow_io::load_flow(&path) {
                 Ok(loaded) => {
-                    let has_nodes = !loaded.nodes.is_empty();
-                    let nc = loaded.nodes.len();
+                    let has_nodes = !loaded.flow_def.process_refs.is_empty();
+                    let nc = loaded.flow_def.process_refs.len();
                     let ec = loaded.flow_def.connections.len();
                     let (new_id, open_task) =
                         window::open(self.child_window_settings(1024.0, 768.0));
@@ -1965,7 +1974,7 @@ impl FlowEdit {
                     }
                     let child = WindowState {
                         kind: WindowKind::FlowEditor,
-                        nodes: loaded.nodes,
+
                         canvas_state: FlowCanvasState::default(),
                         status: format!("Library flow - {nc} nodes, {ec} connections"),
                         selected_node: None,
@@ -2044,10 +2053,10 @@ impl FlowEdit {
             let Some(win) = self.windows.get(&parent_win_id) else {
                 return Task::none();
             };
-            let Some(node) = win.nodes.get(idx) else {
+            let Some(pref) = win.flow_definition.process_refs.get(idx) else {
                 return Task::none();
             };
-            let source = node.source.clone();
+            let source = pref.source.clone();
             let path = library_mgmt::resolve_node_source(win, &source);
             (source, path)
         };
@@ -2086,9 +2095,9 @@ impl FlowEdit {
         // Load the sub-flow and open it in a new window
         match flow_io::load_flow(&path) {
             Ok(loaded) => {
-                let has_nodes = !loaded.nodes.is_empty();
+                let has_nodes = !loaded.flow_def.process_refs.is_empty();
                 let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
-                let nc = loaded.nodes.len();
+                let nc = loaded.flow_def.process_refs.len();
                 let ec = loaded.flow_def.connections.len();
                 let mut flow_def = loaded.flow_def;
                 if let Ok(url) = Url::from_file_path(&path) {
@@ -2096,7 +2105,7 @@ impl FlowEdit {
                 }
                 let child = WindowState {
                     kind: WindowKind::FlowEditor,
-                    nodes: loaded.nodes,
+
                     canvas_state: FlowCanvasState::default(),
                     status: format!("Ready - {nc} nodes, {ec} connections"),
                     selected_node: None,
@@ -2175,7 +2184,7 @@ impl FlowEdit {
         }
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
-            nodes: Vec::new(),
+
             canvas_state: FlowCanvasState::default(),
             status: format!("Function: {func_name}"),
             selected_node: None,
@@ -2273,22 +2282,10 @@ impl FlowEdit {
 
         // Add a process reference in the target flow
         if let Some(win) = self.windows.get_mut(&target_id) {
-            let alias = flow_io::generate_unique_alias(&flow_name, &win.nodes);
-            let (x, y) = flow_io::next_node_position(&win.nodes);
+            let alias =
+                flow_io::generate_unique_alias(&flow_name, &win.flow_definition.process_refs);
+            let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
 
-            let node = NodeLayout {
-                alias: alias.clone(),
-                source: source.clone(),
-                description: String::new(),
-                x,
-                y,
-                width: 180.0,
-                height: 120.0,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-                initializers: HashMap::new(),
-            };
-            win.nodes.push(node);
             win.flow_definition.process_refs.push(ProcessReference {
                 alias: alias.clone(),
                 source,
@@ -2308,7 +2305,7 @@ impl FlowEdit {
 
         let child = WindowState {
             kind: WindowKind::FlowEditor,
-            nodes: Vec::new(),
+
             canvas_state: FlowCanvasState::default(),
             status: format!("New sub-flow: {flow_name}"),
             selected_node: None,
@@ -2384,22 +2381,10 @@ impl FlowEdit {
 
         // Add process reference in the target flow
         if let Some(win) = self.windows.get_mut(&target_id) {
-            let alias = flow_io::generate_unique_alias(&func_name, &win.nodes);
-            let (x, y) = flow_io::next_node_position(&win.nodes);
+            let alias =
+                flow_io::generate_unique_alias(&func_name, &win.flow_definition.process_refs);
+            let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
 
-            let node = NodeLayout {
-                alias: alias.clone(),
-                source: source.clone(),
-                description: String::new(),
-                x,
-                y,
-                width: 180.0,
-                height: 120.0,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-                initializers: HashMap::new(),
-            };
-            win.nodes.push(node);
             win.flow_definition.process_refs.push(ProcessReference {
                 alias: alias.clone(),
                 source,
@@ -2441,7 +2426,7 @@ impl FlowEdit {
         }
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
-            nodes: Vec::new(),
+
             canvas_state: FlowCanvasState::default(),
             status: String::from("New function — add ports and Save"),
             selected_node: None,
@@ -2491,10 +2476,62 @@ impl FlowEdit {
 
         if let Some((parent_id, node_source, new_inputs, new_outputs)) = propagation_data {
             if let Some(parent_win) = windows.get_mut(&parent_id) {
-                for node in &mut parent_win.nodes {
-                    if node.source == node_source {
-                        node.inputs.clone_from(&new_inputs);
-                        node.outputs.clone_from(&new_outputs);
+                // Update subprocess definitions for all process refs with matching source
+                for pref in &parent_win.flow_definition.process_refs {
+                    if pref.source == node_source {
+                        let alias = if pref.alias.is_empty() {
+                            canvas_view::derive_short_name(&pref.source)
+                        } else {
+                            pref.alias.clone()
+                        };
+                        if let Some(proc) = parent_win.flow_definition.subprocesses.get_mut(&alias)
+                        {
+                            // Update the IO definitions in the subprocess
+                            let new_io_inputs: Vec<flowcore::model::io::IO> = new_inputs
+                                .iter()
+                                .map(|p| {
+                                    flowcore::model::io::IO::new_named(
+                                        p.datatypes
+                                            .iter()
+                                            .map(|dt| {
+                                                flowcore::model::datatype::DataType::from(
+                                                    dt.as_str(),
+                                                )
+                                            })
+                                            .collect(),
+                                        flowcore::model::route::Route::default(),
+                                        &p.name,
+                                    )
+                                })
+                                .collect();
+                            let new_io_outputs: Vec<flowcore::model::io::IO> = new_outputs
+                                .iter()
+                                .map(|p| {
+                                    flowcore::model::io::IO::new_named(
+                                        p.datatypes
+                                            .iter()
+                                            .map(|dt| {
+                                                flowcore::model::datatype::DataType::from(
+                                                    dt.as_str(),
+                                                )
+                                            })
+                                            .collect(),
+                                        flowcore::model::route::Route::default(),
+                                        &p.name,
+                                    )
+                                })
+                                .collect();
+                            match proc {
+                                Process::FunctionProcess(ref mut f) => {
+                                    f.inputs = new_io_inputs;
+                                    f.outputs = new_io_outputs;
+                                }
+                                Process::FlowProcess(ref mut f) => {
+                                    f.inputs = new_io_inputs;
+                                    f.outputs = new_io_outputs;
+                                }
+                            }
+                        }
                     }
                 }
                 parent_win.canvas_state.request_redraw();

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -30,7 +30,7 @@ use flowcore::deserializers::deserializer::get;
 use flowcore::meta_provider::MetaProvider;
 use flowcore::model::datatype::DataType;
 use flowcore::model::flow_definition::FlowDefinition;
-use flowcore::model::io::IO;
+use flowcore::model::io::{IOType, IO};
 use flowcore::model::lib_manifest::LibraryManifest;
 use flowcore::model::name::HasName;
 use flowcore::model::process::Process;
@@ -53,6 +53,17 @@ mod library_panel;
 mod window_state;
 
 pub(crate) use window_state::{FunctionViewer, InitializerEditor, WindowKind, WindowState};
+
+fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
+    let mut n = existing.len();
+    loop {
+        let candidate = format!("{prefix}{n}");
+        if !existing.iter().any(|io| io.name() == &candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
 
 #[cfg(test)]
 mod ui_test;
@@ -744,22 +755,26 @@ impl FlowEdit {
                             win.show_metadata = !win.show_metadata;
                         }
                         FlowEditMessage::AddInput => {
-                            let name = format!("input{}", win.flow_definition.inputs.len());
-                            win.flow_definition.inputs.push(IO::new_named(
+                            let name = next_unique_io_name("input", &win.flow_definition.inputs);
+                            let mut io = IO::new_named(
                                 vec![DataType::from("string")],
                                 Route::default(),
                                 name,
-                            ));
+                            );
+                            io.set_io_type(IOType::FlowInput);
+                            win.flow_definition.inputs.push(io);
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::AddOutput => {
-                            let name = format!("output{}", win.flow_definition.outputs.len());
-                            win.flow_definition.outputs.push(IO::new_named(
+                            let name = next_unique_io_name("output", &win.flow_definition.outputs);
+                            let mut io = IO::new_named(
                                 vec![DataType::from("string")],
                                 Route::default(),
                                 name,
-                            ));
+                            );
+                            io.set_io_type(IOType::FlowOutput);
+                            win.flow_definition.outputs.push(io);
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
                         }
@@ -786,18 +801,25 @@ impl FlowEdit {
                             }
                         }
                         FlowEditMessage::InputNameChanged(idx, name) => {
-                            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
-                                let old_name = io.name().clone();
-                                io.set_name(name.clone());
-                                // Update edges referencing the old flow input name
-                                for edge in &mut win.edges {
-                                    if edge.from_node == "input" && edge.from_port == old_name {
-                                        edge.from_port.clone_from(&name);
+                            let duplicate = win
+                                .flow_definition
+                                .inputs
+                                .iter()
+                                .enumerate()
+                                .any(|(i, io)| i != idx && io.name() == &name);
+                            if !duplicate {
+                                if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+                                    let old_name = io.name().clone();
+                                    io.set_name(name.clone());
+                                    for edge in &mut win.edges {
+                                        if edge.from_node == "input" && edge.from_port == old_name {
+                                            edge.from_port.clone_from(&name);
+                                        }
                                     }
                                 }
+                                win.unsaved_edits += 1;
+                                win.canvas_state.request_redraw();
                             }
-                            win.unsaved_edits += 1;
-                            win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::InputTypeChanged(idx, dtype) => {
                             if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
@@ -807,18 +829,25 @@ impl FlowEdit {
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::OutputNameChanged(idx, name) => {
-                            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
-                                let old_name = io.name().clone();
-                                io.set_name(name.clone());
-                                // Update edges referencing the old flow output name
-                                for edge in &mut win.edges {
-                                    if edge.to_node == "output" && edge.to_port == old_name {
-                                        edge.to_port.clone_from(&name);
+                            let duplicate = win
+                                .flow_definition
+                                .outputs
+                                .iter()
+                                .enumerate()
+                                .any(|(i, io)| i != idx && io.name() == &name);
+                            if !duplicate {
+                                if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+                                    let old_name = io.name().clone();
+                                    io.set_name(name.clone());
+                                    for edge in &mut win.edges {
+                                        if edge.to_node == "output" && edge.to_port == old_name {
+                                            edge.to_port.clone_from(&name);
+                                        }
                                     }
                                 }
+                                win.unsaved_edits += 1;
+                                win.canvas_state.request_redraw();
                             }
-                            win.unsaved_edits += 1;
-                            win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::OutputTypeChanged(idx, dtype) => {
                             if let Some(io) = win.flow_definition.outputs.get_mut(idx) {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -285,19 +285,22 @@ impl FlowEdit {
             }
         }
 
-        let (nodes, edges, status, file_path, flow_definition, lib_refs) =
+        let (nodes, edges, status, flow_definition, lib_refs) =
             if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
                 let flow_path = PathBuf::from(flow_path_str);
                 match flow_io::load_flow(&flow_path) {
                     Ok(loaded) => {
                         let nc = loaded.nodes.len();
                         let ec = loaded.edges.len();
+                        let mut fd = loaded.flow_def;
+                        if let Ok(url) = Url::from_file_path(&flow_path) {
+                            fd.source_url = url;
+                        }
                         (
                             loaded.nodes,
                             loaded.edges,
                             format!("Ready - {nc} nodes, {ec} connections"),
-                            Some(flow_path),
-                            loaded.flow_def,
+                            fd,
                             loaded.lib_references,
                         )
                     }
@@ -310,7 +313,6 @@ impl FlowEdit {
                             Vec::new(),
                             Vec::new(),
                             format!("Error loading flow: {e}"),
-                            None,
                             fd,
                             BTreeSet::new(),
                         )
@@ -325,7 +327,6 @@ impl FlowEdit {
                     Vec::new(),
                     Vec::new(),
                     String::from("Ready"),
-                    None,
                     fd,
                     BTreeSet::new(),
                 )
@@ -338,6 +339,7 @@ impl FlowEdit {
         let library_tree = LibraryTree::from_cache(&library_cache, &all_definitions);
 
         // Open the root window via daemon API
+        let file_path = flow_definition.source_url.to_file_path().ok();
         let saved_prefs = file_path
             .as_ref()
             .and_then(|p| flow_io::load_editor_prefs(p));
@@ -358,8 +360,8 @@ impl FlowEdit {
             ..Default::default()
         });
 
-        let root_flow_path = file_path.clone();
-        let flow_hierarchy = file_path
+        let root_flow_path = file_path;
+        let flow_hierarchy = root_flow_path
             .as_ref()
             .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
@@ -377,7 +379,6 @@ impl FlowEdit {
             history: EditHistory::default(),
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path,
             flow_definition,
             tooltip: None,
             initializer_editor: None,
@@ -415,11 +416,11 @@ impl FlowEdit {
         if let Some(win) = self.windows.get(&window_id) {
             let modified = if win.unsaved_edits > 0 { " *" } else { "" };
             let file = win
-                .file_path
+                .file_path()
                 .as_ref()
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
-                .unwrap_or("untitled");
+                .and_then(|p| p.file_name().map(ToOwned::to_owned))
+                .and_then(|n| n.to_str().map(String::from))
+                .unwrap_or_else(|| String::from("untitled"));
             format!(
                 "flowedit - {} ({}){modified}",
                 win.flow_definition.name, file
@@ -451,7 +452,7 @@ impl FlowEdit {
                 if let Some((_source, path)) = open_result {
                     // Check if already open
                     for (&win_id, win) in &self.windows {
-                        if win.file_path.as_ref() == Some(&path) {
+                        if win.file_path().as_ref() == Some(&path) {
                             return window::gain_focus(win_id);
                         }
                     }
@@ -466,6 +467,10 @@ impl FlowEdit {
                         let has_nodes = !loaded.nodes.is_empty();
                         let nc = loaded.nodes.len();
                         let ec = loaded.edges.len();
+                        let mut flow_def = loaded.flow_def;
+                        if let Ok(url) = Url::from_file_path(&path) {
+                            flow_def.source_url = url;
+                        }
                         let child = WindowState {
                             kind: WindowKind::FlowEditor,
                             nodes: loaded.nodes,
@@ -479,8 +484,7 @@ impl FlowEdit {
                             auto_fit_enabled: true,
                             unsaved_edits: 0,
                             compiled_manifest: None,
-                            file_path: Some(path),
-                            flow_definition: loaded.flow_def,
+                            flow_definition: flow_def,
                             tooltip: None,
                             initializer_editor: None,
                             is_root: false,
@@ -681,9 +685,9 @@ impl FlowEdit {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
                         if let Some((lib_refs, _ctx_refs)) = flow_io::perform_open(win) {
-                            self.root_flow_path = win.file_path.clone();
+                            self.root_flow_path = win.file_path();
                             win.flow_hierarchy = win
-                                .file_path
+                                .file_path()
                                 .as_ref()
                                 .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
@@ -1879,7 +1883,7 @@ impl FlowEdit {
 
         // Check if already open
         for (&win_id, win) in &self.windows {
-            if win.file_path.as_ref() == Some(&path) {
+            if win.file_path().as_ref() == Some(&path) {
                 return window::gain_focus(win_id);
             }
         }
@@ -1911,6 +1915,10 @@ impl FlowEdit {
                     let ec = loaded.edges.len();
                     let (new_id, open_task) =
                         window::open(self.child_window_settings(1024.0, 768.0));
+                    let mut flow_def = loaded.flow_def;
+                    if let Ok(url) = Url::from_file_path(&path) {
+                        flow_def.source_url = url;
+                    }
                     let child = WindowState {
                         kind: WindowKind::FlowEditor,
                         nodes: loaded.nodes,
@@ -1924,8 +1932,7 @@ impl FlowEdit {
                         auto_fit_enabled: true,
                         unsaved_edits: 0,
                         compiled_manifest: None,
-                        file_path: Some(path),
-                        flow_definition: loaded.flow_def,
+                        flow_definition: flow_def,
                         tooltip: None,
                         initializer_editor: None,
                         is_root: false,
@@ -2007,7 +2014,7 @@ impl FlowEdit {
 
         // If a window already has this file open, focus it instead of opening a duplicate
         for (&win_id, win) in &self.windows {
-            if win.file_path.as_ref() == Some(&path) && win_id != parent_win_id {
+            if win.file_path().as_ref() == Some(&path) && win_id != parent_win_id {
                 return window::gain_focus(win_id);
             }
         }
@@ -2038,6 +2045,10 @@ impl FlowEdit {
                 let ec = loaded.edges.len();
                 let (fi, fo) =
                     flow_io::extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
+                let mut flow_def = loaded.flow_def;
+                if let Ok(url) = Url::from_file_path(&path) {
+                    flow_def.source_url = url;
+                }
                 let child = WindowState {
                     kind: WindowKind::FlowEditor,
                     nodes: loaded.nodes,
@@ -2051,8 +2062,7 @@ impl FlowEdit {
                     auto_fit_enabled: true,
                     unsaved_edits: 0,
                     compiled_manifest: None,
-                    file_path: Some(path.clone()),
-                    flow_definition: loaded.flow_def,
+                    flow_definition: flow_def,
                     tooltip: None,
                     initializer_editor: None,
                     is_root: false,
@@ -2114,10 +2124,13 @@ impl FlowEdit {
             read_only,
         };
 
-        let func_flow_def = FlowDefinition {
+        let mut func_flow_def = FlowDefinition {
             name: func_name.clone(),
             ..FlowDefinition::default()
         };
+        if let Ok(url) = Url::from_file_path(toml_path) {
+            func_flow_def.source_url = url;
+        }
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
             nodes: Vec::new(),
@@ -2131,7 +2144,6 @@ impl FlowEdit {
             auto_fit_enabled: false,
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path: Some(toml_path.to_path_buf()),
             flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -2166,7 +2178,8 @@ impl FlowEdit {
         let base_dir = self
             .windows
             .get(&target_id)
-            .and_then(|w| w.file_path.as_ref())
+            .and_then(WindowState::file_path)
+            .as_ref()
             .and_then(|p| p.parent())
             .map(Path::to_path_buf);
 
@@ -2194,10 +2207,13 @@ impl FlowEdit {
             .to_string();
 
         // Create the sub-flow definition with empty content
-        let flow_def = FlowDefinition {
+        let mut flow_def = FlowDefinition {
             name: flow_name.clone(),
             ..FlowDefinition::default()
         };
+        if let Ok(url) = Url::from_file_path(&path) {
+            flow_def.source_url = url;
+        }
 
         // Write the initial TOML file
         let toml = format!("flow = \"{flow_name}\"\n");
@@ -2264,7 +2280,6 @@ impl FlowEdit {
             auto_fit_enabled: true,
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path: Some(path),
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -2295,7 +2310,8 @@ impl FlowEdit {
         let base_dir = self
             .windows
             .get(&target_id)
-            .and_then(|w| w.file_path.as_ref())
+            .and_then(WindowState::file_path)
+            .as_ref()
             .and_then(|p| p.parent())
             .map(Path::to_path_buf);
 
@@ -2380,10 +2396,13 @@ impl FlowEdit {
             read_only: false,
         };
 
-        let func_flow_def = FlowDefinition {
+        let mut func_flow_def = FlowDefinition {
             name: func_name,
             ..FlowDefinition::default()
         };
+        if let Ok(url) = Url::from_file_path(&path) {
+            func_flow_def.source_url = url;
+        }
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
             nodes: Vec::new(),
@@ -2397,7 +2416,6 @@ impl FlowEdit {
             auto_fit_enabled: false,
             unsaved_edits: 1,
             compiled_manifest: None,
-            file_path: Some(path),
             flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -30,6 +30,7 @@ use flowcore::deserializers::deserializer::get;
 use flowcore::meta_provider::MetaProvider;
 use flowcore::model::datatype::DataType;
 use flowcore::model::flow_definition::FlowDefinition;
+use flowcore::model::function_definition::FunctionDefinition;
 use flowcore::model::io::{IOType, IO};
 use flowcore::model::lib_manifest::LibraryManifest;
 use flowcore::model::name::HasName;
@@ -38,7 +39,7 @@ use flowcore::model::process_reference::ProcessReference;
 use flowcore::model::route::Route;
 use flowcore::provider::Provider;
 
-use canvas_view::{CanvasMessage, FlowCanvasState, PortInfo};
+use canvas_view::{CanvasMessage, FlowCanvasState};
 use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
 use history::EditHistory;
 use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
@@ -942,7 +943,7 @@ impl FlowEdit {
                     FunctionEditMessage::NameChanged(new_name) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.name = new_name;
+                                viewer.func_def.name = new_name;
                             }
                             win.unsaved_edits += 1;
                         }
@@ -960,7 +961,7 @@ impl FlowEdit {
                         });
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.description.clone_from(&new_desc);
+                                viewer.func_def.description.clone_from(&new_desc);
                             }
                             win.unsaved_edits += 1;
                         }
@@ -998,12 +999,17 @@ impl FlowEdit {
                         if let Some(selected) = dialog.pick_file() {
                             if let Some(win) = self.windows.get_mut(&win_id) {
                                 if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                    let base = viewer.toml_path.parent().unwrap_or(Path::new("."));
-                                    let rel = selected.strip_prefix(base).map_or_else(
+                                    let base = viewer
+                                        .toml_path()
+                                        .as_deref()
+                                        .and_then(Path::parent)
+                                        .unwrap_or(Path::new("."))
+                                        .to_path_buf();
+                                    let rel = selected.strip_prefix(&base).map_or_else(
                                         |_| selected.to_string_lossy().to_string(),
                                         |p| p.to_string_lossy().to_string(),
                                     );
-                                    viewer.source_file = rel;
+                                    viewer.func_def.source = rel;
                                     viewer.rs_content = std::fs::read_to_string(&selected)
                                         .unwrap_or_else(|_| String::from("// Could not read file"));
                                 }
@@ -1014,10 +1020,12 @@ impl FlowEdit {
                     FunctionEditMessage::AddInput => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                v.inputs.push(PortInfo {
-                                    name: format!("input{}", v.inputs.len()),
-                                    datatypes: vec![String::from("string")],
-                                });
+                                let name = next_unique_io_name("input", &v.func_def.inputs);
+                                v.func_def.inputs.push(IO::new_named(
+                                    vec![DataType::from("string")],
+                                    Route::default(),
+                                    &name,
+                                ));
                             }
                             win.unsaved_edits += 1;
                         }
@@ -1026,10 +1034,12 @@ impl FlowEdit {
                     FunctionEditMessage::AddOutput => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                v.outputs.push(PortInfo {
-                                    name: format!("output{}", v.outputs.len()),
-                                    datatypes: vec![String::from("string")],
-                                });
+                                let name = next_unique_io_name("output", &v.func_def.outputs);
+                                v.func_def.outputs.push(IO::new_named(
+                                    vec![DataType::from("string")],
+                                    Route::default(),
+                                    &name,
+                                ));
                             }
                             win.unsaved_edits += 1;
                         }
@@ -1038,8 +1048,8 @@ impl FlowEdit {
                     FunctionEditMessage::DeleteInput(idx) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if idx < v.inputs.len() {
-                                    v.inputs.remove(idx);
+                                if idx < v.func_def.inputs.len() {
+                                    v.func_def.inputs.remove(idx);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1049,8 +1059,8 @@ impl FlowEdit {
                     FunctionEditMessage::DeleteOutput(idx) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if idx < v.outputs.len() {
-                                    v.outputs.remove(idx);
+                                if idx < v.func_def.outputs.len() {
+                                    v.func_def.outputs.remove(idx);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1060,8 +1070,8 @@ impl FlowEdit {
                     FunctionEditMessage::InputNameChanged(idx, name) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(port) = v.inputs.get_mut(idx) {
-                                    port.name = name;
+                                if let Some(io) = v.func_def.inputs.get_mut(idx) {
+                                    io.set_name(name);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1071,8 +1081,8 @@ impl FlowEdit {
                     FunctionEditMessage::InputTypeChanged(idx, dtype) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(port) = v.inputs.get_mut(idx) {
-                                    port.datatypes = vec![dtype];
+                                if let Some(io) = v.func_def.inputs.get_mut(idx) {
+                                    io.set_datatypes(&[DataType::from(dtype)]);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1082,8 +1092,8 @@ impl FlowEdit {
                     FunctionEditMessage::OutputNameChanged(idx, name) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(port) = v.outputs.get_mut(idx) {
-                                    port.name = name;
+                                if let Some(io) = v.func_def.outputs.get_mut(idx) {
+                                    io.set_name(name);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1093,8 +1103,8 @@ impl FlowEdit {
                     FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(port) = v.outputs.get_mut(idx) {
-                                    port.datatypes = vec![dtype];
+                                if let Some(io) = v.func_def.outputs.get_mut(idx) {
+                                    io.set_datatypes(&[DataType::from(dtype)]);
                                 }
                             }
                             win.unsaved_edits += 1;
@@ -1106,7 +1116,11 @@ impl FlowEdit {
                             if let WindowKind::FunctionViewer(ref v) = win.kind {
                                 match flow_io::save_function_definition(v) {
                                     Ok(()) => {
-                                        win.status = format!("Saved: {}", v.toml_path.display());
+                                        let path_display = v.toml_path().map_or_else(
+                                            || String::from("(unknown)"),
+                                            |p| p.display().to_string(),
+                                        );
+                                        win.status = format!("Saved: {path_display}");
                                         win.unsaved_edits = 0;
                                     }
                                     Err(e) => {
@@ -1606,10 +1620,15 @@ impl FlowEdit {
                 // Input ports inside box: semicircle, name, type, (delete if editable)
                 let editable = !viewer.read_only;
                 let mut input_col = Column::new().spacing(6);
-                for (i, port) in viewer.inputs.iter().enumerate() {
-                    let dtype = port.datatypes.first().cloned().unwrap_or_default();
+                for (i, io) in viewer.func_def.inputs.iter().enumerate() {
+                    let port_name = io.name().to_string();
+                    let dtype = io
+                        .datatypes()
+                        .first()
+                        .map(ToString::to_string)
+                        .unwrap_or_default();
                     let mut name_widget =
-                        text_input("name", &port.name).size(13).padding(3).width(90);
+                        text_input("name", &port_name).size(13).padding(3).width(90);
                     let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
                     if editable {
                         name_widget = name_widget.on_input(move |s| {
@@ -1658,11 +1677,16 @@ impl FlowEdit {
 
                 // Output ports inside box: (delete if editable), type, name, semicircle
                 let mut output_col = Column::new().spacing(6).align_x(iced::Alignment::End);
-                for (i, port) in viewer.outputs.iter().enumerate() {
-                    let dtype = port.datatypes.first().cloned().unwrap_or_default();
+                for (i, io) in viewer.func_def.outputs.iter().enumerate() {
+                    let port_name = io.name().to_string();
+                    let dtype = io
+                        .datatypes()
+                        .first()
+                        .map(ToString::to_string)
+                        .unwrap_or_default();
                     let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
                     let mut name_widget =
-                        text_input("name", &port.name).size(13).padding(3).width(90);
+                        text_input("name", &port_name).size(13).padding(3).width(90);
                     if editable {
                         type_widget = type_widget.on_input(move |s| {
                             Message::FunctionEdit(
@@ -1707,7 +1731,7 @@ impl FlowEdit {
                     );
                 }
 
-                let mut name_widget = text_input("Function name", &viewer.name)
+                let mut name_widget = text_input("Function name", &viewer.func_def.name)
                     .size(16)
                     .padding(6)
                     .width(250);
@@ -1718,12 +1742,12 @@ impl FlowEdit {
                 }
                 let name_input = container(name_widget).center_x(Fill);
 
-                let mut desc_widget = text_input("Description", &viewer.description)
+                let mut desc_widget = text_input("Description", &viewer.func_def.description)
                     .size(13)
                     .padding(6)
                     .width(480);
                 if editable {
-                    let ext = std::path::Path::new(&viewer.source_file)
+                    let ext = std::path::Path::new(&viewer.func_def.source)
                         .extension()
                         .unwrap_or_default();
                     let is_provided =
@@ -1741,7 +1765,7 @@ impl FlowEdit {
 
                 let mut source_row = Row::new().spacing(6).align_y(iced::Alignment::Center).push(
                     button(
-                        Text::new(&viewer.source_file)
+                        Text::new(&viewer.func_def.source)
                             .size(13)
                             .color(Color::from_rgb(0.6, 0.8, 1.0)),
                     )
@@ -2144,7 +2168,7 @@ impl FlowEdit {
         &mut self,
         parent_win_id: window::Id,
         toml_path: &Path,
-        func: &flowcore::model::function_definition::FunctionDefinition,
+        func: &FunctionDefinition,
         node_source: &str,
     ) -> Task<Message> {
         let dir = toml_path.parent().unwrap_or(Path::new("."));
@@ -2155,21 +2179,18 @@ impl FlowEdit {
             .unwrap_or_else(|_| String::from("// Source file not found"));
         let docs_content = std::fs::read_to_string(dir.join(format!("{func_name}.md"))).ok();
 
-        let (inputs, outputs) = flow_io::extract_ports(&func.inputs, &func.outputs);
-
         let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
 
         let read_only = node_source.starts_with("lib://") || node_source.starts_with("context://");
+        let mut func_def = func.clone();
+        if let Ok(url) = Url::from_file_path(toml_path) {
+            func_def.source_url = url;
+        }
         let viewer = FunctionViewer {
-            name: func_name.clone(),
-            description: func.description.clone(),
-            source_file: func.source.clone(),
-            inputs,
-            outputs,
+            func_def: func_def.clone(),
             rs_content,
             docs_content,
             active_tab: 0,
-            toml_path: toml_path.to_path_buf(),
             parent_window: Some(parent_win_id),
             node_source: node_source.to_string(),
             read_only,
@@ -2402,16 +2423,17 @@ impl FlowEdit {
         // Open the function viewer window
         let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
 
+        let mut func_def = FunctionDefinition::default();
+        func_def.name.clone_from(&func_name);
+        func_def.source.clone_from(&rs_filename);
+        if let Ok(url) = Url::from_file_path(&path) {
+            func_def.source_url = url;
+        }
         let viewer = FunctionViewer {
-            name: func_name.clone(),
-            description: String::new(),
-            source_file: rs_filename.clone(),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
+            func_def: func_def.clone(),
             rs_content: String::from("// Save to generate skeleton source"),
             docs_content: None,
             active_tab: 0,
-            toml_path: path.clone(),
             parent_window: Some(target_id),
             node_source: rs_filename,
             read_only: false,
@@ -2465,8 +2487,8 @@ impl FlowEdit {
                     (
                         pid,
                         viewer.node_source.clone(),
-                        viewer.inputs.clone(),
-                        viewer.outputs.clone(),
+                        viewer.func_def.inputs.clone(),
+                        viewer.func_def.outputs.clone(),
                     )
                 })
             } else {
@@ -2486,49 +2508,14 @@ impl FlowEdit {
                         };
                         if let Some(proc) = parent_win.flow_definition.subprocesses.get_mut(&alias)
                         {
-                            // Update the IO definitions in the subprocess
-                            let new_io_inputs: Vec<flowcore::model::io::IO> = new_inputs
-                                .iter()
-                                .map(|p| {
-                                    flowcore::model::io::IO::new_named(
-                                        p.datatypes
-                                            .iter()
-                                            .map(|dt| {
-                                                flowcore::model::datatype::DataType::from(
-                                                    dt.as_str(),
-                                                )
-                                            })
-                                            .collect(),
-                                        flowcore::model::route::Route::default(),
-                                        &p.name,
-                                    )
-                                })
-                                .collect();
-                            let new_io_outputs: Vec<flowcore::model::io::IO> = new_outputs
-                                .iter()
-                                .map(|p| {
-                                    flowcore::model::io::IO::new_named(
-                                        p.datatypes
-                                            .iter()
-                                            .map(|dt| {
-                                                flowcore::model::datatype::DataType::from(
-                                                    dt.as_str(),
-                                                )
-                                            })
-                                            .collect(),
-                                        flowcore::model::route::Route::default(),
-                                        &p.name,
-                                    )
-                                })
-                                .collect();
                             match proc {
                                 Process::FunctionProcess(ref mut f) => {
-                                    f.inputs = new_io_inputs;
-                                    f.outputs = new_io_outputs;
+                                    f.inputs.clone_from(&new_inputs);
+                                    f.outputs.clone_from(&new_outputs);
                                 }
                                 Process::FlowProcess(ref mut f) => {
-                                    f.inputs = new_io_inputs;
-                                    f.outputs = new_io_outputs;
+                                    f.inputs.clone_from(&new_inputs);
+                                    f.outputs.clone_from(&new_outputs);
                                 }
                             }
                         }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -34,7 +34,7 @@ use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 use flowcore::provider::Provider;
 
-use canvas_view::{CanvasMessage, EdgeLayout, FlowCanvasState, NodeLayout, PortInfo};
+use canvas_view::{CanvasMessage, FlowCanvasState, NodeLayout, PortInfo};
 use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
 use history::EditHistory;
 use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
@@ -285,7 +285,7 @@ impl FlowEdit {
             }
         }
 
-        let (flow_name, nodes, edges, status, file_path, flow_definition, lib_refs) =
+        let (nodes, edges, status, file_path, flow_definition, lib_refs) =
             if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
                 let flow_path = PathBuf::from(flow_path_str);
                 match flow_io::load_flow(&flow_path) {
@@ -293,7 +293,6 @@ impl FlowEdit {
                         let nc = loaded.nodes.len();
                         let ec = loaded.edges.len();
                         (
-                            loaded.name,
                             loaded.nodes,
                             loaded.edges,
                             format!("Ready - {nc} nodes, {ec} connections"),
@@ -302,24 +301,32 @@ impl FlowEdit {
                             loaded.lib_references,
                         )
                     }
-                    Err(e) => (
-                        String::from("(error)"),
-                        Vec::new(),
-                        Vec::new(),
-                        format!("Error loading flow: {e}"),
-                        None,
-                        FlowDefinition::default(),
-                        BTreeSet::new(),
-                    ),
+                    Err(e) => {
+                        let fd = FlowDefinition {
+                            name: String::from("(error)"),
+                            ..FlowDefinition::default()
+                        };
+                        (
+                            Vec::new(),
+                            Vec::new(),
+                            format!("Error loading flow: {e}"),
+                            None,
+                            fd,
+                            BTreeSet::new(),
+                        )
+                    }
                 }
             } else {
+                let fd = FlowDefinition {
+                    name: String::from("(new flow)"),
+                    ..FlowDefinition::default()
+                };
                 (
-                    String::from("(new flow)"),
                     Vec::new(),
                     Vec::new(),
                     String::from("Ready"),
                     None,
-                    FlowDefinition::default(),
+                    fd,
                     BTreeSet::new(),
                 )
             };
@@ -334,10 +341,10 @@ impl FlowEdit {
         let saved_prefs = file_path
             .as_ref()
             .and_then(|p| flow_io::load_editor_prefs(p));
-        let saved_size = saved_prefs
-            .as_ref()
-            .map(|p| iced::Size::new(p.width, p.height))
-            .unwrap_or_else(|| iced::Size::new(1024.0, 768.0));
+        let saved_size = saved_prefs.as_ref().map_or_else(
+            || iced::Size::new(1024.0, 768.0),
+            |p| iced::Size::new(p.width, p.height),
+        );
         let saved_position = saved_prefs
             .as_ref()
             .and_then(|p| match (p.x, p.y) {
@@ -354,13 +361,11 @@ impl FlowEdit {
         let root_flow_path = file_path.clone();
         let flow_hierarchy = file_path
             .as_ref()
-            .map(|p| FlowHierarchy::build(p))
-            .unwrap_or_else(FlowHierarchy::empty);
+            .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
         let (fi, fo) = flow_io::extract_ports(&flow_definition.inputs, &flow_definition.outputs);
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
-            flow_name,
             nodes,
             edges,
             canvas_state: FlowCanvasState::default(),
@@ -415,7 +420,10 @@ impl FlowEdit {
                 .and_then(|p| p.file_name())
                 .and_then(|n| n.to_str())
                 .unwrap_or("untitled");
-            format!("flowedit - {} ({}){modified}", win.flow_name, file)
+            format!(
+                "flowedit - {} ({}){modified}",
+                win.flow_definition.name, file
+            )
         } else {
             String::from("flowedit")
         }
@@ -448,64 +456,59 @@ impl FlowEdit {
                         }
                     }
                     // Open the flow or function
-                    match flow_io::load_flow(&path) {
-                        Ok(loaded) => {
-                            let (fi, fo) = flow_io::extract_ports(
-                                &loaded.flow_def.inputs,
-                                &loaded.flow_def.outputs,
-                            );
-                            let (new_id, open_task) =
-                                window::open(self.child_window_settings(1024.0, 768.0));
-                            let has_nodes = !loaded.nodes.is_empty();
-                            let nc = loaded.nodes.len();
-                            let ec = loaded.edges.len();
-                            let child = WindowState {
-                                kind: WindowKind::FlowEditor,
-                                flow_name: loaded.name,
-                                nodes: loaded.nodes,
-                                edges: loaded.edges,
-                                canvas_state: FlowCanvasState::default(),
-                                status: format!("Ready - {nc} nodes, {ec} connections"),
-                                selected_node: None,
-                                selected_connection: None,
-                                history: EditHistory::default(),
-                                auto_fit_pending: has_nodes,
-                                auto_fit_enabled: true,
-                                unsaved_edits: 0,
-                                compiled_manifest: None,
-                                file_path: Some(path),
-                                flow_definition: loaded.flow_def,
-                                tooltip: None,
-                                initializer_editor: None,
-                                is_root: false,
-                                flow_inputs: fi,
-                                flow_outputs: fo,
-                                context_menu: None,
-                                show_metadata: false,
-                                flow_hierarchy: self.build_hierarchy(),
-                                last_size: None,
-                                last_position: None,
-                            };
-                            self.windows.insert(new_id, child);
-                            return open_task.discard();
-                        }
-                        Err(_) => {
-                            // Try as function definition
-                            let abs = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                            if let Ok(contents) = std::fs::read_to_string(&abs) {
-                                if let Ok(url) = Url::from_file_path(&abs) {
-                                    if let Ok(deser) = get::<Process>(&url) {
-                                        if let Ok(Process::FunctionProcess(ref func)) =
-                                            deser.deserialize(&contents, Some(&url))
-                                        {
-                                            return self.open_function_viewer(
-                                                hier_win_id,
-                                                &path,
-                                                func,
-                                                &path.to_string_lossy(),
-                                            );
-                                        }
-                                    }
+                    if let Ok(loaded) = flow_io::load_flow(&path) {
+                        let (fi, fo) = flow_io::extract_ports(
+                            &loaded.flow_def.inputs,
+                            &loaded.flow_def.outputs,
+                        );
+                        let (new_id, open_task) =
+                            window::open(self.child_window_settings(1024.0, 768.0));
+                        let has_nodes = !loaded.nodes.is_empty();
+                        let nc = loaded.nodes.len();
+                        let ec = loaded.edges.len();
+                        let child = WindowState {
+                            kind: WindowKind::FlowEditor,
+                            nodes: loaded.nodes,
+                            edges: loaded.edges,
+                            canvas_state: FlowCanvasState::default(),
+                            status: format!("Ready - {nc} nodes, {ec} connections"),
+                            selected_node: None,
+                            selected_connection: None,
+                            history: EditHistory::default(),
+                            auto_fit_pending: has_nodes,
+                            auto_fit_enabled: true,
+                            unsaved_edits: 0,
+                            compiled_manifest: None,
+                            file_path: Some(path),
+                            flow_definition: loaded.flow_def,
+                            tooltip: None,
+                            initializer_editor: None,
+                            is_root: false,
+                            flow_inputs: fi,
+                            flow_outputs: fo,
+                            context_menu: None,
+                            show_metadata: false,
+                            flow_hierarchy: self.build_hierarchy(),
+                            last_size: None,
+                            last_position: None,
+                        };
+                        self.windows.insert(new_id, child);
+                        return open_task.discard();
+                    }
+                    // Try as function definition
+                    let abs = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                    if let Ok(contents) = std::fs::read_to_string(&abs) {
+                        if let Ok(url) = Url::from_file_path(&abs) {
+                            if let Ok(deser) = get::<Process>(&url) {
+                                if let Ok(Process::FunctionProcess(ref func)) =
+                                    deser.deserialize(&contents, Some(&url))
+                                {
+                                    return self.open_function_viewer(
+                                        hier_win_id,
+                                        &path,
+                                        func,
+                                        &path.to_string_lossy(),
+                                    );
                                 }
                             }
                         }
@@ -531,7 +534,7 @@ impl FlowEdit {
                             .to_string();
 
                         // Construct lib:// URL from directory name
-                        if let Ok(lib_url) = Url::parse(&format!("lib://{}", lib_name)) {
+                        if let Ok(lib_url) = Url::parse(&format!("lib://{lib_name}")) {
                             // Add parent directory to provider's search path
                             if let Some(parent) = dir.parent() {
                                 if let Some(parent_str) = parent.to_str() {
@@ -550,14 +553,15 @@ impl FlowEdit {
                                         }
                                     }
 
-                                    let context_root = std::env::var("HOME")
-                                        .map(|h| {
+                                    let context_root = std::env::var("HOME").map_or_else(
+                                        |_| PathBuf::from("/"),
+                                        |h| {
                                             PathBuf::from(h)
                                                 .join(".flow")
                                                 .join("runner")
                                                 .join("flowrcli")
-                                        })
-                                        .unwrap_or_else(|_| PathBuf::from("/"));
+                                        },
+                                    );
                                     let provider = MetaProvider::new(
                                         lib_search_path.clone(),
                                         context_root.clone(),
@@ -589,8 +593,7 @@ impl FlowEdit {
                                                     }
                                                     Err(e) => {
                                                         warn!(
-                                                            "Could not parse library definition '{}': {}",
-                                                            locator_url, e
+                                                            "Could not parse library definition '{locator_url}': {e}"
                                                         );
                                                     }
                                                 }
@@ -614,18 +617,16 @@ impl FlowEdit {
                                             );
 
                                             if let Some(win) = self.windows.get_mut(&win_id) {
-                                                win.status = format!("Added library: {}", lib_name);
+                                                win.status = format!("Added library: {lib_name}");
                                             }
                                         }
                                         Err(e) => {
                                             warn!(
-                                                "Could not load library manifest for '{}': {}",
-                                                lib_url, e
+                                                "Could not load library manifest for '{lib_url}': {e}"
                                             );
                                             if let Some(win) = self.windows.get_mut(&win_id) {
                                                 win.status = format!(
-                                                    "Failed to load library '{}': {}",
-                                                    lib_name, e
+                                                    "Failed to load library '{lib_name}': {e}"
                                                 );
                                             }
                                         }
@@ -684,8 +685,7 @@ impl FlowEdit {
                             win.flow_hierarchy = win
                                 .file_path
                                 .as_ref()
-                                .map(|p| FlowHierarchy::build(p))
-                                .unwrap_or_else(FlowHierarchy::empty);
+                                .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
                             // Rebuild library cache with new flow's references
                             let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
@@ -718,7 +718,7 @@ impl FlowEdit {
                             }
                             Err(e) => {
                                 win.compiled_manifest = None;
-                                win.status = e.to_string();
+                                win.status = e;
                             }
                         }
                     }
@@ -728,7 +728,6 @@ impl FlowEdit {
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     match flow_msg {
                         FlowEditMessage::NameChanged(new_name) => {
-                            win.flow_name = new_name.clone();
                             win.flow_definition.name = new_name;
                             win.unsaved_edits += 1;
                         }
@@ -792,11 +791,11 @@ impl FlowEdit {
                         FlowEditMessage::InputNameChanged(idx, name) => {
                             if let Some(port) = win.flow_inputs.get_mut(idx) {
                                 let old_name = port.name.clone();
-                                port.name = name.clone();
+                                port.name.clone_from(&name);
                                 // Update edges referencing the old flow input name
                                 for edge in &mut win.edges {
                                     if edge.from_node == "input" && edge.from_port == old_name {
-                                        edge.from_port = name.clone();
+                                        edge.from_port.clone_from(&name);
                                     }
                                 }
                             }
@@ -813,11 +812,11 @@ impl FlowEdit {
                         FlowEditMessage::OutputNameChanged(idx, name) => {
                             if let Some(port) = win.flow_outputs.get_mut(idx) {
                                 let old_name = port.name.clone();
-                                port.name = name.clone();
+                                port.name.clone_from(&name);
                                 // Update edges referencing the old flow output name
                                 for edge in &mut win.edges {
                                     if edge.to_node == "output" && edge.to_port == old_name {
-                                        edge.to_port = name.clone();
+                                        edge.to_port.clone_from(&name);
                                     }
                                 }
                             }
@@ -928,7 +927,7 @@ impl FlowEdit {
                         });
                         if let Some(win) = self.windows.get_mut(&win_id) {
                             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.description = new_desc.clone();
+                                viewer.description.clone_from(&new_desc);
                             }
                             win.unsaved_edits += 1;
                         }
@@ -938,7 +937,7 @@ impl FlowEdit {
                             if let Some(parent_win) = self.windows.get_mut(&parent_id) {
                                 for node in &mut parent_win.nodes {
                                     if node.source == node_source {
-                                        node.description = new_desc.clone();
+                                        node.description.clone_from(&new_desc);
                                     }
                                 }
                                 parent_win.canvas_state.request_redraw();
@@ -951,10 +950,10 @@ impl FlowEdit {
                             if let Some(win) = self.windows.get_mut(&win_id) {
                                 if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
                                     let base = viewer.toml_path.parent().unwrap_or(Path::new("."));
-                                    let rel = selected
-                                        .strip_prefix(base)
-                                        .map(|p| p.to_string_lossy().to_string())
-                                        .unwrap_or_else(|_| selected.to_string_lossy().to_string());
+                                    let rel = selected.strip_prefix(base).map_or_else(
+                                        |_| selected.to_string_lossy().to_string(),
+                                        |p| p.to_string_lossy().to_string(),
+                                    );
                                     viewer.source_file = rel;
                                     viewer.rs_content = std::fs::read_to_string(&selected)
                                         .unwrap_or_else(|_| String::from("// Could not read file"));
@@ -973,7 +972,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::AddOutput => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -985,7 +984,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::DeleteInput(idx) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -996,7 +995,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::DeleteOutput(idx) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1007,7 +1006,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::InputNameChanged(idx, name) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1018,7 +1017,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::InputTypeChanged(idx, dtype) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1029,7 +1028,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::OutputNameChanged(idx, name) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1040,7 +1039,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1051,7 +1050,7 @@ impl FlowEdit {
                             }
                             win.unsaved_edits += 1;
                         }
-                        Self::propagate_function_ports(&mut self.windows, &win_id);
+                        Self::propagate_function_ports(&mut self.windows, win_id);
                     }
                     FunctionEditMessage::Save => {
                         if let Some(win) = self.windows.get_mut(&win_id) {
@@ -1134,7 +1133,7 @@ impl FlowEdit {
         };
 
         if let WindowKind::FunctionViewer(ref viewer) = win.kind {
-            return self.view_function(window_id, viewer, &win.status, win.unsaved_edits);
+            return Self::view_function(window_id, viewer, &win.status, win.unsaved_edits);
         }
 
         let canvas_with_controls = canvas_view::view_canvas_area(win, window_id);
@@ -1159,12 +1158,12 @@ impl FlowEdit {
 
         // Flow I/O editor panel for sub-flow windows
         if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(self.view_flow_io_panel(window_id, win));
+            right_col = right_col.push(Self::view_flow_io_panel(window_id, win));
         }
 
         // Metadata editor panel (toggled by Info button)
         if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(self.view_metadata_panel(win, window_id));
+            right_col = right_col.push(Self::view_metadata_panel(win, window_id));
         }
 
         // Library paths panel (toggled by Libs button)
@@ -1288,11 +1287,7 @@ impl FlowEdit {
     }
 
     /// Build the metadata editor panel.
-    fn view_metadata_panel<'a>(
-        &'a self,
-        win: &'a WindowState,
-        window_id: window::Id,
-    ) -> Element<'a, Message> {
+    fn view_metadata_panel(win: &WindowState, window_id: window::Id) -> Element<'_, Message> {
         let authors_str = win.flow_definition.metadata.authors.join(", ");
         let meta_panel = container(
             Column::new()
@@ -1304,7 +1299,7 @@ impl FlowEdit {
                         .align_y(iced::Alignment::Center)
                         .push(Text::new("Name:").size(12).width(70))
                         .push(
-                            text_input("Flow name", &win.flow_name)
+                            text_input("Flow name", &win.flow_definition.name)
                                 .on_input(move |s| {
                                     Message::FlowEdit(window_id, FlowEditMessage::NameChanged(s))
                                 })
@@ -1417,11 +1412,7 @@ impl FlowEdit {
         lib_panel.into()
     }
 
-    fn view_flow_io_panel<'a>(
-        &'a self,
-        window_id: window::Id,
-        win: &'a WindowState,
-    ) -> Element<'a, Message> {
+    fn view_flow_io_panel(window_id: window::Id, win: &WindowState) -> Element<'_, Message> {
         let input_color = Color::from_rgb(0.4, 0.8, 1.0);
         let output_color = Color::from_rgb(1.0, 0.6, 0.3);
 
@@ -1543,7 +1534,6 @@ impl FlowEdit {
     }
 
     fn view_function<'a>(
-        &'a self,
         window_id: window::Id,
         viewer: &'a FunctionViewer,
         status: &'a str,
@@ -1834,6 +1824,7 @@ impl FlowEdit {
     }
 
     fn subscription(&self) -> Subscription<Message> {
+        let _ = self; // required by iced daemon API signature
         let keyboard_sub = keyboard::listen().filter_map(|event| match event {
             keyboard::Event::KeyPressed {
                 key: keyboard::Key::Character(ref c),
@@ -1876,17 +1867,14 @@ impl FlowEdit {
         use flowcore::provider::Provider;
 
         let provider = flow_io::build_meta_provider();
-        let source_url = match Url::parse(source) {
-            Ok(u) => u,
-            Err(_) => return Task::none(),
+        let Ok(source_url) = Url::parse(source) else {
+            return Task::none();
         };
-        let (resolved_url, _) = match provider.resolve_url(&source_url, "default", &["toml"]) {
-            Ok(r) => r,
-            Err(_) => return Task::none(),
+        let Ok((resolved_url, _)) = provider.resolve_url(&source_url, "default", &["toml"]) else {
+            return Task::none();
         };
-        let path = match resolved_url.to_file_path() {
-            Ok(p) => p,
-            Err(()) => return Task::none(),
+        let Ok(path) = resolved_url.to_file_path() else {
+            return Task::none();
         };
 
         // Check if already open
@@ -1897,24 +1885,20 @@ impl FlowEdit {
         }
 
         // Read and parse
-        let contents = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => return Task::none(),
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return Task::none();
         };
-        let url = match Url::from_file_path(&path) {
-            Ok(u) => u,
-            Err(()) => return Task::none(),
+        let Ok(url) = Url::from_file_path(&path) else {
+            return Task::none();
         };
-        let deserializer = match get::<Process>(&url) {
-            Ok(d) => d,
-            Err(_) => return Task::none(),
+        let Ok(deserializer) = get::<Process>(&url) else {
+            return Task::none();
         };
 
         match deserializer.deserialize(&contents, Some(&url)) {
             Ok(Process::FunctionProcess(ref func)) => {
-                let parent = match self.root_window {
-                    Some(id) => id,
-                    None => return Task::none(),
+                let Some(parent) = self.root_window else {
+                    return Task::none();
                 };
                 self.open_function_viewer(parent, &path, func, &path.to_string_lossy())
             }
@@ -1929,7 +1913,6 @@ impl FlowEdit {
                         window::open(self.child_window_settings(1024.0, 768.0));
                     let child = WindowState {
                         kind: WindowKind::FlowEditor,
-                        flow_name: loaded.name,
                         nodes: loaded.nodes,
                         edges: loaded.edges,
                         canvas_state: FlowCanvasState::default(),
@@ -1983,10 +1966,10 @@ impl FlowEdit {
     fn build_hierarchy(&self) -> FlowHierarchy {
         self.root_flow_path
             .as_ref()
-            .map(|p| FlowHierarchy::build(p))
-            .unwrap_or_else(FlowHierarchy::empty)
+            .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p))
     }
 
+    #[allow(clippy::cast_precision_loss)]
     fn child_window_settings(&self, width: f32, height: f32) -> window::Settings {
         let n = self.windows.len() as f32;
         window::Settings {
@@ -2057,7 +2040,6 @@ impl FlowEdit {
                     flow_io::extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
                 let child = WindowState {
                     kind: WindowKind::FlowEditor,
-                    flow_name: loaded.name,
                     nodes: loaded.nodes,
                     edges: loaded.edges,
                     canvas_state: FlowCanvasState::default(),
@@ -2090,7 +2072,7 @@ impl FlowEdit {
             }
             Err(e) => {
                 if let Some(win) = self.windows.get_mut(&parent_win_id) {
-                    win.status = format!("Could not open '{}': {e}", source);
+                    win.status = format!("Could not open '{source}': {e}");
                 }
                 Task::none()
             }
@@ -2132,9 +2114,12 @@ impl FlowEdit {
             read_only,
         };
 
+        let func_flow_def = FlowDefinition {
+            name: func_name.clone(),
+            ..FlowDefinition::default()
+        };
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
-            flow_name: func_name.clone(),
             nodes: Vec::new(),
             edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
@@ -2147,7 +2132,7 @@ impl FlowEdit {
             unsaved_edits: 0,
             compiled_manifest: None,
             file_path: Some(toml_path.to_path_buf()),
-            flow_definition: FlowDefinition::default(),
+            flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,
             is_root: false,
@@ -2224,10 +2209,10 @@ impl FlowEdit {
         }
 
         // Compute relative source path from parent flow to new sub-flow
-        let source = path
-            .strip_prefix(&base)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        let source = path.strip_prefix(&base).map_or_else(
+            |_| path.to_string_lossy().to_string(),
+            |p| p.to_string_lossy().to_string(),
+        );
         // Strip .toml extension for the source reference
         let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
 
@@ -2268,7 +2253,6 @@ impl FlowEdit {
 
         let child = WindowState {
             kind: WindowKind::FlowEditor,
-            flow_name: flow_name.clone(),
             nodes: Vec::new(),
             edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
@@ -2340,10 +2324,10 @@ impl FlowEdit {
         let rs_filename = format!("{func_name}.rs");
 
         // Compute relative source from parent flow
-        let source = path
-            .strip_prefix(&base)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        let source = path.strip_prefix(&base).map_or_else(
+            |_| path.to_string_lossy().to_string(),
+            |p| p.to_string_lossy().to_string(),
+        );
         let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
 
         // Add process reference in the target flow
@@ -2396,9 +2380,12 @@ impl FlowEdit {
             read_only: false,
         };
 
+        let func_flow_def = FlowDefinition {
+            name: func_name,
+            ..FlowDefinition::default()
+        };
         let child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
-            flow_name: func_name,
             nodes: Vec::new(),
             edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
@@ -2411,7 +2398,7 @@ impl FlowEdit {
             unsaved_edits: 1,
             compiled_manifest: None,
             file_path: Some(path),
-            flow_definition: FlowDefinition::default(),
+            flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,
             is_root: false,
@@ -2433,10 +2420,10 @@ impl FlowEdit {
     /// display in sync when ports are added, deleted, or renamed in the function viewer.
     fn propagate_function_ports(
         windows: &mut HashMap<window::Id, WindowState>,
-        viewer_win_id: &window::Id,
+        viewer_win_id: window::Id,
     ) {
         // Extract parent info and current ports from the viewer window
-        let propagation_data = windows.get(viewer_win_id).and_then(|win| {
+        let propagation_data = windows.get(&viewer_win_id).and_then(|win| {
             if let WindowKind::FunctionViewer(ref viewer) = win.kind {
                 viewer.parent_window.map(|pid| {
                     (
@@ -2455,8 +2442,8 @@ impl FlowEdit {
             if let Some(parent_win) = windows.get_mut(&parent_id) {
                 for node in &mut parent_win.nodes {
                     if node.source == node_source {
-                        node.inputs = new_inputs.clone();
-                        node.outputs = new_outputs.clone();
+                        node.inputs.clone_from(&new_inputs);
+                        node.outputs.clone_from(&new_outputs);
                     }
                 }
                 parent_win.canvas_state.request_redraw();

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -28,10 +28,14 @@ use url::Url;
 
 use flowcore::deserializers::deserializer::get;
 use flowcore::meta_provider::MetaProvider;
+use flowcore::model::datatype::DataType;
 use flowcore::model::flow_definition::FlowDefinition;
+use flowcore::model::io::IO;
 use flowcore::model::lib_manifest::LibraryManifest;
+use flowcore::model::name::HasName;
 use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
+use flowcore::model::route::Route;
 use flowcore::provider::Provider;
 
 use canvas_view::{CanvasMessage, FlowCanvasState, NodeLayout, PortInfo};
@@ -365,7 +369,6 @@ impl FlowEdit {
             .as_ref()
             .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
 
-        let (fi, fo) = flow_io::extract_ports(&flow_definition.inputs, &flow_definition.outputs);
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
             nodes,
@@ -383,8 +386,6 @@ impl FlowEdit {
             tooltip: None,
             initializer_editor: None,
             is_root: true,
-            flow_inputs: fi,
-            flow_outputs: fo,
             context_menu: None,
             show_metadata: false,
             flow_hierarchy,
@@ -458,10 +459,6 @@ impl FlowEdit {
                     }
                     // Open the flow or function
                     if let Ok(loaded) = flow_io::load_flow(&path) {
-                        let (fi, fo) = flow_io::extract_ports(
-                            &loaded.flow_def.inputs,
-                            &loaded.flow_def.outputs,
-                        );
                         let (new_id, open_task) =
                             window::open(self.child_window_settings(1024.0, 768.0));
                         let has_nodes = !loaded.nodes.is_empty();
@@ -488,8 +485,6 @@ impl FlowEdit {
                             tooltip: None,
                             initializer_editor: None,
                             is_root: false,
-                            flow_inputs: fi,
-                            flow_outputs: fo,
                             context_menu: None,
                             show_metadata: false,
                             flow_hierarchy: self.build_hierarchy(),
@@ -755,25 +750,29 @@ impl FlowEdit {
                             win.show_metadata = !win.show_metadata;
                         }
                         FlowEditMessage::AddInput => {
-                            win.flow_inputs.push(PortInfo {
-                                name: format!("input{}", win.flow_inputs.len()),
-                                datatypes: vec![String::from("string")],
-                            });
+                            let name = format!("input{}", win.flow_definition.inputs.len());
+                            win.flow_definition.inputs.push(IO::new_named(
+                                vec![DataType::from("string")],
+                                Route::default(),
+                                name,
+                            ));
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::AddOutput => {
-                            win.flow_outputs.push(PortInfo {
-                                name: format!("output{}", win.flow_outputs.len()),
-                                datatypes: vec![String::from("string")],
-                            });
+                            let name = format!("output{}", win.flow_definition.outputs.len());
+                            win.flow_definition.outputs.push(IO::new_named(
+                                vec![DataType::from("string")],
+                                Route::default(),
+                                name,
+                            ));
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::DeleteInput(idx) => {
-                            if let Some(port) = win.flow_inputs.get(idx) {
-                                let name = port.name.clone();
-                                win.flow_inputs.remove(idx);
+                            if let Some(io) = win.flow_definition.inputs.get(idx) {
+                                let name = io.name().clone();
+                                win.flow_definition.inputs.remove(idx);
                                 // Remove edges referencing this flow input
                                 win.edges
                                     .retain(|e| !(e.from_node == "input" && e.from_port == name));
@@ -782,9 +781,9 @@ impl FlowEdit {
                             }
                         }
                         FlowEditMessage::DeleteOutput(idx) => {
-                            if let Some(port) = win.flow_outputs.get(idx) {
-                                let name = port.name.clone();
-                                win.flow_outputs.remove(idx);
+                            if let Some(io) = win.flow_definition.outputs.get(idx) {
+                                let name = io.name().clone();
+                                win.flow_definition.outputs.remove(idx);
                                 // Remove edges referencing this flow output
                                 win.edges
                                     .retain(|e| !(e.to_node == "output" && e.to_port == name));
@@ -793,9 +792,9 @@ impl FlowEdit {
                             }
                         }
                         FlowEditMessage::InputNameChanged(idx, name) => {
-                            if let Some(port) = win.flow_inputs.get_mut(idx) {
-                                let old_name = port.name.clone();
-                                port.name.clone_from(&name);
+                            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+                                let old_name = io.name().clone();
+                                io.set_name(name.clone());
                                 // Update edges referencing the old flow input name
                                 for edge in &mut win.edges {
                                     if edge.from_node == "input" && edge.from_port == old_name {
@@ -807,16 +806,16 @@ impl FlowEdit {
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::InputTypeChanged(idx, dtype) => {
-                            if let Some(port) = win.flow_inputs.get_mut(idx) {
-                                port.datatypes = vec![dtype];
+                            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+                                io.set_datatypes(&[DataType::from(dtype)]);
                             }
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::OutputNameChanged(idx, name) => {
-                            if let Some(port) = win.flow_outputs.get_mut(idx) {
-                                let old_name = port.name.clone();
-                                port.name.clone_from(&name);
+                            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+                                let old_name = io.name().clone();
+                                io.set_name(name.clone());
                                 // Update edges referencing the old flow output name
                                 for edge in &mut win.edges {
                                     if edge.to_node == "output" && edge.to_port == old_name {
@@ -828,8 +827,8 @@ impl FlowEdit {
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::OutputTypeChanged(idx, dtype) => {
-                            if let Some(port) = win.flow_outputs.get_mut(idx) {
-                                port.datatypes = vec![dtype];
+                            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+                                io.set_datatypes(&[DataType::from(dtype)]);
                             }
                             win.unsaved_edits += 1;
                             win.canvas_state.request_redraw();
@@ -1421,14 +1420,19 @@ impl FlowEdit {
         let output_color = Color::from_rgb(1.0, 0.6, 0.3);
 
         let mut input_col = Column::new().spacing(4);
-        for (i, port) in win.flow_inputs.iter().enumerate() {
-            let dtype = port.datatypes.first().cloned().unwrap_or_default();
+        for (i, port) in win.flow_definition.inputs.iter().enumerate() {
+            let port_name = port.name().clone();
+            let dtype = port
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
             let row = Row::new()
                 .spacing(4)
                 .align_y(iced::Alignment::Center)
                 .push(Text::new("\u{25D7}").size(18).color(input_color))
                 .push(
-                    text_input("name", &port.name)
+                    text_input("name", &port_name)
                         .on_input(move |s| {
                             Message::FlowEdit(window_id, FlowEditMessage::InputNameChanged(i, s))
                         })
@@ -1464,8 +1468,13 @@ impl FlowEdit {
         );
 
         let mut output_col = Column::new().spacing(4).align_x(iced::Alignment::End);
-        for (i, port) in win.flow_outputs.iter().enumerate() {
-            let dtype = port.datatypes.first().cloned().unwrap_or_default();
+        for (i, port) in win.flow_definition.outputs.iter().enumerate() {
+            let port_name = port.name().clone();
+            let dtype = port
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
             let row = Row::new()
                 .spacing(4)
                 .align_y(iced::Alignment::Center)
@@ -1488,7 +1497,7 @@ impl FlowEdit {
                         .width(70),
                 )
                 .push(
-                    text_input("name", &port.name)
+                    text_input("name", &port_name)
                         .on_input(move |s| {
                             Message::FlowEdit(window_id, FlowEditMessage::OutputNameChanged(i, s))
                         })
@@ -1908,8 +1917,6 @@ impl FlowEdit {
             }
             Ok(Process::FlowProcess(_)) => match flow_io::load_flow(&path) {
                 Ok(loaded) => {
-                    let (fi, fo) =
-                        flow_io::extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
                     let has_nodes = !loaded.nodes.is_empty();
                     let nc = loaded.nodes.len();
                     let ec = loaded.edges.len();
@@ -1936,8 +1943,6 @@ impl FlowEdit {
                         tooltip: None,
                         initializer_editor: None,
                         is_root: false,
-                        flow_inputs: fi,
-                        flow_outputs: fo,
                         context_menu: None,
                         show_metadata: false,
                         flow_hierarchy: self.build_hierarchy(),
@@ -2043,8 +2048,6 @@ impl FlowEdit {
                 let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
                 let nc = loaded.nodes.len();
                 let ec = loaded.edges.len();
-                let (fi, fo) =
-                    flow_io::extract_ports(&loaded.flow_def.inputs, &loaded.flow_def.outputs);
                 let mut flow_def = loaded.flow_def;
                 if let Ok(url) = Url::from_file_path(&path) {
                     flow_def.source_url = url;
@@ -2066,8 +2069,6 @@ impl FlowEdit {
                     tooltip: None,
                     initializer_editor: None,
                     is_root: false,
-                    flow_inputs: fi,
-                    flow_outputs: fo,
                     context_menu: None,
                     show_metadata: false,
                     flow_hierarchy: self.build_hierarchy(),
@@ -2148,8 +2149,6 @@ impl FlowEdit {
             tooltip: None,
             initializer_editor: None,
             is_root: false,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),
@@ -2284,8 +2283,6 @@ impl FlowEdit {
             tooltip: None,
             initializer_editor: None,
             is_root: false,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),
@@ -2420,8 +2417,6 @@ impl FlowEdit {
             tooltip: None,
             initializer_editor: None,
             is_root: false,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: self.build_hierarchy(),

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -5,24 +5,32 @@ use flowcore::model::connection::Connection;
 use iced_test::simulator::{self, simulator};
 use std::collections::HashMap;
 
-fn test_node(alias: &str, source: &str) -> NodeLayout {
-    NodeLayout {
-        alias: alias.into(),
-        source: source.into(),
-        ..Default::default()
-    }
-}
-
 fn test_win_state() -> WindowState {
     let flow_def = FlowDefinition {
         name: String::from("test"),
+        process_refs: vec![
+            ProcessReference {
+                alias: "add".into(),
+                source: "lib://flowstdlib/math/add".into(),
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(100.0),
+                y: Some(100.0),
+                width: Some(180.0),
+                height: Some(120.0),
+            },
+            ProcessReference {
+                alias: "stdout".into(),
+                source: "context://stdio/stdout".into(),
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(400.0),
+                y: Some(100.0),
+                width: Some(180.0),
+                height: Some(120.0),
+            },
+        ],
         ..FlowDefinition::default()
     };
     WindowState {
-        nodes: vec![
-            test_node("add", "lib://flowstdlib/math/add"),
-            test_node("stdout", "context://stdio/stdout"),
-        ],
         flow_definition: flow_def,
         is_root: true,
         ..Default::default()
@@ -30,24 +38,8 @@ fn test_win_state() -> WindowState {
 }
 
 fn test_app_with_flow(flow: FlowDefinition) -> (FlowEdit, window::Id) {
-    // Build nodes from flow.process_refs
-    let nodes: Vec<NodeLayout> = flow
-        .process_refs
-        .iter()
-        .map(|pref| NodeLayout {
-            alias: pref.alias.clone(),
-            source: pref.source.clone(),
-            x: pref.x.unwrap_or(0.0),
-            y: pref.y.unwrap_or(0.0),
-            width: pref.width.unwrap_or(180.0),
-            height: pref.height.unwrap_or(120.0),
-            ..Default::default()
-        })
-        .collect();
-
     let win_id = window::Id::unique();
     let win_state = WindowState {
-        nodes,
         flow_definition: flow,
         is_root: true,
         ..Default::default()
@@ -182,9 +174,12 @@ fn update_canvas_move_node() {
         win_id,
         CanvasMessage::Moved(0, 200.0, 300.0),
     ));
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.x) - 200.0).abs() < 0.01);
-    assert!((node.map_or(0.0, |n| n.y) - 300.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
+    assert!((node.map_or(0.0, |n| n.y.unwrap_or(0.0)) - 300.0).abs() < 0.01);
 }
 
 #[test]
@@ -200,9 +195,19 @@ fn update_canvas_move_completed_records_history() {
 #[test]
 fn update_canvas_delete_node() {
     let (mut app, win_id) = test_app();
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(2));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(2)
+    );
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(1)
+    );
     assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
 }
 
@@ -282,13 +287,19 @@ fn update_undo_redo_cycle() {
 
     // Undo
     let _ = app.update(Message::Undo);
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.x) - 100.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 100.0).abs() < 0.01);
 
     // Redo
     let _ = app.update(Message::Redo);
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.x) - 200.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
 }
 
 #[test]
@@ -484,9 +495,12 @@ fn update_canvas_resize_node() {
         win_id,
         CanvasMessage::Resized(0, 50.0, 50.0, 200.0, 150.0),
     ));
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.width) - 200.0).abs() < 0.01);
-    assert!((node.map_or(0.0, |n| n.height) - 150.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.width.unwrap_or(0.0)) - 200.0).abs() < 0.01);
+    assert!((node.map_or(0.0, |n| n.height.unwrap_or(0.0)) - 150.0).abs() < 0.01);
 }
 
 #[test]
@@ -801,7 +815,12 @@ fn helper_right_click_sets_context_menu() {
 #[test]
 fn helper_send_key_delete() {
     let (mut app, win_id) = test_app();
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(2));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(2)
+    );
 
     // First, select a node via direct canvas click so the canvas internal state
     // has selected_node set. Then send Delete in the same simulator cycle.
@@ -826,7 +845,9 @@ fn helper_send_key_delete() {
     // The canvas should have emitted Selected(Some(0)) from the click,
     // then Deleted(0) from the Delete key
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.nodes.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
         Some(1),
         "Delete key after selecting a node should remove it"
     );
@@ -853,13 +874,16 @@ fn helper_drag_via_direct_messages() {
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 250.0, 350.0),
     ));
 
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
     assert!(
-        (node.map_or(0.0, |n| n.x) - 250.0).abs() < 0.01,
+        (node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 250.0).abs() < 0.01,
         "Node x should be 250 after drag"
     );
     assert!(
-        (node.map_or(0.0, |n| n.y) - 350.0).abs() < 0.01,
+        (node.map_or(0.0, |n| n.y.unwrap_or(0.0)) - 350.0).abs() < 0.01,
         "Node y should be 350 after drag"
     );
     assert_eq!(
@@ -879,8 +903,8 @@ fn helper_drag_simulator_smoke_test() {
     let original_x = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.nodes.first())
-        .map_or(0.0, |n| n.x);
+        .and_then(|w| w.flow_definition.process_refs.first())
+        .map_or(0.0, |n| n.x.unwrap_or(0.0));
 
     drag(
         &mut app,
@@ -899,8 +923,8 @@ fn helper_drag_simulator_smoke_test() {
     let _current_x = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.nodes.first())
-        .map_or(0.0, |n| n.x);
+        .and_then(|w| w.flow_definition.process_refs.first())
+        .map_or(0.0, |n| n.x.unwrap_or(0.0));
     // Note: if current_x == original_x, the simulator drag didn't produce
     // canvas events. This is expected due to the limitation documented above.
     let _ = original_x; // suppress unused warning
@@ -925,7 +949,12 @@ fn ui_delete_node_removes_connected_edges() {
     );
     // Delete node 0 ("add")
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(1)
+    );
     assert_eq!(
         app.windows
             .get(&win_id)
@@ -938,7 +967,10 @@ fn ui_delete_node_removes_connected_edges() {
 #[test]
 fn ui_delete_with_nothing_selected_no_change() {
     let (mut app, win_id) = test_app();
-    let count_before = app.windows.get(&win_id).map(|w| w.nodes.len());
+    let count_before = app
+        .windows
+        .get(&win_id)
+        .map(|w| w.flow_definition.process_refs.len());
     // Deselect — no node is selected
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Selected(None)));
     // Send Delete key — should not change anything with nothing selected
@@ -948,7 +980,9 @@ fn ui_delete_with_nothing_selected_no_change() {
         iced::keyboard::Key::Named(iced::keyboard::key::Named::Delete),
     );
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.nodes.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
         count_before
     );
 }
@@ -1016,12 +1050,24 @@ fn ui_connection_deselect_on_canvas_click() {
 #[test]
 fn ui_undo_node_deletion() {
     let (mut app, win_id) = test_app();
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(2));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(2)
+    );
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
+        Some(1)
+    );
     let _ = app.update(Message::Undo);
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.nodes.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.process_refs.len()),
         Some(2),
         "Undo should restore deleted node"
     );
@@ -1090,8 +1136,11 @@ fn undo_restores_move() {
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 200.0, 300.0),
     ));
     let _ = app.update(Message::Undo);
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.x) - 100.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 100.0).abs() < 0.01);
 }
 
 #[test]
@@ -1107,8 +1156,11 @@ fn redo_reapplies_move() {
     ));
     let _ = app.update(Message::Undo);
     let _ = app.update(Message::Redo);
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
-    assert!((node.map_or(0.0, |n| n.x) - 200.0).abs() < 0.01);
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
+    assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
 }
 
 // ---- Group 5: Context Menu & Initializer ----
@@ -1152,12 +1204,18 @@ fn ui_initializer_editor_open_and_cancel() {
 #[test]
 fn ui_library_add_function_creates_node() {
     let (mut app, win_id) = test_app();
-    let count_before = app.windows.get(&win_id).map_or(0, |w| w.nodes.len());
+    let count_before = app
+        .windows
+        .get(&win_id)
+        .map_or(0, |w| w.flow_definition.process_refs.len());
     let _ = app.update(Message::Library(
         win_id,
         library_panel::LibraryMessage::AddFunction("lib://test_lib/math/add".into(), "add".into()),
     ));
-    let count_after = app.windows.get(&win_id).map_or(0, |w| w.nodes.len());
+    let count_after = app
+        .windows
+        .get(&win_id)
+        .map_or(0, |w| w.flow_definition.process_refs.len());
     assert_eq!(
         count_after,
         count_before + 1,
@@ -1259,13 +1317,16 @@ fn ui_resize_node_records_history() {
         app.windows.get(&win_id).map_or(0, |w| w.unsaved_edits) > 0,
         "Resize should record an edit"
     );
-    let node = app.windows.get(&win_id).and_then(|w| w.nodes.first());
+    let node = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.flow_definition.process_refs.first());
     assert!(
-        (node.map_or(0.0, |n| n.width) - 250.0).abs() < 0.01,
+        (node.map_or(0.0, |n| n.width.unwrap_or(0.0)) - 250.0).abs() < 0.01,
         "Node width should be 250 after resize"
     );
     assert!(
-        (node.map_or(0.0, |n| n.height) - 180.0).abs() < 0.01,
+        (node.map_or(0.0, |n| n.height.unwrap_or(0.0)) - 180.0).abs() < 0.01,
         "Node height should be 180 after resize"
     );
 }

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -759,7 +759,7 @@ fn click_build_with_saved_flow() {
     let path = dir.join("test.toml");
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.file_path = Some(path.clone());
+        win.set_file_path(&path);
         win.flow_definition.name = "test_build".into();
         flow_io::perform_save(win, &path);
     }

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::indexing_slicing)]
 
 use super::*;
-use canvas_view::EdgeLayout;
+use flowcore::model::connection::Connection;
 use iced_test::simulator::{self, simulator};
 use std::collections::HashMap;
 
@@ -45,15 +45,9 @@ fn test_app_with_flow(flow: FlowDefinition) -> (FlowEdit, window::Id) {
         })
         .collect();
 
-    // Edges are not auto-populated from flow.connections because Connection
-    // uses a complex Direction-based format. Tests that need edges should
-    // add them manually via win.edges.push(EdgeLayout::new(...)).
-    let edges: Vec<EdgeLayout> = Vec::new();
-
     let win_id = window::Id::unique();
     let win_state = WindowState {
         nodes,
-        edges,
         flow_definition: flow,
         is_root: true,
         ..Default::default()
@@ -224,7 +218,12 @@ fn update_canvas_create_connection() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(1)
+    );
     assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
 }
 
@@ -233,12 +232,9 @@ fn update_canvas_select_connection() {
     let (mut app, win_id) = test_app();
     // Add a connection first
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            String::new(),
-            "stdout".into(),
-            String::new(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add", "stdout"));
     }
     let _ = app.update(Message::WindowCanvas(
         win_id,
@@ -254,18 +250,20 @@ fn update_canvas_select_connection() {
 fn update_canvas_delete_connection() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            String::new(),
-            "stdout".into(),
-            String::new(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add", "stdout"));
     }
     let _ = app.update(Message::WindowCanvas(
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(0));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(0)
+    );
 }
 
 #[test]
@@ -913,21 +911,25 @@ fn helper_drag_simulator_smoke_test() {
 #[test]
 fn ui_delete_node_removes_connected_edges() {
     let (mut app, win_id) = test_app();
-    // Add an edge between the two nodes
+    // Add a connection between the two nodes
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            "out".into(),
-            "stdout".into(),
-            "in".into(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add/out", "stdout/in"));
     }
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(1)
+    );
     // Delete node 0 ("add")
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
     assert_eq!(app.windows.get(&win_id).map(|w| w.nodes.len()), Some(1));
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.edges.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
         Some(0),
         "Edge should be removed when connected node is deleted"
     );
@@ -965,7 +967,12 @@ fn ui_select_and_delete_connection() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(1)
+    );
     // Select
     let _ = app.update(Message::WindowCanvas(
         win_id,
@@ -980,19 +987,21 @@ fn ui_select_and_delete_connection() {
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(0));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(0)
+    );
 }
 
 #[test]
 fn ui_connection_deselect_on_canvas_click() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            String::new(),
-            "stdout".into(),
-            String::new(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add", "stdout"));
         win.selected_connection = Some(0);
     }
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Selected(None)));
@@ -1030,15 +1039,27 @@ fn ui_undo_connection_deletion() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(1));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(1)
+    );
     let _ = app.update(Message::WindowCanvas(
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.edges.len()), Some(0));
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
+        Some(0)
+    );
     let _ = app.update(Message::Undo);
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.edges.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.connections.len()),
         Some(1),
         "Undo should restore deleted connection"
     );
@@ -1256,20 +1277,24 @@ fn flow_delete_input_removes_edges() {
     let (mut app, win_id) = test_app();
     // Add a flow input
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
-    // Add an edge referencing "input" node
+    // Add a connection referencing "input" node
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "input".into(),
-            "input0".into(),
-            "add".into(),
-            String::new(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("input/input0", "add"));
     }
-    assert_eq!(app.windows.get(&win_id).map_or(0, |w| w.edges.len()), 1);
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.connections.len()),
+        1
+    );
     // Delete the input — edge should be removed
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
     assert_eq!(
-        app.windows.get(&win_id).map_or(0, |w| w.edges.len()),
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.connections.len()),
         0,
         "Edge should be removed when flow input is deleted"
     );
@@ -1280,20 +1305,24 @@ fn flow_delete_output_removes_edges() {
     let (mut app, win_id) = test_app();
     // Add a flow output
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
-    // Add an edge referencing "output" node
+    // Add a connection referencing "output" node
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            String::new(),
-            "output".into(),
-            "output0".into(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add", "output/output0"));
     }
-    assert_eq!(app.windows.get(&win_id).map_or(0, |w| w.edges.len()), 1);
+    assert_eq!(
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.connections.len()),
+        1
+    );
     // Delete the output — edge should be removed
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
     assert_eq!(
-        app.windows.get(&win_id).map_or(0, |w| w.edges.len()),
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.connections.len()),
         0,
         "Edge should be removed when flow output is deleted"
     );
@@ -1304,24 +1333,21 @@ fn flow_input_rename_updates_edges() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "input".into(),
-            "input0".into(),
-            "add".into(),
-            String::new(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("input/input0", "add"));
     }
     let _ = app.update(Message::FlowEdit(
         win_id,
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
-    // Edge should now reference "data" instead of "input0"
-    let edge_port = app
+    // Connection from-route should now reference "input/data" instead of "input/input0"
+    let from_route = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.edges.first())
-        .map(|e| e.from_port.clone());
-    assert_eq!(edge_port, Some("data".into()));
+        .and_then(|w| w.flow_definition.connections.first())
+        .map(|c| c.from().to_string());
+    assert_eq!(from_route, Some("input/data".into()));
 }
 
 #[test]
@@ -1329,24 +1355,21 @@ fn flow_output_rename_updates_edges() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.edges.push(EdgeLayout::new(
-            "add".into(),
-            String::new(),
-            "output".into(),
-            "output0".into(),
-        ));
+        win.flow_definition
+            .connections
+            .push(Connection::new("add", "output/output0"));
     }
     let _ = app.update(Message::FlowEdit(
         win_id,
         FlowEditMessage::OutputNameChanged(0, "result".into()),
     ));
-    // Edge should now reference "result" instead of "output0"
-    let edge_port = app
+    // Connection to-route should now reference "output/result" instead of "output/output0"
+    let to_route = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.edges.first())
-        .map(|e| e.to_port.clone());
-    assert_eq!(edge_port, Some("result".into()));
+        .and_then(|w| w.flow_definition.connections.first())
+        .and_then(|c| c.to().first().map(ToString::to_string));
+    assert_eq!(to_route, Some("output/result".into()));
 }
 
 // ---- Group 12: PR #2599 Coverage — NewSubFlow and NewFunction with window_id ----

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -369,7 +369,9 @@ fn update_flow_add_input() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.flow_inputs.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.inputs.len()),
         Some(1)
     );
     assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
@@ -380,7 +382,9 @@ fn update_flow_add_output() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.flow_outputs.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.outputs.len()),
         Some(1)
     );
 }
@@ -391,7 +395,9 @@ fn update_flow_delete_input() {
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.flow_inputs.len()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.inputs.len()),
         Some(0)
     );
 }
@@ -405,9 +411,11 @@ fn update_flow_input_name_changed() {
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .and_then(|w| w.flow_inputs.first().map(|p| p.name.as_str())),
+        app.windows.get(&win_id).and_then(|w| w
+            .flow_definition
+            .inputs
+            .first()
+            .map(|io| io.name().as_str())),
         Some("data")
     );
 }
@@ -1390,12 +1398,16 @@ fn flow_edit_add_delete_output() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     assert_eq!(
-        app.windows.get(&win_id).map_or(0, |w| w.flow_outputs.len()),
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.outputs.len()),
         1
     );
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
     assert_eq!(
-        app.windows.get(&win_id).map_or(0, |w| w.flow_outputs.len()),
+        app.windows
+            .get(&win_id)
+            .map_or(0, |w| w.flow_definition.outputs.len()),
         0
     );
 }
@@ -1411,10 +1423,10 @@ fn flow_edit_input_type_changed() {
     let dtype = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.flow_inputs.first())
-        .and_then(|p| p.datatypes.first())
-        .map(String::as_str);
-    assert_eq!(dtype, Some("number"));
+        .and_then(|w| w.flow_definition.inputs.first())
+        .and_then(|io| io.datatypes().first())
+        .map(ToString::to_string);
+    assert_eq!(dtype.as_deref(), Some("number"));
 }
 
 #[test]
@@ -1428,10 +1440,10 @@ fn flow_edit_output_type_changed() {
     let dtype = app
         .windows
         .get(&win_id)
-        .and_then(|w| w.flow_outputs.first())
-        .and_then(|p| p.datatypes.first())
-        .map(String::as_str);
-    assert_eq!(dtype, Some("boolean"));
+        .and_then(|w| w.flow_definition.outputs.first())
+        .and_then(|io| io.datatypes().first())
+        .map(ToString::to_string);
+    assert_eq!(dtype.as_deref(), Some("boolean"));
 }
 
 // ---- Group 14: PR #2599 Coverage — FunctionEditMessage sub-enum routing ----

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::indexing_slicing)]
 
 use super::*;
+use canvas_view::EdgeLayout;
 use iced_test::simulator::{self, simulator};
 use std::collections::HashMap;
 
@@ -13,12 +14,16 @@ fn test_node(alias: &str, source: &str) -> NodeLayout {
 }
 
 fn test_win_state() -> WindowState {
+    let flow_def = FlowDefinition {
+        name: String::from("test"),
+        ..FlowDefinition::default()
+    };
     WindowState {
-        flow_name: String::from("test"),
         nodes: vec![
             test_node("add", "lib://flowstdlib/math/add"),
             test_node("stdout", "context://stdio/stdout"),
         ],
+        flow_definition: flow_def,
         is_root: true,
         ..Default::default()
     }
@@ -47,7 +52,6 @@ fn test_app_with_flow(flow: FlowDefinition) -> (FlowEdit, window::Id) {
 
     let win_id = window::Id::unique();
     let win_state = WindowState {
-        flow_name: flow.name.clone(),
         nodes,
         edges,
         flow_definition: flow,
@@ -307,7 +311,9 @@ fn update_flow_name_changed() {
         FlowEditMessage::NameChanged("new_name".into()),
     ));
     assert_eq!(
-        app.windows.get(&win_id).map(|w| w.flow_name.as_str()),
+        app.windows
+            .get(&win_id)
+            .map(|w| w.flow_definition.name.as_str()),
         Some("new_name")
     );
     assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
@@ -754,7 +760,7 @@ fn click_build_with_saved_flow() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
         win.file_path = Some(path.clone());
-        win.flow_name = "test_build".into();
+        win.flow_definition.name = "test_build".into();
         flow_io::perform_save(win, &path);
     }
     click_and_update(&mut app, win_id, "\u{1F528} Build");
@@ -1248,7 +1254,7 @@ fn flow_delete_input_removes_edges() {
             "input".into(),
             "input0".into(),
             "add".into(),
-            "".into(),
+            String::new(),
         ));
     }
     assert_eq!(app.windows.get(&win_id).map_or(0, |w| w.edges.len()), 1);
@@ -1270,7 +1276,7 @@ fn flow_delete_output_removes_edges() {
     if let Some(win) = app.windows.get_mut(&win_id) {
         win.edges.push(EdgeLayout::new(
             "add".into(),
-            "".into(),
+            String::new(),
             "output".into(),
             "output0".into(),
         ));
@@ -1294,7 +1300,7 @@ fn flow_input_rename_updates_edges() {
             "input".into(),
             "input0".into(),
             "add".into(),
-            "".into(),
+            String::new(),
         ));
     }
     let _ = app.update(Message::FlowEdit(
@@ -1317,7 +1323,7 @@ fn flow_output_rename_updates_edges() {
     if let Some(win) = app.windows.get_mut(&win_id) {
         win.edges.push(EdgeLayout::new(
             "add".into(),
-            "".into(),
+            String::new(),
             "output".into(),
             "output0".into(),
         ));
@@ -1374,9 +1380,9 @@ fn new_function_clears_context_menu() {
 #[test]
 fn flow_edit_toggle_metadata() {
     let (mut app, win_id) = test_app();
-    assert!(!app.windows.get(&win_id).map_or(true, |w| w.show_metadata));
+    assert!(!app.windows.get(&win_id).is_none_or(|w| w.show_metadata));
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
-    assert!(app.windows.get(&win_id).map_or(false, |w| w.show_metadata));
+    assert!(app.windows.get(&win_id).is_some_and(|w| w.show_metadata));
 }
 
 #[test]
@@ -1407,7 +1413,7 @@ fn flow_edit_input_type_changed() {
         .get(&win_id)
         .and_then(|w| w.flow_inputs.first())
         .and_then(|p| p.datatypes.first())
-        .map(|s| s.as_str());
+        .map(String::as_str);
     assert_eq!(dtype, Some("number"));
 }
 
@@ -1424,7 +1430,7 @@ fn flow_edit_output_type_changed() {
         .get(&win_id)
         .and_then(|w| w.flow_outputs.first())
         .and_then(|p| p.datatypes.first())
-        .map(|s| s.as_str());
+        .map(String::as_str);
     assert_eq!(dtype, Some("boolean"));
 }
 

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use flowcore::model::flow_definition::FlowDefinition;
 
-use crate::canvas_view::{FlowCanvasState, NodeLayout, PortInfo};
+use crate::canvas_view::{FlowCanvasState, PortInfo};
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history;
 use crate::history::EditHistory;
@@ -53,8 +53,6 @@ pub(crate) enum WindowKind {
 pub(crate) struct WindowState {
     /// What this window displays
     pub(crate) kind: WindowKind,
-    /// Positioned nodes derived from the flow's process references
-    pub(crate) nodes: Vec<NodeLayout>,
     /// Canvas state for caching rendered geometry
     pub(crate) canvas_state: FlowCanvasState,
     /// Status message displayed in the bottom bar
@@ -97,7 +95,6 @@ impl Default for WindowState {
     fn default() -> Self {
         Self {
             kind: WindowKind::FlowEditor,
-            nodes: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -1,8 +1,9 @@
 //! Per-window state and related types for the flow editor.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use iced::window;
+use url::Url;
 
 use flowcore::model::flow_definition::FlowDefinition;
 
@@ -74,8 +75,6 @@ pub(crate) struct WindowState {
     pub(crate) unsaved_edits: i32,
     /// Path to the last compiled manifest (None if not compiled or edited since)
     pub(crate) compiled_manifest: Option<PathBuf>,
-    /// Path to the currently loaded flow file, if any
-    pub(crate) file_path: Option<PathBuf>,
     /// The original flow definition, used to preserve metadata when saving
     pub(crate) flow_definition: FlowDefinition,
     /// Tooltip text and screen position to display (full source path on hover)
@@ -115,7 +114,6 @@ impl Default for WindowState {
             auto_fit_enabled: false,
             unsaved_edits: 0,
             compiled_manifest: None,
-            file_path: None,
             flow_definition: FlowDefinition::default(),
             tooltip: None,
             initializer_editor: None,
@@ -132,6 +130,24 @@ impl Default for WindowState {
 }
 
 impl WindowState {
+    /// Get the file path from the flow definition's source URL.
+    /// Returns `None` if no file has been saved/loaded yet.
+    pub(crate) fn file_path(&self) -> Option<PathBuf> {
+        self.flow_definition.source_url.to_file_path().ok()
+    }
+
+    /// Set the file path by updating the flow definition's source URL.
+    pub(crate) fn set_file_path(&mut self, path: &Path) {
+        if let Ok(url) = Url::from_file_path(path) {
+            self.flow_definition.source_url = url;
+        }
+    }
+
+    /// Clear the file path by resetting the source URL to the default.
+    pub(crate) fn clear_file_path(&mut self) {
+        self.flow_definition.source_url = FlowDefinition::default_url();
+    }
+
     /// Undo the last edit action.
     pub(crate) fn handle_undo(&mut self) {
         history::handle_undo(self);

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use flowcore::model::flow_definition::FlowDefinition;
 
-use crate::canvas_view::{EdgeLayout, FlowCanvasState, NodeLayout, PortInfo};
+use crate::canvas_view::{FlowCanvasState, NodeLayout, PortInfo};
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history;
 use crate::history::EditHistory;
@@ -55,8 +55,6 @@ pub(crate) struct WindowState {
     pub(crate) kind: WindowKind,
     /// Positioned nodes derived from the flow's process references
     pub(crate) nodes: Vec<NodeLayout>,
-    /// Connection edges between nodes
-    pub(crate) edges: Vec<EdgeLayout>,
     /// Canvas state for caching rendered geometry
     pub(crate) canvas_state: FlowCanvasState,
     /// Status message displayed in the bottom bar
@@ -100,7 +98,6 @@ impl Default for WindowState {
         Self {
             kind: WindowKind::FlowEditor,
             nodes: Vec::new(),
-            edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),
             status: String::new(),
             selected_node: None,

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -132,7 +132,14 @@ impl WindowState {
 
     /// Set the file path by updating the flow definition's source URL.
     pub(crate) fn set_file_path(&mut self, path: &Path) {
-        if let Ok(url) = Url::from_file_path(path) {
+        let abs = path.canonicalize().unwrap_or_else(|_| {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+            }
+        });
+        if let Ok(url) = Url::from_file_path(&abs) {
             self.flow_definition.source_url = url;
         }
     }

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -83,10 +83,6 @@ pub(crate) struct WindowState {
     pub(crate) initializer_editor: Option<InitializerEditor>,
     /// Whether this is the root (main) window
     pub(crate) is_root: bool,
-    /// Flow-level input ports (for sub-flow display)
-    pub(crate) flow_inputs: Vec<PortInfo>,
-    /// Flow-level output ports (for sub-flow display)
-    pub(crate) flow_outputs: Vec<PortInfo>,
     /// Context menu position (screen coords), if showing
     pub(crate) context_menu: Option<(f32, f32)>,
     /// Whether the metadata editor is visible
@@ -118,8 +114,6 @@ impl Default for WindowState {
             tooltip: None,
             initializer_editor: None,
             is_root: false,
-            flow_inputs: Vec::new(),
-            flow_outputs: Vec::new(),
             context_menu: None,
             show_metadata: false,
             flow_hierarchy: FlowHierarchy::empty(),

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -6,8 +6,9 @@ use iced::window;
 use url::Url;
 
 use flowcore::model::flow_definition::FlowDefinition;
+use flowcore::model::function_definition::FunctionDefinition;
 
-use crate::canvas_view::{FlowCanvasState, PortInfo};
+use crate::canvas_view::FlowCanvasState;
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history;
 use crate::history::EditHistory;
@@ -26,21 +27,24 @@ pub(crate) struct InitializerEditor {
 
 /// State for a function definition viewer/editor window.
 pub(crate) struct FunctionViewer {
-    pub(crate) name: String,
-    pub(crate) description: String,
-    pub(crate) source_file: String,
-    pub(crate) inputs: Vec<PortInfo>,
-    pub(crate) outputs: Vec<PortInfo>,
+    /// The canonical function definition (owns name, description, source, inputs, outputs, source_url)
+    pub(crate) func_def: FunctionDefinition,
     pub(crate) rs_content: String,
     pub(crate) docs_content: Option<String>,
     pub(crate) active_tab: usize,
-    pub(crate) toml_path: PathBuf,
     /// Parent window that opened this viewer (for propagating edits back to canvas)
     pub(crate) parent_window: Option<window::Id>,
     /// Source string of the node this viewer is editing (to find the `NodeLayout`)
     pub(crate) node_source: String,
     /// Whether this viewer is read-only (library/context functions cannot be edited)
     pub(crate) read_only: bool,
+}
+
+impl FunctionViewer {
+    /// Derive the TOML file path from the function definition's source URL.
+    pub(crate) fn toml_path(&self) -> Option<PathBuf> {
+        self.func_def.source_url.to_file_path().ok()
+    }
 }
 
 /// What kind of content a window displays.

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -36,7 +36,7 @@ pub(crate) struct FunctionViewer {
     pub(crate) toml_path: PathBuf,
     /// Parent window that opened this viewer (for propagating edits back to canvas)
     pub(crate) parent_window: Option<window::Id>,
-    /// Source string of the node this viewer is editing (to find the NodeLayout)
+    /// Source string of the node this viewer is editing (to find the `NodeLayout`)
     pub(crate) node_source: String,
     /// Whether this viewer is read-only (library/context functions cannot be edited)
     pub(crate) read_only: bool,
@@ -52,8 +52,6 @@ pub(crate) enum WindowKind {
 pub(crate) struct WindowState {
     /// What this window displays
     pub(crate) kind: WindowKind,
-    /// The name of the flow being viewed
-    pub(crate) flow_name: String,
     /// Positioned nodes derived from the flow's process references
     pub(crate) nodes: Vec<NodeLayout>,
     /// Connection edges between nodes
@@ -106,7 +104,6 @@ impl Default for WindowState {
     fn default() -> Self {
         Self {
             kind: WindowKind::FlowEditor,
-            flow_name: String::new(),
             nodes: Vec::new(),
             edges: Vec::new(),
             canvas_state: FlowCanvasState::default(),

--- a/flowr/src/bin/flowrcli/cli/connections.rs
+++ b/flowr/src/bin/flowrcli/cli/connections.rs
@@ -285,7 +285,7 @@ mod test {
             .send(ClientMessage::Hello)
             .expect("Could not send initial 'Hello' message");
 
-        std::thread::sleep(Duration::from_millis(200));
+        std::thread::sleep(Duration::from_millis(500));
 
         assert_eq!(
             coordinator_connection


### PR DESCRIPTION
## Summary

Remove all duplicated state from flowedit. The UI now references canonical flowcore/flowclib types directly instead of maintaining parallel data structures.

### State removed
- **`WindowState.file_path`** → uses `flow_definition.source_url` via `file_path()`/`set_file_path()` helpers
- **`WindowState.flow_inputs`/`flow_outputs`** → uses `flow_definition.inputs`/`outputs` (Vec<IO>) directly
- **`FlowEdit.root_flow_path`** → derived from root window's `source_url`
- **`WindowState.edges: Vec<EdgeLayout>`** → uses `flow_definition.connections` (Vec<Connection>) directly
- **`WindowState.nodes: Vec<NodeLayout>`** → uses `flow_definition.process_refs` + `subprocesses` directly
- **`FunctionViewer` field duplication** → holds `FunctionDefinition` instead of separate name/description/source/inputs/outputs fields

### Structs eliminated
- **`EdgeLayout`** — fully removed; canvas renders from `Connection` directly
- **`NodeLayout`** — removed from persistent state; kept as private ephemeral rendering helper inside `canvas_view.rs`

### Bugs fixed
- Flow I/O edits (add/delete/rename ports) were silently lost on save because only the PortInfo duplicates were updated, not the FlowDefinition
- Duplicate flow I/O names possible after deletions (now generates unique names)
- Missing IOType on new flow ports (now sets FlowInput/FlowOutput correctly)
- Relative paths could silently fail in `set_file_path` (now canonicalized)

### flowcore changes
- `IO::set_name()` method added
- `Connection`: `name()` ungated from debugger feature, `set_name()`/`set_from()`/`set_to()` setters and `new_named()` constructor added

### Other
- ~200 clippy pedantic warnings fixed in flowedit
- Flaky `coordinator_receive_nowait` test timeout increased
- Future architecture plan documented in `docs/superpowers/plans/2026-04-22-single-flowdefinition-owner.md`

Part of #2593

## Test plan

- [x] `cargo test -p flowedit` — 193 tests pass
- [x] `make clippy` — clean (only pre-existing structural warnings)
- [x] `cargo fmt` — clean
- [x] `make test` — all tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flow-level port edits now persist correctly on save.

* **New Features**
  * Port renaming and datatype edits are supported directly in the editor; multi-target connections are handled properly.

* **Refactor**
  * Canvas, undo/redo, and file save/load now operate from a single canonical flow model, simplifying interactions and improving consistency.

* **Documentation**
  * New design/rollout plans added describing the migration away from duplicated UI state.

* **Tests**
  * UI and integration tests updated to exercise the new model-driven behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->