### PR TITLE
flowedit: Encapsulate data and methods, use flowclib types (#2597)

### DIFF
--- a/flowc/src/bin/flowc/lib_build.rs
+++ b/flowc/src/bin/flowc/lib_build.rs
@@ -429,7 +429,7 @@ fn compile_flows(
                 debug!("Trying to load library FlowProcess from '{url}'");
                 match parser::parse(&url, provider) {
                     Ok(FunctionProcess(_)) => {
-                        debug!("Skipping file '{url}'. Reason: 'It is a Function'")
+                        debug!("Skipping file '{url}'. Reason: 'It is a Function'");
                     }
                     Ok(FlowProcess(ref mut flow)) => {
                         // calculate the path of the file's directory, relative to lib_root

--- a/flowc/src/lib/compiler/gatherer.rs
+++ b/flowc/src/lib/compiler/gatherer.rs
@@ -298,7 +298,7 @@ fn find_connection_destinations(
                     }
 
                     IOType::FunctionOutput => {
-                        error!("Error - destination of {next_connection:?} is a functions output!")
+                        error!("Error - destination of {next_connection:?} is a functions output!");
                     }
 
                     IOType::FlowInput => {

--- a/flowc/src/lib/dumper/flow_to_dot.rs
+++ b/flowc/src/lib/dumper/flow_to_dot.rs
@@ -250,7 +250,7 @@ fn process_references_to_dot(flow: &FlowDefinition) -> Result<String> {
                 subflow.route(),
             )?),
             FunctionProcess(ref function) => {
-                contents.push_str(&subfunction_to_dot(function, file_path.as_path())?)
+                contents.push_str(&subfunction_to_dot(function, file_path.as_path())?);
             }
         }
     }

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -30,8 +30,8 @@ use flowcore::model::name::HasName;
 use crate::file_ops;
 use crate::history::EditAction;
 use crate::InitializerEditor;
-use crate::Message;
 use crate::WindowState;
+use crate::{Message, ViewMessage};
 
 /// Action returned by [`handle_canvas_message`] to signal that the caller
 /// (main.rs) needs to perform an operation that requires `FlowEdit` state.
@@ -295,33 +295,33 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
     CanvasAction::None
 }
 
-/// Handle the `ZoomIn` message by zooming in one step.
-pub(crate) fn handle_zoom_in(win: &mut WindowState) {
-    win.auto_fit_enabled = false;
-    win.auto_fit_pending = false;
-    win.canvas_state.zoom_in();
-    let pct = (win.canvas_state.zoom * 100.0) as u32;
-    win.status = format!("Zoom: {pct}%");
-}
-
-/// Handle the `ZoomOut` message by zooming out one step.
-pub(crate) fn handle_zoom_out(win: &mut WindowState) {
-    win.auto_fit_enabled = false;
-    win.auto_fit_pending = false;
-    win.canvas_state.zoom_out();
-    let pct = (win.canvas_state.zoom * 100.0) as u32;
-    win.status = format!("Zoom: {pct}%");
-}
-
-/// Handle the `ToggleAutoFit` message by toggling auto-fit mode.
-pub(crate) fn handle_toggle_auto_fit(win: &mut WindowState) {
-    win.auto_fit_enabled = !win.auto_fit_enabled;
-    if win.auto_fit_enabled {
-        win.auto_fit_pending = true;
-        win.canvas_state.request_redraw();
-        win.status = String::from("Auto-fit enabled");
-    } else {
-        win.status = String::from("Auto-fit disabled");
+/// Handle a view control message (zoom, auto-fit).
+pub(crate) fn handle_view_message(win: &mut WindowState, msg: &ViewMessage) {
+    match msg {
+        ViewMessage::ZoomIn => {
+            win.auto_fit_enabled = false;
+            win.auto_fit_pending = false;
+            win.canvas_state.zoom_in();
+            let pct = (win.canvas_state.zoom * 100.0) as u32;
+            win.status = format!("Zoom: {pct}%");
+        }
+        ViewMessage::ZoomOut => {
+            win.auto_fit_enabled = false;
+            win.auto_fit_pending = false;
+            win.canvas_state.zoom_out();
+            let pct = (win.canvas_state.zoom * 100.0) as u32;
+            win.status = format!("Zoom: {pct}%");
+        }
+        ViewMessage::ToggleAutoFit => {
+            win.auto_fit_enabled = !win.auto_fit_enabled;
+            if win.auto_fit_enabled {
+                win.auto_fit_pending = true;
+                win.canvas_state.request_redraw();
+                win.status = String::from("Auto-fit enabled");
+            } else {
+                win.status = String::from("Auto-fit disabled");
+            }
+        }
     }
 }
 
@@ -2985,19 +2985,19 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
             .spacing(4)
             .push(
                 button(Text::new("+").center())
-                    .on_press(Message::ZoomIn(window_id))
+                    .on_press(Message::View(window_id, ViewMessage::ZoomIn))
                     .width(btn_width)
                     .style(zoom_btn),
             )
             .push(
                 button(Text::new("\u{2212}").center())
-                    .on_press(Message::ZoomOut(window_id))
+                    .on_press(Message::View(window_id, ViewMessage::ZoomOut))
                     .width(btn_width)
                     .style(zoom_btn),
             )
             .push(
                 button(Text::new("Fit").center())
-                    .on_press(Message::ToggleAutoFit(window_id))
+                    .on_press(Message::View(window_id, ViewMessage::ToggleAutoFit))
                     .width(btn_width)
                     .style(if win.auto_fit_enabled {
                         zoom_btn_active

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -295,8 +295,7 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
     CanvasAction::None
 }
 
-/// Handle a view control message (zoom, auto-fit).
-pub(crate) fn handle_view_message(win: &mut WindowState, msg: &ViewMessage) {
+pub(crate) fn update(win: &mut WindowState, msg: &ViewMessage) {
     match msg {
         ViewMessage::ZoomIn => {
             win.auto_fit_enabled = false;

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -28,7 +28,6 @@ use flowcore::model::io::IO;
 use flowcore::model::name::HasName;
 
 use crate::flow_io;
-use crate::history;
 use crate::history::EditAction;
 use crate::InitializerEditor;
 use crate::Message;
@@ -88,16 +87,13 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
         CanvasMessage::MoveCompleted(idx, old_x, old_y, new_x, new_y) => {
             info!("MoveCompleted: idx={idx}, ({old_x},{old_y}) -> ({new_x},{new_y})");
             if (old_x - new_x).abs() > 0.5 || (old_y - new_y).abs() > 0.5 {
-                history::record_edit(
-                    win,
-                    EditAction::MoveNode {
-                        index: idx,
-                        old_x,
-                        old_y,
-                        new_x,
-                        new_y,
-                    },
-                );
+                win.history.record(EditAction::MoveNode {
+                    index: idx,
+                    old_x,
+                    old_y,
+                    new_x,
+                    new_y,
+                });
             }
         }
         #[allow(clippy::similar_names)]
@@ -117,20 +113,17 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                 || (old_w - new_w).abs() > 0.5
                 || (old_h - new_h).abs() > 0.5
             {
-                history::record_edit(
-                    win,
-                    EditAction::ResizeNode {
-                        index: idx,
-                        old_x,
-                        old_y,
-                        old_w,
-                        old_h,
-                        new_x,
-                        new_y,
-                        new_w,
-                        new_h,
-                    },
-                );
+                win.history.record(EditAction::ResizeNode {
+                    index: idx,
+                    old_x,
+                    old_y,
+                    old_w,
+                    old_h,
+                    new_x,
+                    new_y,
+                    new_w,
+                    new_h,
+                });
             }
         }
         CanvasMessage::Deleted(idx) => {
@@ -155,15 +148,12 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                 win.flow_definition
                     .connections
                     .retain(|c| !connection_references_node(c, &alias));
-                history::record_edit(
-                    win,
-                    EditAction::DeleteNode {
-                        index: idx,
-                        process_ref: removed_pref,
-                        subprocess: removed_subprocess.map(|p| (alias, p)),
-                        removed_connections,
-                    },
-                );
+                win.history.record(EditAction::DeleteNode {
+                    index: idx,
+                    process_ref: removed_pref,
+                    subprocess: removed_subprocess.map(|p| (alias, p)),
+                    removed_connections,
+                });
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
@@ -192,12 +182,9 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                 format!("{to_node}/{to_port}")
             };
             let connection = Connection::new(from_route, to_route);
-            history::record_edit(
-                win,
-                EditAction::CreateConnection {
-                    connection: connection.clone(),
-                },
-            );
+            win.history.record(EditAction::CreateConnection {
+                connection: connection.clone(),
+            });
             win.flow_definition.connections.push(connection);
             win.canvas_state.request_redraw();
             let nc = win.flow_definition.process_refs.len();
@@ -231,13 +218,10 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
         CanvasMessage::ConnectionDeleted(idx) => {
             if idx < win.flow_definition.connections.len() {
                 let connection = win.flow_definition.connections.remove(idx);
-                history::record_edit(
-                    win,
-                    EditAction::DeleteConnection {
-                        index: idx,
-                        connection,
-                    },
-                );
+                win.history.record(EditAction::DeleteConnection {
+                    index: idx,
+                    connection,
+                });
                 win.selected_connection = None;
                 win.canvas_state.request_redraw();
                 let nc = win.flow_definition.process_refs.len();

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -27,7 +27,7 @@ use flowcore::model::input::InputInitializer;
 use flowcore::model::io::IO;
 use flowcore::model::name::HasName;
 
-use crate::flow_io;
+use crate::file_ops;
 use crate::history::EditAction;
 use crate::InitializerEditor;
 use crate::Message;
@@ -207,8 +207,8 @@ pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -
                     let (to_node, to_port) = split_route(&to_str);
                     win.status = format!(
                         "Connection: {} -> {}",
-                        flow_io::format_endpoint(&from_node, &from_port),
-                        flow_io::format_endpoint(&to_node, &to_port),
+                        file_ops::format_endpoint(&from_node, &from_port),
+                        file_ops::format_endpoint(&to_node, &to_port),
                     );
                 }
             } else {
@@ -718,8 +718,10 @@ pub(crate) fn build_render_nodes(
 
         let (inputs, outputs) = resolved
             .map(|proc| match proc {
-                Process::FunctionProcess(f) => crate::flow_io::extract_ports(&f.inputs, &f.outputs),
-                Process::FlowProcess(f) => crate::flow_io::extract_ports(&f.inputs, &f.outputs),
+                Process::FunctionProcess(f) => {
+                    crate::file_ops::extract_ports(&f.inputs, &f.outputs)
+                }
+                Process::FlowProcess(f) => crate::file_ops::extract_ports(&f.inputs, &f.outputs),
             })
             .unwrap_or_default();
 

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -1,4 +1,4 @@
-//! Flow file operations: loading, saving, compiling, and editor preferences.
+//! File operations: loading, saving, compiling, and editor preferences.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;

--- a/flowedit/src/flow_io.rs
+++ b/flowedit/src/flow_io.rs
@@ -35,7 +35,7 @@ pub(crate) struct EditorPrefs {
 pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
     match save_flow_toml(&win.flow_definition, path) {
         Ok(()) => {
-            win.unsaved_edits = 0;
+            win.history.clear();
             win.set_file_path(path);
             save_editor_prefs(path, win.last_size, win.last_position);
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
@@ -89,7 +89,6 @@ pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTre
                 win.selected_node = None;
                 win.selected_connection = None;
                 win.history = EditHistory::default();
-                win.unsaved_edits = 0;
                 win.auto_fit_pending = true;
                 win.auto_fit_enabled = true;
                 win.canvas_state = FlowCanvasState::default();
@@ -112,7 +111,6 @@ pub(crate) fn perform_new(win: &mut WindowState) {
     win.selected_node = None;
     win.selected_connection = None;
     win.history = EditHistory::default();
-    win.unsaved_edits = 0;
     win.auto_fit_pending = false;
     win.auto_fit_enabled = true;
     win.canvas_state = FlowCanvasState::default();
@@ -136,9 +134,9 @@ pub(crate) fn perform_compile(win: &mut WindowState) -> Result<PathBuf, String> 
     };
 
     // Save any unsaved edits so the file on disk matches the editor state
-    if win.unsaved_edits > 0 {
+    if !win.history.is_empty() {
         perform_save(win, &flow_path);
-        if win.unsaved_edits > 0 {
+        if !win.history.is_empty() {
             return Err("Save failed — cannot compile stale content".to_string());
         }
     }
@@ -1168,8 +1166,6 @@ mod test {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: false,
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -1188,11 +1184,11 @@ mod test {
         let path = dir.join("saved.toml");
 
         let mut win = test_win_state();
-        win.unsaved_edits = 5;
+        win.history.mark_modified();
         win.flow_definition.name = "saved_flow".into();
 
         perform_save(&mut win, &path);
-        assert_eq!(win.unsaved_edits, 0);
+        assert!(win.history.is_empty());
         let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
         assert_eq!(win.file_path(), Some(canonical));
 

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -2,12 +2,12 @@
 //! as a collapsible tree view. The root flow is at the top, with child
 //! sub-flows and functions as children, recursively.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use iced::widget::{button, container, scrollable, text, Column, Row};
 use iced::{Color, Element, Length};
 
-use flowcore::deserializers::deserializer::get;
+use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::process::Process;
 
 const PANEL_WIDTH: f32 = 220.0;
@@ -41,9 +41,9 @@ pub(crate) struct FlowHierarchy {
 }
 
 impl FlowHierarchy {
-    pub(crate) fn build(flow_path: &Path) -> Self {
-        let root = build_node_from_path(flow_path, 0);
-        Self { root }
+    pub(crate) fn from_flow_definition(flow_def: &FlowDefinition) -> Self {
+        let root = build_node_from_flow(flow_def);
+        Self { root: Some(root) }
     }
 
     pub(crate) fn empty() -> Self {
@@ -188,112 +188,72 @@ fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, Hierarc
     col.into()
 }
 
-fn build_node_from_path(flow_path: &Path, depth: usize) -> Option<HierarchyNode> {
-    if depth > 10 || !flow_path.exists() {
-        return None;
-    }
+fn build_node_from_flow(flow_def: &FlowDefinition) -> HierarchyNode {
+    let mut children = Vec::new();
 
-    let contents = std::fs::read_to_string(flow_path).ok()?;
-    let url = url::Url::from_file_path(std::fs::canonicalize(flow_path).ok()?).ok()?;
-    let deserializer = get::<Process>(&url).ok()?;
-    let process = deserializer.deserialize(&contents, Some(&url)).ok()?;
+    for pref in &flow_def.process_refs {
+        let alias = if pref.alias.is_empty() {
+            crate::canvas_view::derive_short_name(&pref.source)
+        } else {
+            pref.alias.clone()
+        };
 
-    let dir = flow_path.parent()?;
-    let name = match &process {
-        Process::FlowProcess(f) => f.name.clone(),
-        Process::FunctionProcess(f) => f.name.clone(),
-    };
-
-    match process {
-        Process::FlowProcess(flow) => {
-            let mut children = Vec::new();
-            for pref in &flow.process_refs {
-                let alias = if pref.alias.is_empty() {
-                    pref.source
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&pref.source)
-                        .to_string()
-                } else {
-                    pref.alias.clone()
-                };
-
-                if pref.source.starts_with("lib://") || pref.source.starts_with("context://") {
-                    children.push(HierarchyNode {
-                        name: alias,
-                        kind: NodeKind::Library,
-                        source: pref.source.clone(),
-                        path: None,
-                        children: Vec::new(),
-                        expanded: false,
-                    });
-                } else {
-                    // Relative source — resolve to file
-                    let resolved = resolve_source(dir, &pref.source);
-                    if let Some(ref resolved_path) = resolved {
-                        if let Some(child) = build_node_from_path(resolved_path, depth + 1) {
-                            children.push(HierarchyNode {
-                                name: alias,
-                                path: Some(resolved_path.clone()),
-                                ..child
-                            });
-                        } else {
-                            children.push(HierarchyNode {
-                                name: alias,
-                                kind: NodeKind::Function,
-                                source: pref.source.clone(),
-                                path: resolved,
-                                children: Vec::new(),
-                                expanded: false,
-                            });
-                        }
-                    } else {
-                        children.push(HierarchyNode {
-                            name: alias,
-                            kind: NodeKind::Function,
-                            source: pref.source.clone(),
-                            path: None,
-                            children: Vec::new(),
-                            expanded: false,
-                        });
-                    }
-                }
+        match flow_def.subprocesses.get(&alias) {
+            Some(Process::FlowProcess(sub_flow)) => {
+                // Recursively build children from the sub-flow
+                let child = build_node_from_flow(sub_flow);
+                children.push(HierarchyNode {
+                    name: alias,
+                    kind: NodeKind::Flow,
+                    source: pref.source.clone(),
+                    path: sub_flow.source_url.to_file_path().ok(),
+                    children: child.children,
+                    expanded: true,
+                });
             }
-
-            Some(HierarchyNode {
-                name,
-                kind: NodeKind::Flow,
-                source: String::new(),
-                path: Some(flow_path.to_path_buf()),
-                children,
-                expanded: true,
-            })
+            Some(Process::FunctionProcess(func)) => {
+                let kind = if func.lib_reference.is_some() || func.context_reference.is_some() {
+                    NodeKind::Library
+                } else {
+                    NodeKind::Function
+                };
+                children.push(HierarchyNode {
+                    name: alias,
+                    kind,
+                    source: pref.source.clone(),
+                    path: func.source_url.to_file_path().ok(),
+                    children: Vec::new(),
+                    expanded: false,
+                });
+            }
+            None => {
+                // Unresolved - determine kind from source string
+                let kind =
+                    if pref.source.starts_with("lib://") || pref.source.starts_with("context://") {
+                        NodeKind::Library
+                    } else {
+                        NodeKind::Function
+                    };
+                children.push(HierarchyNode {
+                    name: alias,
+                    kind,
+                    source: pref.source.clone(),
+                    path: None,
+                    children: Vec::new(),
+                    expanded: false,
+                });
+            }
         }
-        Process::FunctionProcess(_) => Some(HierarchyNode {
-            name,
-            kind: NodeKind::Function,
-            source: String::new(),
-            path: Some(flow_path.to_path_buf()),
-            children: Vec::new(),
-            expanded: false,
-        }),
     }
-}
 
-fn resolve_source(dir: &Path, source: &str) -> Option<PathBuf> {
-    let candidate = dir.join(source);
-    if candidate.exists() {
-        return Some(std::fs::canonicalize(&candidate).unwrap_or(candidate));
+    HierarchyNode {
+        name: flow_def.name.clone(),
+        kind: NodeKind::Flow,
+        source: String::new(),
+        path: flow_def.source_url.to_file_path().ok(),
+        children,
+        expanded: true,
     }
-    let with_ext = dir.join(format!("{source}.toml"));
-    if with_ext.exists() {
-        return Some(std::fs::canonicalize(&with_ext).unwrap_or(with_ext));
-    }
-    let dir_default = dir.join(source).join("default.toml");
-    if dir_default.exists() {
-        return Some(std::fs::canonicalize(&dir_default).unwrap_or(dir_default));
-    }
-    None
 }
 
 #[cfg(test)]

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -188,8 +188,25 @@ fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, Hierarc
     col.into()
 }
 
+const MAX_HIERARCHY_DEPTH: usize = 10;
+
 fn build_node_from_flow(flow_def: &FlowDefinition) -> HierarchyNode {
+    build_node_from_flow_recursive(flow_def, 0)
+}
+
+fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> HierarchyNode {
     let mut children = Vec::new();
+
+    if depth >= MAX_HIERARCHY_DEPTH {
+        return HierarchyNode {
+            name: flow_def.name.clone(),
+            kind: NodeKind::Flow,
+            source: String::new(),
+            path: flow_def.source_url.to_file_path().ok(),
+            children,
+            expanded: false,
+        };
+    }
 
     for pref in &flow_def.process_refs {
         let alias = if pref.alias.is_empty() {
@@ -201,7 +218,7 @@ fn build_node_from_flow(flow_def: &FlowDefinition) -> HierarchyNode {
         match flow_def.subprocesses.get(&alias) {
             Some(Process::FlowProcess(sub_flow)) => {
                 // Recursively build children from the sub-flow
-                let child = build_node_from_flow(sub_flow);
+                let child = build_node_from_flow_recursive(sub_flow, depth + 1);
                 children.push(HierarchyNode {
                     name: alias,
                     kind: NodeKind::Flow,

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -52,6 +52,15 @@ pub(crate) enum EditAction {
         /// New geometry
         new_h: f32,
     },
+    /// A node was created. Stores the info needed to undo (remove) and redo (re-add) it.
+    CreateNode {
+        /// Index where the node was added
+        index: usize,
+        /// The created process reference
+        process_ref: ProcessReference,
+        /// The subprocess definition, if any
+        subprocess: Option<(Name, Process)>,
+    },
     /// A node was deleted. Stores the process reference and subprocess for restoration.
     DeleteNode {
         /// Index where the node was
@@ -203,6 +212,25 @@ fn apply_undo(win: &mut WindowState) {
                 }
                 win.status = String::from("Undo: resize");
             }
+            EditAction::CreateNode {
+                index,
+                ref process_ref,
+                ..
+            } => {
+                let alias = if process_ref.alias.is_empty() {
+                    crate::canvas_view::derive_short_name(&process_ref.source)
+                } else {
+                    process_ref.alias.clone()
+                };
+                if index < win.flow_definition.process_refs.len() {
+                    win.flow_definition.process_refs.remove(index);
+                    win.flow_definition.subprocesses.remove(&alias);
+                    win.flow_definition
+                        .connections
+                        .retain(|c| !crate::canvas_view::connection_references_node(c, &alias));
+                }
+                win.status = String::from("Undo: create node");
+            }
             EditAction::DeleteNode {
                 index,
                 process_ref,
@@ -275,6 +303,18 @@ fn apply_redo(win: &mut WindowState) {
                     pref.height = Some(new_h);
                 }
                 win.status = String::from("Redo: resize");
+            }
+            EditAction::CreateNode {
+                index,
+                process_ref,
+                subprocess,
+            } => {
+                let idx = index.min(win.flow_definition.process_refs.len());
+                win.flow_definition.process_refs.insert(idx, process_ref);
+                if let Some((name, proc)) = subprocess {
+                    win.flow_definition.subprocesses.insert(name, proc);
+                }
+                win.status = String::from("Redo: create node");
             }
             EditAction::DeleteNode {
                 index,

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -4,6 +4,8 @@
 //! information to both undo and redo the operation. The history is lost
 //! when the application exits.
 
+use std::path::{Path, PathBuf};
+
 use flowcore::model::connection::Connection;
 use flowcore::model::input::InputInitializer;
 use flowcore::model::name::Name;
@@ -86,20 +88,29 @@ pub(crate) enum EditAction {
     },
 }
 
-/// Edit history supporting undo and redo.
+/// Edit history supporting undo and redo, plus tracking of unsaved changes.
+///
+/// The `dirty` flag tracks non-undoable edits (e.g. metadata changes).
+/// The `compiled_manifest` is invalidated whenever any edit occurs.
 #[derive(Default)]
 pub(crate) struct EditHistory {
     /// Stack of actions that can be undone (most recent last)
     undo_stack: Vec<EditAction>,
     /// Stack of actions that can be redone (most recent last)
     redo_stack: Vec<EditAction>,
+    /// Whether non-undoable edits have been made since the last save/clear
+    dirty: bool,
+    /// Path to the last compiled manifest (invalidated on any edit)
+    compiled_manifest: Option<PathBuf>,
 }
 
 impl EditHistory {
-    /// Record a new action. Clears the redo stack since the history has diverged.
+    /// Record a new undoable action. Clears the redo stack since the history
+    /// has diverged, and invalidates the compiled manifest.
     pub(crate) fn record(&mut self, action: EditAction) {
         self.undo_stack.push(action);
         self.redo_stack.clear();
+        self.compiled_manifest = None;
     }
 
     /// Pop the most recent action for undoing. Returns `None` if nothing to undo.
@@ -116,22 +127,48 @@ impl EditHistory {
         Some(action)
     }
 
-    /// Returns true if there are actions that can be undone.
-    pub(crate) fn can_undo(&self) -> bool {
-        !self.undo_stack.is_empty()
+    /// Number of undoable actions on the stack.
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.undo_stack.len()
+    }
+
+    /// Returns `true` if there are no unsaved changes -- neither undoable
+    /// actions on the stack nor a non-undoable `dirty` flag.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.undo_stack.is_empty() && !self.dirty
+    }
+
+    /// Clear both stacks and the dirty flag. Called after a successful save.
+    pub(crate) fn clear(&mut self) {
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.dirty = false;
     }
 
     /// Returns true if there are actions that can be redone.
+    #[allow(dead_code)]
     pub(crate) fn can_redo(&self) -> bool {
         !self.redo_stack.is_empty()
     }
-}
 
-/// Record an edit action in the history and increment the unsaved edit count.
-pub(crate) fn record_edit(win: &mut WindowState, action: EditAction) {
-    win.history.record(action);
-    win.unsaved_edits += 1;
-    win.compiled_manifest = None; // Invalidate compilation on any edit
+    /// Mark the history as having non-undoable modifications (e.g. metadata
+    /// edits). Invalidates the compiled manifest.
+    pub(crate) fn mark_modified(&mut self) {
+        self.dirty = true;
+        self.compiled_manifest = None;
+    }
+
+    /// Path to the last compiled manifest, if any and still valid.
+    #[allow(dead_code)]
+    pub(crate) fn compiled_manifest(&self) -> Option<&Path> {
+        self.compiled_manifest.as_deref()
+    }
+
+    /// Store the path to a successfully compiled manifest.
+    pub(crate) fn set_compiled_manifest(&mut self, path: PathBuf) {
+        self.compiled_manifest = Some(path);
+    }
 }
 
 /// Apply an undo action -- reverse the last edit.
@@ -292,20 +329,14 @@ fn apply_redo(win: &mut WindowState) {
     }
 }
 
-/// Handle undo message -- applies undo and decrements unsaved edit count.
+/// Handle undo message -- applies the most recent undoable action in reverse.
 pub(crate) fn handle_undo(win: &mut WindowState) {
-    if win.history.can_undo() {
-        apply_undo(win);
-        win.unsaved_edits = (win.unsaved_edits - 1).max(0);
-    }
+    apply_undo(win);
 }
 
-/// Handle redo message -- applies redo and increments unsaved edit count.
+/// Handle redo message -- re-applies the most recently undone action.
 pub(crate) fn handle_redo(win: &mut WindowState) {
-    if win.history.can_redo() {
-        apply_redo(win);
-        win.unsaved_edits += 1;
-    }
+    apply_redo(win);
 }
 
 #[cfg(test)]
@@ -335,12 +366,14 @@ mod test {
             new_x: 100.0,
             new_y: 100.0,
         });
-        assert!(history.can_undo());
+        assert!(!history.is_empty());
+        assert_eq!(history.len(), 1);
         assert!(!history.can_redo());
 
         let action = history.undo();
         assert!(action.is_some());
-        assert!(!history.can_undo());
+        assert!(history.is_empty());
+        assert_eq!(history.len(), 0);
         assert!(history.can_redo());
     }
 
@@ -357,7 +390,7 @@ mod test {
         history.undo();
         let action = history.redo();
         assert!(action.is_some());
-        assert!(history.can_undo());
+        assert!(!history.is_empty());
         assert!(!history.can_redo());
     }
 
@@ -382,6 +415,46 @@ mod test {
             new_y: 50.0,
         });
         assert!(!history.can_redo());
+    }
+
+    #[test]
+    fn compiled_manifest_lifecycle() {
+        let mut history = EditHistory::default();
+        assert!(history.compiled_manifest().is_none());
+
+        history.set_compiled_manifest(PathBuf::from("/tmp/test.manifest"));
+        assert_eq!(
+            history.compiled_manifest().map(Path::to_path_buf),
+            Some(PathBuf::from("/tmp/test.manifest"))
+        );
+
+        // Recording an action invalidates the manifest
+        history.record(EditAction::MoveNode {
+            index: 0,
+            old_x: 0.0,
+            old_y: 0.0,
+            new_x: 1.0,
+            new_y: 1.0,
+        });
+        assert!(history.compiled_manifest().is_none());
+
+        // Setting again, then mark_modified also invalidates
+        history.set_compiled_manifest(PathBuf::from("/tmp/test2.manifest"));
+        assert!(history.compiled_manifest().is_some());
+        history.mark_modified();
+        assert!(history.compiled_manifest().is_none());
+    }
+
+    #[test]
+    fn dirty_flag_with_clear() {
+        let mut history = EditHistory::default();
+        assert!(history.is_empty());
+
+        history.mark_modified();
+        assert!(!history.is_empty());
+
+        history.clear();
+        assert!(history.is_empty());
     }
 
     #[test]
@@ -505,17 +578,14 @@ mod test {
             pref.x = Some(200.0);
             pref.y = Some(300.0);
         }
-        record_edit(
-            &mut win,
-            EditAction::MoveNode {
-                index: 0,
-                old_x: 100.0,
-                old_y: 100.0,
-                new_x: 200.0,
-                new_y: 300.0,
-            },
-        );
-        assert_eq!(win.unsaved_edits, 1);
+        win.history.record(EditAction::MoveNode {
+            index: 0,
+            old_x: 100.0,
+            old_y: 100.0,
+            new_x: 200.0,
+            new_y: 300.0,
+        });
+        assert!(!win.history.is_empty());
 
         // Undo
         handle_undo(&mut win);
@@ -538,20 +608,17 @@ mod test {
             pref.width = Some(250.0);
             pref.height = Some(180.0);
         }
-        record_edit(
-            &mut win,
-            EditAction::ResizeNode {
-                index: 0,
-                old_x: 100.0,
-                old_y: 100.0,
-                old_w: 180.0,
-                old_h: 120.0,
-                new_x: 100.0,
-                new_y: 100.0,
-                new_w: 250.0,
-                new_h: 180.0,
-            },
-        );
+        win.history.record(EditAction::ResizeNode {
+            index: 0,
+            old_x: 100.0,
+            old_y: 100.0,
+            old_w: 180.0,
+            old_h: 120.0,
+            new_x: 100.0,
+            new_y: 100.0,
+            new_w: 250.0,
+            new_h: 180.0,
+        });
 
         // Undo
         handle_undo(&mut win);
@@ -571,15 +638,12 @@ mod test {
         let mut win = test_win_state();
         assert_eq!(win.flow_definition.process_refs.len(), 2);
         let removed_pref = win.flow_definition.process_refs.remove(0);
-        record_edit(
-            &mut win,
-            EditAction::DeleteNode {
-                index: 0,
-                process_ref: removed_pref,
-                subprocess: None,
-                removed_connections: Vec::new(),
-            },
-        );
+        win.history.record(EditAction::DeleteNode {
+            index: 0,
+            process_ref: removed_pref,
+            subprocess: None,
+            removed_connections: Vec::new(),
+        });
         assert_eq!(win.flow_definition.process_refs.len(), 1);
 
         // Undo restores
@@ -596,7 +660,8 @@ mod test {
         let mut win = test_win_state();
         let connection = Connection::new("add/out", "stdout/in");
         win.flow_definition.connections.push(connection.clone());
-        record_edit(&mut win, EditAction::CreateConnection { connection });
+        win.history
+            .record(EditAction::CreateConnection { connection });
         assert_eq!(win.flow_definition.connections.len(), 1);
 
         // Undo removes
@@ -615,13 +680,10 @@ mod test {
             .connections
             .push(Connection::new("add/out", "stdout/in"));
         let removed_conn = win.flow_definition.connections.remove(0);
-        record_edit(
-            &mut win,
-            EditAction::DeleteConnection {
-                index: 0,
-                connection: removed_conn,
-            },
-        );
+        win.history.record(EditAction::DeleteConnection {
+            index: 0,
+            connection: removed_conn,
+        });
         assert_eq!(win.flow_definition.connections.len(), 0);
 
         // Undo restores
@@ -639,17 +701,14 @@ mod test {
 
         let mut win = test_win_state();
         // Record an initializer edit
-        record_edit(
-            &mut win,
-            EditAction::EditInitializer {
-                node_index: 0,
-                port_name: "input".into(),
-                old_init: None,
-                new_init: Some(InputInitializer::Once(serde_json::json!(42))),
-            },
-        );
+        win.history.record(EditAction::EditInitializer {
+            node_index: 0,
+            port_name: "input".into(),
+            old_init: None,
+            new_init: Some(InputInitializer::Once(serde_json::json!(42))),
+        });
 
-        // Apply the new state manually (record_edit only records, doesn't apply)
+        // Apply the new state manually (record only records, doesn't apply)
         initializer::apply_initializer_state(
             &mut win,
             0,

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -63,8 +63,6 @@ pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &Initializer
         old_init,
         new_init,
     });
-    win.unsaved_edits += 1;
-    win.compiled_manifest = None;
     win.canvas_state.request_redraw();
     win.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
 }
@@ -166,7 +164,7 @@ mod test {
             value_text: "42".into(),
         };
         apply_initializer_edit(&mut win, &editor);
-        assert!(win.unsaved_edits > 0);
+        assert!(!win.history.is_empty());
         // Check model was updated
         assert!(win
             .flow_definition
@@ -253,7 +251,7 @@ mod test {
     #[test]
     fn initializer_apply_invalid_type_no_change() {
         let mut win = test_win_state();
-        let edits_before = win.unsaved_edits;
+        let empty_before = win.history.is_empty();
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
@@ -262,7 +260,8 @@ mod test {
         };
         apply_initializer_edit(&mut win, &editor);
         assert_eq!(
-            win.unsaved_edits, edits_before,
+            win.history.is_empty(),
+            empty_before,
             "Invalid type should not create an edit"
         );
     }

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -13,7 +13,6 @@ use flowcore::model::process_reference::ProcessReference;
 use flowcore::provider::Provider;
 
 use crate::flow_io;
-use crate::history;
 use crate::history::EditAction;
 use crate::WindowState;
 
@@ -179,19 +178,16 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
         win.flow_definition.subprocesses.insert(alias.clone(), proc);
     }
 
-    history::record_edit(
-        win,
-        EditAction::DeleteNode {
-            index,
-            process_ref: pref,
-            subprocess: win
-                .flow_definition
-                .subprocesses
-                .get(&alias)
-                .map(|p| (alias.clone(), p.clone())),
-            removed_connections: Vec::new(),
-        },
-    );
+    win.history.record(EditAction::DeleteNode {
+        index,
+        process_ref: pref,
+        subprocess: win
+            .flow_definition
+            .subprocesses
+            .get(&alias)
+            .map(|p| (alias.clone(), p.clone())),
+        removed_connections: Vec::new(),
+    });
     // Note: We record a DeleteNode so that *undo* removes the added node.
     // This is intentional: undoing an "add" means deleting what was added.
 
@@ -273,8 +269,6 @@ mod test {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: false,
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -12,7 +12,7 @@ use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 use flowcore::provider::Provider;
 
-use crate::flow_io;
+use crate::file_ops;
 use crate::history::EditAction;
 use crate::WindowState;
 
@@ -24,7 +24,7 @@ use crate::WindowState;
 pub(crate) fn load_library_catalogs(
     lib_references: &BTreeSet<Url>,
 ) -> (HashMap<Url, LibraryManifest>, HashMap<Url, Process>) {
-    let provider = flow_io::build_meta_provider();
+    let provider = file_ops::build_meta_provider();
     let arc_provider: Arc<dyn Provider> = Arc::new(provider);
     let mut library_cache = HashMap::new();
     let mut all_definitions = HashMap::new();
@@ -51,7 +51,7 @@ pub(crate) fn load_library_catalogs(
                 );
 
                 // Parse each function/flow in the manifest
-                let meta_provider = flow_io::build_meta_provider();
+                let meta_provider = file_ops::build_meta_provider();
                 for locator_url in manifest.locators.keys() {
                     match flowrclib::compiler::parser::parse(locator_url, &meta_provider) {
                         Ok(process) => {
@@ -74,7 +74,7 @@ pub(crate) fn load_library_catalogs(
     // Discover and parse context functions from the flowrcli runner directory.
     // Only scan ~/.flow/runner/flowrcli/ since flowedit only supports the flowrcli runner,
     // and the MetaProvider is configured with that context root.
-    let ctx_provider = flow_io::build_meta_provider();
+    let ctx_provider = file_ops::build_meta_provider();
     let runner_dir = std::env::var("HOME")
         .map(|h| {
             std::path::PathBuf::from(h)
@@ -137,15 +137,15 @@ pub(crate) fn load_library_catalogs(
 /// in the flow definition, and records the action in the edit history.
 pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_name: &str) {
     // Generate a unique alias: if the name already exists, append a number
-    let alias = flow_io::generate_unique_alias(func_name, &win.flow_definition.process_refs);
+    let alias = file_ops::generate_unique_alias(func_name, &win.flow_definition.process_refs);
 
     // Place the new node at a default position offset from existing nodes
-    let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
+    let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
 
     // Resolve the subprocess definition by parsing the function/flow
     let resolved_process = match Url::parse(source) {
         Ok(url) => {
-            let provider = flow_io::build_meta_provider();
+            let provider = file_ops::build_meta_provider();
             match flowrclib::compiler::parser::parse(&url, &provider) {
                 Ok(proc) => Some(proc),
                 Err(e) => {

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -178,7 +178,7 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
         win.flow_definition.subprocesses.insert(alias.clone(), proc);
     }
 
-    win.history.record(EditAction::DeleteNode {
+    win.history.record(EditAction::CreateNode {
         index,
         process_ref: pref,
         subprocess: win
@@ -186,10 +186,7 @@ pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_nam
             .subprocesses
             .get(&alias)
             .map(|p| (alias.clone(), p.clone())),
-        removed_connections: Vec::new(),
     });
-    // Note: We record a DeleteNode so that *undo* removes the added node.
-    // This is intentional: undoing an "add" means deleting what was added.
 
     win.selected_node = Some(index);
     win.canvas_state.request_redraw();

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -42,24 +42,13 @@ pub(crate) enum LibraryAction {
     AddLibrary,
 }
 
-/// A single function entry in the library tree.
-#[derive(Debug, Clone)]
-pub(crate) struct FunctionEntry {
-    /// Display name of the function (e.g., "add")
-    pub name: String,
-    /// Source URL for this function (e.g., `lib://flowstdlib/math/add`)
-    pub source: String,
-    /// Description from the canonical definition
-    pub description: String,
-}
-
 /// A category grouping functions within a library.
 #[derive(Debug, Clone)]
 pub(crate) struct CategoryEntry {
     /// Category name (e.g., "math")
     pub name: String,
-    /// Functions in this category
-    pub functions: Vec<FunctionEntry>,
+    /// URLs of functions in this category, pointing into `all_definitions`
+    pub function_urls: Vec<Url>,
     /// Whether the category is expanded in the tree view
     pub expanded: bool,
 }
@@ -97,7 +86,7 @@ impl LibraryTree {
         // Build tree entries from library manifests
         for manifest in library_cache.values() {
             let lib_name = manifest.lib_url.host_str().unwrap_or("unknown").to_string();
-            let categories = build_categories_from_manifest(&manifest.locators, all_definitions);
+            let categories = build_categories_from_manifest(&manifest.locators);
 
             if !categories.is_empty() {
                 libraries.push(LibraryEntry {
@@ -109,11 +98,11 @@ impl LibraryTree {
         }
 
         // Build context functions entry from context:// definitions in the unified map
-        let context_defs: HashMap<&Url, &Process> = all_definitions
-            .iter()
-            .filter(|(url, _)| url.scheme() == "context")
+        let context_urls: Vec<&Url> = all_definitions
+            .keys()
+            .filter(|url| url.scheme() == "context")
             .collect();
-        let context_entry = build_context_entry(&context_defs);
+        let context_entry = build_context_entry(&context_urls);
         let has_context = !context_entry.categories.is_empty();
         if has_context {
             libraries.insert(0, context_entry);
@@ -159,7 +148,13 @@ impl LibraryTree {
     }
 
     /// Render the library panel as an iced `Element`.
-    pub(crate) fn view(&self) -> Element<'_, LibraryMessage> {
+    ///
+    /// Function names and descriptions are looked up from `all_definitions`
+    /// at render time, avoiding duplication of data from the canonical types.
+    pub(crate) fn view<'a>(
+        &'a self,
+        all_definitions: &'a HashMap<Url, Process>,
+    ) -> Element<'a, LibraryMessage> {
         let mut content = Column::new().spacing(2).padding(6);
 
         let header = text("Process Library").size(14);
@@ -217,20 +212,22 @@ impl LibraryTree {
                     content = content.push(cat_btn);
 
                     if cat.expanded {
-                        for func in &cat.functions {
+                        for func_url in &cat.function_urls {
+                            let func_name = func_name_from_url(func_url);
+                            let description =
+                                func_description_from_definitions(func_url, all_definitions);
+                            let source = func_url.to_string();
+
                             let view_btn = button(text("\u{270E}").size(10))
                                 .on_press(LibraryMessage::ViewFunction(
-                                    func.source.clone(),
-                                    func.name.clone(),
+                                    source.clone(),
+                                    func_name.clone(),
                                 ))
                                 .style(button::text)
                                 .padding([1, 3]);
 
-                            let func_btn = button(text(&func.name).size(11))
-                                .on_press(LibraryMessage::AddFunction(
-                                    func.source.clone(),
-                                    func.name.clone(),
-                                ))
+                            let func_btn = button(text(func_name.clone()).size(11))
+                                .on_press(LibraryMessage::AddFunction(source, func_name))
                                 .style(button::text)
                                 .padding([2, 4]);
 
@@ -240,15 +237,12 @@ impl LibraryTree {
                                 .push(view_btn)
                                 .push(func_btn);
 
-                            let entry_widget: Element<'_, LibraryMessage> =
-                                if func.description.is_empty() {
-                                    row.into()
-                                } else {
-                                    tooltip(
-                                        row,
-                                        text(&func.description).size(14),
-                                        tooltip::Position::Bottom,
-                                    )
+                            let entry_widget: Element<'_, LibraryMessage> = if description
+                                .is_empty()
+                            {
+                                row.into()
+                            } else {
+                                tooltip(row, text(description).size(14), tooltip::Position::Bottom)
                                     .gap(2)
                                     .style(|_theme: &iced::Theme| container::Style {
                                         background: Some(iced::Background::Color(
@@ -262,7 +256,7 @@ impl LibraryTree {
                                         ..Default::default()
                                     })
                                     .into()
-                                };
+                            };
 
                             content =
                                 content.push(container(entry_widget).padding(iced::Padding {
@@ -292,16 +286,41 @@ impl LibraryTree {
     }
 }
 
+/// Extract a display name for a function from its URL.
+///
+/// For lib URLs like `lib://flowstdlib/math/add`, returns the path after the
+/// category (e.g., "add"). For context URLs like `context://stdio/stdout`,
+/// returns the last path segment (e.g., "stdout").
+fn func_name_from_url(url: &Url) -> String {
+    let path = url.path();
+    let segments: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+    match segments.as_slice() {
+        [] => String::new(),
+        [single] => (*single).to_string(),
+        [_first, rest @ ..] => rest.join("/"),
+    }
+}
+
+/// Look up description for a function URL from the definitions map.
+fn func_description_from_definitions(url: &Url, all_definitions: &HashMap<Url, Process>) -> String {
+    all_definitions
+        .get(url)
+        .map(|process| match process {
+            Process::FlowProcess(flow_def) => flow_def.description.clone(),
+            Process::FunctionProcess(func_def) => func_def.description.clone(),
+        })
+        .unwrap_or_default()
+}
+
 /// Build category entries from a manifest's locator map.
 ///
 /// Each locator URL has the form `lib://library/category/function`.
-/// We extract category and function names from the URL path segments.
+/// We extract the category name from the URL path segments and store just the URL.
 fn build_categories_from_manifest(
     locators: &BTreeMap<Url, flowcore::model::lib_manifest::ImplementationLocator>,
-    all_definitions: &HashMap<Url, Process>,
 ) -> Vec<CategoryEntry> {
-    // Group functions by category
-    let mut category_map: BTreeMap<String, Vec<FunctionEntry>> = BTreeMap::new();
+    // Group function URLs by category
+    let mut category_map: BTreeMap<String, Vec<Url>> = BTreeMap::new();
 
     for url in locators.keys() {
         // URL path looks like "/category/function" (leading slash)
@@ -318,32 +337,16 @@ fn build_categories_from_manifest(
             continue;
         }
 
-        // Extract description from definition if available
-        let description = all_definitions
-            .get(url)
-            .map(|process| match process {
-                Process::FlowProcess(flow_def) => flow_def.description.clone(),
-                Process::FunctionProcess(func_def) => func_def.description.clone(),
-            })
-            .unwrap_or_default();
-
-        category_map
-            .entry(cat_name)
-            .or_default()
-            .push(FunctionEntry {
-                name: func_name,
-                source: url.to_string(),
-                description,
-            });
+        category_map.entry(cat_name).or_default().push(url.clone());
     }
 
     let mut categories: Vec<CategoryEntry> = category_map
         .into_iter()
-        .map(|(name, mut functions)| {
-            functions.sort_by(|a, b| a.name.cmp(&b.name));
+        .map(|(name, mut function_urls)| {
+            function_urls.sort_by_key(func_name_from_url);
             CategoryEntry {
                 name,
-                functions,
+                function_urls,
                 expanded: false,
             }
         })
@@ -356,10 +359,10 @@ fn build_categories_from_manifest(
 /// Build a "Context" library entry from parsed context definitions.
 ///
 /// Context URLs have the form `context://category/function`.
-fn build_context_entry(context_definitions: &HashMap<&Url, &Process>) -> LibraryEntry {
-    let mut category_map: BTreeMap<String, Vec<FunctionEntry>> = BTreeMap::new();
+fn build_context_entry(context_urls: &[&Url]) -> LibraryEntry {
+    let mut category_map: BTreeMap<String, Vec<Url>> = BTreeMap::new();
 
-    for (url, process) in context_definitions {
+    for url in context_urls {
         // context://category/function
         let cat_name = url.host_str().unwrap_or("general").to_string();
         let func_name = url
@@ -374,29 +377,19 @@ fn build_context_entry(context_definitions: &HashMap<&Url, &Process>) -> Library
             continue;
         }
 
-        // Extract description from definition
-        let description = match process {
-            Process::FlowProcess(flow_def) => flow_def.description.clone(),
-            Process::FunctionProcess(func_def) => func_def.description.clone(),
-        };
-
         category_map
             .entry(cat_name)
             .or_default()
-            .push(FunctionEntry {
-                name: func_name,
-                source: url.to_string(),
-                description,
-            });
+            .push((*url).clone());
     }
 
     let mut categories: Vec<CategoryEntry> = category_map
         .into_iter()
-        .map(|(name, mut functions)| {
-            functions.sort_by(|a, b| a.name.cmp(&b.name));
+        .map(|(name, mut function_urls)| {
+            function_urls.sort_by_key(func_name_from_url);
             CategoryEntry {
                 name,
-                functions,
+                function_urls,
                 expanded: false,
             }
         })
@@ -421,8 +414,9 @@ mod test {
         let tree = LibraryTree {
             libraries: Vec::new(),
         };
+        let all_defs = HashMap::new();
         // Should render without panic
-        let _element: Element<'_, LibraryMessage> = tree.view();
+        let _element: Element<'_, LibraryMessage> = tree.view(&all_defs);
     }
 
     #[test]
@@ -446,7 +440,7 @@ mod test {
                 name: "test".into(),
                 categories: vec![CategoryEntry {
                     name: "math".into(),
-                    functions: Vec::new(),
+                    function_urls: Vec::new(),
                     expanded: false,
                 }],
                 expanded: true,
@@ -498,7 +492,7 @@ mod test {
         let mut all_defs = HashMap::new();
         let url = Url::parse("context://stdio/stdout").expect("valid url");
         all_defs.insert(
-            url,
+            url.clone(),
             Process::FunctionProcess(
                 flowcore::model::function_definition::FunctionDefinition::default(),
             ),
@@ -508,8 +502,8 @@ mod test {
         assert_eq!(tree.libraries[0].name, "Context");
         assert_eq!(tree.libraries[0].categories.len(), 1);
         assert_eq!(tree.libraries[0].categories[0].name, "stdio");
-        assert_eq!(tree.libraries[0].categories[0].functions.len(), 1);
-        assert_eq!(tree.libraries[0].categories[0].functions[0].name, "stdout");
+        assert_eq!(tree.libraries[0].categories[0].function_urls.len(), 1);
+        assert_eq!(tree.libraries[0].categories[0].function_urls[0], url);
     }
 
     #[test]
@@ -605,32 +599,38 @@ mod test {
     #[test]
     fn build_categories_from_locators() {
         let mut locators = BTreeMap::new();
+        let add_url = Url::parse("lib://flowstdlib/math/add").expect("valid url");
+        let subtract_url = Url::parse("lib://flowstdlib/math/subtract").expect("valid url");
+        let tap_url = Url::parse("lib://flowstdlib/control/tap").expect("valid url");
         locators.insert(
-            Url::parse("lib://flowstdlib/math/add").expect("valid url"),
+            add_url.clone(),
             flowcore::model::lib_manifest::ImplementationLocator::RelativePath(
                 "math/add.wasm".into(),
             ),
         );
         locators.insert(
-            Url::parse("lib://flowstdlib/math/subtract").expect("valid url"),
+            subtract_url.clone(),
             flowcore::model::lib_manifest::ImplementationLocator::RelativePath(
                 "math/subtract.wasm".into(),
             ),
         );
         locators.insert(
-            Url::parse("lib://flowstdlib/control/tap").expect("valid url"),
+            tap_url,
             flowcore::model::lib_manifest::ImplementationLocator::RelativePath(
                 "control/tap.wasm".into(),
             ),
         );
 
-        let categories = build_categories_from_manifest(&locators, &HashMap::new());
+        let categories = build_categories_from_manifest(&locators);
         assert_eq!(categories.len(), 2);
         // Categories should be sorted alphabetically
         assert_eq!(categories[0].name, "control");
         assert_eq!(categories[1].name, "math");
-        assert_eq!(categories[1].functions.len(), 2);
-        assert_eq!(categories[1].functions[0].name, "add");
-        assert_eq!(categories[1].functions[1].name, "subtract");
+        assert_eq!(categories[1].function_urls.len(), 2);
+        assert_eq!(func_name_from_url(&categories[1].function_urls[0]), "add");
+        assert_eq!(
+            func_name_from_url(&categories[1].function_urls[1]),
+            "subtract"
+        );
     }
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -372,8 +372,6 @@ impl FlowEdit {
             auto_fit_pending: has_nodes,
             auto_fit_enabled: true,
             history: EditHistory::default(),
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition,
             tooltip: None,
             initializer_editor: None,
@@ -406,7 +404,7 @@ impl FlowEdit {
     /// Return the window title, showing the flow name, file name, and unsaved indicator.
     fn title(&self, window_id: window::Id) -> String {
         if let Some(win) = self.windows.get(&window_id) {
-            let modified = if win.unsaved_edits > 0 { " *" } else { "" };
+            let modified = if win.history.is_empty() { "" } else { " *" };
             let file = win
                 .file_path()
                 .as_ref()
@@ -469,8 +467,6 @@ impl FlowEdit {
                             history: EditHistory::default(),
                             auto_fit_pending: has_nodes,
                             auto_fit_enabled: true,
-                            unsaved_edits: 0,
-                            compiled_manifest: None,
                             flow_definition: flow_def,
                             tooltip: None,
                             initializer_editor: None,
@@ -701,11 +697,10 @@ impl FlowEdit {
                     if !win.flow_definition.process_refs.is_empty() {
                         match flow_io::perform_compile(win) {
                             Ok(path) => {
-                                win.compiled_manifest = Some(path.clone());
+                                win.history.set_compiled_manifest(path.clone());
                                 win.status = format!("Compiled: {}", path.display());
                             }
                             Err(e) => {
-                                win.compiled_manifest = None;
                                 win.status = e;
                             }
                         }
@@ -717,15 +712,15 @@ impl FlowEdit {
                     match flow_msg {
                         FlowEditMessage::NameChanged(new_name) => {
                             win.flow_definition.name = new_name;
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         FlowEditMessage::VersionChanged(version) => {
                             win.flow_definition.metadata.version = version;
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         FlowEditMessage::DescriptionChanged(desc) => {
                             win.flow_definition.metadata.description = desc;
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         FlowEditMessage::AuthorsChanged(authors_str) => {
                             win.flow_definition.metadata.authors = authors_str
@@ -733,7 +728,7 @@ impl FlowEdit {
                                 .map(|s| s.trim().to_string())
                                 .filter(|s| !s.is_empty())
                                 .collect();
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         FlowEditMessage::ToggleMetadata => {
                             win.show_metadata = !win.show_metadata;
@@ -747,7 +742,7 @@ impl FlowEdit {
                             );
                             io.set_io_type(IOType::FlowInput);
                             win.flow_definition.inputs.push(io);
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::AddOutput => {
@@ -759,7 +754,7 @@ impl FlowEdit {
                             );
                             io.set_io_type(IOType::FlowOutput);
                             win.flow_definition.outputs.push(io);
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::DeleteInput(idx) => {
@@ -772,7 +767,7 @@ impl FlowEdit {
                                         canvas_view::split_route(c.from().as_ref());
                                     !(from_node == "input" && from_port == name)
                                 });
-                                win.unsaved_edits += 1;
+                                win.history.mark_modified();
                                 win.canvas_state.request_redraw();
                             }
                         }
@@ -791,7 +786,7 @@ impl FlowEdit {
                                     }
                                     true
                                 });
-                                win.unsaved_edits += 1;
+                                win.history.mark_modified();
                                 win.canvas_state.request_redraw();
                             }
                         }
@@ -814,7 +809,7 @@ impl FlowEdit {
                                         }
                                     }
                                 }
-                                win.unsaved_edits += 1;
+                                win.history.mark_modified();
                                 win.canvas_state.request_redraw();
                             }
                         }
@@ -822,7 +817,7 @@ impl FlowEdit {
                             if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
                                 io.set_datatypes(&[DataType::from(dtype)]);
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                             win.canvas_state.request_redraw();
                         }
                         FlowEditMessage::OutputNameChanged(idx, name) => {
@@ -853,7 +848,7 @@ impl FlowEdit {
                                         conn.set_to(new_to);
                                     }
                                 }
-                                win.unsaved_edits += 1;
+                                win.history.mark_modified();
                                 win.canvas_state.request_redraw();
                             }
                         }
@@ -861,7 +856,7 @@ impl FlowEdit {
                             if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
                                 io.set_datatypes(&[DataType::from(dtype)]);
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                             win.canvas_state.request_redraw();
                         }
                     }
@@ -945,7 +940,7 @@ impl FlowEdit {
                             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
                                 viewer.func_def.name = new_name;
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                     }
                     FunctionEditMessage::DescriptionChanged(new_desc) => {
@@ -963,7 +958,7 @@ impl FlowEdit {
                             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
                                 viewer.func_def.description.clone_from(&new_desc);
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         // Propagate description to the parent window's subprocess definitions
                         if let Some((parent_id, node_source)) = parent_info {
@@ -1013,7 +1008,7 @@ impl FlowEdit {
                                     viewer.rs_content = std::fs::read_to_string(&selected)
                                         .unwrap_or_else(|_| String::from("// Could not read file"));
                                 }
-                                win.unsaved_edits += 1;
+                                win.history.mark_modified();
                             }
                         }
                     }
@@ -1027,7 +1022,7 @@ impl FlowEdit {
                                     &name,
                                 ));
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1041,7 +1036,7 @@ impl FlowEdit {
                                     &name,
                                 ));
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1052,7 +1047,7 @@ impl FlowEdit {
                                     v.func_def.inputs.remove(idx);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1063,7 +1058,7 @@ impl FlowEdit {
                                     v.func_def.outputs.remove(idx);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1074,7 +1069,7 @@ impl FlowEdit {
                                     io.set_name(name);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1085,7 +1080,7 @@ impl FlowEdit {
                                     io.set_datatypes(&[DataType::from(dtype)]);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1096,7 +1091,7 @@ impl FlowEdit {
                                     io.set_name(name);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1107,7 +1102,7 @@ impl FlowEdit {
                                     io.set_datatypes(&[DataType::from(dtype)]);
                                 }
                             }
-                            win.unsaved_edits += 1;
+                            win.history.mark_modified();
                         }
                         Self::propagate_function_ports(&mut self.windows, win_id);
                     }
@@ -1121,7 +1116,7 @@ impl FlowEdit {
                                             |p| p.display().to_string(),
                                         );
                                         win.status = format!("Saved: {path_display}");
-                                        win.unsaved_edits = 0;
+                                        win.history.clear();
                                     }
                                     Err(e) => {
                                         win.status = format!("Save failed: {e}");
@@ -1151,7 +1146,7 @@ impl FlowEdit {
                     return Task::none();
                 };
                 if let Some(win) = self.windows.get(&id) {
-                    if win.unsaved_edits > 0 {
+                    if !win.history.is_empty() {
                         let dialog = rfd::MessageDialog::new()
                             .set_title("Unsaved Changes")
                             .set_description(
@@ -1172,7 +1167,7 @@ impl FlowEdit {
             }
             Message::QuitAll => {
                 // Check for unsaved edits in any window
-                let has_unsaved = self.windows.values().any(|w| w.unsaved_edits > 0);
+                let has_unsaved = self.windows.values().any(|w| !w.history.is_empty());
                 if has_unsaved {
                     let dialog = rfd::MessageDialog::new()
                         .set_title("Unsaved Changes")
@@ -1196,7 +1191,7 @@ impl FlowEdit {
         };
 
         if let WindowKind::FunctionViewer(ref viewer) = win.kind {
-            return Self::view_function(window_id, viewer, &win.status, win.unsaved_edits);
+            return Self::view_function(window_id, viewer, &win.status, !win.history.is_empty());
         }
 
         let canvas_with_controls = canvas_view::view_canvas_area(win, window_id);
@@ -1246,10 +1241,10 @@ impl FlowEdit {
         win: &'a WindowState,
         window_id: window::Id,
     ) -> Element<'a, Message> {
-        let edit_indicator = if win.unsaved_edits > 0 {
-            format!("  |  {} unsaved edit(s)", win.unsaved_edits)
-        } else {
+        let edit_indicator = if win.history.is_empty() {
             String::from("  |  saved")
+        } else {
+            String::from("  |  unsaved edit(s)")
         };
 
         let btn_pad = [6, 14];
@@ -1610,7 +1605,7 @@ impl FlowEdit {
         window_id: window::Id,
         viewer: &'a FunctionViewer,
         status: &'a str,
-        unsaved_edits: i32,
+        has_unsaved: bool,
     ) -> Element<'a, Message> {
         let content: Element<'_, Message> = match viewer.active_tab {
             0 => {
@@ -1883,13 +1878,13 @@ impl FlowEdit {
         };
 
         let mut save_btn = button(Text::new("\u{1F4BE} Save").size(14).center())
-            .style(if unsaved_edits > 0 && !viewer.read_only {
+            .style(if has_unsaved && !viewer.read_only {
                 button::primary
             } else {
                 button::secondary
             })
             .padding([6, 14]);
-        if unsaved_edits > 0 && !viewer.read_only {
+        if has_unsaved && !viewer.read_only {
             save_btn =
                 save_btn.on_press(Message::FunctionEdit(window_id, FunctionEditMessage::Save));
         }
@@ -2006,8 +2001,6 @@ impl FlowEdit {
                         history: EditHistory::default(),
                         auto_fit_pending: has_nodes,
                         auto_fit_enabled: true,
-                        unsaved_edits: 0,
-                        compiled_manifest: None,
                         flow_definition: flow_def,
                         tooltip: None,
                         initializer_editor: None,
@@ -2137,8 +2130,6 @@ impl FlowEdit {
                     history: EditHistory::default(),
                     auto_fit_pending: has_nodes,
                     auto_fit_enabled: true,
-                    unsaved_edits: 0,
-                    compiled_manifest: None,
                     flow_definition: flow_def,
                     tooltip: None,
                     initializer_editor: None,
@@ -2213,8 +2204,6 @@ impl FlowEdit {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: false,
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -2316,7 +2305,7 @@ impl FlowEdit {
                 width: Some(180.0),
                 height: Some(120.0),
             });
-            win.unsaved_edits += 1;
+            win.history.mark_modified();
             win.canvas_state.request_redraw();
             win.status = format!("Created sub-flow: {alias}");
         }
@@ -2334,8 +2323,6 @@ impl FlowEdit {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: true,
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition: flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -2415,7 +2402,7 @@ impl FlowEdit {
                 width: Some(180.0),
                 height: Some(120.0),
             });
-            win.unsaved_edits += 1;
+            win.history.mark_modified();
             win.canvas_state.request_redraw();
             win.status = format!("Created function: {alias}");
         }
@@ -2446,7 +2433,7 @@ impl FlowEdit {
         if let Ok(url) = Url::from_file_path(&path) {
             func_flow_def.source_url = url;
         }
-        let child = WindowState {
+        let mut child = WindowState {
             kind: WindowKind::FunctionViewer(viewer),
 
             canvas_state: FlowCanvasState::default(),
@@ -2456,8 +2443,6 @@ impl FlowEdit {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: false,
-            unsaved_edits: 1,
-            compiled_manifest: None,
             flow_definition: func_flow_def,
             tooltip: None,
             initializer_editor: None,
@@ -2468,6 +2453,7 @@ impl FlowEdit {
             last_size: None,
             last_position: None,
         };
+        child.history.mark_modified(); // New function starts dirty
 
         self.windows.insert(new_id, child);
         open_task.discard()

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -795,62 +795,8 @@ impl FlowEdit {
                     win.handle_redo();
                 }
             }
-            Message::Save => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::handle_save(win);
-                }
-            }
-            Message::SaveAs => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::handle_save_as(win);
-                }
-            }
-            Message::Open => {
-                if let Some(root_id) = self.root_window {
-                    if let Some(win) = self.windows.get_mut(&root_id) {
-                        if let Some((lib_refs, _ctx_refs)) = file_ops::perform_open(win) {
-                            win.flow_hierarchy = win
-                                .file_path()
-                                .as_ref()
-                                .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
-
-                            // Rebuild library cache with new flow's references
-                            let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
-                            self.library_cache = lc;
-                            self.all_definitions = ad;
-                            self.library_tree =
-                                LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
-                        }
-                    }
-                }
-            }
-            Message::New => {
-                if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::perform_new(win);
-                    // Clear the library cache for a new (empty) flow
-                    self.library_cache.clear();
-                    self.all_definitions.clear();
-                    self.library_tree =
-                        LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
-                }
-            }
-            Message::Compile => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    if !win.flow_definition.process_refs.is_empty() {
-                        match file_ops::perform_compile(win) {
-                            Ok(path) => {
-                                win.history.set_compiled_manifest(path.clone());
-                                win.status = format!("Compiled: {}", path.display());
-                            }
-                            Err(e) => {
-                                win.status = e;
-                            }
-                        }
-                    }
-                }
+            Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
+                self.handle_file_message(message);
             }
             Message::FlowEdit(win_id, flow_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -2254,6 +2200,68 @@ impl FlowEdit {
 
         self.windows.insert(new_id, child);
         open_task.discard()
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn handle_file_message(&mut self, message: Message) {
+        match message {
+            Message::Save => {
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    file_ops::handle_save(win);
+                }
+            }
+            Message::SaveAs => {
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    file_ops::handle_save_as(win);
+                }
+            }
+            Message::Open => {
+                if let Some(root_id) = self.root_window {
+                    if let Some(win) = self.windows.get_mut(&root_id) {
+                        if let Some((lib_refs, _ctx_refs)) = file_ops::perform_open(win) {
+                            win.flow_hierarchy = win
+                                .file_path()
+                                .as_ref()
+                                .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
+
+                            let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
+                            self.library_cache = lc;
+                            self.all_definitions = ad;
+                            self.library_tree =
+                                LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
+                        }
+                    }
+                }
+            }
+            Message::New => {
+                if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
+                    file_ops::perform_new(win);
+                    self.library_cache.clear();
+                    self.all_definitions.clear();
+                    self.library_tree =
+                        LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
+                }
+            }
+            Message::Compile => {
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    if !win.flow_definition.process_refs.is_empty() {
+                        match file_ops::perform_compile(win) {
+                            Ok(path) => {
+                                win.history.set_compiled_manifest(path.clone());
+                                win.status = format!("Compiled: {}", path.display());
+                            }
+                            Err(e) => {
+                                win.status = e;
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Handle function definition viewing/editing messages.

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -45,7 +45,7 @@ use history::EditHistory;
 use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
 
 mod canvas_view;
-mod flow_io;
+mod file_ops;
 mod hierarchy_panel;
 mod history;
 mod initializer;
@@ -446,7 +446,7 @@ impl FlowEdit {
         let (status, flow_definition, lib_refs) =
             if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
                 let flow_path = PathBuf::from(flow_path_str);
-                match flow_io::load_flow(&flow_path) {
+                match file_ops::load_flow(&flow_path) {
                     Ok(loaded) => {
                         let nc = loaded.flow_def.process_refs.len();
                         let ec = loaded.flow_def.connections.len();
@@ -486,7 +486,7 @@ impl FlowEdit {
         let file_path = flow_definition.source_url.to_file_path().ok();
         let saved_prefs = file_path
             .as_ref()
-            .and_then(|p| flow_io::load_editor_prefs(p));
+            .and_then(|p| file_ops::load_editor_prefs(p));
         let saved_size = saved_prefs.as_ref().map_or_else(
             || iced::Size::new(1024.0, 768.0),
             |p| iced::Size::new(p.width, p.height),
@@ -531,7 +531,7 @@ impl FlowEdit {
         let mut windows = HashMap::new();
         windows.insert(root_id, win_state);
 
-        let lib_paths = flow_io::resolve_lib_paths();
+        let lib_paths = file_ops::resolve_lib_paths();
         let app = FlowEdit {
             windows,
             root_window: Some(root_id),
@@ -592,7 +592,7 @@ impl FlowEdit {
                         }
                     }
                     // Open the flow or function
-                    if let Ok(loaded) = flow_io::load_flow(&path) {
+                    if let Ok(loaded) = file_ops::load_flow(&path) {
                         let (new_id, open_task) =
                             window::open(self.child_window_settings(1024.0, 768.0));
                         let has_nodes = !loaded.flow_def.process_refs.is_empty();
@@ -798,19 +798,19 @@ impl FlowEdit {
             Message::Save => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    flow_io::handle_save(win);
+                    file_ops::handle_save(win);
                 }
             }
             Message::SaveAs => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    flow_io::handle_save_as(win);
+                    file_ops::handle_save_as(win);
                 }
             }
             Message::Open => {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
-                        if let Some((lib_refs, _ctx_refs)) = flow_io::perform_open(win) {
+                        if let Some((lib_refs, _ctx_refs)) = file_ops::perform_open(win) {
                             win.flow_hierarchy = win
                                 .file_path()
                                 .as_ref()
@@ -828,7 +828,7 @@ impl FlowEdit {
             }
             Message::New => {
                 if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
-                    flow_io::perform_new(win);
+                    file_ops::perform_new(win);
                     // Clear the library cache for a new (empty) flow
                     self.library_cache.clear();
                     self.all_definitions.clear();
@@ -840,7 +840,7 @@ impl FlowEdit {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
                     if !win.flow_definition.process_refs.is_empty() {
-                        match flow_io::perform_compile(win) {
+                        match file_ops::perform_compile(win) {
                             Ok(path) => {
                                 win.history.set_compiled_manifest(path.clone());
                                 win.status = format!("Compiled: {}", path.display());
@@ -1741,7 +1741,7 @@ impl FlowEdit {
     fn open_library_function(&mut self, source: &str) -> Task<Message> {
         use flowcore::provider::Provider;
 
-        let provider = flow_io::build_meta_provider();
+        let provider = file_ops::build_meta_provider();
         let Ok(source_url) = Url::parse(source) else {
             return Task::none();
         };
@@ -1777,7 +1777,7 @@ impl FlowEdit {
                 };
                 self.open_function_viewer(parent, &path, func, &path.to_string_lossy())
             }
-            Ok(Process::FlowProcess(_)) => match flow_io::load_flow(&path) {
+            Ok(Process::FlowProcess(_)) => match file_ops::load_flow(&path) {
                 Ok(loaded) => {
                     let has_nodes = !loaded.flow_def.process_refs.is_empty();
                     let nc = loaded.flow_def.process_refs.len();
@@ -1907,7 +1907,7 @@ impl FlowEdit {
         }
 
         // Load the sub-flow and open it in a new window
-        match flow_io::load_flow(&path) {
+        match file_ops::load_flow(&path) {
             Ok(loaded) => {
                 let has_nodes = !loaded.flow_def.process_refs.is_empty();
                 let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
@@ -2090,8 +2090,8 @@ impl FlowEdit {
         // Add a process reference in the target flow
         if let Some(win) = self.windows.get_mut(&target_id) {
             let alias =
-                flow_io::generate_unique_alias(&flow_name, &win.flow_definition.process_refs);
-            let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
+                file_ops::generate_unique_alias(&flow_name, &win.flow_definition.process_refs);
+            let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
 
             win.flow_definition.process_refs.push(ProcessReference {
                 alias: alias.clone(),
@@ -2187,8 +2187,8 @@ impl FlowEdit {
         // Add process reference in the target flow
         if let Some(win) = self.windows.get_mut(&target_id) {
             let alias =
-                flow_io::generate_unique_alias(&func_name, &win.flow_definition.process_refs);
-            let (x, y) = flow_io::next_node_position(&win.flow_definition.process_refs);
+                file_ops::generate_unique_alias(&func_name, &win.flow_definition.process_refs);
+            let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
 
             win.flow_definition.process_refs.push(ProcessReference {
                 alias: alias.clone(),
@@ -2440,7 +2440,7 @@ impl FlowEdit {
             FunctionEditMessage::Save => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        match flow_io::save_function_definition(v) {
+                        match file_ops::save_function_definition(v) {
                             Ok(()) => {
                                 let path_display = v.toml_path().map_or_else(
                                     || String::from("(unknown)"),

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -276,6 +276,14 @@ enum FunctionEditMessage {
     Save,
 }
 
+/// View control messages for zoom and auto-fit
+#[derive(Debug, Clone)]
+enum ViewMessage {
+    ZoomIn,
+    ZoomOut,
+    ToggleAutoFit,
+}
+
 /// Messages handled by the flowedit application
 #[derive(Debug, Clone)]
 enum Message {
@@ -285,12 +293,8 @@ enum Message {
     Library(window::Id, LibraryMessage),
     /// A message from the flow hierarchy panel, tagged with window ID
     Hierarchy(window::Id, HierarchyMessage),
-    /// Zoom in by one step, tagged with the originating window ID
-    ZoomIn(window::Id),
-    /// Zoom out by one step, tagged with the originating window ID
-    ZoomOut(window::Id),
-    /// Toggle auto-fit mode, tagged with the originating window ID
-    ToggleAutoFit(window::Id),
+    /// A view control message (zoom, auto-fit), tagged with window ID
+    View(window::Id, ViewMessage),
     /// Undo the last edit action
     Undo,
     /// Redo the last undone action
@@ -766,19 +770,9 @@ impl FlowEdit {
                 }
                 LibraryAction::None => {}
             },
-            Message::ZoomIn(win_id) => {
+            Message::View(win_id, view_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    canvas_view::handle_zoom_in(win);
-                }
-            }
-            Message::ZoomOut(win_id) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    canvas_view::handle_zoom_out(win);
-                }
-            }
-            Message::ToggleAutoFit(win_id) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    canvas_view::handle_toggle_auto_fit(win);
+                    canvas_view::handle_view_message(win, &view_msg);
                 }
             }
             Message::Undo => {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -504,9 +504,7 @@ impl FlowEdit {
             ..Default::default()
         });
 
-        let flow_hierarchy = file_path
-            .as_ref()
-            .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
+        let flow_hierarchy = FlowHierarchy::from_flow_definition(&flow_definition);
 
         let win_state = WindowState {
             kind: WindowKind::FlowEditor,
@@ -1780,16 +1778,12 @@ impl FlowEdit {
         self.library_tree = LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
     }
 
-    fn root_flow_path(&self) -> Option<PathBuf> {
+    fn build_hierarchy(&self) -> FlowHierarchy {
         self.root_window
             .and_then(|id| self.windows.get(&id))
-            .and_then(WindowState::file_path)
-    }
-
-    fn build_hierarchy(&self) -> FlowHierarchy {
-        self.root_flow_path()
-            .as_ref()
-            .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p))
+            .map_or_else(FlowHierarchy::empty, |win| {
+                FlowHierarchy::from_flow_definition(&win.flow_definition)
+            })
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -2221,10 +2215,8 @@ impl FlowEdit {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
                         if let Some((lib_refs, _ctx_refs)) = file_ops::perform_open(win) {
-                            win.flow_hierarchy = win
-                                .file_path()
-                                .as_ref()
-                                .map_or_else(FlowHierarchy::empty, |p| FlowHierarchy::build(p));
+                            win.flow_hierarchy =
+                                FlowHierarchy::from_flow_definition(&win.flow_definition);
 
                             let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
                             self.library_cache = lc;

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -944,7 +944,7 @@ impl FlowEdit {
 
         let library_panel = self
             .library_tree
-            .view()
+            .view(&self.all_definitions)
             .map(move |msg| Message::Library(window_id, msg));
 
         let left_panel = Column::new()

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -772,7 +772,7 @@ impl FlowEdit {
             },
             Message::View(win_id, view_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    canvas_view::handle_view_message(win, &view_msg);
+                    canvas_view::update(win, &view_msg);
                 }
             }
             Message::Undo => {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -2196,13 +2196,39 @@ impl FlowEdit {
             Message::Save => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::handle_save(win);
+                    match &win.kind {
+                        WindowKind::FunctionViewer(_) => {
+                            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                                match file_ops::save_function_definition(v) {
+                                    Ok(()) => {
+                                        win.history.clear();
+                                        win.status = String::from("Function saved");
+                                    }
+                                    Err(e) => win.status = format!("Save failed: {e}"),
+                                }
+                            }
+                        }
+                        WindowKind::FlowEditor => file_ops::handle_save(win),
+                    }
                 }
             }
             Message::SaveAs => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::handle_save_as(win);
+                    match &win.kind {
+                        WindowKind::FunctionViewer(_) => {
+                            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                                match file_ops::save_function_definition(v) {
+                                    Ok(()) => {
+                                        win.history.clear();
+                                        win.status = String::from("Function saved");
+                                    }
+                                    Err(e) => win.status = format!("Save failed: {e}"),
+                                }
+                            }
+                        }
+                        WindowKind::FlowEditor => file_ops::handle_save_as(win),
+                    }
                 }
             }
             Message::Open => {
@@ -2224,6 +2250,7 @@ impl FlowEdit {
             Message::New => {
                 if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
                     file_ops::perform_new(win);
+                    win.flow_hierarchy = FlowHierarchy::empty();
                     self.library_cache.clear();
                     self.all_definitions.clear();
                     self.library_tree =

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -125,16 +125,21 @@ fn handle_flow_edit_message(win: &mut WindowState, msg: FlowEditMessage) {
             if let Some(io) = win.flow_definition.outputs.get(idx) {
                 let name = io.name().clone();
                 win.flow_definition.outputs.remove(idx);
-                // Remove connections referencing this flow output
-                win.flow_definition.connections.retain(|c| {
-                    for to_route in c.to() {
-                        let (to_node, to_port) = canvas_view::split_route(to_route.as_ref());
-                        if to_node == "output" && to_port == name {
-                            return false;
-                        }
-                    }
-                    true
-                });
+                for conn in &mut win.flow_definition.connections {
+                    let new_to: Vec<Route> = conn
+                        .to()
+                        .iter()
+                        .filter(|to_route| {
+                            let (to_node, to_port) = canvas_view::split_route(to_route.as_ref());
+                            !(to_node == "output" && to_port == name)
+                        })
+                        .cloned()
+                        .collect();
+                    conn.set_to(new_to);
+                }
+                win.flow_definition
+                    .connections
+                    .retain(|c| !c.to().is_empty());
                 win.history.mark_modified();
                 win.canvas_state.request_redraw();
             }
@@ -2393,6 +2398,13 @@ impl FlowEdit {
                 Self::propagate_function_ports(&mut self.windows, win_id);
             }
             FunctionEditMessage::DeleteInput(idx) => {
+                let old_name = self.windows.get(&win_id).and_then(|win| {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        v.func_def.inputs.get(idx).map(|io| io.name().clone())
+                    } else {
+                        None
+                    }
+                });
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref mut v) = win.kind {
                         if idx < v.func_def.inputs.len() {
@@ -2402,8 +2414,23 @@ impl FlowEdit {
                     win.history.mark_modified();
                 }
                 Self::propagate_function_ports(&mut self.windows, win_id);
+                if let Some(port_name) = old_name {
+                    Self::remove_parent_connections_to_port(
+                        &mut self.windows,
+                        win_id,
+                        &port_name,
+                        true,
+                    );
+                }
             }
             FunctionEditMessage::DeleteOutput(idx) => {
+                let old_name = self.windows.get(&win_id).and_then(|win| {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        v.func_def.outputs.get(idx).map(|io| io.name().clone())
+                    } else {
+                        None
+                    }
+                });
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref mut v) = win.kind {
                         if idx < v.func_def.outputs.len() {
@@ -2413,17 +2440,41 @@ impl FlowEdit {
                     win.history.mark_modified();
                 }
                 Self::propagate_function_ports(&mut self.windows, win_id);
+                if let Some(port_name) = old_name {
+                    Self::remove_parent_connections_to_port(
+                        &mut self.windows,
+                        win_id,
+                        &port_name,
+                        false,
+                    );
+                }
             }
             FunctionEditMessage::InputNameChanged(idx, name) => {
+                let old_name = self.windows.get(&win_id).and_then(|win| {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        v.func_def.inputs.get(idx).map(|io| io.name().clone())
+                    } else {
+                        None
+                    }
+                });
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref mut v) = win.kind {
                         if let Some(io) = v.func_def.inputs.get_mut(idx) {
-                            io.set_name(name);
+                            io.set_name(name.clone());
                         }
                     }
                     win.history.mark_modified();
                 }
                 Self::propagate_function_ports(&mut self.windows, win_id);
+                if let Some(old) = old_name {
+                    Self::rename_parent_connections_port(
+                        &mut self.windows,
+                        win_id,
+                        &old,
+                        &name,
+                        true,
+                    );
+                }
             }
             FunctionEditMessage::InputTypeChanged(idx, dtype) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -2437,15 +2488,31 @@ impl FlowEdit {
                 Self::propagate_function_ports(&mut self.windows, win_id);
             }
             FunctionEditMessage::OutputNameChanged(idx, name) => {
+                let old_name = self.windows.get(&win_id).and_then(|win| {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        v.func_def.outputs.get(idx).map(|io| io.name().clone())
+                    } else {
+                        None
+                    }
+                });
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     if let WindowKind::FunctionViewer(ref mut v) = win.kind {
                         if let Some(io) = v.func_def.outputs.get_mut(idx) {
-                            io.set_name(name);
+                            io.set_name(name.clone());
                         }
                     }
                     win.history.mark_modified();
                 }
                 Self::propagate_function_ports(&mut self.windows, win_id);
+                if let Some(old) = old_name {
+                    Self::rename_parent_connections_port(
+                        &mut self.windows,
+                        win_id,
+                        &old,
+                        &name,
+                        false,
+                    );
+                }
             }
             FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
@@ -2525,6 +2592,108 @@ impl FlowEdit {
                                     f.outputs.clone_from(&new_outputs);
                                 }
                             }
+                        }
+                    }
+                }
+                parent_win.canvas_state.request_redraw();
+            }
+        }
+    }
+
+    fn remove_parent_connections_to_port(
+        windows: &mut HashMap<window::Id, WindowState>,
+        viewer_win_id: window::Id,
+        port_name: &str,
+        is_input: bool,
+    ) {
+        let info = windows.get(&viewer_win_id).and_then(|win| {
+            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                v.parent_window.map(|pid| (pid, v.node_source.clone()))
+            } else {
+                None
+            }
+        });
+        if let Some((parent_id, node_source)) = info {
+            if let Some(parent_win) = windows.get_mut(&parent_id) {
+                for pref in &parent_win.flow_definition.process_refs {
+                    if pref.source != node_source {
+                        continue;
+                    }
+                    let alias = if pref.alias.is_empty() {
+                        canvas_view::derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    let route = format!("{alias}/{port_name}");
+                    if is_input {
+                        for conn in &mut parent_win.flow_definition.connections {
+                            let new_to: Vec<Route> = conn
+                                .to()
+                                .iter()
+                                .filter(|r| r.as_ref() != route)
+                                .cloned()
+                                .collect();
+                            conn.set_to(new_to);
+                        }
+                        parent_win
+                            .flow_definition
+                            .connections
+                            .retain(|c| !c.to().is_empty());
+                    } else {
+                        parent_win
+                            .flow_definition
+                            .connections
+                            .retain(|c| c.from().as_ref() != route);
+                    }
+                }
+                parent_win.canvas_state.request_redraw();
+            }
+        }
+    }
+
+    fn rename_parent_connections_port(
+        windows: &mut HashMap<window::Id, WindowState>,
+        viewer_win_id: window::Id,
+        old_port: &str,
+        new_port: &str,
+        is_input: bool,
+    ) {
+        let info = windows.get(&viewer_win_id).and_then(|win| {
+            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                v.parent_window.map(|pid| (pid, v.node_source.clone()))
+            } else {
+                None
+            }
+        });
+        if let Some((parent_id, node_source)) = info {
+            if let Some(parent_win) = windows.get_mut(&parent_id) {
+                for pref in &parent_win.flow_definition.process_refs {
+                    if pref.source != node_source {
+                        continue;
+                    }
+                    let alias = if pref.alias.is_empty() {
+                        canvas_view::derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    let old_route = format!("{alias}/{old_port}");
+                    let new_route = format!("{alias}/{new_port}");
+                    for conn in &mut parent_win.flow_definition.connections {
+                        if is_input {
+                            let new_to: Vec<Route> = conn
+                                .to()
+                                .iter()
+                                .map(|r| {
+                                    if r.as_ref() == old_route {
+                                        Route::from(new_route.as_str())
+                                    } else {
+                                        r.clone()
+                                    }
+                                })
+                                .collect();
+                            conn.set_to(new_to);
+                        } else if conn.from().as_ref() == old_route {
+                            conn.set_from(new_route.as_str());
                         }
                     }
                 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -66,6 +66,151 @@ fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
     }
 }
 
+/// Handle flow metadata and I/O editing messages for a single window.
+fn handle_flow_edit_message(win: &mut WindowState, msg: FlowEditMessage) {
+    match msg {
+        FlowEditMessage::NameChanged(new_name) => {
+            win.flow_definition.name = new_name;
+            win.history.mark_modified();
+        }
+        FlowEditMessage::VersionChanged(version) => {
+            win.flow_definition.metadata.version = version;
+            win.history.mark_modified();
+        }
+        FlowEditMessage::DescriptionChanged(desc) => {
+            win.flow_definition.metadata.description = desc;
+            win.history.mark_modified();
+        }
+        FlowEditMessage::AuthorsChanged(authors_str) => {
+            win.flow_definition.metadata.authors = authors_str
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            win.history.mark_modified();
+        }
+        FlowEditMessage::ToggleMetadata => {
+            win.show_metadata = !win.show_metadata;
+        }
+        FlowEditMessage::AddInput => {
+            let name = next_unique_io_name("input", &win.flow_definition.inputs);
+            let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
+            io.set_io_type(IOType::FlowInput);
+            win.flow_definition.inputs.push(io);
+            win.history.mark_modified();
+            win.canvas_state.request_redraw();
+        }
+        FlowEditMessage::AddOutput => {
+            let name = next_unique_io_name("output", &win.flow_definition.outputs);
+            let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
+            io.set_io_type(IOType::FlowOutput);
+            win.flow_definition.outputs.push(io);
+            win.history.mark_modified();
+            win.canvas_state.request_redraw();
+        }
+        FlowEditMessage::DeleteInput(idx) => {
+            if let Some(io) = win.flow_definition.inputs.get(idx) {
+                let name = io.name().clone();
+                win.flow_definition.inputs.remove(idx);
+                // Remove connections referencing this flow input
+                win.flow_definition.connections.retain(|c| {
+                    let (from_node, from_port) = canvas_view::split_route(c.from().as_ref());
+                    !(from_node == "input" && from_port == name)
+                });
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+            }
+        }
+        FlowEditMessage::DeleteOutput(idx) => {
+            if let Some(io) = win.flow_definition.outputs.get(idx) {
+                let name = io.name().clone();
+                win.flow_definition.outputs.remove(idx);
+                // Remove connections referencing this flow output
+                win.flow_definition.connections.retain(|c| {
+                    for to_route in c.to() {
+                        let (to_node, to_port) = canvas_view::split_route(to_route.as_ref());
+                        if to_node == "output" && to_port == name {
+                            return false;
+                        }
+                    }
+                    true
+                });
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+            }
+        }
+        FlowEditMessage::InputNameChanged(idx, name) => {
+            let duplicate = win
+                .flow_definition
+                .inputs
+                .iter()
+                .enumerate()
+                .any(|(i, io)| i != idx && io.name() == &name);
+            if !duplicate {
+                if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+                    let old_name = io.name().clone();
+                    io.set_name(name.clone());
+                    let old_route = format!("input/{old_name}");
+                    let new_route = format!("input/{name}");
+                    for conn in &mut win.flow_definition.connections {
+                        if conn.from().to_string() == old_route {
+                            conn.set_from(Route::from(new_route.as_str()));
+                        }
+                    }
+                }
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+            }
+        }
+        FlowEditMessage::InputTypeChanged(idx, dtype) => {
+            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
+                io.set_datatypes(&[DataType::from(dtype)]);
+            }
+            win.history.mark_modified();
+            win.canvas_state.request_redraw();
+        }
+        FlowEditMessage::OutputNameChanged(idx, name) => {
+            let duplicate = win
+                .flow_definition
+                .outputs
+                .iter()
+                .enumerate()
+                .any(|(i, io)| i != idx && io.name() == &name);
+            if !duplicate {
+                if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+                    let old_name = io.name().clone();
+                    io.set_name(name.clone());
+                    let old_route_str = format!("output/{old_name}");
+                    let new_route_str = format!("output/{name}");
+                    for conn in &mut win.flow_definition.connections {
+                        let new_to: Vec<Route> = conn
+                            .to()
+                            .iter()
+                            .map(|r| {
+                                if r.to_string() == old_route_str {
+                                    Route::from(new_route_str.as_str())
+                                } else {
+                                    r.clone()
+                                }
+                            })
+                            .collect();
+                        conn.set_to(new_to);
+                    }
+                }
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+            }
+        }
+        FlowEditMessage::OutputTypeChanged(idx, dtype) => {
+            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
+                io.set_datatypes(&[DataType::from(dtype)]);
+            }
+            win.history.mark_modified();
+            win.canvas_state.request_redraw();
+        }
+    }
+}
+
 #[cfg(test)]
 mod ui_test;
 
@@ -709,157 +854,7 @@ impl FlowEdit {
             }
             Message::FlowEdit(win_id, flow_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    match flow_msg {
-                        FlowEditMessage::NameChanged(new_name) => {
-                            win.flow_definition.name = new_name;
-                            win.history.mark_modified();
-                        }
-                        FlowEditMessage::VersionChanged(version) => {
-                            win.flow_definition.metadata.version = version;
-                            win.history.mark_modified();
-                        }
-                        FlowEditMessage::DescriptionChanged(desc) => {
-                            win.flow_definition.metadata.description = desc;
-                            win.history.mark_modified();
-                        }
-                        FlowEditMessage::AuthorsChanged(authors_str) => {
-                            win.flow_definition.metadata.authors = authors_str
-                                .split(',')
-                                .map(|s| s.trim().to_string())
-                                .filter(|s| !s.is_empty())
-                                .collect();
-                            win.history.mark_modified();
-                        }
-                        FlowEditMessage::ToggleMetadata => {
-                            win.show_metadata = !win.show_metadata;
-                        }
-                        FlowEditMessage::AddInput => {
-                            let name = next_unique_io_name("input", &win.flow_definition.inputs);
-                            let mut io = IO::new_named(
-                                vec![DataType::from("string")],
-                                Route::default(),
-                                name,
-                            );
-                            io.set_io_type(IOType::FlowInput);
-                            win.flow_definition.inputs.push(io);
-                            win.history.mark_modified();
-                            win.canvas_state.request_redraw();
-                        }
-                        FlowEditMessage::AddOutput => {
-                            let name = next_unique_io_name("output", &win.flow_definition.outputs);
-                            let mut io = IO::new_named(
-                                vec![DataType::from("string")],
-                                Route::default(),
-                                name,
-                            );
-                            io.set_io_type(IOType::FlowOutput);
-                            win.flow_definition.outputs.push(io);
-                            win.history.mark_modified();
-                            win.canvas_state.request_redraw();
-                        }
-                        FlowEditMessage::DeleteInput(idx) => {
-                            if let Some(io) = win.flow_definition.inputs.get(idx) {
-                                let name = io.name().clone();
-                                win.flow_definition.inputs.remove(idx);
-                                // Remove connections referencing this flow input
-                                win.flow_definition.connections.retain(|c| {
-                                    let (from_node, from_port) =
-                                        canvas_view::split_route(c.from().as_ref());
-                                    !(from_node == "input" && from_port == name)
-                                });
-                                win.history.mark_modified();
-                                win.canvas_state.request_redraw();
-                            }
-                        }
-                        FlowEditMessage::DeleteOutput(idx) => {
-                            if let Some(io) = win.flow_definition.outputs.get(idx) {
-                                let name = io.name().clone();
-                                win.flow_definition.outputs.remove(idx);
-                                // Remove connections referencing this flow output
-                                win.flow_definition.connections.retain(|c| {
-                                    for to_route in c.to() {
-                                        let (to_node, to_port) =
-                                            canvas_view::split_route(to_route.as_ref());
-                                        if to_node == "output" && to_port == name {
-                                            return false;
-                                        }
-                                    }
-                                    true
-                                });
-                                win.history.mark_modified();
-                                win.canvas_state.request_redraw();
-                            }
-                        }
-                        FlowEditMessage::InputNameChanged(idx, name) => {
-                            let duplicate = win
-                                .flow_definition
-                                .inputs
-                                .iter()
-                                .enumerate()
-                                .any(|(i, io)| i != idx && io.name() == &name);
-                            if !duplicate {
-                                if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
-                                    let old_name = io.name().clone();
-                                    io.set_name(name.clone());
-                                    let old_route = format!("input/{old_name}");
-                                    let new_route = format!("input/{name}");
-                                    for conn in &mut win.flow_definition.connections {
-                                        if conn.from().to_string() == old_route {
-                                            conn.set_from(Route::from(new_route.as_str()));
-                                        }
-                                    }
-                                }
-                                win.history.mark_modified();
-                                win.canvas_state.request_redraw();
-                            }
-                        }
-                        FlowEditMessage::InputTypeChanged(idx, dtype) => {
-                            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
-                                io.set_datatypes(&[DataType::from(dtype)]);
-                            }
-                            win.history.mark_modified();
-                            win.canvas_state.request_redraw();
-                        }
-                        FlowEditMessage::OutputNameChanged(idx, name) => {
-                            let duplicate = win
-                                .flow_definition
-                                .outputs
-                                .iter()
-                                .enumerate()
-                                .any(|(i, io)| i != idx && io.name() == &name);
-                            if !duplicate {
-                                if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
-                                    let old_name = io.name().clone();
-                                    io.set_name(name.clone());
-                                    let old_route_str = format!("output/{old_name}");
-                                    let new_route_str = format!("output/{name}");
-                                    for conn in &mut win.flow_definition.connections {
-                                        let new_to: Vec<Route> = conn
-                                            .to()
-                                            .iter()
-                                            .map(|r| {
-                                                if r.to_string() == old_route_str {
-                                                    Route::from(new_route_str.as_str())
-                                                } else {
-                                                    r.clone()
-                                                }
-                                            })
-                                            .collect();
-                                        conn.set_to(new_to);
-                                    }
-                                }
-                                win.history.mark_modified();
-                                win.canvas_state.request_redraw();
-                            }
-                        }
-                        FlowEditMessage::OutputTypeChanged(idx, dtype) => {
-                            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
-                                io.set_datatypes(&[DataType::from(dtype)]);
-                            }
-                            win.history.mark_modified();
-                            win.canvas_state.request_redraw();
-                        }
-                    }
+                    handle_flow_edit_message(win, flow_msg);
                 }
             }
             Message::NewSubFlow(target_win_id) => {
@@ -927,205 +922,7 @@ impl FlowEdit {
                 self.show_lib_paths = !self.show_lib_paths;
             }
             Message::FunctionEdit(win_id, func_msg) => {
-                match func_msg {
-                    FunctionEditMessage::TabSelected(tab) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.active_tab = tab;
-                            }
-                        }
-                    }
-                    FunctionEditMessage::NameChanged(new_name) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.func_def.name = new_name;
-                            }
-                            win.history.mark_modified();
-                        }
-                    }
-                    FunctionEditMessage::DescriptionChanged(new_desc) => {
-                        // Extract parent info before mutating
-                        let parent_info = self.windows.get(&win_id).and_then(|win| {
-                            if let WindowKind::FunctionViewer(ref viewer) = win.kind {
-                                viewer
-                                    .parent_window
-                                    .map(|pid| (pid, viewer.node_source.clone()))
-                            } else {
-                                None
-                            }
-                        });
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                viewer.func_def.description.clone_from(&new_desc);
-                            }
-                            win.history.mark_modified();
-                        }
-                        // Propagate description to the parent window's subprocess definitions
-                        if let Some((parent_id, node_source)) = parent_info {
-                            if let Some(parent_win) = self.windows.get_mut(&parent_id) {
-                                // Update subprocess definitions with matching source
-                                for pref in &parent_win.flow_definition.process_refs {
-                                    if pref.source == node_source {
-                                        let alias = if pref.alias.is_empty() {
-                                            canvas_view::derive_short_name(&pref.source)
-                                        } else {
-                                            pref.alias.clone()
-                                        };
-                                        if let Some(proc) =
-                                            parent_win.flow_definition.subprocesses.get_mut(&alias)
-                                        {
-                                            match proc {
-                                                Process::FunctionProcess(ref mut f) => {
-                                                    f.description.clone_from(&new_desc);
-                                                }
-                                                Process::FlowProcess(ref mut f) => {
-                                                    f.description.clone_from(&new_desc);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                parent_win.canvas_state.request_redraw();
-                            }
-                        }
-                    }
-                    FunctionEditMessage::BrowseSource => {
-                        let dialog = rfd::FileDialog::new().add_filter("Rust", &["rs"]);
-                        if let Some(selected) = dialog.pick_file() {
-                            if let Some(win) = self.windows.get_mut(&win_id) {
-                                if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                                    let base = viewer
-                                        .toml_path()
-                                        .as_deref()
-                                        .and_then(Path::parent)
-                                        .unwrap_or(Path::new("."))
-                                        .to_path_buf();
-                                    let rel = selected.strip_prefix(&base).map_or_else(
-                                        |_| selected.to_string_lossy().to_string(),
-                                        |p| p.to_string_lossy().to_string(),
-                                    );
-                                    viewer.func_def.source = rel;
-                                    viewer.rs_content = std::fs::read_to_string(&selected)
-                                        .unwrap_or_else(|_| String::from("// Could not read file"));
-                                }
-                                win.history.mark_modified();
-                            }
-                        }
-                    }
-                    FunctionEditMessage::AddInput => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                let name = next_unique_io_name("input", &v.func_def.inputs);
-                                v.func_def.inputs.push(IO::new_named(
-                                    vec![DataType::from("string")],
-                                    Route::default(),
-                                    &name,
-                                ));
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::AddOutput => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                let name = next_unique_io_name("output", &v.func_def.outputs);
-                                v.func_def.outputs.push(IO::new_named(
-                                    vec![DataType::from("string")],
-                                    Route::default(),
-                                    &name,
-                                ));
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::DeleteInput(idx) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if idx < v.func_def.inputs.len() {
-                                    v.func_def.inputs.remove(idx);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::DeleteOutput(idx) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if idx < v.func_def.outputs.len() {
-                                    v.func_def.outputs.remove(idx);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::InputNameChanged(idx, name) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(io) = v.func_def.inputs.get_mut(idx) {
-                                    io.set_name(name);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::InputTypeChanged(idx, dtype) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(io) = v.func_def.inputs.get_mut(idx) {
-                                    io.set_datatypes(&[DataType::from(dtype)]);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::OutputNameChanged(idx, name) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(io) = v.func_def.outputs.get_mut(idx) {
-                                    io.set_name(name);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                                if let Some(io) = v.func_def.outputs.get_mut(idx) {
-                                    io.set_datatypes(&[DataType::from(dtype)]);
-                                }
-                            }
-                            win.history.mark_modified();
-                        }
-                        Self::propagate_function_ports(&mut self.windows, win_id);
-                    }
-                    FunctionEditMessage::Save => {
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            if let WindowKind::FunctionViewer(ref v) = win.kind {
-                                match flow_io::save_function_definition(v) {
-                                    Ok(()) => {
-                                        let path_display = v.toml_path().map_or_else(
-                                            || String::from("(unknown)"),
-                                            |p| p.display().to_string(),
-                                        );
-                                        win.status = format!("Saved: {path_display}");
-                                        win.history.clear();
-                                    }
-                                    Err(e) => {
-                                        win.status = format!("Save failed: {e}");
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                self.handle_function_edit_message(win_id, func_msg);
             }
             Message::WindowClosed(id) => {
                 self.windows.remove(&id);
@@ -2457,6 +2254,209 @@ impl FlowEdit {
 
         self.windows.insert(new_id, child);
         open_task.discard()
+    }
+
+    /// Handle function definition viewing/editing messages.
+    fn handle_function_edit_message(&mut self, win_id: window::Id, func_msg: FunctionEditMessage) {
+        match func_msg {
+            FunctionEditMessage::TabSelected(tab) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        viewer.active_tab = tab;
+                    }
+                }
+            }
+            FunctionEditMessage::NameChanged(new_name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        viewer.func_def.name = new_name;
+                    }
+                    win.history.mark_modified();
+                }
+            }
+            FunctionEditMessage::DescriptionChanged(new_desc) => {
+                // Extract parent info before mutating
+                let parent_info = self.windows.get(&win_id).and_then(|win| {
+                    if let WindowKind::FunctionViewer(ref viewer) = win.kind {
+                        viewer
+                            .parent_window
+                            .map(|pid| (pid, viewer.node_source.clone()))
+                    } else {
+                        None
+                    }
+                });
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        viewer.func_def.description.clone_from(&new_desc);
+                    }
+                    win.history.mark_modified();
+                }
+                // Propagate description to the parent window's subprocess definitions
+                if let Some((parent_id, node_source)) = parent_info {
+                    if let Some(parent_win) = self.windows.get_mut(&parent_id) {
+                        // Update subprocess definitions with matching source
+                        for pref in &parent_win.flow_definition.process_refs {
+                            if pref.source == node_source {
+                                let alias = if pref.alias.is_empty() {
+                                    canvas_view::derive_short_name(&pref.source)
+                                } else {
+                                    pref.alias.clone()
+                                };
+                                if let Some(proc) =
+                                    parent_win.flow_definition.subprocesses.get_mut(&alias)
+                                {
+                                    match proc {
+                                        Process::FunctionProcess(ref mut f) => {
+                                            f.description.clone_from(&new_desc);
+                                        }
+                                        Process::FlowProcess(ref mut f) => {
+                                            f.description.clone_from(&new_desc);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        parent_win.canvas_state.request_redraw();
+                    }
+                }
+            }
+            FunctionEditMessage::BrowseSource => {
+                let dialog = rfd::FileDialog::new().add_filter("Rust", &["rs"]);
+                if let Some(selected) = dialog.pick_file() {
+                    if let Some(win) = self.windows.get_mut(&win_id) {
+                        if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                            let base = viewer
+                                .toml_path()
+                                .as_deref()
+                                .and_then(Path::parent)
+                                .unwrap_or(Path::new("."))
+                                .to_path_buf();
+                            let rel = selected.strip_prefix(&base).map_or_else(
+                                |_| selected.to_string_lossy().to_string(),
+                                |p| p.to_string_lossy().to_string(),
+                            );
+                            viewer.func_def.source = rel;
+                            viewer.rs_content = std::fs::read_to_string(&selected)
+                                .unwrap_or_else(|_| String::from("// Could not read file"));
+                        }
+                        win.history.mark_modified();
+                    }
+                }
+            }
+            FunctionEditMessage::AddInput => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        let name = next_unique_io_name("input", &v.func_def.inputs);
+                        v.func_def.inputs.push(IO::new_named(
+                            vec![DataType::from("string")],
+                            Route::default(),
+                            &name,
+                        ));
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::AddOutput => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        let name = next_unique_io_name("output", &v.func_def.outputs);
+                        v.func_def.outputs.push(IO::new_named(
+                            vec![DataType::from("string")],
+                            Route::default(),
+                            &name,
+                        ));
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::DeleteInput(idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if idx < v.func_def.inputs.len() {
+                            v.func_def.inputs.remove(idx);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::DeleteOutput(idx) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if idx < v.func_def.outputs.len() {
+                            v.func_def.outputs.remove(idx);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::InputNameChanged(idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(io) = v.func_def.inputs.get_mut(idx) {
+                            io.set_name(name);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::InputTypeChanged(idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(io) = v.func_def.inputs.get_mut(idx) {
+                            io.set_datatypes(&[DataType::from(dtype)]);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::OutputNameChanged(idx, name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(io) = v.func_def.outputs.get_mut(idx) {
+                            io.set_name(name);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                        if let Some(io) = v.func_def.outputs.get_mut(idx) {
+                            io.set_datatypes(&[DataType::from(dtype)]);
+                        }
+                    }
+                    win.history.mark_modified();
+                }
+                Self::propagate_function_ports(&mut self.windows, win_id);
+            }
+            FunctionEditMessage::Save => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        match flow_io::save_function_definition(v) {
+                            Ok(()) => {
+                                let path_display = v.toml_path().map_or_else(
+                                    || String::from("(unknown)"),
+                                    |p| p.display().to_string(),
+                                );
+                                win.status = format!("Saved: {path_display}");
+                                win.history.clear();
+                            }
+                            Err(e) => {
+                                win.status = format!("Save failed: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Propagate the current function viewer's ports (inputs/outputs) to matching

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -189,7 +189,10 @@ fn update_canvas_move_completed_records_history() {
         win_id,
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 200.0, 300.0),
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 }
 
 #[test]
@@ -208,7 +211,10 @@ fn update_canvas_delete_node() {
             .map(|w| w.flow_definition.process_refs.len()),
         Some(1)
     );
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 }
 
 #[test]
@@ -229,7 +235,10 @@ fn update_canvas_create_connection() {
             .map(|w| w.flow_definition.connections.len()),
         Some(1)
     );
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 }
 
 #[test]
@@ -283,7 +292,10 @@ fn update_undo_redo_cycle() {
         win_id,
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 200.0, 300.0),
     ));
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 
     // Undo
     let _ = app.update(Message::Undo);
@@ -325,7 +337,10 @@ fn update_flow_name_changed() {
             .map(|w| w.flow_definition.name.as_str()),
         Some("new_name")
     );
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 }
 
 #[test]
@@ -383,7 +398,10 @@ fn update_flow_add_input() {
             .map(|w| w.flow_definition.inputs.len()),
         Some(1)
     );
-    assert_eq!(app.windows.get(&win_id).map(|w| w.unsaved_edits), Some(1));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
 }
 
 #[test]
@@ -886,9 +904,10 @@ fn helper_drag_via_direct_messages() {
         (node.map_or(0.0, |n| n.y.unwrap_or(0.0)) - 350.0).abs() < 0.01,
         "Node y should be 350 after drag"
     );
-    assert_eq!(
-        app.windows.get(&win_id).map(|w| w.unsaved_edits),
-        Some(1),
+    assert!(
+        app.windows
+            .get(&win_id)
+            .is_some_and(|w| !w.history.is_empty()),
         "Drag should record an edit"
     );
 }
@@ -1257,7 +1276,7 @@ fn ui_close_active_window() {
     app.windows.insert(second_id, test_win_state());
     app.root_window = Some(second_id);
     assert_eq!(app.focused_window, Some(win_id));
-    // CloseActiveWindow closes the focused window (unsaved_edits == 0, no dialog)
+    // CloseActiveWindow closes the focused window (no unsaved edits, no dialog)
     let _ = app.update(Message::CloseActiveWindow);
     assert!(
         !app.windows.contains_key(&win_id),
@@ -1314,7 +1333,9 @@ fn ui_resize_node_records_history() {
         CanvasMessage::ResizeCompleted(0, 100.0, 100.0, 180.0, 120.0, 100.0, 100.0, 250.0, 180.0),
     ));
     assert!(
-        app.windows.get(&win_id).map_or(0, |w| w.unsaved_edits) > 0,
+        app.windows
+            .get(&win_id)
+            .is_some_and(|w| !w.history.is_empty()),
         "Resize should record an edit"
     );
     let node = app

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -107,7 +107,7 @@ fn update_zoom_in() {
         .windows
         .get(&win_id)
         .map_or(1.0, |w| w.canvas_state.zoom);
-    let _ = app.update(Message::ZoomIn(win_id));
+    let _ = app.update(Message::View(win_id, ViewMessage::ZoomIn));
     let new_zoom = app
         .windows
         .get(&win_id)
@@ -122,7 +122,7 @@ fn update_zoom_out() {
         .windows
         .get(&win_id)
         .map_or(1.0, |w| w.canvas_state.zoom);
-    let _ = app.update(Message::ZoomOut(win_id));
+    let _ = app.update(Message::View(win_id, ViewMessage::ZoomOut));
     let new_zoom = app
         .windows
         .get(&win_id)
@@ -136,7 +136,7 @@ fn update_toggle_auto_fit() {
     if let Some(w) = app.windows.get_mut(&win_id) {
         w.auto_fit_enabled = false;
     }
-    let _ = app.update(Message::ToggleAutoFit(win_id));
+    let _ = app.update(Message::View(win_id, ViewMessage::ToggleAutoFit));
     assert!(app.windows.get(&win_id).is_some_and(|w| w.auto_fit_enabled));
 }
 

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -54,11 +54,7 @@ fn test_app_with_flow(flow: FlowDefinition) -> (FlowEdit, window::Id) {
                 name: "test_lib".into(),
                 categories: vec![library_panel::CategoryEntry {
                     name: "math".into(),
-                    functions: vec![library_panel::FunctionEntry {
-                        name: "add".into(),
-                        source: "lib://test_lib/math/add".into(),
-                        description: String::new(),
-                    }],
+                    function_urls: vec![Url::parse("lib://test_lib/math/add").expect("valid url")],
                     expanded: true,
                 }],
                 expanded: true,

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -799,7 +799,7 @@ fn click_build_with_saved_flow() {
     if let Some(win) = app.windows.get_mut(&win_id) {
         win.set_file_path(&path);
         win.flow_definition.name = "test_build".into();
-        flow_io::perform_save(win, &path);
+        file_ops::perform_save(win, &path);
     }
     click_and_update(&mut app, win_id, "\u{1F528} Build");
     let status = app

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -71,10 +71,6 @@ pub(crate) struct WindowState {
     pub(crate) auto_fit_pending: bool,
     /// Whether auto-fit mode is active (continuously fits to window)
     pub(crate) auto_fit_enabled: bool,
-    /// Count of unsaved edits (increments on edit/redo, decrements on undo)
-    pub(crate) unsaved_edits: i32,
-    /// Path to the last compiled manifest (None if not compiled or edited since)
-    pub(crate) compiled_manifest: Option<PathBuf>,
     /// The original flow definition, used to preserve metadata when saving
     pub(crate) flow_definition: FlowDefinition,
     /// Tooltip text and screen position to display (full source path on hover)
@@ -106,8 +102,6 @@ impl Default for WindowState {
             history: EditHistory::default(),
             auto_fit_pending: false,
             auto_fit_enabled: false,
-            unsaved_edits: 0,
-            compiled_manifest: None,
             flow_definition: FlowDefinition::default(),
             tooltip: None,
             initializer_editor: None,

--- a/flowr/src/lib/discovery.rs
+++ b/flowr/src/lib/discovery.rs
@@ -47,6 +47,10 @@ pub fn enable_service_discovery(name: &str, service_port: u16) -> Result<Service
 /// or the default timeout (30 seconds) expires.
 ///
 /// Returns the service address as `"{ip}:{port}"`.
+///
+/// # Errors
+/// - Cannot create `ServiceDaemon`
+/// - Cannot get receiver for discovery messages
 pub fn discover_service(name: &str) -> Result<String> {
     let mdns = ServiceDaemon::new().map_err(|e| format!("Could not create mDNS daemon: {e}"))?;
 
@@ -66,25 +70,21 @@ pub fn discover_service(name: &str) -> Result<String> {
             ));
         }
 
-        match receiver.recv_timeout(Duration::from_millis(500)) {
-            Ok(ServiceEvent::ServiceResolved(info)) => {
-                let instance = info
-                    .get_fullname()
-                    .strip_suffix(&full_name_suffix)
-                    .unwrap_or(info.get_fullname());
+        if let Ok(ServiceEvent::ServiceResolved(info)) = receiver.recv_timeout(Duration::from_millis(500)) {
+            let instance = info
+                .get_fullname()
+                .strip_suffix(&full_name_suffix)
+                .unwrap_or(info.get_fullname());
 
-                if instance == name {
-                    let port = info.get_port();
-                    if let Some(addr) = info.get_addresses_v4().into_iter().next() {
-                        let address = format!("{addr}:{port}");
-                        info!("Discovered mDNS service '{name}' at {address}");
-                        mdns.shutdown().ok();
-                        return Ok(address);
-                    }
+            if instance == name {
+                let port = info.get_port();
+                if let Some(addr) = info.get_addresses_v4().into_iter().next() {
+                    let address = format!("{addr}:{port}");
+                    info!("Discovered mDNS service '{name}' at {address}");
+                    mdns.shutdown().ok();
+                    return Ok(address);
                 }
             }
-            Err(_) => continue, // Timeout or disconnected — retry until overall timeout
-            _ => {}             // Ignore other events (SearchStarted, ServiceFound, etc.)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **EditHistory encapsulation** — absorbs `unsaved_edits` and `compiled_manifest` from WindowState; provides `record()`, `is_empty()`, `clear()`, `mark_modified()` API; undo stack cleared on save
- **Extract FlowEdit/FunctionEdit handlers** — ~350 lines moved out of `update()` into `handle_flow_edit_message()` and `handle_function_edit_message()`, reducing `update()` from ~764 to ~414 lines
- **Rename flow_io.rs to file_ops.rs** — better name; extract file-ops message handling into `handle_file_message()`
- **Hierarchy panel uses FlowDefinition** — `FlowHierarchy::from_flow_definition()` walks `subprocesses` tree directly instead of re-reading files from disk; removes all filesystem I/O from hierarchy panel (-48 lines)
- **Library panel uses flowclib types** — removes `FunctionEntry` struct; `CategoryEntry` stores `Vec<Url>` keys into `all_definitions`; names/descriptions resolved at render time from canonical `Process` definitions

### Structs eliminated
- `FunctionEntry` (library_panel.rs)

### Fields moved
- `unsaved_edits` and `compiled_manifest` from WindowState into EditHistory

### File I/O removed
- `build_node_from_path()` and `resolve_source()` from hierarchy_panel.rs

Part of #2597

## Test plan

- [x] `cargo test -p flowedit` — 196 tests pass
- [x] `make clippy` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Save/dirty tracking moved to history-based state for more reliable unsaved change detection and clearer save/close behavior.
  * Flow hierarchy now builds from in-memory definitions instead of filesystem deserialization.
  * Consolidated file and view handling, and simplified undo/redo logic for more consistent editor behavior.

* **Bug Fixes**
  * Window title/status, save button enablement, and close/quit confirmations now reflect actual unsaved edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->