### PR TITLE
flowedit: Encapsulate structs, use flowcore types, convert free functions to methods

### DIFF
--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -26,6 +26,7 @@ use log::info;
 use flowcore::model::input::InputInitializer;
 use flowcore::model::io::IO;
 use flowcore::model::name::HasName;
+use flowcore::model::process::Process;
 
 use crate::file_ops;
 use crate::history::EditAction;
@@ -555,25 +556,11 @@ impl PortInfo {
     }
 }
 
-/// The kind of process a node represents, determined from resolved metadata.
-#[derive(Debug, Clone, Default)]
-enum NodeKind {
-    /// Function from a compiled library (`lib://` reference).
-    Library,
-    /// Function provided by the runtime context (`context://` reference).
-    Context,
-    /// A provided implementation (`.rs` or `.wasm` source).
-    ProvidedImplementation,
-    /// A nested flow (the default).
-    #[default]
-    Flow,
-}
-
 /// A positioned node derived from a [`ProcessReference`], ready for rendering.
 #[derive(Debug, Clone)]
 pub(crate) struct NodeLayout {
-    /// What kind of process this node represents.
-    kind: NodeKind,
+    /// The resolved process, if available (used to derive color, openability, etc.)
+    pub(crate) process: Option<Process>,
     /// Display name (alias) for this node
     pub alias: String,
     /// Source path of the process
@@ -599,7 +586,7 @@ pub(crate) struct NodeLayout {
 impl Default for NodeLayout {
     fn default() -> Self {
         Self {
-            kind: NodeKind::default(),
+            process: None,
             alias: String::new(),
             source: String::new(),
             description: String::new(),
@@ -615,19 +602,38 @@ impl Default for NodeLayout {
 }
 
 impl NodeLayout {
-    /// Determine the fill color based on the resolved [`NodeKind`].
     fn fill_color(&self) -> Color {
-        match self.kind {
-            NodeKind::Library => Color::from_rgb(0.3, 0.5, 0.9),
-            NodeKind::Context => Color::from_rgb(0.3, 0.75, 0.45),
-            NodeKind::ProvidedImplementation => Color::from_rgb(0.6, 0.3, 0.8),
-            NodeKind::Flow => Color::from_rgb(0.9, 0.6, 0.2),
+        match &self.process {
+            Some(Process::FlowProcess(_)) => Color::from_rgb(0.9, 0.6, 0.2),
+            Some(Process::FunctionProcess(f)) => {
+                if f.get_lib_reference().is_some() {
+                    Color::from_rgb(0.3, 0.5, 0.9)
+                } else if f.get_context_reference().is_some() {
+                    Color::from_rgb(0.3, 0.75, 0.45)
+                } else {
+                    Color::from_rgb(0.6, 0.3, 0.8)
+                }
+            }
+            None => {
+                if self.source.starts_with("lib://") {
+                    Color::from_rgb(0.3, 0.5, 0.9)
+                } else if self.source.starts_with("context://") {
+                    Color::from_rgb(0.3, 0.75, 0.45)
+                } else {
+                    Color::from_rgb(0.9, 0.6, 0.2)
+                }
+            }
         }
     }
 
-    /// Whether this node's source can be opened (sub-flow or provided implementation).
     pub(crate) fn is_openable(&self) -> bool {
-        matches!(self.kind, NodeKind::Flow | NodeKind::ProvidedImplementation)
+        match &self.process {
+            Some(Process::FlowProcess(_)) => true,
+            Some(Process::FunctionProcess(f)) => {
+                f.get_lib_reference().is_none() && f.get_context_reference().is_none()
+            }
+            None => !self.source.starts_with("lib://") && !self.source.starts_with("context://"),
+        }
     }
 
     /// Get the position of an output port (right edge of node)
@@ -675,8 +681,6 @@ impl NodeLayout {
 pub(crate) fn build_render_nodes(
     flow_def: &flowcore::model::flow_definition::FlowDefinition,
 ) -> Vec<NodeLayout> {
-    use flowcore::model::process::Process;
-
     let topo_positions = compute_topological_layout(&flow_def.process_refs, &flow_def.connections);
 
     let mut nodes = Vec::with_capacity(flow_def.process_refs.len());
@@ -689,31 +693,6 @@ pub(crate) fn build_render_nodes(
         };
 
         let resolved = flow_def.subprocesses.get(&alias);
-
-        let kind = resolved.map_or_else(
-            || {
-                // Fallback for unresolved: check source string
-                if pref.source.starts_with("lib://") {
-                    NodeKind::Library
-                } else if pref.source.starts_with("context://") {
-                    NodeKind::Context
-                } else {
-                    NodeKind::Flow
-                }
-            },
-            |proc| match proc {
-                Process::FunctionProcess(f) => {
-                    if f.get_lib_reference().is_some() {
-                        NodeKind::Library
-                    } else if f.get_context_reference().is_some() {
-                        NodeKind::Context
-                    } else {
-                        NodeKind::ProvidedImplementation
-                    }
-                }
-                Process::FlowProcess(_) => NodeKind::Flow,
-            },
-        );
 
         let (inputs, outputs) = resolved
             .map(|proc| match proc {
@@ -763,7 +742,7 @@ pub(crate) fn build_render_nodes(
             .unwrap_or_default();
 
         nodes.push(NodeLayout {
-            kind,
+            process: resolved.cloned(),
             alias: alias.clone(),
             source: pref.source.clone(),
             description,
@@ -3157,7 +3136,22 @@ pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Elem
 #[allow(clippy::indexing_slicing)]
 mod test {
     use super::*;
+    use flowcore::model::flow_definition::FlowDefinition;
+    use flowcore::model::function_definition::FunctionDefinition;
     use iced::Point;
+    use url::Url;
+
+    fn lib_function() -> FunctionDefinition {
+        let mut f = FunctionDefinition::default();
+        f.lib_reference = Some(Url::parse("lib://test").expect("valid url"));
+        f
+    }
+
+    fn context_function() -> FunctionDefinition {
+        let mut f = FunctionDefinition::default();
+        f.context_reference = Some(Url::parse("context://stdio/stdout").expect("valid url"));
+        f
+    }
 
     #[test]
     fn split_route_with_port() {
@@ -3455,13 +3449,13 @@ mod test {
     #[test]
     fn hit_test_open_icon_only_openable() {
         let lib_node = NodeLayout {
-            kind: NodeKind::Library,
+            process: Some(Process::FunctionProcess(lib_function())),
             alias: "n".into(),
             source: "lib://test".into(),
             ..Default::default()
         };
         let local_node = NodeLayout {
-            kind: NodeKind::Flow,
+            process: Some(Process::FlowProcess(FlowDefinition::default())),
             source: "subflow".into(),
             ..lib_node.clone()
         };
@@ -3477,7 +3471,7 @@ mod test {
     #[test]
     fn is_openable_lib() {
         let node = NodeLayout {
-            kind: NodeKind::Library,
+            process: Some(Process::FunctionProcess(lib_function())),
             alias: "n".into(),
             ..Default::default()
         };
@@ -3487,7 +3481,7 @@ mod test {
     #[test]
     fn is_openable_context() {
         let node = NodeLayout {
-            kind: NodeKind::Context,
+            process: Some(Process::FunctionProcess(context_function())),
             alias: "n".into(),
             ..Default::default()
         };
@@ -3497,7 +3491,7 @@ mod test {
     #[test]
     fn is_openable_local() {
         let node = NodeLayout {
-            kind: NodeKind::Flow,
+            process: Some(Process::FlowProcess(FlowDefinition::default())),
             alias: "n".into(),
             ..Default::default()
         };
@@ -3507,7 +3501,7 @@ mod test {
     #[test]
     fn is_openable_provided_impl() {
         let node = NodeLayout {
-            kind: NodeKind::ProvidedImplementation,
+            process: Some(Process::FunctionProcess(FunctionDefinition::default())),
             alias: "n".into(),
             ..Default::default()
         };
@@ -3687,17 +3681,27 @@ mod test {
     }
 
     #[test]
-    fn fill_color_by_kind() {
-        let make = |kind: NodeKind| NodeLayout {
-            kind,
+    fn fill_color_by_process() {
+        let lib = NodeLayout {
+            process: Some(Process::FunctionProcess(lib_function())),
             alias: "n".into(),
             ..Default::default()
         };
-        let lib = make(NodeKind::Library);
-        let ctx = make(NodeKind::Context);
-        let prov = make(NodeKind::ProvidedImplementation);
-        let flow = make(NodeKind::Flow);
-        // Different kinds should produce different colors
+        let ctx = NodeLayout {
+            process: Some(Process::FunctionProcess(context_function())),
+            alias: "n".into(),
+            ..Default::default()
+        };
+        let prov = NodeLayout {
+            process: Some(Process::FunctionProcess(FunctionDefinition::default())),
+            alias: "n".into(),
+            ..Default::default()
+        };
+        let flow = NodeLayout {
+            process: Some(Process::FlowProcess(FlowDefinition::default())),
+            alias: "n".into(),
+            ..Default::default()
+        };
         assert_ne!(lib.fill_color(), ctx.fill_color());
         assert_ne!(lib.fill_color(), prov.fill_color());
         assert_ne!(lib.fill_color(), flow.fill_color());

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -43,283 +43,285 @@ pub(crate) enum CanvasAction {
     OpenNode(usize),
 }
 
-/// Handle a [`CanvasMessage`] by mutating the given window state.
-///
-/// Returns a [`CanvasAction`] when the caller needs to perform cross-window
-/// operations (e.g. opening a sub-flow in a new editor window).
-pub(crate) fn handle_canvas_message(win: &mut WindowState, msg: CanvasMessage) -> CanvasAction {
-    match msg {
-        CanvasMessage::Selected(idx) => {
-            win.selected_node = idx;
-            win.context_menu = None;
-            if win.selected_connection.is_some() {
-                win.selected_connection = None;
-                win.canvas_state.request_redraw();
+impl WindowState {
+    /// Handle a [`CanvasMessage`] by mutating canvas/selection state.
+    ///
+    /// Returns a [`CanvasAction`] when the caller needs to perform cross-window
+    /// operations (e.g. opening a sub-flow in a new editor window).
+    pub(crate) fn handle_canvas_message(&mut self, msg: CanvasMessage) -> CanvasAction {
+        match msg {
+            CanvasMessage::Selected(idx) => {
+                self.selected_node = idx;
+                self.context_menu = None;
+                if self.selected_connection.is_some() {
+                    self.selected_connection = None;
+                    self.canvas_state.request_redraw();
+                }
+                if let Some(i) = idx {
+                    if let Some(pref) = self.flow_definition.process_refs.get(i) {
+                        let alias = if pref.alias.is_empty() {
+                            derive_short_name(&pref.source)
+                        } else {
+                            pref.alias.clone()
+                        };
+                        self.status = format!("Selected: {alias}");
+                    }
+                } else {
+                    self.status = String::from("Ready");
+                }
             }
-            if let Some(i) = idx {
-                if let Some(pref) = win.flow_definition.process_refs.get(i) {
+            CanvasMessage::Moved(idx, x, y) => {
+                if let Some(pref) = self.flow_definition.process_refs.get_mut(idx) {
+                    pref.x = Some(x);
+                    pref.y = Some(y);
+                    self.canvas_state.request_redraw();
+                }
+            }
+            CanvasMessage::Resized(idx, x, y, w, h) => {
+                if let Some(pref) = self.flow_definition.process_refs.get_mut(idx) {
+                    pref.x = Some(x);
+                    pref.y = Some(y);
+                    pref.width = Some(w);
+                    pref.height = Some(h);
+                    self.canvas_state.request_redraw();
+                }
+            }
+            CanvasMessage::MoveCompleted(idx, old_x, old_y, new_x, new_y) => {
+                info!("MoveCompleted: idx={idx}, ({old_x},{old_y}) -> ({new_x},{new_y})");
+                if (old_x - new_x).abs() > 0.5 || (old_y - new_y).abs() > 0.5 {
+                    self.history.record(EditAction::MoveNode {
+                        index: idx,
+                        old_x,
+                        old_y,
+                        new_x,
+                        new_y,
+                    });
+                }
+            }
+            #[allow(clippy::similar_names)]
+            CanvasMessage::ResizeCompleted(
+                idx,
+                old_x,
+                old_y,
+                old_w,
+                old_h,
+                new_x,
+                new_y,
+                new_w,
+                new_h,
+            ) => {
+                if (old_x - new_x).abs() > 0.5
+                    || (old_y - new_y).abs() > 0.5
+                    || (old_w - new_w).abs() > 0.5
+                    || (old_h - new_h).abs() > 0.5
+                {
+                    self.history.record(EditAction::ResizeNode {
+                        index: idx,
+                        old_x,
+                        old_y,
+                        old_w,
+                        old_h,
+                        new_x,
+                        new_y,
+                        new_w,
+                        new_h,
+                    });
+                }
+            }
+            CanvasMessage::Deleted(idx) => {
+                if idx < self.flow_definition.process_refs.len() {
+                    let Some(pref) = self.flow_definition.process_refs.get(idx).cloned() else {
+                        return CanvasAction::None;
+                    };
                     let alias = if pref.alias.is_empty() {
                         derive_short_name(&pref.source)
                     } else {
                         pref.alias.clone()
                     };
-                    win.status = format!("Selected: {alias}");
+                    let removed_connections: Vec<Connection> = self
+                        .flow_definition
+                        .connections
+                        .iter()
+                        .filter(|c| connection_references_node(c, &alias))
+                        .cloned()
+                        .collect();
+                    let removed_pref = self.flow_definition.process_refs.remove(idx);
+                    let removed_subprocess = self.flow_definition.subprocesses.remove(&alias);
+                    self.flow_definition
+                        .connections
+                        .retain(|c| !connection_references_node(c, &alias));
+                    self.history.record(EditAction::DeleteNode {
+                        index: idx,
+                        process_ref: removed_pref,
+                        subprocess: removed_subprocess.map(|p| (alias, p)),
+                        removed_connections,
+                    });
+                    self.selected_node = None;
+                    self.selected_connection = None;
+                    self.canvas_state.request_redraw();
+                    let nc = self.flow_definition.process_refs.len();
+                    let ec = self.flow_definition.connections.len();
+                    self.status = format!("Node deleted - {nc} nodes, {ec} connections");
+                    if self.auto_fit_enabled {
+                        self.auto_fit_pending = true;
+                    }
                 }
-            } else {
-                win.status = String::from("Ready");
             }
-        }
-        CanvasMessage::Moved(idx, x, y) => {
-            if let Some(pref) = win.flow_definition.process_refs.get_mut(idx) {
-                pref.x = Some(x);
-                pref.y = Some(y);
-                win.canvas_state.request_redraw();
-            }
-        }
-        CanvasMessage::Resized(idx, x, y, w, h) => {
-            if let Some(pref) = win.flow_definition.process_refs.get_mut(idx) {
-                pref.x = Some(x);
-                pref.y = Some(y);
-                pref.width = Some(w);
-                pref.height = Some(h);
-                win.canvas_state.request_redraw();
-            }
-        }
-        CanvasMessage::MoveCompleted(idx, old_x, old_y, new_x, new_y) => {
-            info!("MoveCompleted: idx={idx}, ({old_x},{old_y}) -> ({new_x},{new_y})");
-            if (old_x - new_x).abs() > 0.5 || (old_y - new_y).abs() > 0.5 {
-                win.history.record(EditAction::MoveNode {
-                    index: idx,
-                    old_x,
-                    old_y,
-                    new_x,
-                    new_y,
-                });
-            }
-        }
-        #[allow(clippy::similar_names)]
-        CanvasMessage::ResizeCompleted(
-            idx,
-            old_x,
-            old_y,
-            old_w,
-            old_h,
-            new_x,
-            new_y,
-            new_w,
-            new_h,
-        ) => {
-            if (old_x - new_x).abs() > 0.5
-                || (old_y - new_y).abs() > 0.5
-                || (old_w - new_w).abs() > 0.5
-                || (old_h - new_h).abs() > 0.5
-            {
-                win.history.record(EditAction::ResizeNode {
-                    index: idx,
-                    old_x,
-                    old_y,
-                    old_w,
-                    old_h,
-                    new_x,
-                    new_y,
-                    new_w,
-                    new_h,
-                });
-            }
-        }
-        CanvasMessage::Deleted(idx) => {
-            if idx < win.flow_definition.process_refs.len() {
-                let Some(pref) = win.flow_definition.process_refs.get(idx).cloned() else {
-                    return CanvasAction::None;
-                };
-                let alias = if pref.alias.is_empty() {
-                    derive_short_name(&pref.source)
+            CanvasMessage::ConnectionCreated {
+                from_node,
+                from_port,
+                to_node,
+                to_port,
+            } => {
+                let from_route = if from_port.is_empty() {
+                    from_node.clone()
                 } else {
-                    pref.alias.clone()
+                    format!("{from_node}/{from_port}")
                 };
-                let removed_connections: Vec<Connection> = win
-                    .flow_definition
-                    .connections
-                    .iter()
-                    .filter(|c| connection_references_node(c, &alias))
-                    .cloned()
-                    .collect();
-                let removed_pref = win.flow_definition.process_refs.remove(idx);
-                let removed_subprocess = win.flow_definition.subprocesses.remove(&alias);
-                win.flow_definition
-                    .connections
-                    .retain(|c| !connection_references_node(c, &alias));
-                win.history.record(EditAction::DeleteNode {
-                    index: idx,
-                    process_ref: removed_pref,
-                    subprocess: removed_subprocess.map(|p| (alias, p)),
-                    removed_connections,
+                let to_route = if to_port.is_empty() {
+                    to_node.clone()
+                } else {
+                    format!("{to_node}/{to_port}")
+                };
+                let connection = Connection::new(from_route, to_route);
+                self.history.record(EditAction::CreateConnection {
+                    connection: connection.clone(),
                 });
-                win.selected_node = None;
-                win.selected_connection = None;
-                win.canvas_state.request_redraw();
-                let nc = win.flow_definition.process_refs.len();
-                let ec = win.flow_definition.connections.len();
-                win.status = format!("Node deleted - {nc} nodes, {ec} connections");
-                if win.auto_fit_enabled {
-                    win.auto_fit_pending = true;
-                }
-            }
-        }
-        CanvasMessage::ConnectionCreated {
-            from_node,
-            from_port,
-            to_node,
-            to_port,
-        } => {
-            let from_route = if from_port.is_empty() {
-                from_node.clone()
-            } else {
-                format!("{from_node}/{from_port}")
-            };
-            let to_route = if to_port.is_empty() {
-                to_node.clone()
-            } else {
-                format!("{to_node}/{to_port}")
-            };
-            let connection = Connection::new(from_route, to_route);
-            win.history.record(EditAction::CreateConnection {
-                connection: connection.clone(),
-            });
-            win.flow_definition.connections.push(connection);
-            win.canvas_state.request_redraw();
-            let nc = win.flow_definition.process_refs.len();
-            let ec = win.flow_definition.connections.len();
-            win.status = format!(
+                self.flow_definition.connections.push(connection);
+                self.canvas_state.request_redraw();
+                let nc = self.flow_definition.process_refs.len();
+                let ec = self.flow_definition.connections.len();
+                self.status = format!(
                 "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
             );
-        }
-        CanvasMessage::ConnectionSelected(idx) => {
-            win.selected_connection = idx;
-            win.selected_node = None;
-            win.canvas_state.request_redraw();
-            if let Some(i) = idx {
-                if let Some(conn) = win.flow_definition.connections.get(i) {
-                    let (from_node, from_port) = split_route(conn.from().as_ref());
-                    let to_str = conn
-                        .to()
-                        .first()
-                        .map_or_else(String::new, ToString::to_string);
-                    let (to_node, to_port) = split_route(&to_str);
-                    win.status = format!(
-                        "Connection: {} -> {}",
-                        file_ops::format_endpoint(&from_node, &from_port),
-                        file_ops::format_endpoint(&to_node, &to_port),
-                    );
+            }
+            CanvasMessage::ConnectionSelected(idx) => {
+                self.selected_connection = idx;
+                self.selected_node = None;
+                self.canvas_state.request_redraw();
+                if let Some(i) = idx {
+                    if let Some(conn) = self.flow_definition.connections.get(i) {
+                        let (from_node, from_port) = split_route(conn.from().as_ref());
+                        let to_str = conn
+                            .to()
+                            .first()
+                            .map_or_else(String::new, ToString::to_string);
+                        let (to_node, to_port) = split_route(&to_str);
+                        self.status = format!(
+                            "Connection: {} -> {}",
+                            file_ops::format_endpoint(&from_node, &from_port),
+                            file_ops::format_endpoint(&to_node, &to_port),
+                        );
+                    }
+                } else {
+                    self.status = String::from("Ready");
                 }
-            } else {
-                win.status = String::from("Ready");
             }
-        }
-        CanvasMessage::ConnectionDeleted(idx) => {
-            if idx < win.flow_definition.connections.len() {
-                let connection = win.flow_definition.connections.remove(idx);
-                win.history.record(EditAction::DeleteConnection {
-                    index: idx,
-                    connection,
+            CanvasMessage::ConnectionDeleted(idx) => {
+                if idx < self.flow_definition.connections.len() {
+                    let connection = self.flow_definition.connections.remove(idx);
+                    self.history.record(EditAction::DeleteConnection {
+                        index: idx,
+                        connection,
+                    });
+                    self.selected_connection = None;
+                    self.canvas_state.request_redraw();
+                    let nc = self.flow_definition.process_refs.len();
+                    let ec = self.flow_definition.connections.len();
+                    self.status = format!("Connection deleted - {nc} nodes, {ec} connections");
+                }
+            }
+            CanvasMessage::HoverChanged(data) => {
+                self.tooltip = data;
+            }
+            CanvasMessage::AutoFitViewport(viewport) => {
+                if self.auto_fit_enabled || self.auto_fit_pending {
+                    let has_flow_io = !self.flow_definition.inputs.is_empty()
+                        || !self.flow_definition.outputs.is_empty();
+                    let render_nodes = build_render_nodes(&self.flow_definition);
+                    self.canvas_state
+                        .auto_fit(&render_nodes, has_flow_io, viewport);
+                    self.auto_fit_pending = false;
+                }
+            }
+            CanvasMessage::Pan(dx, dy) => {
+                self.auto_fit_enabled = false; // Manual pan disables auto-fit
+                self.auto_fit_pending = false;
+                self.canvas_state.scroll_offset.x += dx;
+                self.canvas_state.scroll_offset.y += dy;
+                self.canvas_state.request_redraw();
+            }
+            CanvasMessage::ZoomBy(factor) => {
+                self.auto_fit_enabled = false; // Manual zoom disables auto-fit
+                self.auto_fit_pending = false;
+                self.canvas_state.zoom = (self.canvas_state.zoom * factor).clamp(0.1, 5.0);
+                self.canvas_state.request_redraw();
+                let pct = (self.canvas_state.zoom * 100.0) as u32;
+                self.status = format!("Zoom: {pct}%");
+            }
+            CanvasMessage::InitializerEdit(node_idx, port_name) => {
+                // Look up current initializer from the model (flow definition)
+                let (init_type, value_text) = self
+                    .flow_definition
+                    .process_refs
+                    .get(node_idx)
+                    .and_then(|pr| pr.initializations.get(&port_name))
+                    .map_or_else(
+                        || ("none".to_string(), String::new()),
+                        |init| match init {
+                            InputInitializer::Once(v) => (
+                                "once".to_string(),
+                                serde_json::to_string(v).unwrap_or_default(),
+                            ),
+                            InputInitializer::Always(v) => (
+                                "always".to_string(),
+                                serde_json::to_string(v).unwrap_or_default(),
+                            ),
+                        },
+                    );
+
+                self.initializer_editor = Some(InitializerEditor {
+                    node_index: node_idx,
+                    port_name,
+                    init_type,
+                    value_text,
                 });
-                win.selected_connection = None;
-                win.canvas_state.request_redraw();
-                let nc = win.flow_definition.process_refs.len();
-                let ec = win.flow_definition.connections.len();
-                win.status = format!("Connection deleted - {nc} nodes, {ec} connections");
+            }
+            CanvasMessage::OpenNode(idx) => {
+                return CanvasAction::OpenNode(idx);
+            }
+            CanvasMessage::ContextMenu(x, y) => {
+                self.context_menu = Some((x, y));
             }
         }
-        CanvasMessage::HoverChanged(data) => {
-            win.tooltip = data;
-        }
-        CanvasMessage::AutoFitViewport(viewport) => {
-            if win.auto_fit_enabled || win.auto_fit_pending {
-                let has_flow_io = !win.flow_definition.inputs.is_empty()
-                    || !win.flow_definition.outputs.is_empty();
-                let render_nodes = build_render_nodes(&win.flow_definition);
-                win.canvas_state
-                    .auto_fit(&render_nodes, has_flow_io, viewport);
-                win.auto_fit_pending = false;
-            }
-        }
-        CanvasMessage::Pan(dx, dy) => {
-            win.auto_fit_enabled = false; // Manual pan disables auto-fit
-            win.auto_fit_pending = false;
-            win.canvas_state.scroll_offset.x += dx;
-            win.canvas_state.scroll_offset.y += dy;
-            win.canvas_state.request_redraw();
-        }
-        CanvasMessage::ZoomBy(factor) => {
-            win.auto_fit_enabled = false; // Manual zoom disables auto-fit
-            win.auto_fit_pending = false;
-            win.canvas_state.zoom = (win.canvas_state.zoom * factor).clamp(0.1, 5.0);
-            win.canvas_state.request_redraw();
-            let pct = (win.canvas_state.zoom * 100.0) as u32;
-            win.status = format!("Zoom: {pct}%");
-        }
-        CanvasMessage::InitializerEdit(node_idx, port_name) => {
-            // Look up current initializer from the model (flow definition)
-            let (init_type, value_text) = win
-                .flow_definition
-                .process_refs
-                .get(node_idx)
-                .and_then(|pr| pr.initializations.get(&port_name))
-                .map_or_else(
-                    || ("none".to_string(), String::new()),
-                    |init| match init {
-                        InputInitializer::Once(v) => (
-                            "once".to_string(),
-                            serde_json::to_string(v).unwrap_or_default(),
-                        ),
-                        InputInitializer::Always(v) => (
-                            "always".to_string(),
-                            serde_json::to_string(v).unwrap_or_default(),
-                        ),
-                    },
-                );
-
-            win.initializer_editor = Some(InitializerEditor {
-                node_index: node_idx,
-                port_name,
-                init_type,
-                value_text,
-            });
-        }
-        CanvasMessage::OpenNode(idx) => {
-            return CanvasAction::OpenNode(idx);
-        }
-        CanvasMessage::ContextMenu(x, y) => {
-            win.context_menu = Some((x, y));
-        }
+        CanvasAction::None
     }
-    CanvasAction::None
-}
 
-pub(crate) fn update(win: &mut WindowState, msg: &ViewMessage) {
-    match msg {
-        ViewMessage::ZoomIn => {
-            win.auto_fit_enabled = false;
-            win.auto_fit_pending = false;
-            win.canvas_state.zoom_in();
-            let pct = (win.canvas_state.zoom * 100.0) as u32;
-            win.status = format!("Zoom: {pct}%");
-        }
-        ViewMessage::ZoomOut => {
-            win.auto_fit_enabled = false;
-            win.auto_fit_pending = false;
-            win.canvas_state.zoom_out();
-            let pct = (win.canvas_state.zoom * 100.0) as u32;
-            win.status = format!("Zoom: {pct}%");
-        }
-        ViewMessage::ToggleAutoFit => {
-            win.auto_fit_enabled = !win.auto_fit_enabled;
-            if win.auto_fit_enabled {
-                win.auto_fit_pending = true;
-                win.canvas_state.request_redraw();
-                win.status = String::from("Auto-fit enabled");
-            } else {
-                win.status = String::from("Auto-fit disabled");
+    pub(crate) fn handle_view_message(&mut self, msg: &ViewMessage) {
+        match msg {
+            ViewMessage::ZoomIn => {
+                self.auto_fit_enabled = false;
+                self.auto_fit_pending = false;
+                self.canvas_state.zoom_in();
+                let pct = (self.canvas_state.zoom * 100.0) as u32;
+                self.status = format!("Zoom: {pct}%");
+            }
+            ViewMessage::ZoomOut => {
+                self.auto_fit_enabled = false;
+                self.auto_fit_pending = false;
+                self.canvas_state.zoom_out();
+                let pct = (self.canvas_state.zoom * 100.0) as u32;
+                self.status = format!("Zoom: {pct}%");
+            }
+            ViewMessage::ToggleAutoFit => {
+                self.auto_fit_enabled = !self.auto_fit_enabled;
+                if self.auto_fit_enabled {
+                    self.auto_fit_pending = true;
+                    self.canvas_state.request_redraw();
+                    self.status = String::from("Auto-fit enabled");
+                } else {
+                    self.status = String::from("Auto-fit disabled");
+                }
             }
         }
     }
@@ -670,6 +672,42 @@ impl NodeLayout {
             (ResizeHandle::Bottom, Point::new(mid_x, bottom)),
             (ResizeHandle::BottomRight, Point::new(right, bottom)),
         ]
+    }
+
+    fn is_in_source_text_zone(&self, point: Point) -> bool {
+        let text_center_x = self.x + self.width / 2.0;
+        let text_top_y = self.y + 34.0;
+        let text_height = SOURCE_FONT_SIZE + 4.0;
+        let text_half_width = self.width * 0.4;
+
+        point.x >= text_center_x - text_half_width
+            && point.x <= text_center_x + text_half_width
+            && point.y >= text_top_y
+            && point.y <= text_top_y + text_height
+    }
+
+    fn find_output_pos_inline(&self, port: &str) -> Point {
+        if port.is_empty() {
+            self.output_port_position(0)
+        } else {
+            let base = base_port_name(port);
+            let idx = self
+                .outputs
+                .iter()
+                .position(|p| p.name == base)
+                .unwrap_or(0);
+            self.output_port_position(idx)
+        }
+    }
+
+    fn find_input_pos_inline(&self, port: &str) -> Point {
+        if port.is_empty() {
+            self.input_port_position(0)
+        } else {
+            let base = base_port_name(port);
+            let idx = self.inputs.iter().position(|p| p.name == base).unwrap_or(0);
+            self.input_port_position(idx)
+        }
     }
 }
 
@@ -1112,17 +1150,6 @@ fn hit_test_node(nodes: &[NodeLayout], point: Point) -> Option<usize> {
 /// Check whether `point` (world coords) is within the source text zone of a node.
 /// The source text zone is the area where the source path is displayed, centered
 /// horizontally at 34px below the node top.
-fn is_in_source_text_zone(node: &NodeLayout, point: Point) -> bool {
-    let text_center_x = node.x + node.width / 2.0;
-    let text_top_y = node.y + 34.0;
-    let text_height = SOURCE_FONT_SIZE + 4.0;
-    let text_half_width = node.width * 0.4;
-
-    point.x >= text_center_x - text_half_width
-        && point.x <= text_center_x + text_half_width
-        && point.y >= text_top_y
-        && point.y <= text_top_y + text_height
-}
 
 /// Check whether `point` (world coords) is on the open icon of an openable node.
 /// The icon occupies a 16x16 area in the top-right corner of the node.
@@ -1274,30 +1301,6 @@ fn base_port_name(port: &str) -> &str {
     }
 }
 
-fn find_node_output_pos_inline(node: &NodeLayout, port: &str) -> Point {
-    if port.is_empty() {
-        node.output_port_position(0)
-    } else {
-        let base = base_port_name(port);
-        let idx = node
-            .outputs
-            .iter()
-            .position(|p| p.name == base)
-            .unwrap_or(0);
-        node.output_port_position(idx)
-    }
-}
-
-fn find_node_input_pos_inline(node: &NodeLayout, port: &str) -> Point {
-    if port.is_empty() {
-        node.input_port_position(0)
-    } else {
-        let base = base_port_name(port);
-        let idx = node.inputs.iter().position(|p| p.name == base).unwrap_or(0);
-        node.input_port_position(idx)
-    }
-}
-
 /// Squared distance from point `p` to the line segment `a`--`b`.
 #[allow(clippy::similar_names)]
 fn distance_to_segment_sq(p: Point, a: Point, b: Point) -> f32 {
@@ -1364,7 +1367,7 @@ fn hit_test_connection(
             } else {
                 node_map
                     .get(from_node_str.as_str())
-                    .map(|n| find_node_output_pos_inline(n, &from_port_str))
+                    .map(|n| n.find_output_pos_inline(&from_port_str))
             };
 
             let to_point = if to_node_str == "output" {
@@ -1373,7 +1376,7 @@ fn hit_test_connection(
             } else {
                 node_map
                     .get(to_node_str.as_str())
-                    .map(|n| find_node_input_pos_inline(n, &to_port_str))
+                    .map(|n| n.find_input_pos_inline(&to_port_str))
             };
 
             if let (Some(from_point), Some(to_point)) = (from_point, to_point) {
@@ -1805,7 +1808,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                     zoom,
                                     offset,
                                 );
-                                if is_in_source_text_zone(n, world_pos) {
+                                if n.is_in_source_text_zone(world_pos) {
                                     Some((n.source.clone(), bottom_center.x, bottom_center.y))
                                 } else if !n.description.is_empty() {
                                     Some((n.description.clone(), bottom_center.x, bottom_center.y))
@@ -2908,229 +2911,229 @@ fn check_port_type_compatibility(
 /// Build the complete canvas area for a flow-editor window, including the
 /// interactive canvas, zoom controls, tooltip overlay, initializer editor
 /// dialog, and right-click context menu.
-pub(crate) fn view_canvas_area(win: &WindowState, window_id: window::Id) -> Element<'_, Message> {
-    let canvas = win
-        .canvas_state
-        .view(
-            &win.flow_definition,
-            &win.flow_definition.connections,
-            &win.flow_definition.name,
-            &win.flow_definition.inputs,
-            &win.flow_definition.outputs,
-            !win.is_root,
-            win.auto_fit_pending,
-            win.auto_fit_enabled,
-        )
-        .map(move |msg| Message::WindowCanvas(window_id, msg));
+impl WindowState {
+    pub(crate) fn view_canvas_area(&self, window_id: window::Id) -> Element<'_, Message> {
+        let canvas = self
+            .canvas_state
+            .view(
+                &self.flow_definition,
+                &self.flow_definition.connections,
+                &self.flow_definition.name,
+                &self.flow_definition.inputs,
+                &self.flow_definition.outputs,
+                !self.is_root,
+                self.auto_fit_pending,
+                self.auto_fit_enabled,
+            )
+            .map(move |msg| Message::WindowCanvas(window_id, msg));
 
-    let zoom_btn = |_theme: &Theme, status: button::Status| -> button::Style {
-        let is_hovered = matches!(status, button::Status::Hovered);
-        button::Style {
-            background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
-            text_color: Color::WHITE,
-            border: iced::Border {
-                color: if is_hovered {
-                    Color::WHITE
-                } else {
-                    Color::from_rgb(0.4, 0.4, 0.45)
-                },
-                width: 2.0,
-                radius: 8.0.into(),
-            },
-            ..Default::default()
-        }
-    };
-    let zoom_btn_active = |_theme: &Theme, status: button::Status| -> button::Style {
-        let is_hovered = matches!(status, button::Status::Hovered);
-        button::Style {
-            background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
-            text_color: Color::WHITE,
-            border: iced::Border {
-                color: if is_hovered {
-                    Color::WHITE
-                } else {
-                    Color::from_rgb(0.4, 0.5, 0.7)
-                },
-                width: 2.0,
-                radius: 8.0.into(),
-            },
-            ..Default::default()
-        }
-    };
-    let btn_width = 40;
-    let zoom_controls = container(
-        Column::new()
-            .spacing(4)
-            .push(
-                button(Text::new("+").center())
-                    .on_press(Message::View(window_id, ViewMessage::ZoomIn))
-                    .width(btn_width)
-                    .style(zoom_btn),
-            )
-            .push(
-                button(Text::new("\u{2212}").center())
-                    .on_press(Message::View(window_id, ViewMessage::ZoomOut))
-                    .width(btn_width)
-                    .style(zoom_btn),
-            )
-            .push(
-                button(Text::new("Fit").center())
-                    .on_press(Message::View(window_id, ViewMessage::ToggleAutoFit))
-                    .width(btn_width)
-                    .style(if win.auto_fit_enabled {
-                        zoom_btn_active
+        let zoom_btn = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
                     } else {
-                        zoom_btn
-                    }),
-            ),
-    )
-    .align_right(Fill)
-    .align_bottom(Fill)
-    .padding(10);
-
-    let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
-
-    if let Some((ref tip_text, tx, ty)) = win.tooltip {
-        let tooltip_widget = container(
-            container(Text::new(tip_text.clone()).size(20).color(Color::WHITE))
-                .padding(8)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(iced::Background::Color(Color::from_rgb(0.12, 0.12, 0.12))),
-                    border: iced::Border {
-                        color: Color::WHITE,
-                        width: 1.0,
-                        radius: 6.0.into(),
+                        Color::from_rgb(0.4, 0.4, 0.45)
                     },
-                    ..Default::default()
-                }),
-        )
-        .padding(iced::Padding {
-            top: ty + 6.0,
-            right: 0.0,
-            bottom: 0.0,
-            left: (tx - 80.0).max(0.0),
-        });
-        canvas_stack.push(tooltip_widget.into());
-    }
-
-    // Initializer editor dialog overlay
-    if let Some(ref editor) = win.initializer_editor {
-        let port_label = if let Some(pref) = win.flow_definition.process_refs.get(editor.node_index)
-        {
-            let alias = if pref.alias.is_empty() {
-                derive_short_name(&pref.source)
-            } else {
-                pref.alias.clone()
-            };
-            format!("{}/{}", alias, editor.port_name)
-        } else {
-            editor.port_name.clone()
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
         };
-
-        let init_types = vec!["none", "once", "always"];
-        let selected: Option<&str> = init_types.iter().find(|&&t| t == editor.init_type).copied();
-
-        let mut dialog_col = Column::new()
-            .spacing(8)
-            .padding(12)
-            .push(Text::new(format!("Initializer: {port_label}")).size(14))
-            .push(
-                pick_list(init_types, selected, move |s: &str| {
-                    Message::InitializerTypeChanged(window_id, s.to_string())
-                })
-                .text_size(12),
-            );
-
-        if editor.init_type != "none" {
-            dialog_col = dialog_col.push(
-                text_input("JSON value (e.g. 42, \"hello\", true)", &editor.value_text)
-                    .on_input(move |v| Message::InitializerValueChanged(window_id, v))
-                    .size(12)
-                    .padding(6),
-            );
-        }
-
-        dialog_col = dialog_col.push(
-            Row::new()
-                .spacing(8)
+        let zoom_btn_active = |_theme: &Theme, status: button::Status| -> button::Style {
+            let is_hovered = matches!(status, button::Status::Hovered);
+            button::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
+                text_color: Color::WHITE,
+                border: iced::Border {
+                    color: if is_hovered {
+                        Color::WHITE
+                    } else {
+                        Color::from_rgb(0.4, 0.5, 0.7)
+                    },
+                    width: 2.0,
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        };
+        let btn_width = 40;
+        let zoom_controls = container(
+            Column::new()
+                .spacing(4)
                 .push(
-                    button(Text::new("Apply").size(12).center())
-                        .on_press(Message::InitializerApply(window_id))
-                        .style(button::primary)
-                        .padding(6),
+                    button(Text::new("+").center())
+                        .on_press(Message::View(window_id, ViewMessage::ZoomIn))
+                        .width(btn_width)
+                        .style(zoom_btn),
                 )
                 .push(
-                    button(Text::new("Cancel").size(12).center())
-                        .on_press(Message::InitializerCancel(window_id))
-                        .style(button::secondary)
-                        .padding(6),
+                    button(Text::new("\u{2212}").center())
+                        .on_press(Message::View(window_id, ViewMessage::ZoomOut))
+                        .width(btn_width)
+                        .style(zoom_btn),
+                )
+                .push(
+                    button(Text::new("Fit").center())
+                        .on_press(Message::View(window_id, ViewMessage::ToggleAutoFit))
+                        .width(btn_width)
+                        .style(if self.auto_fit_enabled {
+                            zoom_btn_active
+                        } else {
+                            zoom_btn
+                        }),
                 ),
-        );
+        )
+        .align_right(Fill)
+        .align_bottom(Fill)
+        .padding(10);
 
-        let dialog =
-            container(
-                container(dialog_col)
-                    .width(280)
+        let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
+
+        if let Some((ref tip_text, tx, ty)) = self.tooltip {
+            let tooltip_widget = container(
+                container(Text::new(tip_text.clone()).size(20).color(Color::WHITE))
+                    .padding(8)
                     .style(|_theme: &Theme| container::Style {
                         background: Some(iced::Background::Color(Color::from_rgb(
-                            0.15, 0.15, 0.15,
+                            0.12, 0.12, 0.12,
                         ))),
                         border: iced::Border {
-                            color: Color::from_rgb(0.4, 0.4, 0.4),
+                            color: Color::WHITE,
                             width: 1.0,
-                            radius: 8.0.into(),
+                            radius: 6.0.into(),
                         },
                         ..Default::default()
                     }),
             )
+            .padding(iced::Padding {
+                top: ty + 6.0,
+                right: 0.0,
+                bottom: 0.0,
+                left: (tx - 80.0).max(0.0),
+            });
+            canvas_stack.push(tooltip_widget.into());
+        }
+
+        // Initializer editor dialog overlay
+        if let Some(ref editor) = self.initializer_editor {
+            let port_label =
+                if let Some(pref) = self.flow_definition.process_refs.get(editor.node_index) {
+                    let alias = if pref.alias.is_empty() {
+                        derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    format!("{}/{}", alias, editor.port_name)
+                } else {
+                    editor.port_name.clone()
+                };
+
+            let init_types = vec!["none", "once", "always"];
+            let selected: Option<&str> =
+                init_types.iter().find(|&&t| t == editor.init_type).copied();
+
+            let mut dialog_col = Column::new()
+                .spacing(8)
+                .padding(12)
+                .push(Text::new(format!("Initializer: {port_label}")).size(14))
+                .push(
+                    pick_list(init_types, selected, move |s: &str| {
+                        Message::InitializerTypeChanged(window_id, s.to_string())
+                    })
+                    .text_size(12),
+                );
+
+            if editor.init_type != "none" {
+                dialog_col = dialog_col.push(
+                    text_input("JSON value (e.g. 42, \"hello\", true)", &editor.value_text)
+                        .on_input(move |v| Message::InitializerValueChanged(window_id, v))
+                        .size(12)
+                        .padding(6),
+                );
+            }
+
+            dialog_col = dialog_col.push(
+                Row::new()
+                    .spacing(8)
+                    .push(
+                        button(Text::new("Apply").size(12).center())
+                            .on_press(Message::InitializerApply(window_id))
+                            .style(button::primary)
+                            .padding(6),
+                    )
+                    .push(
+                        button(Text::new("Cancel").size(12).center())
+                            .on_press(Message::InitializerCancel(window_id))
+                            .style(button::secondary)
+                            .padding(6),
+                    ),
+            );
+
+            let dialog = container(container(dialog_col).width(280).style(|_theme: &Theme| {
+                container::Style {
+                    background: Some(iced::Background::Color(Color::from_rgb(0.15, 0.15, 0.15))),
+                    border: iced::Border {
+                        color: Color::from_rgb(0.4, 0.4, 0.4),
+                        width: 1.0,
+                        radius: 8.0.into(),
+                    },
+                    ..Default::default()
+                }
+            }))
             .center(Fill);
 
-        canvas_stack.push(dialog.into());
+            canvas_stack.push(dialog.into());
+        }
+
+        // Context menu overlay (right-click on empty canvas)
+        if let Some((cx, cy)) = self.context_menu {
+            let menu = container(
+                Column::new()
+                    .spacing(2)
+                    .push(
+                        button(Text::new("+ New Sub-flow").size(13))
+                            .on_press(Message::NewSubFlow(window_id))
+                            .style(button::text)
+                            .padding([6, 16])
+                            .width(Fill),
+                    )
+                    .push(
+                        button(Text::new("+ New Function").size(13))
+                            .on_press(Message::NewFunction(window_id))
+                            .style(button::text)
+                            .padding([6, 16])
+                            .width(Fill),
+                    ),
+            )
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
+                border: iced::Border {
+                    color: Color::from_rgb(0.4, 0.4, 0.4),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+            .width(160)
+            .padding(4);
+
+            let positioned = container(menu).padding(iced::Padding {
+                top: cy,
+                left: cx,
+                right: 0.0,
+                bottom: 0.0,
+            });
+            canvas_stack.push(positioned.into());
+        }
+
+        stack(canvas_stack).into()
     }
-
-    // Context menu overlay (right-click on empty canvas)
-    if let Some((cx, cy)) = win.context_menu {
-        let menu = container(
-            Column::new()
-                .spacing(2)
-                .push(
-                    button(Text::new("+ New Sub-flow").size(13))
-                        .on_press(Message::NewSubFlow(window_id))
-                        .style(button::text)
-                        .padding([6, 16])
-                        .width(Fill),
-                )
-                .push(
-                    button(Text::new("+ New Function").size(13))
-                        .on_press(Message::NewFunction(window_id))
-                        .style(button::text)
-                        .padding([6, 16])
-                        .width(Fill),
-                ),
-        )
-        .style(|_theme: &Theme| container::Style {
-            background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
-            border: iced::Border {
-                color: Color::from_rgb(0.4, 0.4, 0.4),
-                width: 1.0,
-                radius: 6.0.into(),
-            },
-            ..Default::default()
-        })
-        .width(160)
-        .padding(4);
-
-        let positioned = container(menu).padding(iced::Padding {
-            top: cy,
-            left: cx,
-            right: 0.0,
-            bottom: 0.0,
-        });
-        canvas_stack.push(positioned.into());
-    }
-
-    stack(canvas_stack).into()
-}
+} // impl WindowState (view)
 
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
@@ -3300,10 +3303,10 @@ mod test {
         };
         // Source text is centered at (node.x + width/2, node.y + 34.0)
         let source_center = Point::new(190.0, 134.0);
-        assert!(is_in_source_text_zone(&node, source_center));
+        assert!(node.is_in_source_text_zone(source_center));
         // Point clearly outside source text zone but inside node
         let node_body = Point::new(110.0, 200.0);
-        assert!(!is_in_source_text_zone(&node, node_body));
+        assert!(!node.is_in_source_text_zone(node_body));
     }
 
     #[test]
@@ -3674,8 +3677,8 @@ mod test {
             ],
             ..Default::default()
         };
-        let string_pos = find_node_output_pos_inline(&node, "string/1");
-        let json_pos = find_node_output_pos_inline(&node, "json/2");
+        let string_pos = node.find_output_pos_inline("string/1");
+        let json_pos = node.find_output_pos_inline("json/2");
         // string is output 0, json is output 1 — different y positions
         assert!((json_pos.y - string_pos.y).abs() > 1.0);
     }

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -492,18 +492,14 @@ struct PanState {
     last_screen_pos: Point,
 }
 
-/// Tracks a connection drag in progress (started from a port).
+// TODO: Replace from_node/from_port strings with a Route reference and derive
+// start_pos from the node layout, so renames don't cause stale data.
 #[derive(Debug, Clone)]
 struct ConnectingState {
-    /// Node alias of the starting port
     from_node: String,
-    /// Port name of the starting port
     from_port: String,
-    /// Whether we started from an output port (true) or input port (false)
     from_output: bool,
-    /// World-space position of the starting port
     start_pos: Point,
-    /// Current cursor position in screen space (updated during drag)
     current_screen_pos: Point,
 }
 
@@ -538,72 +534,126 @@ const PORT_START_Y: f32 = 55.0;
 /// Maximum characters for source label before truncation
 const MAX_SOURCE_CHARS: usize = 22;
 
-/// Information about a port (input or output) on a node.
-#[derive(Debug, Clone)]
-pub(crate) struct PortInfo {
-    /// The port name
-    pub name: String,
-    /// The data types accepted or produced by this port (stored for future hover display)
-    #[allow(dead_code)]
-    pub datatypes: Vec<String>,
-}
-
-impl PortInfo {
-    #[cfg(test)]
-    fn from_name(name: String) -> Self {
-        Self {
-            name,
-            datatypes: Vec::new(),
-        }
-    }
-}
-
 /// A positioned node derived from a [`ProcessReference`], ready for rendering.
+///
+/// Combines a `ProcessReference` (position, alias, source, initializations)
+/// with its resolved `Process` (ports, description, type) for rendering.
+/// Rebuilt every frame from `FlowDefinition` — not persisted.
 #[derive(Debug, Clone)]
 pub(crate) struct NodeLayout {
-    /// The resolved process, if available (used to derive color, openability, etc.)
+    pub(crate) process_ref: ProcessReference,
     pub(crate) process: Option<Process>,
-    /// Display name (alias) for this node
-    pub alias: String,
-    /// Source path of the process
-    pub(crate) source: String,
-    /// Optional description of what this process does
-    pub description: String,
-    /// X coordinate on the canvas
-    pub x: f32,
-    /// Y coordinate on the canvas
-    pub y: f32,
-    /// Width of the node rectangle
-    pub width: f32,
-    /// Height of the node rectangle
-    pub height: f32,
-    /// Input ports with names and type information
-    pub inputs: Vec<PortInfo>,
-    /// Output ports with names and type information
-    pub outputs: Vec<PortInfo>,
-    /// Initializer display strings keyed by port name (e.g., "start" → "1 once")
-    pub initializers: HashMap<String, String>,
 }
+
+static EMPTY_IO: Vec<IO> = Vec::new();
 
 impl Default for NodeLayout {
     fn default() -> Self {
         Self {
+            process_ref: ProcessReference {
+                alias: String::new(),
+                source: String::new(),
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(100.0),
+                y: Some(100.0),
+                width: Some(180.0),
+                height: Some(120.0),
+            },
             process: None,
-            alias: String::new(),
-            source: String::new(),
-            description: String::new(),
-            x: 100.0,
-            y: 100.0,
-            width: 180.0,
-            height: 120.0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            initializers: HashMap::new(),
         }
     }
 }
 
 impl NodeLayout {
+    pub(crate) fn alias(&self) -> &str {
+        if self.process_ref.alias.is_empty() {
+            &self.process_ref.source
+        } else {
+            &self.process_ref.alias
+        }
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        &self.process_ref.source
+    }
+
+    pub(crate) fn description(&self) -> String {
+        match &self.process {
+            Some(Process::FunctionProcess(f)) => f.description.clone(),
+            Some(Process::FlowProcess(f)) => f.description.clone(),
+            None => String::new(),
+        }
+    }
+
+    pub(crate) fn x(&self) -> f32 {
+        self.process_ref.x.unwrap_or(100.0)
+    }
+
+    pub(crate) fn y(&self) -> f32 {
+        self.process_ref.y.unwrap_or(100.0)
+    }
+
+    pub(crate) fn width(&self) -> f32 {
+        self.process_ref.width.unwrap_or(DEFAULT_WIDTH)
+    }
+
+    pub(crate) fn height(&self) -> f32 {
+        self.process_ref.height.unwrap_or(DEFAULT_HEIGHT)
+    }
+
+    pub(crate) fn inputs(&self) -> &[IO] {
+        match &self.process {
+            Some(Process::FunctionProcess(f)) => &f.inputs,
+            Some(Process::FlowProcess(f)) => &f.inputs,
+            None => &EMPTY_IO,
+        }
+    }
+
+    pub(crate) fn outputs(&self) -> &[IO] {
+        match &self.process {
+            Some(Process::FunctionProcess(f)) => &f.outputs,
+            Some(Process::FlowProcess(f)) => &f.outputs,
+            None => &EMPTY_IO,
+        }
+    }
+
+    pub(crate) fn has_initializers(&self) -> bool {
+        !self.process_ref.initializations.is_empty()
+    }
+
+    pub(crate) fn max_initializer_display_len(&self) -> usize {
+        self.process_ref
+            .initializations
+            .values()
+            .map(|init| {
+                let s = match init {
+                    flowcore::model::input::InputInitializer::Once(v) => {
+                        format!("once: {}", format_value(v))
+                    }
+                    flowcore::model::input::InputInitializer::Always(v) => {
+                        format!("always: {}", format_value(v))
+                    }
+                };
+                s.len()
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn initializer_display(&self, port_name: &str) -> Option<String> {
+        self.process_ref
+            .initializations
+            .get(port_name)
+            .map(|init| match init {
+                flowcore::model::input::InputInitializer::Once(v) => {
+                    format!("once: {}", format_value(v))
+                }
+                flowcore::model::input::InputInitializer::Always(v) => {
+                    format!("always: {}", format_value(v))
+                }
+            })
+    }
+
     fn fill_color(&self) -> Color {
         match &self.process {
             Some(Process::FlowProcess(_)) => Color::from_rgb(0.9, 0.6, 0.2),
@@ -617,9 +667,9 @@ impl NodeLayout {
                 }
             }
             None => {
-                if self.source.starts_with("lib://") {
+                if self.source().starts_with("lib://") {
                     Color::from_rgb(0.3, 0.5, 0.9)
-                } else if self.source.starts_with("context://") {
+                } else if self.source().starts_with("context://") {
                     Color::from_rgb(0.3, 0.75, 0.45)
                 } else {
                     Color::from_rgb(0.9, 0.6, 0.2)
@@ -634,51 +684,48 @@ impl NodeLayout {
             Some(Process::FunctionProcess(f)) => {
                 f.get_lib_reference().is_none() && f.get_context_reference().is_none()
             }
-            None => !self.source.starts_with("lib://") && !self.source.starts_with("context://"),
+            None => {
+                !self.source().starts_with("lib://") && !self.source().starts_with("context://")
+            }
         }
     }
 
-    /// Get the position of an output port (right edge of node)
     fn output_port_position(&self, port_index: usize) -> Point {
         Point::new(
-            self.x + self.width,
-            self.y + PORT_START_Y + port_index as f32 * PORT_SPACING,
+            self.x() + self.width(),
+            self.y() + PORT_START_Y + port_index as f32 * PORT_SPACING,
         )
     }
 
-    /// Get the position of an input port (left edge of node)
     fn input_port_position(&self, port_index: usize) -> Point {
         Point::new(
-            self.x,
-            self.y + PORT_START_Y + port_index as f32 * PORT_SPACING,
+            self.x(),
+            self.y() + PORT_START_Y + port_index as f32 * PORT_SPACING,
         )
     }
 
-    /// Return the 8 resize handle positions in world coordinates.
-    ///
-    /// Order: `TopLeft`, Top, `TopRight`, Left, Right, `BottomLeft`, Bottom, `BottomRight`.
     fn resize_handle_positions(&self) -> [(ResizeHandle, Point); 8] {
-        let mid_x = self.x + self.width / 2.0;
-        let mid_y = self.y + self.height / 2.0;
-        let right = self.x + self.width;
-        let bottom = self.y + self.height;
+        let mid_x = self.x() + self.width() / 2.0;
+        let mid_y = self.y() + self.height() / 2.0;
+        let right = self.x() + self.width();
+        let bottom = self.y() + self.height();
         [
-            (ResizeHandle::TopLeft, Point::new(self.x, self.y)),
-            (ResizeHandle::Top, Point::new(mid_x, self.y)),
-            (ResizeHandle::TopRight, Point::new(right, self.y)),
-            (ResizeHandle::Left, Point::new(self.x, mid_y)),
+            (ResizeHandle::TopLeft, Point::new(self.x(), self.y())),
+            (ResizeHandle::Top, Point::new(mid_x, self.y())),
+            (ResizeHandle::TopRight, Point::new(right, self.y())),
+            (ResizeHandle::Left, Point::new(self.x(), mid_y)),
             (ResizeHandle::Right, Point::new(right, mid_y)),
-            (ResizeHandle::BottomLeft, Point::new(self.x, bottom)),
+            (ResizeHandle::BottomLeft, Point::new(self.x(), bottom)),
             (ResizeHandle::Bottom, Point::new(mid_x, bottom)),
             (ResizeHandle::BottomRight, Point::new(right, bottom)),
         ]
     }
 
     fn is_in_source_text_zone(&self, point: Point) -> bool {
-        let text_center_x = self.x + self.width / 2.0;
-        let text_top_y = self.y + 34.0;
+        let text_center_x = self.x() + self.width() / 2.0;
+        let text_top_y = self.y() + 34.0;
         let text_height = SOURCE_FONT_SIZE + 4.0;
-        let text_half_width = self.width * 0.4;
+        let text_half_width = self.width() * 0.4;
 
         point.x >= text_center_x - text_half_width
             && point.x <= text_center_x + text_half_width
@@ -692,9 +739,9 @@ impl NodeLayout {
         } else {
             let base = base_port_name(port);
             let idx = self
-                .outputs
+                .outputs()
                 .iter()
-                .position(|p| p.name == base)
+                .position(|p| p.name() == base)
                 .unwrap_or(0);
             self.output_port_position(idx)
         }
@@ -705,7 +752,11 @@ impl NodeLayout {
             self.input_port_position(0)
         } else {
             let base = base_port_name(port);
-            let idx = self.inputs.iter().position(|p| p.name == base).unwrap_or(0);
+            let idx = self
+                .inputs()
+                .iter()
+                .position(|p| p.name() == base)
+                .unwrap_or(0);
             self.input_port_position(idx)
         }
     }
@@ -732,16 +783,15 @@ pub(crate) fn build_render_nodes(
 
         let resolved = flow_def.subprocesses.get(&alias);
 
-        let (inputs, outputs) = resolved
-            .map(|proc| match proc {
-                Process::FunctionProcess(f) => {
-                    crate::file_ops::extract_ports(&f.inputs, &f.outputs)
-                }
-                Process::FlowProcess(f) => crate::file_ops::extract_ports(&f.inputs, &f.outputs),
-            })
-            .unwrap_or_default();
-
-        let min_ports = inputs.len().max(outputs.len());
+        let input_count = resolved.map_or(0, |p| match p {
+            Process::FunctionProcess(f) => f.inputs.len(),
+            Process::FlowProcess(f) => f.inputs.len(),
+        });
+        let output_count = resolved.map_or(0, |p| match p {
+            Process::FunctionProcess(f) => f.outputs.len(),
+            Process::FlowProcess(f) => f.outputs.len(),
+        });
+        let min_ports = input_count.max(output_count);
         let min_height = PORT_START_Y + (min_ports as f32 + 1.0) * PORT_SPACING;
 
         let (default_x, default_y) = if let Some((tx, ty)) = topo_positions.get(&alias) {
@@ -754,43 +804,19 @@ pub(crate) fn build_render_nodes(
                 GRID_ORIGIN_Y + row as f32 * GRID_SPACING_Y,
             )
         };
-        let x = pref.x.unwrap_or(default_x);
-        let y = pref.y.unwrap_or(default_y);
-        let width = pref.width.unwrap_or(DEFAULT_WIDTH);
-        let height = pref.height.unwrap_or(DEFAULT_HEIGHT.max(min_height));
 
-        let mut initializers = HashMap::new();
-        for (port_name, init) in &pref.initializations {
-            let display = match init {
-                flowcore::model::input::InputInitializer::Once(v) => {
-                    format!("once: {}", format_value(v))
-                }
-                flowcore::model::input::InputInitializer::Always(v) => {
-                    format!("always: {}", format_value(v))
-                }
-            };
-            initializers.insert(port_name.clone(), display);
+        let mut process_ref = pref.clone();
+        if process_ref.alias.is_empty() {
+            process_ref.alias = alias;
         }
-
-        let description = resolved
-            .map(|proc| match proc {
-                Process::FunctionProcess(func) => func.description.clone(),
-                Process::FlowProcess(flow) => flow.description.clone(),
-            })
-            .unwrap_or_default();
+        process_ref.x = Some(pref.x.unwrap_or(default_x));
+        process_ref.y = Some(pref.y.unwrap_or(default_y));
+        process_ref.width = Some(pref.width.unwrap_or(DEFAULT_WIDTH));
+        process_ref.height = Some(pref.height.unwrap_or(DEFAULT_HEIGHT.max(min_height)));
 
         nodes.push(NodeLayout {
+            process_ref,
             process: resolved.cloned(),
-            alias: alias.clone(),
-            source: pref.source.clone(),
-            description,
-            x,
-            y,
-            width,
-            height,
-            inputs,
-            outputs,
-            initializers,
         });
     }
 
@@ -1044,28 +1070,22 @@ impl FlowCanvasState {
             (f32::MAX, f32::MAX, f32::MIN, f32::MIN)
         };
         for node in nodes {
-            let init_margin = if node.initializers.is_empty() {
-                0.0
+            let init_margin = if node.has_initializers() {
+                node.max_initializer_display_len() as f32 * 8.0
             } else {
-                let max_len = node
-                    .initializers
-                    .values()
-                    .map(String::len)
-                    .max()
-                    .unwrap_or(0);
-                max_len as f32 * 8.0
+                0.0
             };
-            if node.x - init_margin < min_x {
-                min_x = node.x - init_margin;
+            if node.x() - init_margin < min_x {
+                min_x = node.x() - init_margin;
             }
-            if node.y < min_y {
-                min_y = node.y;
+            if node.y() < min_y {
+                min_y = node.y();
             }
-            if node.x + node.width > max_x {
-                max_x = node.x + node.width;
+            if node.x() + node.width() > max_x {
+                max_x = node.x() + node.width();
             }
-            if node.y + node.height > max_y {
-                max_y = node.y + node.height;
+            if node.y() + node.height() > max_y {
+                max_y = node.y() + node.height();
             }
         }
 
@@ -1135,10 +1155,10 @@ struct FlowCanvas<'a> {
 /// Find the index of the first node whose bounding rectangle contains `point`.
 fn hit_test_node(nodes: &[NodeLayout], point: Point) -> Option<usize> {
     nodes.iter().enumerate().find_map(|(i, node)| {
-        if point.x >= node.x
-            && point.x <= node.x + node.width
-            && point.y >= node.y
-            && point.y <= node.y + node.height
+        if point.x >= node.x()
+            && point.x <= node.x() + node.width()
+            && point.y >= node.y()
+            && point.y <= node.y() + node.height()
         {
             Some(i)
         } else {
@@ -1147,10 +1167,6 @@ fn hit_test_node(nodes: &[NodeLayout], point: Point) -> Option<usize> {
     })
 }
 
-/// Check whether `point` (world coords) is within the source text zone of a node.
-/// The source text zone is the area where the source path is displayed, centered
-/// horizontally at 34px below the node top.
-
 /// Check whether `point` (world coords) is on the open icon of an openable node.
 /// The icon occupies a 16x16 area in the top-right corner of the node.
 fn hit_test_open_icon(nodes: &[NodeLayout], point: Point) -> Option<usize> {
@@ -1158,8 +1174,8 @@ fn hit_test_open_icon(nodes: &[NodeLayout], point: Point) -> Option<usize> {
         if !node.is_openable() {
             return None;
         }
-        let icon_x = node.x + node.width - 22.0;
-        let icon_y = node.y + 4.0;
+        let icon_x = node.x() + node.width() - 22.0;
+        let icon_y = node.y() + 4.0;
         if point.x >= icon_x
             && point.x <= icon_x + 24.0
             && point.y >= icon_y
@@ -1206,23 +1222,23 @@ fn hit_test_port(
 ) -> Option<(usize, String, bool)> {
     for (node_idx, node) in nodes.iter().enumerate() {
         // Check output ports (right side)
-        for (port_idx, port_info) in node.outputs.iter().enumerate() {
+        for (port_idx, port_info) in node.outputs().iter().enumerate() {
             let world_pt = node.output_port_position(port_idx);
             let screen_pt = transform_point(world_pt, zoom, offset);
             let dx = screen_pos.x - screen_pt.x;
             let dy = screen_pos.y - screen_pt.y;
             if dx * dx + dy * dy <= PORT_HIT_RADIUS * PORT_HIT_RADIUS {
-                return Some((node_idx, port_info.name.clone(), true));
+                return Some((node_idx, port_info.name().clone(), true));
             }
         }
         // Check input ports (left side)
-        for (port_idx, port_info) in node.inputs.iter().enumerate() {
+        for (port_idx, port_info) in node.inputs().iter().enumerate() {
             let world_pt = node.input_port_position(port_idx);
             let screen_pt = transform_point(world_pt, zoom, offset);
             let dx = screen_pos.x - screen_pt.x;
             let dy = screen_pos.y - screen_pt.y;
             if dx * dx + dy * dy <= PORT_HIT_RADIUS * PORT_HIT_RADIUS {
-                return Some((node_idx, port_info.name.clone(), false));
+                return Some((node_idx, port_info.name().clone(), false));
             }
         }
     }
@@ -1262,12 +1278,15 @@ fn compute_flow_io_positions(
         (150.0, 350.0, 100.0, 100.0 + default_h)
     } else {
         (
-            nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min),
-            nodes.iter().map(|n| n.x + n.width).fold(f32::MIN, f32::max),
-            nodes.iter().map(|n| n.y).fold(f32::MAX, f32::min),
+            nodes.iter().map(|n| n.x()).fold(f32::MAX, f32::min),
             nodes
                 .iter()
-                .map(|n| n.y + n.height)
+                .map(|n| n.x() + n.width())
+                .fold(f32::MIN, f32::max),
+            nodes.iter().map(|n| n.y()).fold(f32::MAX, f32::min),
+            nodes
+                .iter()
+                .map(|n| n.y() + n.height())
                 .fold(f32::MIN, f32::max),
         )
     };
@@ -1347,8 +1366,7 @@ fn hit_test_connection(
     offset: Point,
 ) -> Option<usize> {
     use std::collections::HashMap;
-    let node_map: HashMap<&str, &NodeLayout> =
-        nodes.iter().map(|n| (n.alias.as_str(), n)).collect();
+    let node_map: HashMap<&str, &NodeLayout> = nodes.iter().map(|n| (n.alias(), n)).collect();
 
     // Compute flow I/O port positions (same layout as draw_flow_io_ports)
     let flow_io_positions = compute_flow_io_positions(nodes, flow_inputs, flow_outputs);
@@ -1392,10 +1410,10 @@ fn hit_test_connection(
                         continue;
                     };
                     let (box_right, box_bottom, box_left, mid_x) = loopback_waypoints(
-                        from_n.x,
-                        from_n.y,
-                        from_n.width,
-                        from_n.height,
+                        from_n.x(),
+                        from_n.y(),
+                        from_n.width(),
+                        from_n.height(),
                         zoom,
                         offset,
                     );
@@ -1562,10 +1580,10 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                 handle,
                                 start_x: world_pos.x,
                                 start_y: world_pos.y,
-                                start_node_x: sel_node.x,
-                                start_node_y: sel_node.y,
-                                start_width: sel_node.width,
-                                start_height: sel_node.height,
+                                start_node_x: sel_node.x(),
+                                start_node_y: sel_node.y(),
+                                start_width: sel_node.width(),
+                                start_height: sel_node.height(),
                             });
                             return Some(canvas::Action::request_redraw().and_capture());
                         }
@@ -1603,21 +1621,21 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     if let Some(node) = self.nodes.get(node_idx) {
                         let port_world_pos = if is_output {
                             let port_idx = node
-                                .outputs
+                                .outputs()
                                 .iter()
-                                .position(|p| p.name == port_name)
+                                .position(|p| p.name() == &port_name)
                                 .unwrap_or(0);
                             node.output_port_position(port_idx)
                         } else {
                             let port_idx = node
-                                .inputs
+                                .inputs()
                                 .iter()
-                                .position(|p| p.name == port_name)
+                                .position(|p| p.name() == &port_name)
                                 .unwrap_or(0);
                             node.input_port_position(port_idx)
                         };
                         state.connecting = Some(ConnectingState {
-                            from_node: node.alias.clone(),
+                            from_node: node.alias().to_string(),
                             from_port: port_name,
                             from_output: is_output,
                             start_pos: port_world_pos,
@@ -1641,10 +1659,10 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     state.selected_connection = None;
                     state.dragging = Some(DragState {
                         node_index: idx,
-                        offset_x: world_pos.x - node.x,
-                        offset_y: world_pos.y - node.y,
-                        start_x: node.x,
-                        start_y: node.y,
+                        offset_x: world_pos.x - node.x(),
+                        offset_y: world_pos.y - node.y(),
+                        start_x: node.x(),
+                        start_y: node.y(),
                     });
                     Some(canvas::Action::publish(CanvasMessage::Selected(Some(idx))).and_capture())
                 } else {
@@ -1776,20 +1794,28 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     {
                         if let Some(node) = self.nodes.get(node_idx) {
                             let ports = if is_output {
-                                &node.outputs
+                                node.outputs()
                             } else {
-                                &node.inputs
+                                node.inputs()
                             };
-                            let type_text = ports.iter().find(|p| p.name == port_name).map_or_else(
-                                || port_name.clone(),
-                                |p| {
-                                    if p.datatypes.is_empty() {
-                                        format!("{port_name}: (any)")
-                                    } else {
-                                        format!("{port_name}: {}", p.datatypes.join(", "))
-                                    }
-                                },
-                            );
+                            let type_text =
+                                ports.iter().find(|p| p.name() == &port_name).map_or_else(
+                                    || port_name.clone(),
+                                    |p| {
+                                        if p.datatypes().is_empty() {
+                                            format!("{port_name}: (any)")
+                                        } else {
+                                            format!(
+                                                "{port_name}: {}",
+                                                p.datatypes()
+                                                    .iter()
+                                                    .map(ToString::to_string)
+                                                    .collect::<Vec<_>>()
+                                                    .join(", ")
+                                            )
+                                        }
+                                    },
+                                );
                             state.hover_node = None;
                             return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
                                 Some((type_text, cursor_position.x, cursor_position.y - 20.0)),
@@ -1804,14 +1830,14 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         let tooltip_data =
                             new_hover.and_then(|idx| self.nodes.get(idx)).and_then(|n| {
                                 let bottom_center = transform_point(
-                                    Point::new(n.x + n.width / 2.0, n.y + n.height),
+                                    Point::new(n.x() + n.width() / 2.0, n.y() + n.height()),
                                     zoom,
                                     offset,
                                 );
                                 if n.is_in_source_text_zone(world_pos) {
-                                    Some((n.source.clone(), bottom_center.x, bottom_center.y))
-                                } else if !n.description.is_empty() {
-                                    Some((n.description.clone(), bottom_center.x, bottom_center.y))
+                                    Some((n.source().to_string(), bottom_center.x, bottom_center.y))
+                                } else if !n.description().is_empty() {
+                                    Some((n.description(), bottom_center.x, bottom_center.y))
                                 } else {
                                     None
                                 }
@@ -1835,8 +1861,10 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         if connecting.from_output != target_is_output {
                             if let Some(target_node) = self.nodes.get(target_idx) {
                                 // Check type compatibility before creating connection
-                                let source_node =
-                                    self.nodes.iter().find(|n| n.alias == connecting.from_node);
+                                let source_node = self
+                                    .nodes
+                                    .iter()
+                                    .find(|n| n.alias() == connecting.from_node);
                                 let types_ok = check_port_type_compatibility(
                                     source_node,
                                     &connecting.from_port,
@@ -1852,12 +1880,12 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                             (
                                                 connecting.from_node,
                                                 connecting.from_port,
-                                                target_node.alias.clone(),
+                                                target_node.alias().to_string(),
                                                 target_port,
                                             )
                                         } else {
                                             (
-                                                target_node.alias.clone(),
+                                                target_node.alias().to_string(),
                                                 target_port,
                                                 connecting.from_node,
                                                 connecting.from_port,
@@ -1889,10 +1917,10 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                 resize.start_node_y,
                                 resize.start_width,
                                 resize.start_height,
-                                node.x,
-                                node.y,
-                                node.width,
-                                node.height,
+                                node.x(),
+                                node.y(),
+                                node.width(),
+                                node.height(),
                             ))
                             .and_capture(),
                         );
@@ -1906,8 +1934,8 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                 drag.node_index,
                                 drag.start_x,
                                 drag.start_y,
-                                node.x,
-                                node.y,
+                                node.x(),
+                                node.y(),
                             ))
                             .and_capture(),
                         );
@@ -2009,8 +2037,8 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             // Draw selected node highlight and resize handles
             if let Some(selected_idx) = state.selected_node {
                 if let Some(node) = self.nodes.get(selected_idx) {
-                    let screen_pos = transform_point(Point::new(node.x, node.y), zoom, offset);
-                    let screen_size = Size::new(node.width * zoom, node.height * zoom);
+                    let screen_pos = transform_point(Point::new(node.x(), node.y()), zoom, offset);
+                    let screen_size = Size::new(node.width() * zoom, node.height() * zoom);
                     let selection_color = Color::from_rgb(1.0, 0.85, 0.0);
                     let highlight = Path::new(|builder| {
                         rounded_rect(builder, screen_pos, screen_size, CORNER_RADIUS * zoom);
@@ -2080,16 +2108,16 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                         if let Some(target_node) = self.nodes.get(target_idx) {
                             let port_world = if target_is_output {
                                 let pidx = target_node
-                                    .outputs
+                                    .outputs()
                                     .iter()
-                                    .position(|p| p.name == target_port)
+                                    .position(|p| p.name() == &target_port)
                                     .unwrap_or(0);
                                 target_node.output_port_position(pidx)
                             } else {
                                 let pidx = target_node
-                                    .inputs
+                                    .inputs()
                                     .iter()
-                                    .position(|p| p.name == target_port)
+                                    .position(|p| p.name() == &target_port)
                                     .unwrap_or(0);
                                 target_node.input_port_position(pidx)
                             };
@@ -2179,8 +2207,7 @@ fn draw_edges(
     selected: Option<usize>,
 ) {
     // Build a lookup from alias to node
-    let node_map: HashMap<&str, &NodeLayout> =
-        nodes.iter().map(|n| (n.alias.as_str(), n)).collect();
+    let node_map: HashMap<&str, &NodeLayout> = nodes.iter().map(|n| (n.alias(), n)).collect();
 
     // Draw selected connection last so it renders on top of crossing connections
     let draw_order: Vec<usize> = (0..connections.len())
@@ -2205,9 +2232,9 @@ fn draw_edges(
                 } else {
                     let base = base_port_name(&from_port_str);
                     let port_idx = from
-                        .outputs
+                        .outputs()
                         .iter()
-                        .position(|p| p.name == base)
+                        .position(|p| p.name() == base)
                         .unwrap_or(0);
                     from.output_port_position(port_idx)
                 };
@@ -2216,13 +2243,17 @@ fn draw_edges(
                     to.input_port_position(0)
                 } else {
                     let base = base_port_name(&to_port_str);
-                    let port_idx = to.inputs.iter().position(|p| p.name == base).unwrap_or(0);
+                    let port_idx = to
+                        .inputs()
+                        .iter()
+                        .position(|p| p.name() == base)
+                        .unwrap_or(0);
                     to.input_port_position(port_idx)
                 };
 
                 let is_self_connection = from_node_str == to_node_str;
                 let node_bounds = if is_self_connection {
-                    Some((from.x, from.y, from.width, from.height))
+                    Some((from.x(), from.y(), from.width(), from.height()))
                 } else {
                     None
                 };
@@ -2244,10 +2275,10 @@ fn draw_edges(
                     let to_s = transform_point(to_point, zoom, offset);
                     let mid = if is_self_connection {
                         let (_, box_bottom, box_left, mid_x) = loopback_waypoints(
-                            from.x,
-                            from.y,
-                            from.width,
-                            from.height,
+                            from.x(),
+                            from.y(),
+                            from.width(),
+                            from.height(),
                             zoom,
                             offset,
                         );
@@ -2403,12 +2434,15 @@ fn draw_flow_io_ports(
         (150.0, 350.0, 100.0, 100.0 + default_h)
     } else {
         (
-            nodes.iter().map(|n| n.x).fold(f32::MAX, f32::min),
-            nodes.iter().map(|n| n.x + n.width).fold(f32::MIN, f32::max),
-            nodes.iter().map(|n| n.y).fold(f32::MAX, f32::min),
+            nodes.iter().map(|n| n.x()).fold(f32::MAX, f32::min),
             nodes
                 .iter()
-                .map(|n| n.y + n.height)
+                .map(|n| n.x() + n.width())
+                .fold(f32::MIN, f32::max),
+            nodes.iter().map(|n| n.y()).fold(f32::MAX, f32::min),
+            nodes
+                .iter()
+                .map(|n| n.y() + n.height())
                 .fold(f32::MIN, f32::max),
         )
     };
@@ -2549,22 +2583,26 @@ fn draw_flow_io_ports(
 }
 
 fn find_node_input_pos(nodes: &[NodeLayout], alias: &str, port: &str) -> Option<Point> {
-    let node = nodes.iter().find(|n| n.alias == alias)?;
+    let node = nodes.iter().find(|n| n.alias() == alias)?;
     let base = base_port_name(port);
-    let port_idx = node.inputs.iter().position(|p| p.name == base).unwrap_or(0);
+    let port_idx = node
+        .inputs()
+        .iter()
+        .position(|p| p.name() == base)
+        .unwrap_or(0);
     Some(node.input_port_position(port_idx))
 }
 
 fn find_node_output_pos(nodes: &[NodeLayout], alias: &str, port: &str) -> Option<Point> {
-    let node = nodes.iter().find(|n| n.alias == alias)?;
+    let node = nodes.iter().find(|n| n.alias() == alias)?;
     if port.is_empty() {
         Some(node.output_port_position(0))
     } else {
         let base = base_port_name(port);
         let port_idx = node
-            .outputs
+            .outputs()
             .iter()
-            .position(|p| p.name == base)
+            .position(|p| p.name() == base)
             .unwrap_or(0);
         Some(node.output_port_position(port_idx))
     }
@@ -2598,8 +2636,8 @@ fn draw_flow_io_bezier(
 
 /// Draw a single node as a rounded rectangle with title, source, and ports.
 fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
-    let top_left = transform_point(Point::new(node.x, node.y), zoom, offset);
-    let size = Size::new(node.width * zoom, node.height * zoom);
+    let top_left = transform_point(Point::new(node.x(), node.y()), zoom, offset);
+    let size = Size::new(node.width() * zoom, node.height() * zoom);
     let fill_color = node.fill_color();
 
     // Draw filled rounded rectangle
@@ -2613,12 +2651,12 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
 
     // Draw alias title centered near top of node
     let title_pos = transform_point(
-        Point::new(node.x + node.width / 2.0, node.y + 12.0),
+        Point::new(node.x() + node.width() / 2.0, node.y() + 12.0),
         zoom,
         offset,
     );
     let title = CanvasText {
-        content: node.alias.clone(),
+        content: node.alias().to_string(),
         position: title_pos,
         color: Color::WHITE,
         size: (TITLE_FONT_SIZE * zoom).into(),
@@ -2629,9 +2667,9 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
     frame.fill_text(title);
 
     // Draw source label below title (truncated with ellipsis)
-    let source_display = truncate_source(&node.source, MAX_SOURCE_CHARS);
+    let source_display = truncate_source(node.source(), MAX_SOURCE_CHARS);
     let source_pos = transform_point(
-        Point::new(node.x + node.width / 2.0, node.y + 34.0),
+        Point::new(node.x() + node.width() / 2.0, node.y() + 34.0),
         zoom,
         offset,
     );
@@ -2649,8 +2687,8 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
     // Draw open icon for sub-flows and provided implementations
     if node.is_openable() {
         let icon_size = 26.0 * zoom;
-        let icon_x = node.x + node.width - 22.0;
-        let icon_y = node.y + 4.0;
+        let icon_x = node.x() + node.width() - 22.0;
+        let icon_y = node.y() + 4.0;
         let icon_pos = transform_point(Point::new(icon_x, icon_y), zoom, offset);
 
         let icon_text = CanvasText {
@@ -2664,27 +2702,27 @@ fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
     }
 
     // Draw input ports on the left edge
-    for (i, input_port) in node.inputs.iter().enumerate() {
+    for (i, input_port) in node.inputs().iter().enumerate() {
         let port_pos = node.input_port_position(i);
-        let init_label = node.initializers.get(&input_port.name).map(String::as_str);
+        let init_label = node.initializer_display(input_port.name());
         draw_port(
             frame,
             port_pos,
-            &input_port.name,
+            input_port.name(),
             true,
-            init_label,
+            init_label.as_deref(),
             zoom,
             offset,
         );
     }
 
     // Draw output ports on the right edge
-    for (i, output_port) in node.outputs.iter().enumerate() {
+    for (i, output_port) in node.outputs().iter().enumerate() {
         let port_pos = node.output_port_position(i);
         draw_port(
             frame,
             port_pos,
-            &output_port.name,
+            output_port.name(),
             false,
             None,
             zoom,
@@ -2857,44 +2895,41 @@ fn check_port_type_compatibility(
 ) -> bool {
     let source_types = source_node.and_then(|n| {
         let ports = if source_is_output {
-            &n.outputs
+            n.outputs()
         } else {
-            &n.inputs
+            n.inputs()
         };
-        ports.iter().find(|p| p.name == source_port)
+        ports.iter().find(|p| p.name() == source_port)
     });
 
     let target_types = {
         let ports = if target_is_output {
-            &target_node.outputs
+            target_node.outputs()
         } else {
-            &target_node.inputs
+            target_node.inputs()
         };
-        ports.iter().find(|p| p.name == target_port)
+        ports.iter().find(|p| p.name() == target_port)
     };
 
     match (source_types, target_types) {
         (Some(src), Some(tgt)) => {
             log::info!(
                 "Type check: src port '{}' types {:?} → tgt port '{}' types {:?}",
-                src.name,
-                src.datatypes,
-                tgt.name,
-                tgt.datatypes
+                src.name(),
+                src.datatypes(),
+                tgt.name(),
+                tgt.datatypes()
             );
-            // If either has no type info (empty list or only empty strings),
-            // allow the connection — untyped ports accept anything
-            let src_untyped =
-                src.datatypes.is_empty() || src.datatypes.iter().all(String::is_empty);
-            let tgt_untyped =
-                tgt.datatypes.is_empty() || tgt.datatypes.iter().all(String::is_empty);
+            let src_untyped = src.datatypes().is_empty()
+                || src.datatypes().iter().all(|d| d.to_string().is_empty());
+            let tgt_untyped = tgt.datatypes().is_empty()
+                || tgt.datatypes().iter().all(|d| d.to_string().is_empty());
             if src_untyped || tgt_untyped {
                 return true;
             }
-            // Check for at least one matching type
-            src.datatypes
+            src.datatypes()
                 .iter()
-                .any(|st| tgt.datatypes.iter().any(|tt| st == tt))
+                .any(|st| tgt.datatypes().iter().any(|tt| st == tt))
         }
         // Unknown port or no type info — allow
         (src, tgt) => {
@@ -3141,8 +3176,24 @@ mod test {
     use super::*;
     use flowcore::model::flow_definition::FlowDefinition;
     use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::route::Route;
     use iced::Point;
     use url::Url;
+
+    fn test_node(alias: &str, source: &str, process: Option<Process>) -> NodeLayout {
+        NodeLayout {
+            process_ref: ProcessReference {
+                alias: alias.into(),
+                source: source.into(),
+                initializations: std::collections::BTreeMap::new(),
+                x: Some(100.0),
+                y: Some(100.0),
+                width: Some(180.0),
+                height: Some(120.0),
+            },
+            process,
+        }
+    }
 
     fn lib_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
@@ -3153,6 +3204,13 @@ mod test {
     fn context_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
         f.context_reference = Some(Url::parse("context://stdio/stdout").expect("valid url"));
+        f
+    }
+
+    fn function_with_io(inputs: Vec<IO>, outputs: Vec<IO>) -> FunctionDefinition {
+        let mut f = FunctionDefinition::default();
+        f.inputs = inputs;
+        f.outputs = outputs;
         f
     }
 
@@ -3276,32 +3334,20 @@ mod test {
 
     #[test]
     fn hit_test_node_inside() {
-        let nodes = vec![NodeLayout {
-            alias: "test".into(),
-            source: "lib://test".into(),
-            ..Default::default()
-        }];
+        let nodes = vec![test_node("test", "lib://test", None)];
         assert_eq!(hit_test_node(&nodes, Point::new(150.0, 150.0)), Some(0));
     }
 
     #[test]
     fn hit_test_node_outside() {
-        let nodes = vec![NodeLayout {
-            alias: "test".into(),
-            source: "lib://test".into(),
-            ..Default::default()
-        }];
+        let nodes = vec![test_node("test", "lib://test", None)];
         assert_eq!(hit_test_node(&nodes, Point::new(50.0, 50.0)), None);
     }
 
     #[test]
     fn hit_test_source_text_zone() {
-        let node = NodeLayout {
-            alias: "test".into(),
-            source: "lib://flowstdlib/math/add".into(),
-            ..Default::default()
-        };
-        // Source text is centered at (node.x + width/2, node.y + 34.0)
+        let node = test_node("test", "lib://flowstdlib/math/add", None);
+        // Source text is centered at (node.x() + width/2, node.y() + 34.0)
         let source_center = Point::new(190.0, 134.0);
         assert!(node.is_in_source_text_zone(source_center));
         // Point clearly outside source text zone but inside node
@@ -3320,16 +3366,14 @@ mod test {
 
     #[test]
     fn node_layout_port_positions() {
-        let node = NodeLayout {
-            alias: "test".into(),
-            source: "lib://test".into(),
-            inputs: vec![
-                PortInfo::from_name("i1".into()),
-                PortInfo::from_name("i2".into()),
+        let f = function_with_io(
+            vec![
+                IO::new_named(vec![], Route::default(), "i1"),
+                IO::new_named(vec![], Route::default(), "i2"),
             ],
-            outputs: vec![PortInfo::from_name("out".into())],
-            ..Default::default()
-        };
+            vec![IO::new_named(vec![], Route::default(), "out")],
+        );
+        let node = test_node("test", "lib://test", Some(Process::FunctionProcess(f)));
         let ip0 = node.input_port_position(0);
         let ip1 = node.input_port_position(1);
         let op0 = node.output_port_position(0);
@@ -3437,11 +3481,7 @@ mod test {
 
     #[test]
     fn hit_test_node_miss() {
-        let node = NodeLayout {
-            alias: "n".into(),
-            source: "lib://test".into(),
-            ..Default::default()
-        };
+        let node = test_node("n", "lib://test", None);
         assert_eq!(
             hit_test_node(std::slice::from_ref(&node), Point::new(150.0, 150.0)),
             Some(0)
@@ -3451,17 +3491,16 @@ mod test {
 
     #[test]
     fn hit_test_open_icon_only_openable() {
-        let lib_node = NodeLayout {
-            process: Some(Process::FunctionProcess(lib_function())),
-            alias: "n".into(),
-            source: "lib://test".into(),
-            ..Default::default()
-        };
-        let local_node = NodeLayout {
-            process: Some(Process::FlowProcess(FlowDefinition::default())),
-            source: "subflow".into(),
-            ..lib_node.clone()
-        };
+        let lib_node = test_node(
+            "n",
+            "lib://test",
+            Some(Process::FunctionProcess(lib_function())),
+        );
+        let local_node = test_node(
+            "n",
+            "subflow",
+            Some(Process::FlowProcess(FlowDefinition::default())),
+        );
         // Library nodes are not openable
         assert_eq!(
             hit_test_open_icon(&[lib_node], Point::new(278.0, 104.0)),
@@ -3473,41 +3512,33 @@ mod test {
 
     #[test]
     fn is_openable_lib() {
-        let node = NodeLayout {
-            process: Some(Process::FunctionProcess(lib_function())),
-            alias: "n".into(),
-            ..Default::default()
-        };
+        let node = test_node("n", "", Some(Process::FunctionProcess(lib_function())));
         assert!(!node.is_openable());
     }
 
     #[test]
     fn is_openable_context() {
-        let node = NodeLayout {
-            process: Some(Process::FunctionProcess(context_function())),
-            alias: "n".into(),
-            ..Default::default()
-        };
+        let node = test_node("n", "", Some(Process::FunctionProcess(context_function())));
         assert!(!node.is_openable());
     }
 
     #[test]
     fn is_openable_local() {
-        let node = NodeLayout {
-            process: Some(Process::FlowProcess(FlowDefinition::default())),
-            alias: "n".into(),
-            ..Default::default()
-        };
+        let node = test_node(
+            "n",
+            "",
+            Some(Process::FlowProcess(FlowDefinition::default())),
+        );
         assert!(node.is_openable());
     }
 
     #[test]
     fn is_openable_provided_impl() {
-        let node = NodeLayout {
-            process: Some(Process::FunctionProcess(FunctionDefinition::default())),
-            alias: "n".into(),
-            ..Default::default()
-        };
+        let node = test_node(
+            "n",
+            "",
+            Some(Process::FunctionProcess(FunctionDefinition::default())),
+        );
         assert!(node.is_openable());
     }
 
@@ -3527,26 +3558,26 @@ mod test {
     #[test]
     fn check_type_compat_same_type() {
         let nodes = [
-            NodeLayout {
-                alias: "a".into(),
-                x: 0.0,
-                y: 0.0,
-                outputs: vec![PortInfo {
-                    name: "out".into(),
-                    datatypes: vec!["number".into()],
-                }],
-                ..Default::default()
-            },
-            NodeLayout {
-                alias: "b".into(),
-                x: 0.0,
-                y: 0.0,
-                inputs: vec![PortInfo {
-                    name: "in".into(),
-                    datatypes: vec!["number".into()],
-                }],
-                ..Default::default()
-            },
+            test_node(
+                "a",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![],
+                    vec![IO::new_named(
+                        vec!["number".into()],
+                        Route::default(),
+                        "out",
+                    )],
+                ))),
+            ),
+            test_node(
+                "b",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![IO::new_named(vec!["number".into()], Route::default(), "in")],
+                    vec![],
+                ))),
+            ),
         ];
         assert!(check_port_type_compatibility(
             Some(&nodes[0]),
@@ -3561,26 +3592,26 @@ mod test {
     #[test]
     fn check_type_compat_different_type() {
         let nodes = [
-            NodeLayout {
-                alias: "a".into(),
-                x: 0.0,
-                y: 0.0,
-                outputs: vec![PortInfo {
-                    name: "out".into(),
-                    datatypes: vec!["number".into()],
-                }],
-                ..Default::default()
-            },
-            NodeLayout {
-                alias: "b".into(),
-                x: 0.0,
-                y: 0.0,
-                inputs: vec![PortInfo {
-                    name: "in".into(),
-                    datatypes: vec!["string".into()],
-                }],
-                ..Default::default()
-            },
+            test_node(
+                "a",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![],
+                    vec![IO::new_named(
+                        vec!["number".into()],
+                        Route::default(),
+                        "out",
+                    )],
+                ))),
+            ),
+            test_node(
+                "b",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![IO::new_named(vec!["string".into()], Route::default(), "in")],
+                    vec![],
+                ))),
+            ),
         ];
         assert!(!check_port_type_compatibility(
             Some(&nodes[0]),
@@ -3595,26 +3626,22 @@ mod test {
     #[test]
     fn check_type_compat_untyped_allows_any() {
         let nodes = [
-            NodeLayout {
-                alias: "a".into(),
-                x: 0.0,
-                y: 0.0,
-                outputs: vec![PortInfo {
-                    name: "out".into(),
-                    datatypes: vec![],
-                }],
-                ..Default::default()
-            },
-            NodeLayout {
-                alias: "b".into(),
-                x: 0.0,
-                y: 0.0,
-                inputs: vec![PortInfo {
-                    name: "in".into(),
-                    datatypes: vec!["string".into()],
-                }],
-                ..Default::default()
-            },
+            test_node(
+                "a",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![],
+                    vec![IO::new_named(vec![], Route::default(), "out")],
+                ))),
+            ),
+            test_node(
+                "b",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![IO::new_named(vec!["string".into()], Route::default(), "in")],
+                    vec![],
+                ))),
+            ),
         ];
         assert!(check_port_type_compatibility(
             Some(&nodes[0]),
@@ -3628,11 +3655,7 @@ mod test {
 
     #[test]
     fn compute_flow_io_positions_with_nodes() {
-        use flowcore::model::route::Route;
-        let nodes = vec![NodeLayout {
-            alias: "n".into(),
-            ..Default::default()
-        }];
+        let nodes = vec![test_node("n", "", None)];
         let inputs = vec![IO::new_named(vec![], Route::default(), "data")];
         let outputs = vec![IO::new_named(vec![], Route::default(), "result")];
         let (inp, outp) = compute_flow_io_positions(&nodes, &inputs, &outputs);
@@ -3646,7 +3669,6 @@ mod test {
 
     #[test]
     fn compute_flow_io_positions_empty_nodes() {
-        use flowcore::model::route::Route;
         let inputs = vec![IO::new_named(vec![], Route::default(), "in")];
         let outputs = vec![IO::new_named(vec![], Route::default(), "out")];
         let (inp, outp) = compute_flow_io_positions(&[], &inputs, &outputs);
@@ -3663,20 +3685,14 @@ mod test {
 
     #[test]
     fn find_node_output_inline_with_subroute() {
-        let node = NodeLayout {
-            alias: "get".into(),
-            outputs: vec![
-                PortInfo {
-                    name: "string".into(),
-                    datatypes: vec![],
-                },
-                PortInfo {
-                    name: "json".into(),
-                    datatypes: vec![],
-                },
+        let f = function_with_io(
+            vec![],
+            vec![
+                IO::new_named(vec![], Route::default(), "string"),
+                IO::new_named(vec![], Route::default(), "json"),
             ],
-            ..Default::default()
-        };
+        );
+        let node = test_node("get", "", Some(Process::FunctionProcess(f)));
         let string_pos = node.find_output_pos_inline("string/1");
         let json_pos = node.find_output_pos_inline("json/2");
         // string is output 0, json is output 1 — different y positions
@@ -3685,26 +3701,18 @@ mod test {
 
     #[test]
     fn fill_color_by_process() {
-        let lib = NodeLayout {
-            process: Some(Process::FunctionProcess(lib_function())),
-            alias: "n".into(),
-            ..Default::default()
-        };
-        let ctx = NodeLayout {
-            process: Some(Process::FunctionProcess(context_function())),
-            alias: "n".into(),
-            ..Default::default()
-        };
-        let prov = NodeLayout {
-            process: Some(Process::FunctionProcess(FunctionDefinition::default())),
-            alias: "n".into(),
-            ..Default::default()
-        };
-        let flow = NodeLayout {
-            process: Some(Process::FlowProcess(FlowDefinition::default())),
-            alias: "n".into(),
-            ..Default::default()
-        };
+        let lib = test_node("n", "", Some(Process::FunctionProcess(lib_function())));
+        let ctx = test_node("n", "", Some(Process::FunctionProcess(context_function())));
+        let prov = test_node(
+            "n",
+            "",
+            Some(Process::FunctionProcess(FunctionDefinition::default())),
+        );
+        let flow = test_node(
+            "n",
+            "",
+            Some(Process::FlowProcess(FlowDefinition::default())),
+        );
         assert_ne!(lib.fill_color(), ctx.fill_color());
         assert_ne!(lib.fill_color(), prov.fill_color());
         assert_ne!(lib.fill_color(), flow.fill_color());

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -291,7 +291,7 @@ impl WindowState {
                 return CanvasAction::OpenNode(idx);
             }
             CanvasMessage::ContextMenu(x, y) => {
-                self.context_menu = Some((x, y));
+                self.context_menu = Some(crate::window_state::MenuPosition { x, y });
             }
         }
         CanvasAction::None
@@ -398,7 +398,7 @@ pub(crate) enum CanvasMessage {
     /// Auto-fit with the actual viewport size (triggered on initial load).
     AutoFitViewport(Size),
     /// Hover state changed — full source path and screen position for tooltip (or None to hide)
-    HoverChanged(Option<(String, f32, f32)>),
+    HoverChanged(Option<crate::window_state::Tooltip>),
     /// Right-click on empty canvas — show context menu at screen position
     ContextMenu(f32, f32),
 }
@@ -983,9 +983,9 @@ pub(crate) struct FlowCanvasState {
     /// The geometry cache — cleared when the flow data changes
     cache: canvas::Cache,
     /// Current zoom level (1.0 = 100%)
-    pub zoom: f32,
+    pub(crate) zoom: f32,
     /// Scroll offset in world coordinates
-    pub scroll_offset: Point,
+    pub(crate) scroll_offset: Point,
 }
 
 impl Default for FlowCanvasState {
@@ -1818,7 +1818,11 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                 );
                             state.hover_node = None;
                             return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
-                                Some((type_text, cursor_position.x, cursor_position.y - 20.0)),
+                                Some(crate::window_state::Tooltip {
+                                    text: type_text,
+                                    x: cursor_position.x,
+                                    y: cursor_position.y - 20.0,
+                                }),
                             )));
                         }
                     }
@@ -1835,9 +1839,17 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                                     offset,
                                 );
                                 if n.is_in_source_text_zone(world_pos) {
-                                    Some((n.source().to_string(), bottom_center.x, bottom_center.y))
+                                    Some(crate::window_state::Tooltip {
+                                        text: n.source().to_string(),
+                                        x: bottom_center.x,
+                                        y: bottom_center.y,
+                                    })
                                 } else if !n.description().is_empty() {
-                                    Some((n.description(), bottom_center.x, bottom_center.y))
+                                    Some(crate::window_state::Tooltip {
+                                        text: n.description(),
+                                        x: bottom_center.x,
+                                        y: bottom_center.y,
+                                    })
                                 } else {
                                     None
                                 }
@@ -3029,9 +3041,9 @@ impl WindowState {
 
         let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
 
-        if let Some((ref tip_text, tx, ty)) = self.tooltip {
+        if let Some(ref tip) = self.tooltip {
             let tooltip_widget = container(
-                container(Text::new(tip_text.clone()).size(20).color(Color::WHITE))
+                container(Text::new(tip.text.clone()).size(20).color(Color::WHITE))
                     .padding(8)
                     .style(|_theme: &Theme| container::Style {
                         background: Some(iced::Background::Color(Color::from_rgb(
@@ -3046,10 +3058,10 @@ impl WindowState {
                     }),
             )
             .padding(iced::Padding {
-                top: ty + 26.0,
+                top: tip.y + 26.0,
                 right: 0.0,
                 bottom: 0.0,
-                left: (tx - 80.0).max(0.0),
+                left: (tip.x - 80.0).max(0.0),
             });
             canvas_stack.push(tooltip_widget.into());
         }
@@ -3126,7 +3138,7 @@ impl WindowState {
         }
 
         // Context menu overlay (right-click on empty canvas)
-        if let Some((cx, cy)) = self.context_menu {
+        if let Some(menu_pos) = self.context_menu {
             let menu = container(
                 Column::new()
                     .spacing(2)
@@ -3158,8 +3170,8 @@ impl WindowState {
             .padding(4);
 
             let positioned = container(menu).padding(iced::Padding {
-                top: cy,
-                left: cx,
+                top: menu_pos.y,
+                left: menu_pos.x,
                 right: 0.0,
                 bottom: 0.0,
             });

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -3011,7 +3011,7 @@ impl WindowState {
                     }),
             )
             .padding(iced::Padding {
-                top: ty + 6.0,
+                top: ty + 26.0,
                 right: 0.0,
                 bottom: 0.0,
                 left: (tx - 80.0).max(0.0),

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -2,7 +2,7 @@
 //!
 //! Each [`ProcessReference`] is drawn as a rounded rectangle with its alias
 //! displayed as a title. Node fill color is determined by the resolved
-//! [`NodeKind`]: blue for library functions, green for context functions,
+//! [`Process`] variant: blue for library functions, green for context functions,
 //! purple for provided implementations, and orange for nested flows.
 
 #![allow(
@@ -34,8 +34,8 @@ use crate::InitializerEditor;
 use crate::WindowState;
 use crate::{Message, ViewMessage};
 
-/// Action returned by [`handle_canvas_message`] to signal that the caller
-/// (main.rs) needs to perform an operation that requires `FlowEdit` state.
+/// Action returned by [`WindowState::handle_canvas_message`] to signal that
+/// the caller needs to perform an operation that requires `FlowEdit` state.
 pub(crate) enum CanvasAction {
     /// No further action needed.
     None,

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -88,6 +88,10 @@ impl WindowState {
                     self.set_file_path(&path);
                     self.selected_node = None;
                     self.selected_connection = None;
+                    self.tooltip = None;
+                    self.context_menu = None;
+                    self.initializer_editor = None;
+                    self.show_metadata = false;
                     self.history = EditHistory::default();
                     self.auto_fit_pending = true;
                     self.auto_fit_enabled = true;
@@ -110,6 +114,10 @@ impl WindowState {
         self.clear_file_path();
         self.selected_node = None;
         self.selected_connection = None;
+        self.tooltip = None;
+        self.context_menu = None;
+        self.initializer_editor = None;
+        self.show_metadata = false;
         self.history = EditHistory::default();
         self.auto_fit_pending = false;
         self.auto_fit_enabled = true;

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use simpath::Simpath;
 use url::Url;
 
-use crate::canvas_view::{derive_short_name, FlowCanvasState, PortInfo};
+use crate::canvas_view::{derive_short_name, FlowCanvasState};
 use crate::history::EditHistory;
 use crate::{FunctionViewer, WindowState};
 use flowcore::meta_provider::MetaProvider;
@@ -231,28 +231,6 @@ pub(crate) fn resolve_lib_paths() -> Vec<String> {
     }
 
     paths
-}
-
-/// Extract input and output port information from IO definitions.
-pub(crate) fn extract_ports(
-    inputs: &[flowcore::model::io::IO],
-    outputs: &[flowcore::model::io::IO],
-) -> (Vec<PortInfo>, Vec<PortInfo>) {
-    let input_ports = inputs
-        .iter()
-        .map(|io| PortInfo {
-            name: io.name().clone(),
-            datatypes: io.datatypes().iter().map(ToString::to_string).collect(),
-        })
-        .collect();
-    let output_ports = outputs
-        .iter()
-        .map(|io| PortInfo {
-            name: io.name().clone(),
-            datatypes: io.datatypes().iter().map(ToString::to_string).collect(),
-        })
-        .collect();
-    (input_ports, output_ports)
 }
 
 /// Load a flow definition file and return the flow name, node layouts, edge layouts,
@@ -537,10 +515,10 @@ fn assign_default_positions(flow: &mut FlowDefinition) {
     let render_nodes = canvas_view::build_render_nodes(flow);
     for (pref, node) in flow.process_refs.iter_mut().zip(render_nodes.iter()) {
         if pref.x.is_none() {
-            pref.x = Some(node.x);
+            pref.x = Some(node.x());
         }
         if pref.y.is_none() {
-            pref.y = Some(node.y);
+            pref.y = Some(node.y());
         }
     }
 }

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -31,152 +31,158 @@ pub(crate) struct EditorPrefs {
     pub(crate) y: Option<f32>,
 }
 
-/// Save the current flow to the given path.
-pub(crate) fn perform_save(win: &mut WindowState, path: &PathBuf) {
-    match save_flow_toml(&win.flow_definition, path) {
-        Ok(()) => {
-            win.history.clear();
-            win.set_file_path(path);
-            save_editor_prefs(path, win.last_size, win.last_position);
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                win.status = format!("Saved to {name}");
-            } else {
-                win.status = String::from("Saved");
-            }
-        }
-        Err(e) => {
-            win.status = format!("Save failed: {e}");
-        }
-    }
-}
-
-/// Prompt the user with a save dialog and save to the chosen path.
-pub(crate) fn perform_save_as(win: &mut WindowState) {
-    let dialog = rfd::FileDialog::new()
-        .add_filter("Flow", &["toml"])
-        .set_file_name(format!("{}.toml", win.flow_definition.name));
-    if let Some(path) = dialog.save_file() {
-        perform_save(win, &path);
-    }
-}
-
-/// Handle save message -- saves to existing path or prompts with save dialog.
-pub(crate) fn handle_save(win: &mut WindowState) {
-    if let Some(path) = win.file_path() {
-        perform_save(win, &path);
-    } else {
-        perform_save_as(win);
-    }
-}
-
-/// Handle save-as message -- prompts with save dialog.
-pub(crate) fn handle_save_as(win: &mut WindowState) {
-    perform_save_as(win);
-}
-
-/// Prompt the user with an open dialog and load the selected flow file.
-/// Open a flow file and update the window state.
-/// Returns the lib and context references if successful, for rebuilding the library cache.
-pub(crate) fn perform_open(win: &mut WindowState) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
-    let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
-    if let Some(path) = dialog.pick_file() {
-        match load_flow(&path) {
-            Ok(loaded) => {
-                let nc = loaded.flow_def.process_refs.len();
-                let ec = loaded.flow_def.connections.len();
-                win.flow_definition = loaded.flow_def;
-                win.set_file_path(&path);
-                win.selected_node = None;
-                win.selected_connection = None;
-                win.history = EditHistory::default();
-                win.auto_fit_pending = true;
-                win.auto_fit_enabled = true;
-                win.canvas_state = FlowCanvasState::default();
-                win.status = format!("Loaded - {nc} nodes, {ec} connections");
-                return Some((loaded.lib_references, loaded.context_references));
+impl WindowState {
+    pub(crate) fn perform_save(&mut self, path: &PathBuf) {
+        match save_flow_toml(&self.flow_definition, path) {
+            Ok(()) => {
+                self.history.clear();
+                self.set_file_path(path);
+                save_editor_prefs(path, self.last_size, self.last_position);
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    self.status = format!("Saved to {name}");
+                } else {
+                    self.status = String::from("Saved");
+                }
             }
             Err(e) => {
-                win.status = format!("Open failed: {e}");
+                self.status = format!("Save failed: {e}");
             }
         }
     }
-    None
-}
 
-/// Clear the canvas and reset to an empty flow state.
-pub(crate) fn perform_new(win: &mut WindowState) {
-    win.flow_definition = FlowDefinition::default();
-    win.flow_definition.name = String::from("(new flow)");
-    win.clear_file_path();
-    win.selected_node = None;
-    win.selected_connection = None;
-    win.history = EditHistory::default();
-    win.auto_fit_pending = false;
-    win.auto_fit_enabled = true;
-    win.canvas_state = FlowCanvasState::default();
-    win.status = String::from("New flow");
-}
-
-/// Compile the current flow to a manifest.
-///
-/// Writes a temporary copy of the current editor state for the compiler
-/// to parse -- the user's flow definition file is never modified.
-///
-/// Returns the path to the generated manifest on success, or a human-readable
-/// error message on failure.
-pub(crate) fn perform_compile(win: &mut WindowState) -> Result<PathBuf, String> {
-    // New flows must be saved first so the compiler has a real file path
-    if win.file_path().is_none() {
-        perform_save_as(win);
-    }
-    let Some(flow_path) = win.file_path() else {
-        return Err("Flow must be saved before compiling".to_string());
-    };
-
-    // Save any unsaved edits so the file on disk matches the editor state
-    if !win.history.is_empty() {
-        perform_save(win, &flow_path);
-        if !win.history.is_empty() {
-            return Err("Save failed — cannot compile stale content".to_string());
+    /// Prompt the user with a save dialog and save to the chosen path.
+    pub(crate) fn perform_save_as(&mut self) {
+        let dialog = rfd::FileDialog::new()
+            .add_filter("Flow", &["toml"])
+            .set_file_name(format!("{}.toml", self.flow_definition.name));
+        if let Some(path) = dialog.save_file() {
+            self.perform_save(&path);
         }
     }
 
-    let flow_path = &flow_path;
-    let abs_path = if flow_path.is_absolute() {
-        flow_path.clone()
-    } else {
-        std::env::current_dir()
-            .map_err(|e| format!("Could not get current directory: {e}"))?
-            .join(flow_path)
-    };
+    /// Handle save message -- saves to existing path or prompts with save dialog.
+    pub(crate) fn handle_save(&mut self) {
+        if let Some(path) = self.file_path() {
+            self.perform_save(&path);
+        } else {
+            self.perform_save_as();
+        }
+    }
 
-    let provider = build_meta_provider();
+    /// Handle save-as message -- prompts with save dialog.
+    pub(crate) fn handle_save_as(&mut self) {
+        self.perform_save_as();
+    }
 
-    let url = Url::from_file_path(&abs_path)
-        .map_err(|()| format!("Invalid file path: {}", abs_path.display()))?;
-    let process = flowrclib::compiler::parser::parse(&url, &provider)
-        .map_err(|e| format!("Parse error: {e}"))?;
-    let flow = match process {
-        Process::FlowProcess(f) => f,
-        Process::FunctionProcess(_) => return Err("Not a flow definition".to_string()),
-    };
+    /// Prompt the user with an open dialog and load the selected flow file.
+    /// Open a flow file and update the window state.
+    /// Returns the lib and context references if successful, for rebuilding the library cache.
+    pub(crate) fn perform_open(&mut self) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
+        let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
+        if let Some(path) = dialog.pick_file() {
+            match load_flow(&path) {
+                Ok(loaded) => {
+                    let nc = loaded.flow_def.process_refs.len();
+                    let ec = loaded.flow_def.connections.len();
+                    self.flow_definition = loaded.flow_def;
+                    self.set_file_path(&path);
+                    self.selected_node = None;
+                    self.selected_connection = None;
+                    self.history = EditHistory::default();
+                    self.auto_fit_pending = true;
+                    self.auto_fit_enabled = true;
+                    self.canvas_state = FlowCanvasState::default();
+                    self.status = format!("Loaded - {nc} nodes, {ec} connections");
+                    return Some((loaded.lib_references, loaded.context_references));
+                }
+                Err(e) => {
+                    self.status = format!("Open failed: {e}");
+                }
+            }
+        }
+        None
+    }
 
-    let output_dir = abs_path.parent().unwrap_or(Path::new(".")).to_path_buf();
-    let mut source_urls = BTreeMap::<String, Url>::new();
-    let tables =
-        flowrclib::compiler::compile::compile(&flow, &output_dir, false, false, &mut source_urls)
-            .map_err(|e| e.to_string())?;
+    /// Clear the canvas and reset to an empty flow state.
+    pub(crate) fn perform_new(&mut self) {
+        self.flow_definition = FlowDefinition::default();
+        self.flow_definition.name = String::from("(new flow)");
+        self.clear_file_path();
+        self.selected_node = None;
+        self.selected_connection = None;
+        self.history = EditHistory::default();
+        self.auto_fit_pending = false;
+        self.auto_fit_enabled = true;
+        self.canvas_state = FlowCanvasState::default();
+        self.status = String::from("New flow");
+    }
 
-    let manifest_path = flowrclib::generator::generate::write_flow_manifest(
-        &flow,
-        false,
-        &output_dir,
-        &tables,
-        source_urls,
-    )
-    .map_err(|e| format!("Manifest error: {e}"))?;
+    /// Compile the current flow to a manifest.
+    ///
+    /// Writes a temporary copy of the current editor state for the compiler
+    /// to parse -- the user's flow definition file is never modified.
+    ///
+    /// Returns the path to the generated manifest on success, or a human-readable
+    /// error message on failure.
+    pub(crate) fn perform_compile(&mut self) -> Result<PathBuf, String> {
+        // New flows must be saved first so the compiler has a real file path
+        if self.file_path().is_none() {
+            self.perform_save_as();
+        }
+        let Some(flow_path) = self.file_path() else {
+            return Err("Flow must be saved before compiling".to_string());
+        };
 
-    Ok(manifest_path)
+        // Save any unsaved edits so the file on disk matches the editor state
+        if !self.history.is_empty() {
+            self.perform_save(&flow_path);
+            if !self.history.is_empty() {
+                return Err("Save failed — cannot compile stale content".to_string());
+            }
+        }
+
+        let flow_path = &flow_path;
+        let abs_path = if flow_path.is_absolute() {
+            flow_path.clone()
+        } else {
+            std::env::current_dir()
+                .map_err(|e| format!("Could not get current directory: {e}"))?
+                .join(flow_path)
+        };
+
+        let provider = build_meta_provider();
+
+        let url = Url::from_file_path(&abs_path)
+            .map_err(|()| format!("Invalid file path: {}", abs_path.display()))?;
+        let process = flowrclib::compiler::parser::parse(&url, &provider)
+            .map_err(|e| format!("Parse error: {e}"))?;
+        let flow = match process {
+            Process::FlowProcess(f) => f,
+            Process::FunctionProcess(_) => return Err("Not a flow definition".to_string()),
+        };
+
+        let output_dir = abs_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let mut source_urls = BTreeMap::<String, Url>::new();
+        let tables = flowrclib::compiler::compile::compile(
+            &flow,
+            &output_dir,
+            false,
+            false,
+            &mut source_urls,
+        )
+        .map_err(|e| e.to_string())?;
+
+        let manifest_path = flowrclib::generator::generate::write_flow_manifest(
+            &flow,
+            false,
+            &output_dir,
+            &tables,
+            source_urls,
+        )
+        .map_err(|e| format!("Manifest error: {e}"))?;
+
+        Ok(manifest_path)
+    }
 }
 
 /// Build a `MetaProvider` with `FLOW_LIB_PATH` (plus `~/.flow/lib` default)
@@ -1187,7 +1193,7 @@ mod test {
         win.history.mark_modified();
         win.flow_definition.name = "saved_flow".into();
 
-        perform_save(&mut win, &path);
+        win.perform_save(&path);
         assert!(win.history.is_empty());
         let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
         assert_eq!(win.file_path(), Some(canonical));

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -19,16 +19,9 @@ pub(crate) enum HierarchyMessage {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum NodeKind {
-    Flow,
-    Function,
-    Library,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) struct HierarchyNode {
     pub name: String,
-    pub kind: NodeKind,
+    pub process: Option<Process>,
     pub source: String,
     pub path: Option<PathBuf>,
     pub children: Vec<HierarchyNode>,
@@ -108,22 +101,35 @@ fn toggle_at(node: &mut HierarchyNode, indices: &[usize], depth: usize) {
 #[allow(clippy::cast_precision_loss)]
 fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, HierarchyMessage> {
     let indent = path.len() as f32 * 16.0;
-    let icon = match node.kind {
-        NodeKind::Flow => {
-            if node.expanded {
-                "\u{25BC}"
-            } else {
-                "\u{25B6}"
-            }
+    let is_flow = matches!(node.process, Some(Process::FlowProcess(_)) | None)
+        && !node.source.starts_with("lib://")
+        && !node.source.starts_with("context://");
+    let is_library = match &node.process {
+        Some(Process::FunctionProcess(f)) => {
+            f.lib_reference.is_some() || f.context_reference.is_some()
         }
-        NodeKind::Function => "\u{25C6}",
-        NodeKind::Library => "\u{25CB}",
+        None => node.source.starts_with("lib://") || node.source.starts_with("context://"),
+        _ => false,
     };
 
-    let color = match node.kind {
-        NodeKind::Flow => Color::from_rgb(0.9, 0.6, 0.2),
-        NodeKind::Function => Color::from_rgb(0.6, 0.3, 0.8),
-        NodeKind::Library => Color::from_rgb(0.3, 0.5, 0.9),
+    let icon = if is_flow {
+        if node.expanded {
+            "\u{25BC}"
+        } else {
+            "\u{25B6}"
+        }
+    } else if is_library {
+        "\u{25CB}"
+    } else {
+        "\u{25C6}"
+    };
+
+    let color = if is_flow {
+        Color::from_rgb(0.9, 0.6, 0.2)
+    } else if is_library {
+        Color::from_rgb(0.3, 0.5, 0.9)
+    } else {
+        Color::from_rgb(0.6, 0.3, 0.8)
     };
 
     let path_vec: Vec<usize> = path.to_vec();
@@ -132,29 +138,20 @@ fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, Hierarc
         .push(text(icon).size(11).color(color))
         .push(text(&node.name).size(13).color(color));
 
-    let label_btn = match node.kind {
-        NodeKind::Flow => {
-            // Flows toggle expand/collapse on click
-            button(label)
-                .on_press(HierarchyMessage::Toggle(path_vec))
-                .style(button::text)
-                .padding([2, 4])
-        }
-        NodeKind::Function => {
-            // Functions open in editor on click
-            if let Some(ref p) = node.path {
-                button(label)
-                    .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
-                    .style(button::text)
-                    .padding([2, 4])
-            } else {
-                button(label).style(button::text).padding([2, 4])
-            }
-        }
-        NodeKind::Library => {
-            // Library nodes are non-interactive (no path)
-            button(label).style(button::text).padding([2, 4])
-        }
+    let label_btn = if is_flow {
+        button(label)
+            .on_press(HierarchyMessage::Toggle(path_vec))
+            .style(button::text)
+            .padding([2, 4])
+    } else if is_library {
+        button(label).style(button::text).padding([2, 4])
+    } else if let Some(ref p) = node.path {
+        button(label)
+            .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
+            .style(button::text)
+            .padding([2, 4])
+    } else {
+        button(label).style(button::text).padding([2, 4])
     };
 
     // Add a small open button for flows (except root)
@@ -164,7 +161,7 @@ fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, Hierarc
         left: indent,
         right: 0.0,
     }));
-    if matches!(node.kind, NodeKind::Flow) && !path.is_empty() {
+    if is_flow && !path.is_empty() {
         if let Some(ref p) = node.path {
             row = row.push(
                 button(text("\u{270E}").size(11).color(color))
@@ -200,7 +197,7 @@ fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Hi
     if depth >= MAX_HIERARCHY_DEPTH {
         return HierarchyNode {
             name: flow_def.name.clone(),
-            kind: NodeKind::Flow,
+            process: Some(Process::FlowProcess(flow_def.clone())),
             source: String::new(),
             path: flow_def.source_url.to_file_path().ok(),
             children,
@@ -216,27 +213,21 @@ fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Hi
         };
 
         match flow_def.subprocesses.get(&alias) {
-            Some(Process::FlowProcess(sub_flow)) => {
-                // Recursively build children from the sub-flow
+            Some(proc @ Process::FlowProcess(sub_flow)) => {
                 let child = build_node_from_flow_recursive(sub_flow, depth + 1);
                 children.push(HierarchyNode {
                     name: alias,
-                    kind: NodeKind::Flow,
+                    process: Some(proc.clone()),
                     source: pref.source.clone(),
                     path: sub_flow.source_url.to_file_path().ok(),
                     children: child.children,
                     expanded: true,
                 });
             }
-            Some(Process::FunctionProcess(func)) => {
-                let kind = if func.lib_reference.is_some() || func.context_reference.is_some() {
-                    NodeKind::Library
-                } else {
-                    NodeKind::Function
-                };
+            Some(proc @ Process::FunctionProcess(func)) => {
                 children.push(HierarchyNode {
                     name: alias,
-                    kind,
+                    process: Some(proc.clone()),
                     source: pref.source.clone(),
                     path: func.source_url.to_file_path().ok(),
                     children: Vec::new(),
@@ -244,16 +235,9 @@ fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Hi
                 });
             }
             None => {
-                // Unresolved - determine kind from source string
-                let kind =
-                    if pref.source.starts_with("lib://") || pref.source.starts_with("context://") {
-                        NodeKind::Library
-                    } else {
-                        NodeKind::Function
-                    };
                 children.push(HierarchyNode {
                     name: alias,
-                    kind,
+                    process: None,
                     source: pref.source.clone(),
                     path: None,
                     children: Vec::new(),
@@ -265,7 +249,7 @@ fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Hi
 
     HierarchyNode {
         name: flow_def.name.clone(),
-        kind: NodeKind::Flow,
+        process: Some(Process::FlowProcess(flow_def.clone())),
         source: String::new(),
         path: flow_def.source_url.to_file_path().ok(),
         children,
@@ -276,6 +260,7 @@ fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Hi
 #[cfg(test)]
 mod test {
     use super::*;
+    use flowcore::model::function_definition::FunctionDefinition;
 
     #[test]
     fn empty_hierarchy() {
@@ -283,17 +268,21 @@ mod test {
         assert!(h.root.is_none());
     }
 
+    fn flow_node(name: &str, children: Vec<HierarchyNode>, expanded: bool) -> HierarchyNode {
+        HierarchyNode {
+            name: name.into(),
+            process: Some(Process::FlowProcess(FlowDefinition::default())),
+            source: String::new(),
+            path: None,
+            children,
+            expanded,
+        }
+    }
+
     #[test]
     fn toggle_root_node() {
         let mut h = FlowHierarchy {
-            root: Some(HierarchyNode {
-                name: "root_flow".into(),
-                kind: NodeKind::Flow,
-                source: String::new(),
-                path: None,
-                children: Vec::new(),
-                expanded: true,
-            }),
+            root: Some(flow_node("root_flow", Vec::new(), true)),
         };
         h.update(&HierarchyMessage::Toggle(vec![]));
         assert!(h.root.as_ref().is_some_and(|r| !r.expanded));
@@ -304,21 +293,18 @@ mod test {
     #[test]
     fn toggle_child_node() {
         let mut h = FlowHierarchy {
-            root: Some(HierarchyNode {
-                name: "root".into(),
-                kind: NodeKind::Flow,
-                source: String::new(),
-                path: None,
-                children: vec![HierarchyNode {
+            root: Some(flow_node(
+                "root",
+                vec![HierarchyNode {
                     name: "child_flow".into(),
-                    kind: NodeKind::Flow,
+                    process: Some(Process::FlowProcess(FlowDefinition::default())),
                     source: "child.toml".into(),
                     path: None,
                     children: Vec::new(),
                     expanded: false,
                 }],
-                expanded: true,
-            }),
+                true,
+            )),
         };
         h.update(&HierarchyMessage::Toggle(vec![0]));
         assert!(h
@@ -331,28 +317,15 @@ mod test {
     #[test]
     fn toggle_nested_child() {
         let mut h = FlowHierarchy {
-            root: Some(HierarchyNode {
-                name: "root".into(),
-                kind: NodeKind::Flow,
-                source: String::new(),
-                path: None,
-                children: vec![HierarchyNode {
-                    name: "sub".into(),
-                    kind: NodeKind::Flow,
-                    source: String::new(),
-                    path: None,
-                    children: vec![HierarchyNode {
-                        name: "deep".into(),
-                        kind: NodeKind::Flow,
-                        source: String::new(),
-                        path: None,
-                        children: Vec::new(),
-                        expanded: false,
-                    }],
-                    expanded: true,
-                }],
-                expanded: true,
-            }),
+            root: Some(flow_node(
+                "root",
+                vec![flow_node(
+                    "sub",
+                    vec![flow_node("deep", Vec::new(), false)],
+                    true,
+                )],
+                true,
+            )),
         };
         h.update(&HierarchyMessage::Toggle(vec![0, 0]));
         assert!(h
@@ -366,14 +339,7 @@ mod test {
     #[test]
     fn toggle_invalid_index_no_panic() {
         let mut h = FlowHierarchy {
-            root: Some(HierarchyNode {
-                name: "root".into(),
-                kind: NodeKind::Flow,
-                source: String::new(),
-                path: None,
-                children: Vec::new(),
-                expanded: true,
-            }),
+            root: Some(flow_node("root", Vec::new(), true)),
         };
         h.update(&HierarchyMessage::Toggle(vec![99]));
     }
@@ -400,16 +366,19 @@ mod test {
 
     #[test]
     fn view_with_nodes_renders() {
+        let mut lib_func = FunctionDefinition::default();
+        lib_func.lib_reference =
+            Some(url::Url::parse("lib://flowstdlib/math/add").expect("valid url"));
         let h = FlowHierarchy {
             root: Some(HierarchyNode {
                 name: "test_flow".into(),
-                kind: NodeKind::Flow,
+                process: Some(Process::FlowProcess(FlowDefinition::default())),
                 source: String::new(),
                 path: None,
                 children: vec![
                     HierarchyNode {
                         name: "func".into(),
-                        kind: NodeKind::Function,
+                        process: Some(Process::FunctionProcess(FunctionDefinition::default())),
                         source: "func.rs".into(),
                         path: Some(PathBuf::from("/tmp/func.toml")),
                         children: Vec::new(),
@@ -417,7 +386,7 @@ mod test {
                     },
                     HierarchyNode {
                         name: "lib_func".into(),
-                        kind: NodeKind::Library,
+                        process: Some(Process::FunctionProcess(lib_func)),
                         source: "lib://flowstdlib/math/add".into(),
                         path: None,
                         children: Vec::new(),

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -20,17 +20,17 @@ pub(crate) enum HierarchyMessage {
 
 #[derive(Debug, Clone)]
 pub(crate) struct HierarchyNode {
-    pub name: String,
-    pub process: Option<Process>,
-    pub source: String,
-    pub path: Option<PathBuf>,
-    pub children: Vec<HierarchyNode>,
-    pub expanded: bool,
+    pub(crate) name: String,
+    pub(crate) process: Option<Process>,
+    pub(crate) source: String,
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) children: Vec<HierarchyNode>,
+    pub(crate) expanded: bool,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct FlowHierarchy {
-    pub root: Option<HierarchyNode>,
+    pub(crate) root: Option<HierarchyNode>,
 }
 
 impl FlowHierarchy {
@@ -109,7 +109,7 @@ impl HierarchyNode {
             && !self.source.starts_with("context://");
         let is_library = match &self.process {
             Some(Process::FunctionProcess(f)) => {
-                f.lib_reference.is_some() || f.context_reference.is_some()
+                f.get_lib_reference().is_some() || f.get_context_reference().is_some()
             }
             None => self.source.starts_with("lib://") || self.source.starts_with("context://"),
             _ => false,

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -35,7 +35,7 @@ pub(crate) struct FlowHierarchy {
 
 impl FlowHierarchy {
     pub(crate) fn from_flow_definition(flow_def: &FlowDefinition) -> Self {
-        let root = build_node_from_flow(flow_def);
+        let root = HierarchyNode::from_flow_definition(flow_def);
         Self { root: Some(root) }
     }
 
@@ -47,7 +47,7 @@ impl FlowHierarchy {
         match msg {
             HierarchyMessage::Toggle(indices) => {
                 if let Some(ref mut root) = self.root {
-                    toggle_at(root, indices, 0);
+                    root.toggle_at(indices, 0);
                 }
                 None
             }
@@ -63,7 +63,7 @@ impl FlowHierarchy {
         );
 
         if let Some(ref root) = self.root {
-            col = col.push(view_node(root, &[]));
+            col = col.push(root.view(&[]));
         }
 
         container(scrollable(col).height(Length::Fill))
@@ -81,179 +81,180 @@ impl FlowHierarchy {
     }
 }
 
-fn toggle_at(node: &mut HierarchyNode, indices: &[usize], depth: usize) {
-    if depth >= indices.len() {
-        node.expanded = !node.expanded;
-        return;
-    }
-    let Some(&idx) = indices.get(depth) else {
-        return;
-    };
-    if let Some(child) = node.children.get_mut(idx) {
-        if depth + 1 == indices.len() {
-            child.expanded = !child.expanded;
-        } else {
-            toggle_at(child, indices, depth + 1);
-        }
-    }
-}
-
-#[allow(clippy::cast_precision_loss)]
-fn view_node<'a>(node: &'a HierarchyNode, path: &[usize]) -> Element<'a, HierarchyMessage> {
-    let indent = path.len() as f32 * 16.0;
-    let is_flow = matches!(node.process, Some(Process::FlowProcess(_)) | None)
-        && !node.source.starts_with("lib://")
-        && !node.source.starts_with("context://");
-    let is_library = match &node.process {
-        Some(Process::FunctionProcess(f)) => {
-            f.lib_reference.is_some() || f.context_reference.is_some()
-        }
-        None => node.source.starts_with("lib://") || node.source.starts_with("context://"),
-        _ => false,
-    };
-
-    let icon = if is_flow {
-        if node.expanded {
-            "\u{25BC}"
-        } else {
-            "\u{25B6}"
-        }
-    } else if is_library {
-        "\u{25CB}"
-    } else {
-        "\u{25C6}"
-    };
-
-    let color = if is_flow {
-        Color::from_rgb(0.9, 0.6, 0.2)
-    } else if is_library {
-        Color::from_rgb(0.3, 0.5, 0.9)
-    } else {
-        Color::from_rgb(0.6, 0.3, 0.8)
-    };
-
-    let path_vec: Vec<usize> = path.to_vec();
-    let label = Row::new()
-        .spacing(4)
-        .push(text(icon).size(11).color(color))
-        .push(text(&node.name).size(13).color(color));
-
-    let label_btn = if is_flow {
-        button(label)
-            .on_press(HierarchyMessage::Toggle(path_vec))
-            .style(button::text)
-            .padding([2, 4])
-    } else if is_library {
-        button(label).style(button::text).padding([2, 4])
-    } else if let Some(ref p) = node.path {
-        button(label)
-            .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
-            .style(button::text)
-            .padding([2, 4])
-    } else {
-        button(label).style(button::text).padding([2, 4])
-    };
-
-    // Add a small open button for flows (except root)
-    let mut row = Row::new().push(container(label_btn).padding(iced::Padding {
-        top: 0.0,
-        bottom: 0.0,
-        left: indent,
-        right: 0.0,
-    }));
-    if is_flow && !path.is_empty() {
-        if let Some(ref p) = node.path {
-            row = row.push(
-                button(text("\u{270E}").size(11).color(color))
-                    .on_press(HierarchyMessage::Open(node.source.clone(), p.clone()))
-                    .style(button::text)
-                    .padding([2, 4]),
-            );
-        }
-    }
-
-    let mut col = Column::new().push(row);
-
-    if node.expanded {
-        for (i, child) in node.children.iter().enumerate() {
-            let mut child_path = path.to_vec();
-            child_path.push(i);
-            col = col.push(view_node(child, &child_path));
-        }
-    }
-
-    col.into()
-}
-
 const MAX_HIERARCHY_DEPTH: usize = 10;
 
-fn build_node_from_flow(flow_def: &FlowDefinition) -> HierarchyNode {
-    build_node_from_flow_recursive(flow_def, 0)
-}
+impl HierarchyNode {
+    fn toggle_at(&mut self, indices: &[usize], depth: usize) {
+        if depth >= indices.len() {
+            self.expanded = !self.expanded;
+            return;
+        }
+        let Some(&idx) = indices.get(depth) else {
+            return;
+        };
+        if let Some(child) = self.children.get_mut(idx) {
+            if depth + 1 == indices.len() {
+                child.expanded = !child.expanded;
+            } else {
+                child.toggle_at(indices, depth + 1);
+            }
+        }
+    }
 
-fn build_node_from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> HierarchyNode {
-    let mut children = Vec::new();
+    #[allow(clippy::cast_precision_loss)]
+    fn view<'a>(&'a self, path: &[usize]) -> Element<'a, HierarchyMessage> {
+        let indent = path.len() as f32 * 16.0;
+        let is_flow = matches!(self.process, Some(Process::FlowProcess(_)) | None)
+            && !self.source.starts_with("lib://")
+            && !self.source.starts_with("context://");
+        let is_library = match &self.process {
+            Some(Process::FunctionProcess(f)) => {
+                f.lib_reference.is_some() || f.context_reference.is_some()
+            }
+            None => self.source.starts_with("lib://") || self.source.starts_with("context://"),
+            _ => false,
+        };
 
-    if depth >= MAX_HIERARCHY_DEPTH {
-        return HierarchyNode {
+        let icon = if is_flow {
+            if self.expanded {
+                "\u{25BC}"
+            } else {
+                "\u{25B6}"
+            }
+        } else if is_library {
+            "\u{25CB}"
+        } else {
+            "\u{25C6}"
+        };
+
+        let color = if is_flow {
+            Color::from_rgb(0.9, 0.6, 0.2)
+        } else if is_library {
+            Color::from_rgb(0.3, 0.5, 0.9)
+        } else {
+            Color::from_rgb(0.6, 0.3, 0.8)
+        };
+
+        let path_vec: Vec<usize> = path.to_vec();
+        let label = Row::new()
+            .spacing(4)
+            .push(text(icon).size(11).color(color))
+            .push(text(&self.name).size(13).color(color));
+
+        let label_btn = if is_flow {
+            button(label)
+                .on_press(HierarchyMessage::Toggle(path_vec))
+                .style(button::text)
+                .padding([2, 4])
+        } else if is_library {
+            button(label).style(button::text).padding([2, 4])
+        } else if let Some(ref p) = self.path {
+            button(label)
+                .on_press(HierarchyMessage::Open(self.source.clone(), p.clone()))
+                .style(button::text)
+                .padding([2, 4])
+        } else {
+            button(label).style(button::text).padding([2, 4])
+        };
+
+        let mut row = Row::new().push(container(label_btn).padding(iced::Padding {
+            top: 0.0,
+            bottom: 0.0,
+            left: indent,
+            right: 0.0,
+        }));
+        if is_flow && !path.is_empty() {
+            if let Some(ref p) = self.path {
+                row = row.push(
+                    button(text("\u{270E}").size(11).color(color))
+                        .on_press(HierarchyMessage::Open(self.source.clone(), p.clone()))
+                        .style(button::text)
+                        .padding([2, 4]),
+                );
+            }
+        }
+
+        let mut col = Column::new().push(row);
+
+        if self.expanded {
+            for (i, child) in self.children.iter().enumerate() {
+                let mut child_path = path.to_vec();
+                child_path.push(i);
+                col = col.push(child.view(&child_path));
+            }
+        }
+
+        col.into()
+    }
+
+    fn from_flow_definition(flow_def: &FlowDefinition) -> Self {
+        Self::from_flow_recursive(flow_def, 0)
+    }
+
+    fn from_flow_recursive(flow_def: &FlowDefinition, depth: usize) -> Self {
+        let mut children = Vec::new();
+
+        if depth >= MAX_HIERARCHY_DEPTH {
+            return HierarchyNode {
+                name: flow_def.name.clone(),
+                process: Some(Process::FlowProcess(flow_def.clone())),
+                source: String::new(),
+                path: flow_def.source_url.to_file_path().ok(),
+                children,
+                expanded: false,
+            };
+        }
+
+        for pref in &flow_def.process_refs {
+            let alias = if pref.alias.is_empty() {
+                crate::canvas_view::derive_short_name(&pref.source)
+            } else {
+                pref.alias.clone()
+            };
+
+            match flow_def.subprocesses.get(&alias) {
+                Some(proc @ Process::FlowProcess(sub_flow)) => {
+                    let child = Self::from_flow_recursive(sub_flow, depth + 1);
+                    children.push(HierarchyNode {
+                        name: alias,
+                        process: Some(proc.clone()),
+                        source: pref.source.clone(),
+                        path: sub_flow.source_url.to_file_path().ok(),
+                        children: child.children,
+                        expanded: true,
+                    });
+                }
+                Some(proc @ Process::FunctionProcess(func)) => {
+                    children.push(HierarchyNode {
+                        name: alias,
+                        process: Some(proc.clone()),
+                        source: pref.source.clone(),
+                        path: func.source_url.to_file_path().ok(),
+                        children: Vec::new(),
+                        expanded: false,
+                    });
+                }
+                None => {
+                    children.push(HierarchyNode {
+                        name: alias,
+                        process: None,
+                        source: pref.source.clone(),
+                        path: None,
+                        children: Vec::new(),
+                        expanded: false,
+                    });
+                }
+            }
+        }
+
+        HierarchyNode {
             name: flow_def.name.clone(),
             process: Some(Process::FlowProcess(flow_def.clone())),
             source: String::new(),
             path: flow_def.source_url.to_file_path().ok(),
             children,
-            expanded: false,
-        };
-    }
-
-    for pref in &flow_def.process_refs {
-        let alias = if pref.alias.is_empty() {
-            crate::canvas_view::derive_short_name(&pref.source)
-        } else {
-            pref.alias.clone()
-        };
-
-        match flow_def.subprocesses.get(&alias) {
-            Some(proc @ Process::FlowProcess(sub_flow)) => {
-                let child = build_node_from_flow_recursive(sub_flow, depth + 1);
-                children.push(HierarchyNode {
-                    name: alias,
-                    process: Some(proc.clone()),
-                    source: pref.source.clone(),
-                    path: sub_flow.source_url.to_file_path().ok(),
-                    children: child.children,
-                    expanded: true,
-                });
-            }
-            Some(proc @ Process::FunctionProcess(func)) => {
-                children.push(HierarchyNode {
-                    name: alias,
-                    process: Some(proc.clone()),
-                    source: pref.source.clone(),
-                    path: func.source_url.to_file_path().ok(),
-                    children: Vec::new(),
-                    expanded: false,
-                });
-            }
-            None => {
-                children.push(HierarchyNode {
-                    name: alias,
-                    process: None,
-                    source: pref.source.clone(),
-                    path: None,
-                    children: Vec::new(),
-                    expanded: false,
-                });
-            }
+            expanded: true,
         }
-    }
-
-    HierarchyNode {
-        name: flow_def.name.clone(),
-        process: Some(Process::FlowProcess(flow_def.clone())),
-        source: String::new(),
-        path: flow_def.source_url.to_file_path().ok(),
-        children,
-        expanded: true,
     }
 }
 

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -12,7 +12,6 @@ use flowcore::model::name::Name;
 use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 
-use crate::initializer;
 use crate::WindowState;
 
 /// An editing action that can be undone and redone.
@@ -180,203 +179,203 @@ impl EditHistory {
     }
 }
 
-/// Apply an undo action -- reverse the last edit.
-fn apply_undo(win: &mut WindowState) {
-    if let Some(action) = win.history.undo() {
-        match action {
-            EditAction::MoveNode {
-                index,
-                old_x,
-                old_y,
-                ..
-            } => {
-                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
-                    pref.x = Some(old_x);
-                    pref.y = Some(old_y);
+impl WindowState {
+    fn apply_undo(&mut self) {
+        if let Some(action) = self.history.undo() {
+            match action {
+                EditAction::MoveNode {
+                    index,
+                    old_x,
+                    old_y,
+                    ..
+                } => {
+                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                        pref.x = Some(old_x);
+                        pref.y = Some(old_y);
+                    }
+                    self.status = String::from("Undo: move");
                 }
-                win.status = String::from("Undo: move");
-            }
-            EditAction::ResizeNode {
-                index,
-                old_x,
-                old_y,
-                old_w,
-                old_h,
-                ..
-            } => {
-                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
-                    pref.x = Some(old_x);
-                    pref.y = Some(old_y);
-                    pref.width = Some(old_w);
-                    pref.height = Some(old_h);
+                EditAction::ResizeNode {
+                    index,
+                    old_x,
+                    old_y,
+                    old_w,
+                    old_h,
+                    ..
+                } => {
+                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                        pref.x = Some(old_x);
+                        pref.y = Some(old_y);
+                        pref.width = Some(old_w);
+                        pref.height = Some(old_h);
+                    }
+                    self.status = String::from("Undo: resize");
                 }
-                win.status = String::from("Undo: resize");
-            }
-            EditAction::CreateNode {
-                index,
-                ref process_ref,
-                ..
-            } => {
-                let alias = if process_ref.alias.is_empty() {
-                    crate::canvas_view::derive_short_name(&process_ref.source)
-                } else {
-                    process_ref.alias.clone()
-                };
-                if index < win.flow_definition.process_refs.len() {
-                    win.flow_definition.process_refs.remove(index);
-                    win.flow_definition.subprocesses.remove(&alias);
-                    win.flow_definition
-                        .connections
-                        .retain(|c| !crate::canvas_view::connection_references_node(c, &alias));
-                }
-                win.status = String::from("Undo: create node");
-            }
-            EditAction::DeleteNode {
-                index,
-                process_ref,
-                subprocess,
-                removed_connections,
-            } => {
-                win.flow_definition.process_refs.insert(index, process_ref);
-                if let Some((name, proc)) = subprocess {
-                    win.flow_definition.subprocesses.insert(name, proc);
-                }
-                win.flow_definition.connections.extend(removed_connections);
-                win.status = String::from("Undo: delete node");
-            }
-            EditAction::CreateConnection { connection } => {
-                let from_str = connection.from().to_string();
-                let to_strs: Vec<String> =
-                    connection.to().iter().map(ToString::to_string).collect();
-                win.flow_definition.connections.retain(|c| {
-                    c.from().to_string() != from_str
-                        || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
-                });
-                win.status = String::from("Undo: create connection");
-            }
-            EditAction::DeleteConnection { index, connection } => {
-                win.flow_definition.connections.insert(index, connection);
-                win.status = String::from("Undo: delete connection");
-            }
-            EditAction::EditInitializer {
-                node_index,
-                ref port_name,
-                ref old_init,
-                ..
-            } => {
-                initializer::apply_initializer_state(win, node_index, port_name, old_init.as_ref());
-                win.status = String::from("Undo: initializer");
-            }
-        }
-        win.canvas_state.request_redraw();
-    }
-}
-
-/// Apply a redo action -- re-apply the last undone edit.
-fn apply_redo(win: &mut WindowState) {
-    if let Some(action) = win.history.redo() {
-        match action {
-            EditAction::MoveNode {
-                index,
-                new_x,
-                new_y,
-                ..
-            } => {
-                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
-                    pref.x = Some(new_x);
-                    pref.y = Some(new_y);
-                }
-                win.status = String::from("Redo: move");
-            }
-            EditAction::ResizeNode {
-                index,
-                new_x,
-                new_y,
-                new_w,
-                new_h,
-                ..
-            } => {
-                if let Some(pref) = win.flow_definition.process_refs.get_mut(index) {
-                    pref.x = Some(new_x);
-                    pref.y = Some(new_y);
-                    pref.width = Some(new_w);
-                    pref.height = Some(new_h);
-                }
-                win.status = String::from("Redo: resize");
-            }
-            EditAction::CreateNode {
-                index,
-                process_ref,
-                subprocess,
-            } => {
-                let idx = index.min(win.flow_definition.process_refs.len());
-                win.flow_definition.process_refs.insert(idx, process_ref);
-                if let Some((name, proc)) = subprocess {
-                    win.flow_definition.subprocesses.insert(name, proc);
-                }
-                win.status = String::from("Redo: create node");
-            }
-            EditAction::DeleteNode {
-                index,
-                subprocess,
-                removed_connections,
-                ..
-            } => {
-                if index < win.flow_definition.process_refs.len() {
-                    let removed = win.flow_definition.process_refs.remove(index);
-                    let alias = if removed.alias.is_empty() {
-                        crate::canvas_view::derive_short_name(&removed.source)
+                EditAction::CreateNode {
+                    index,
+                    ref process_ref,
+                    ..
+                } => {
+                    let alias = if process_ref.alias.is_empty() {
+                        crate::canvas_view::derive_short_name(&process_ref.source)
                     } else {
-                        removed.alias.clone()
+                        process_ref.alias.clone()
                     };
-                    win.flow_definition.subprocesses.remove(&alias);
+                    if index < self.flow_definition.process_refs.len() {
+                        self.flow_definition.process_refs.remove(index);
+                        self.flow_definition.subprocesses.remove(&alias);
+                        self.flow_definition
+                            .connections
+                            .retain(|c| !crate::canvas_view::connection_references_node(c, &alias));
+                    }
+                    self.status = String::from("Undo: create node");
                 }
-                // Also remove re-inserted subprocess if it was restored during undo
-                if let Some((ref name, _)) = subprocess {
-                    win.flow_definition.subprocesses.remove(name);
+                EditAction::DeleteNode {
+                    index,
+                    process_ref,
+                    subprocess,
+                    removed_connections,
+                } => {
+                    self.flow_definition.process_refs.insert(index, process_ref);
+                    if let Some((name, proc)) = subprocess {
+                        self.flow_definition.subprocesses.insert(name, proc);
+                    }
+                    self.flow_definition.connections.extend(removed_connections);
+                    self.status = String::from("Undo: delete node");
                 }
-                for conn in &removed_connections {
-                    let from_str = conn.from().to_string();
-                    let to_strs: Vec<String> = conn.to().iter().map(ToString::to_string).collect();
-                    win.flow_definition.connections.retain(|c| {
+                EditAction::CreateConnection { connection } => {
+                    let from_str = connection.from().to_string();
+                    let to_strs: Vec<String> =
+                        connection.to().iter().map(ToString::to_string).collect();
+                    self.flow_definition.connections.retain(|c| {
                         c.from().to_string() != from_str
                             || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
                     });
+                    self.status = String::from("Undo: create connection");
                 }
-                win.status = String::from("Redo: delete node");
-            }
-            EditAction::CreateConnection { connection } => {
-                win.flow_definition.connections.push(connection);
-                win.status = String::from("Redo: create connection");
-            }
-            EditAction::DeleteConnection { index, .. } => {
-                if index < win.flow_definition.connections.len() {
-                    win.flow_definition.connections.remove(index);
+                EditAction::DeleteConnection { index, connection } => {
+                    self.flow_definition.connections.insert(index, connection);
+                    self.status = String::from("Undo: delete connection");
                 }
-                win.status = String::from("Redo: delete connection");
+                EditAction::EditInitializer {
+                    node_index,
+                    ref port_name,
+                    ref old_init,
+                    ..
+                } => {
+                    self.apply_initializer_state(node_index, port_name, old_init.as_ref());
+                    self.status = String::from("Undo: initializer");
+                }
             }
-            EditAction::EditInitializer {
-                node_index,
-                ref port_name,
-                ref new_init,
-                ..
-            } => {
-                initializer::apply_initializer_state(win, node_index, port_name, new_init.as_ref());
-                win.status = String::from("Redo: initializer");
-            }
+            self.canvas_state.request_redraw();
         }
-        win.canvas_state.request_redraw();
     }
-}
 
-/// Handle undo message -- applies the most recent undoable action in reverse.
-pub(crate) fn handle_undo(win: &mut WindowState) {
-    apply_undo(win);
-}
+    fn apply_redo(&mut self) {
+        if let Some(action) = self.history.redo() {
+            match action {
+                EditAction::MoveNode {
+                    index,
+                    new_x,
+                    new_y,
+                    ..
+                } => {
+                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                        pref.x = Some(new_x);
+                        pref.y = Some(new_y);
+                    }
+                    self.status = String::from("Redo: move");
+                }
+                EditAction::ResizeNode {
+                    index,
+                    new_x,
+                    new_y,
+                    new_w,
+                    new_h,
+                    ..
+                } => {
+                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                        pref.x = Some(new_x);
+                        pref.y = Some(new_y);
+                        pref.width = Some(new_w);
+                        pref.height = Some(new_h);
+                    }
+                    self.status = String::from("Redo: resize");
+                }
+                EditAction::CreateNode {
+                    index,
+                    process_ref,
+                    subprocess,
+                } => {
+                    let idx = index.min(self.flow_definition.process_refs.len());
+                    self.flow_definition.process_refs.insert(idx, process_ref);
+                    if let Some((name, proc)) = subprocess {
+                        self.flow_definition.subprocesses.insert(name, proc);
+                    }
+                    self.status = String::from("Redo: create node");
+                }
+                EditAction::DeleteNode {
+                    index,
+                    subprocess,
+                    removed_connections,
+                    ..
+                } => {
+                    if index < self.flow_definition.process_refs.len() {
+                        let removed = self.flow_definition.process_refs.remove(index);
+                        let alias = if removed.alias.is_empty() {
+                            crate::canvas_view::derive_short_name(&removed.source)
+                        } else {
+                            removed.alias.clone()
+                        };
+                        self.flow_definition.subprocesses.remove(&alias);
+                    }
+                    // Also remove re-inserted subprocess if it was restored during undo
+                    if let Some((ref name, _)) = subprocess {
+                        self.flow_definition.subprocesses.remove(name);
+                    }
+                    for conn in &removed_connections {
+                        let from_str = conn.from().to_string();
+                        let to_strs: Vec<String> =
+                            conn.to().iter().map(ToString::to_string).collect();
+                        self.flow_definition.connections.retain(|c| {
+                            c.from().to_string() != from_str
+                                || c.to().iter().map(ToString::to_string).collect::<Vec<_>>()
+                                    != to_strs
+                        });
+                    }
+                    self.status = String::from("Redo: delete node");
+                }
+                EditAction::CreateConnection { connection } => {
+                    self.flow_definition.connections.push(connection);
+                    self.status = String::from("Redo: create connection");
+                }
+                EditAction::DeleteConnection { index, .. } => {
+                    if index < self.flow_definition.connections.len() {
+                        self.flow_definition.connections.remove(index);
+                    }
+                    self.status = String::from("Redo: delete connection");
+                }
+                EditAction::EditInitializer {
+                    node_index,
+                    ref port_name,
+                    ref new_init,
+                    ..
+                } => {
+                    self.apply_initializer_state(node_index, port_name, new_init.as_ref());
+                    self.status = String::from("Redo: initializer");
+                }
+            }
+            self.canvas_state.request_redraw();
+        }
+    }
 
-/// Handle redo message -- re-applies the most recently undone action.
-pub(crate) fn handle_redo(win: &mut WindowState) {
-    apply_redo(win);
+    pub(crate) fn handle_undo(&mut self) {
+        self.apply_undo();
+    }
+
+    pub(crate) fn handle_redo(&mut self) {
+        self.apply_redo();
+    }
 }
 
 #[cfg(test)]
@@ -628,13 +627,13 @@ mod test {
         assert!(!win.history.is_empty());
 
         // Undo
-        handle_undo(&mut win);
+        win.handle_undo();
         let pref = win.flow_definition.process_refs.first();
         assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 100.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 100.0).abs() < 0.01));
 
         // Redo
-        handle_redo(&mut win);
+        win.handle_redo();
         let pref = win.flow_definition.process_refs.first();
         assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 200.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 300.0).abs() < 0.01));
@@ -661,13 +660,13 @@ mod test {
         });
 
         // Undo
-        handle_undo(&mut win);
+        win.handle_undo();
         let pref = win.flow_definition.process_refs.first();
         assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 180.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 120.0).abs() < 0.01));
 
         // Redo
-        handle_redo(&mut win);
+        win.handle_redo();
         let pref = win.flow_definition.process_refs.first();
         assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 250.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 180.0).abs() < 0.01));
@@ -687,11 +686,11 @@ mod test {
         assert_eq!(win.flow_definition.process_refs.len(), 1);
 
         // Undo restores
-        handle_undo(&mut win);
+        win.handle_undo();
         assert_eq!(win.flow_definition.process_refs.len(), 2);
 
         // Redo removes again
-        handle_redo(&mut win);
+        win.handle_redo();
         assert_eq!(win.flow_definition.process_refs.len(), 1);
     }
 
@@ -705,11 +704,11 @@ mod test {
         assert_eq!(win.flow_definition.connections.len(), 1);
 
         // Undo removes
-        handle_undo(&mut win);
+        win.handle_undo();
         assert_eq!(win.flow_definition.connections.len(), 0);
 
         // Redo re-adds
-        handle_redo(&mut win);
+        win.handle_redo();
         assert_eq!(win.flow_definition.connections.len(), 1);
     }
 
@@ -727,11 +726,11 @@ mod test {
         assert_eq!(win.flow_definition.connections.len(), 0);
 
         // Undo restores
-        handle_undo(&mut win);
+        win.handle_undo();
         assert_eq!(win.flow_definition.connections.len(), 1);
 
         // Redo removes again
-        handle_redo(&mut win);
+        win.handle_redo();
         assert_eq!(win.flow_definition.connections.len(), 0);
     }
 
@@ -749,8 +748,7 @@ mod test {
         });
 
         // Apply the new state manually (record only records, doesn't apply)
-        initializer::apply_initializer_state(
-            &mut win,
+        win.apply_initializer_state(
             0,
             "input",
             Some(&InputInitializer::Once(serde_json::json!(42))),
@@ -763,7 +761,7 @@ mod test {
             .is_some());
 
         // Undo
-        handle_undo(&mut win);
+        win.handle_undo();
         assert!(win
             .flow_definition
             .process_refs
@@ -772,7 +770,7 @@ mod test {
             .is_none());
 
         // Redo
-        handle_redo(&mut win);
+        win.handle_redo();
         assert!(win
             .flow_definition
             .process_refs

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -6,111 +6,104 @@ use crate::canvas_view::derive_short_name;
 use crate::history::EditAction;
 use crate::{InitializerEditor, WindowState};
 
-/// Apply an initializer edit to the flow definition.
-pub(crate) fn apply_initializer_edit(win: &mut WindowState, editor: &InitializerEditor) {
-    let alias = win
-        .flow_definition
-        .process_refs
-        .get(editor.node_index)
-        .map(|pr| {
-            if pr.alias.is_empty() {
-                derive_short_name(&pr.source)
-            } else {
-                pr.alias.clone()
+impl WindowState {
+    pub(crate) fn apply_initializer_edit(&mut self, editor: &InitializerEditor) {
+        let alias = self
+            .flow_definition
+            .process_refs
+            .get(editor.node_index)
+            .map(|pr| {
+                if pr.alias.is_empty() {
+                    derive_short_name(&pr.source)
+                } else {
+                    pr.alias.clone()
+                }
+            })
+            .unwrap_or_default();
+
+        let old_init = self
+            .flow_definition
+            .process_refs
+            .get(editor.node_index)
+            .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
+
+        let new_init = match editor.init_type.as_str() {
+            "none" => None,
+            "once" | "always" => {
+                let value = serde_json::from_str(&editor.value_text)
+                    .unwrap_or_else(|_| serde_json::Value::String(editor.value_text.clone()));
+                let init = if editor.init_type == "once" {
+                    InputInitializer::Once(value)
+                } else {
+                    InputInitializer::Always(value)
+                };
+                Some(init)
             }
-        })
-        .unwrap_or_default();
+            _ => return,
+        };
 
-    // Capture old state for undo
-    let old_init = win
-        .flow_definition
-        .process_refs
-        .get(editor.node_index)
-        .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
-
-    // Compute new initializer
-    let new_init = match editor.init_type.as_str() {
-        "none" => None,
-        "once" | "always" => {
-            let value = serde_json::from_str(&editor.value_text)
-                .unwrap_or_else(|_| serde_json::Value::String(editor.value_text.clone()));
-            let init = if editor.init_type == "once" {
-                InputInitializer::Once(value)
-            } else {
-                InputInitializer::Always(value)
-            };
-            Some(init)
-        }
-        _ => return,
-    };
-
-    // Apply to model
-    if let Some(pref) = win.flow_definition.process_refs.get_mut(editor.node_index) {
-        match &new_init {
-            Some(init) => {
-                pref.initializations
-                    .insert(editor.port_name.clone(), init.clone());
-            }
-            None => {
-                pref.initializations.remove(&editor.port_name);
+        if let Some(pref) = self.flow_definition.process_refs.get_mut(editor.node_index) {
+            match &new_init {
+                Some(init) => {
+                    pref.initializations
+                        .insert(editor.port_name.clone(), init.clone());
+                }
+                None => {
+                    pref.initializations.remove(&editor.port_name);
+                }
             }
         }
+
+        self.history.record(EditAction::EditInitializer {
+            node_index: editor.node_index,
+            port_name: editor.port_name.clone(),
+            old_init,
+            new_init,
+        });
+        self.canvas_state.request_redraw();
+        self.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
     }
 
-    win.history.record(EditAction::EditInitializer {
-        node_index: editor.node_index,
-        port_name: editor.port_name.clone(),
-        old_init,
-        new_init,
-    });
-    win.canvas_state.request_redraw();
-    win.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
-}
-
-/// Apply an initializer state to the model (`process_refs`).
-pub(crate) fn apply_initializer_state(
-    win: &mut WindowState,
-    node_index: usize,
-    port_name: &str,
-    init: Option<&InputInitializer>,
-) {
-    if let Some(pref) = win.flow_definition.process_refs.get_mut(node_index) {
-        match init {
-            Some(i) => {
-                pref.initializations
-                    .insert(port_name.to_string(), i.clone());
-            }
-            None => {
-                pref.initializations.remove(port_name);
+    pub(crate) fn apply_initializer_state(
+        &mut self,
+        node_index: usize,
+        port_name: &str,
+        init: Option<&InputInitializer>,
+    ) {
+        if let Some(pref) = self.flow_definition.process_refs.get_mut(node_index) {
+            match init {
+                Some(i) => {
+                    pref.initializations
+                        .insert(port_name.to_string(), i.clone());
+                }
+                None => {
+                    pref.initializations.remove(port_name);
+                }
             }
         }
     }
-}
 
-/// Handle initializer type change message.
-pub(crate) fn handle_type_changed(win: &mut WindowState, new_type: String) {
-    if let Some(ref mut editor) = win.initializer_editor {
-        editor.init_type = new_type;
+    pub(crate) fn handle_initializer_type_changed(&mut self, new_type: String) {
+        if let Some(ref mut editor) = self.initializer_editor {
+            editor.init_type = new_type;
+        }
     }
-}
 
-/// Handle initializer value change message.
-pub(crate) fn handle_value_changed(win: &mut WindowState, new_value: String) {
-    if let Some(ref mut editor) = win.initializer_editor {
-        editor.value_text = new_value;
+    pub(crate) fn handle_initializer_value_changed(&mut self, new_value: String) {
+        if let Some(ref mut editor) = self.initializer_editor {
+            editor.value_text = new_value;
+        }
     }
-}
 
-/// Handle initializer apply message.
-pub(crate) fn handle_apply(win: &mut WindowState) {
-    if let Some(editor) = win.initializer_editor.take() {
-        apply_initializer_edit(win, &editor);
+    pub(crate) fn handle_initializer_apply(&mut self) {
+        if let Some(editor) = self.initializer_editor.take() {
+            self.apply_initializer_edit(&editor);
+        }
     }
-}
 
-/// Handle initializer cancel message.
-pub(crate) fn handle_cancel(win: &mut WindowState) {
-    win.initializer_editor = None;
+    pub(crate) fn handle_initializer_cancel(&mut self) {
+        self.initializer_editor = None;
+    }
 }
 
 #[cfg(test)]
@@ -163,9 +156,8 @@ mod test {
             init_type: "once".into(),
             value_text: "42".into(),
         };
-        apply_initializer_edit(&mut win, &editor);
+        win.apply_initializer_edit(&editor);
         assert!(!win.history.is_empty());
-        // Check model was updated
         assert!(win
             .flow_definition
             .process_refs
@@ -183,7 +175,7 @@ mod test {
             init_type: "always".into(),
             value_text: "\"hello\"".into(),
         };
-        apply_initializer_edit(&mut win, &editor);
+        win.apply_initializer_edit(&editor);
         assert!(win
             .flow_definition
             .process_refs
@@ -195,14 +187,13 @@ mod test {
     #[test]
     fn initializer_apply_none_removes() {
         let mut win = test_win_state();
-        // First set one
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
             init_type: "once".into(),
             value_text: "42".into(),
         };
-        apply_initializer_edit(&mut win, &editor);
+        win.apply_initializer_edit(&editor);
         assert!(win
             .flow_definition
             .process_refs
@@ -210,14 +201,13 @@ mod test {
             .and_then(|p| p.initializations.get("input"))
             .is_some());
 
-        // Then remove it
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
             init_type: "none".into(),
             value_text: String::new(),
         };
-        apply_initializer_edit(&mut win, &editor);
+        win.apply_initializer_edit(&editor);
         assert!(win
             .flow_definition
             .process_refs
@@ -230,7 +220,7 @@ mod test {
     fn initializer_apply_state_set_and_remove() {
         let mut win = test_win_state();
         let init = InputInitializer::Once(serde_json::json!(99));
-        apply_initializer_state(&mut win, 0, "port", Some(&init));
+        win.apply_initializer_state(0, "port", Some(&init));
         assert!(win
             .flow_definition
             .process_refs
@@ -238,8 +228,7 @@ mod test {
             .and_then(|p| p.initializations.get("port"))
             .is_some());
 
-        // Remove
-        apply_initializer_state(&mut win, 0, "port", None);
+        win.apply_initializer_state(0, "port", None);
         assert!(win
             .flow_definition
             .process_refs
@@ -258,7 +247,7 @@ mod test {
             init_type: "bogus".into(),
             value_text: "42".into(),
         };
-        apply_initializer_edit(&mut win, &editor);
+        win.apply_initializer_edit(&editor);
         assert_eq!(
             win.history.is_empty(),
             empty_before,

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -42,15 +42,16 @@ impl WindowState {
             _ => return,
         };
 
-        if let Some(pref) = self.flow_definition.process_refs.get_mut(editor.node_index) {
-            match &new_init {
-                Some(init) => {
-                    pref.initializations
-                        .insert(editor.port_name.clone(), init.clone());
-                }
-                None => {
-                    pref.initializations.remove(&editor.port_name);
-                }
+        let Some(pref) = self.flow_definition.process_refs.get_mut(editor.node_index) else {
+            return;
+        };
+        match &new_init {
+            Some(init) => {
+                pref.initializations
+                    .insert(editor.port_name.clone(), init.clone());
+            }
+            None => {
+                pref.initializations.remove(&editor.port_name);
             }
         }
 

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -131,91 +131,92 @@ pub(crate) fn load_library_catalogs(
     (library_cache, all_definitions)
 }
 
-/// Add a function from the library panel as a new node on the canvas.
-///
-/// Creates a `NodeLayout` at a default position and a `ProcessReference`
-/// in the flow definition, and records the action in the edit history.
-pub(crate) fn add_library_function(win: &mut WindowState, source: &str, func_name: &str) {
-    // Generate a unique alias: if the name already exists, append a number
-    let alias = file_ops::generate_unique_alias(func_name, &win.flow_definition.process_refs);
+impl WindowState {
+    /// Add a library function as a new node on the canvas.
+    pub(crate) fn add_library_function(&mut self, source: &str, func_name: &str) {
+        // Generate a unique alias: if the name already exists, append a number
+        let alias = file_ops::generate_unique_alias(func_name, &self.flow_definition.process_refs);
 
-    // Place the new node at a default position offset from existing nodes
-    let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
+        // Place the new node at a default position offset from existing nodes
+        let (x, y) = file_ops::next_node_position(&self.flow_definition.process_refs);
 
-    // Resolve the subprocess definition by parsing the function/flow
-    let resolved_process = match Url::parse(source) {
-        Ok(url) => {
-            let provider = file_ops::build_meta_provider();
-            match flowrclib::compiler::parser::parse(&url, &provider) {
-                Ok(proc) => Some(proc),
-                Err(e) => {
-                    info!("add_library_function: could not parse '{source}': {e}");
-                    None
+        // Resolve the subprocess definition by parsing the function/flow
+        let resolved_process = match Url::parse(source) {
+            Ok(url) => {
+                let provider = file_ops::build_meta_provider();
+                match flowrclib::compiler::parser::parse(&url, &provider) {
+                    Ok(proc) => Some(proc),
+                    Err(e) => {
+                        info!("add_library_function: could not parse '{source}': {e}");
+                        None
+                    }
                 }
             }
+            Err(e) => {
+                info!("add_library_function: could not parse URL '{source}': {e}");
+                None
+            }
+        };
+
+        let pref = ProcessReference {
+            alias: alias.clone(),
+            source: source.to_string(),
+            initializations: std::collections::BTreeMap::new(),
+            x: Some(x),
+            y: Some(y),
+            width: Some(180.0),
+            height: Some(120.0),
+        };
+
+        let index = self.flow_definition.process_refs.len();
+        self.flow_definition.process_refs.push(pref.clone());
+
+        // Add the resolved subprocess definition if we have one
+        if let Some(proc) = resolved_process {
+            self.flow_definition
+                .subprocesses
+                .insert(alias.clone(), proc);
         }
-        Err(e) => {
-            info!("add_library_function: could not parse URL '{source}': {e}");
-            None
+
+        self.history.record(EditAction::CreateNode {
+            index,
+            process_ref: pref,
+            subprocess: self
+                .flow_definition
+                .subprocesses
+                .get(&alias)
+                .map(|p| (alias.clone(), p.clone())),
+        });
+
+        self.selected_node = Some(index);
+        self.canvas_state.request_redraw();
+        // Trigger auto-fit if enabled so the new node is visible
+        if self.auto_fit_enabled {
+            self.auto_fit_pending = true;
         }
-    };
-
-    let pref = ProcessReference {
-        alias: alias.clone(),
-        source: source.to_string(),
-        initializations: std::collections::BTreeMap::new(),
-        x: Some(x),
-        y: Some(y),
-        width: Some(180.0),
-        height: Some(120.0),
-    };
-
-    let index = win.flow_definition.process_refs.len();
-    win.flow_definition.process_refs.push(pref.clone());
-
-    // Add the resolved subprocess definition if we have one
-    if let Some(proc) = resolved_process {
-        win.flow_definition.subprocesses.insert(alias.clone(), proc);
+        let nc = self.flow_definition.process_refs.len();
+        self.status = format!("Added {alias} from library - {nc} nodes");
     }
 
-    win.history.record(EditAction::CreateNode {
-        index,
-        process_ref: pref,
-        subprocess: win
-            .flow_definition
-            .subprocesses
-            .get(&alias)
-            .map(|p| (alias.clone(), p.clone())),
-    });
-
-    win.selected_node = Some(index);
-    win.canvas_state.request_redraw();
-    // Trigger auto-fit if enabled so the new node is visible
-    if win.auto_fit_enabled {
-        win.auto_fit_pending = true;
+    /// Resolve a node's source path relative to the current flow file.
+    pub(crate) fn resolve_node_source(&self, source: &str) -> Option<PathBuf> {
+        let base_dir = self.file_path()?.parent()?.to_path_buf();
+        let base_dir = &base_dir;
+        let canonicalize = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
+        let candidate = base_dir.join(source);
+        if candidate.exists() {
+            return Some(canonicalize(candidate));
+        }
+        let with_ext = base_dir.join(format!("{source}.toml"));
+        if with_ext.exists() {
+            return Some(canonicalize(with_ext));
+        }
+        let dir_default = base_dir.join(source).join("default.toml");
+        if dir_default.exists() {
+            return Some(canonicalize(dir_default));
+        }
+        None
     }
-    let nc = win.flow_definition.process_refs.len();
-    win.status = format!("Added {alias} from library - {nc} nodes");
-}
-
-/// Resolve a node's source path relative to the current flow file.
-pub(crate) fn resolve_node_source(win: &WindowState, source: &str) -> Option<PathBuf> {
-    let base_dir = win.file_path()?.parent()?.to_path_buf();
-    let base_dir = &base_dir;
-    let canonicalize = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
-    let candidate = base_dir.join(source);
-    if candidate.exists() {
-        return Some(canonicalize(candidate));
-    }
-    let with_ext = base_dir.join(format!("{source}.toml"));
-    if with_ext.exists() {
-        return Some(canonicalize(with_ext));
-    }
-    let dir_default = base_dir.join(source).join("default.toml");
-    if dir_default.exists() {
-        return Some(canonicalize(dir_default));
-    }
-    None
 }
 
 #[cfg(test)]
@@ -295,7 +296,7 @@ mod test {
         let mut win = test_win_state();
         win.set_file_path(&flow_path);
 
-        let resolved = resolve_node_source(&win, "sub");
+        let resolved = win.resolve_node_source("sub");
         assert!(resolved.is_some());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -305,7 +306,7 @@ mod test {
     fn resolve_node_source_not_found() {
         let mut win = test_win_state();
         win.set_file_path(Path::new("/tmp/flowedit_tests/nonexistent/root.toml"));
-        let resolved = resolve_node_source(&win, "missing");
+        let resolved = win.resolve_node_source("missing");
         assert!(resolved.is_none());
     }
 }

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -46,29 +46,29 @@ pub(crate) enum LibraryAction {
 #[derive(Debug, Clone)]
 pub(crate) struct CategoryEntry {
     /// Category name (e.g., "math")
-    pub name: String,
+    pub(crate) name: String,
     /// URLs of functions in this category, pointing into `all_definitions`
-    pub function_urls: Vec<Url>,
+    pub(crate) function_urls: Vec<Url>,
     /// Whether the category is expanded in the tree view
-    pub expanded: bool,
+    pub(crate) expanded: bool,
 }
 
 /// A top-level library entry.
 #[derive(Debug, Clone)]
 pub(crate) struct LibraryEntry {
     /// Library name (e.g., "flowstdlib")
-    pub name: String,
+    pub(crate) name: String,
     /// Categories in this library
-    pub categories: Vec<CategoryEntry>,
+    pub(crate) categories: Vec<CategoryEntry>,
     /// Whether the library is expanded in the tree view
-    pub expanded: bool,
+    pub(crate) expanded: bool,
 }
 
 /// The complete library tree built from cached manifests and definitions.
 #[derive(Debug, Clone)]
 pub(crate) struct LibraryTree {
     /// All discovered libraries
-    pub libraries: Vec<LibraryEntry>,
+    pub(crate) libraries: Vec<LibraryEntry>,
 }
 
 impl LibraryTree {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -66,152 +66,155 @@ fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
     }
 }
 
-/// Handle flow metadata and I/O editing messages for a single window.
-fn handle_flow_edit_message(win: &mut WindowState, msg: FlowEditMessage) {
-    match msg {
-        FlowEditMessage::NameChanged(new_name) => {
-            win.flow_definition.name = new_name;
-            win.history.mark_modified();
-        }
-        FlowEditMessage::VersionChanged(version) => {
-            win.flow_definition.metadata.version = version;
-            win.history.mark_modified();
-        }
-        FlowEditMessage::DescriptionChanged(desc) => {
-            win.flow_definition.metadata.description = desc;
-            win.history.mark_modified();
-        }
-        FlowEditMessage::AuthorsChanged(authors_str) => {
-            win.flow_definition.metadata.authors = authors_str
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            win.history.mark_modified();
-        }
-        FlowEditMessage::ToggleMetadata => {
-            win.show_metadata = !win.show_metadata;
-        }
-        FlowEditMessage::AddInput => {
-            let name = next_unique_io_name("input", &win.flow_definition.inputs);
-            let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
-            io.set_io_type(IOType::FlowInput);
-            win.flow_definition.inputs.push(io);
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
-        }
-        FlowEditMessage::AddOutput => {
-            let name = next_unique_io_name("output", &win.flow_definition.outputs);
-            let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
-            io.set_io_type(IOType::FlowOutput);
-            win.flow_definition.outputs.push(io);
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
-        }
-        FlowEditMessage::DeleteInput(idx) => {
-            if let Some(io) = win.flow_definition.inputs.get(idx) {
-                let name = io.name().clone();
-                win.flow_definition.inputs.remove(idx);
-                // Remove connections referencing this flow input
-                win.flow_definition.connections.retain(|c| {
-                    let (from_node, from_port) = canvas_view::split_route(c.from().as_ref());
-                    !(from_node == "input" && from_port == name)
-                });
-                win.history.mark_modified();
-                win.canvas_state.request_redraw();
+impl WindowState {
+    /// Handle flow metadata and I/O editing messages.
+    fn handle_flow_edit_message(&mut self, msg: FlowEditMessage) {
+        match msg {
+            FlowEditMessage::NameChanged(new_name) => {
+                self.flow_definition.name = new_name;
+                self.history.mark_modified();
             }
-        }
-        FlowEditMessage::DeleteOutput(idx) => {
-            if let Some(io) = win.flow_definition.outputs.get(idx) {
-                let name = io.name().clone();
-                win.flow_definition.outputs.remove(idx);
-                for conn in &mut win.flow_definition.connections {
-                    let new_to: Vec<Route> = conn
-                        .to()
-                        .iter()
-                        .filter(|to_route| {
-                            let (to_node, to_port) = canvas_view::split_route(to_route.as_ref());
-                            !(to_node == "output" && to_port == name)
-                        })
-                        .cloned()
-                        .collect();
-                    conn.set_to(new_to);
+            FlowEditMessage::VersionChanged(version) => {
+                self.flow_definition.metadata.version = version;
+                self.history.mark_modified();
+            }
+            FlowEditMessage::DescriptionChanged(desc) => {
+                self.flow_definition.metadata.description = desc;
+                self.history.mark_modified();
+            }
+            FlowEditMessage::AuthorsChanged(authors_str) => {
+                self.flow_definition.metadata.authors = authors_str
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                self.history.mark_modified();
+            }
+            FlowEditMessage::ToggleMetadata => {
+                self.show_metadata = !self.show_metadata;
+            }
+            FlowEditMessage::AddInput => {
+                let name = next_unique_io_name("input", &self.flow_definition.inputs);
+                let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
+                io.set_io_type(IOType::FlowInput);
+                self.flow_definition.inputs.push(io);
+                self.history.mark_modified();
+                self.canvas_state.request_redraw();
+            }
+            FlowEditMessage::AddOutput => {
+                let name = next_unique_io_name("output", &self.flow_definition.outputs);
+                let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
+                io.set_io_type(IOType::FlowOutput);
+                self.flow_definition.outputs.push(io);
+                self.history.mark_modified();
+                self.canvas_state.request_redraw();
+            }
+            FlowEditMessage::DeleteInput(idx) => {
+                if let Some(io) = self.flow_definition.inputs.get(idx) {
+                    let name = io.name().clone();
+                    self.flow_definition.inputs.remove(idx);
+                    // Remove connections referencing this flow input
+                    self.flow_definition.connections.retain(|c| {
+                        let (from_node, from_port) = canvas_view::split_route(c.from().as_ref());
+                        !(from_node == "input" && from_port == name)
+                    });
+                    self.history.mark_modified();
+                    self.canvas_state.request_redraw();
                 }
-                win.flow_definition
-                    .connections
-                    .retain(|c| !c.to().is_empty());
-                win.history.mark_modified();
-                win.canvas_state.request_redraw();
             }
-        }
-        FlowEditMessage::InputNameChanged(idx, name) => {
-            let duplicate = win
-                .flow_definition
-                .inputs
-                .iter()
-                .enumerate()
-                .any(|(i, io)| i != idx && io.name() == &name);
-            if !duplicate {
-                if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
-                    let old_name = io.name().clone();
-                    io.set_name(name.clone());
-                    let old_route = format!("input/{old_name}");
-                    let new_route = format!("input/{name}");
-                    for conn in &mut win.flow_definition.connections {
-                        if conn.from().to_string() == old_route {
-                            conn.set_from(Route::from(new_route.as_str()));
-                        }
-                    }
-                }
-                win.history.mark_modified();
-                win.canvas_state.request_redraw();
-            }
-        }
-        FlowEditMessage::InputTypeChanged(idx, dtype) => {
-            if let Some(io) = win.flow_definition.inputs.get_mut(idx) {
-                io.set_datatypes(&[DataType::from(dtype)]);
-            }
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
-        }
-        FlowEditMessage::OutputNameChanged(idx, name) => {
-            let duplicate = win
-                .flow_definition
-                .outputs
-                .iter()
-                .enumerate()
-                .any(|(i, io)| i != idx && io.name() == &name);
-            if !duplicate {
-                if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
-                    let old_name = io.name().clone();
-                    io.set_name(name.clone());
-                    let old_route_str = format!("output/{old_name}");
-                    let new_route_str = format!("output/{name}");
-                    for conn in &mut win.flow_definition.connections {
+            FlowEditMessage::DeleteOutput(idx) => {
+                if let Some(io) = self.flow_definition.outputs.get(idx) {
+                    let name = io.name().clone();
+                    self.flow_definition.outputs.remove(idx);
+                    for conn in &mut self.flow_definition.connections {
                         let new_to: Vec<Route> = conn
                             .to()
                             .iter()
-                            .map(|r| {
-                                if r.to_string() == old_route_str {
-                                    Route::from(new_route_str.as_str())
-                                } else {
-                                    r.clone()
-                                }
+                            .filter(|to_route| {
+                                let (to_node, to_port) =
+                                    canvas_view::split_route(to_route.as_ref());
+                                !(to_node == "output" && to_port == name)
                             })
+                            .cloned()
                             .collect();
                         conn.set_to(new_to);
                     }
+                    self.flow_definition
+                        .connections
+                        .retain(|c| !c.to().is_empty());
+                    self.history.mark_modified();
+                    self.canvas_state.request_redraw();
                 }
-                win.history.mark_modified();
-                win.canvas_state.request_redraw();
             }
-        }
-        FlowEditMessage::OutputTypeChanged(idx, dtype) => {
-            if let Some(io) = win.flow_definition.outputs.get_mut(idx) {
-                io.set_datatypes(&[DataType::from(dtype)]);
+            FlowEditMessage::InputNameChanged(idx, name) => {
+                let duplicate = self
+                    .flow_definition
+                    .inputs
+                    .iter()
+                    .enumerate()
+                    .any(|(i, io)| i != idx && io.name() == &name);
+                if !duplicate {
+                    if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
+                        let old_name = io.name().clone();
+                        io.set_name(name.clone());
+                        let old_route = format!("input/{old_name}");
+                        let new_route = format!("input/{name}");
+                        for conn in &mut self.flow_definition.connections {
+                            if conn.from().to_string() == old_route {
+                                conn.set_from(Route::from(new_route.as_str()));
+                            }
+                        }
+                    }
+                    self.history.mark_modified();
+                    self.canvas_state.request_redraw();
+                }
             }
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
+            FlowEditMessage::InputTypeChanged(idx, dtype) => {
+                if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
+                    io.set_datatypes(&[DataType::from(dtype)]);
+                }
+                self.history.mark_modified();
+                self.canvas_state.request_redraw();
+            }
+            FlowEditMessage::OutputNameChanged(idx, name) => {
+                let duplicate = self
+                    .flow_definition
+                    .outputs
+                    .iter()
+                    .enumerate()
+                    .any(|(i, io)| i != idx && io.name() == &name);
+                if !duplicate {
+                    if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
+                        let old_name = io.name().clone();
+                        io.set_name(name.clone());
+                        let old_route_str = format!("output/{old_name}");
+                        let new_route_str = format!("output/{name}");
+                        for conn in &mut self.flow_definition.connections {
+                            let new_to: Vec<Route> = conn
+                                .to()
+                                .iter()
+                                .map(|r| {
+                                    if r.to_string() == old_route_str {
+                                        Route::from(new_route_str.as_str())
+                                    } else {
+                                        r.clone()
+                                    }
+                                })
+                                .collect();
+                            conn.set_to(new_to);
+                        }
+                    }
+                    self.history.mark_modified();
+                    self.canvas_state.request_redraw();
+                }
+            }
+            FlowEditMessage::OutputTypeChanged(idx, dtype) => {
+                if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
+                    io.set_datatypes(&[DataType::from(dtype)]);
+                }
+                self.history.mark_modified();
+                self.canvas_state.request_redraw();
+            }
         }
     }
 }
@@ -579,7 +582,7 @@ impl FlowEdit {
                 let Some(win) = self.windows.get_mut(&win_id) else {
                     return Task::none();
                 };
-                match canvas_view::handle_canvas_message(win, canvas_msg) {
+                match win.handle_canvas_message(canvas_msg) {
                     canvas_view::CanvasAction::OpenNode(idx) => {
                         return self.open_node(win_id, idx);
                     }
@@ -655,7 +658,7 @@ impl FlowEdit {
             Message::Library(win_id, ref lib_msg) => match self.library_tree.update(lib_msg) {
                 LibraryAction::Add(source, func_name) => {
                     if let Some(win) = self.windows.get_mut(&win_id) {
-                        library_mgmt::add_library_function(win, &source, &func_name);
+                        win.add_library_function(&source, &func_name);
                     }
                 }
                 LibraryAction::View(source, _name) => {
@@ -777,7 +780,7 @@ impl FlowEdit {
             },
             Message::View(win_id, view_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    canvas_view::update(win, &view_msg);
+                    win.handle_view_message(&view_msg);
                 }
             }
             Message::Undo => {
@@ -797,7 +800,7 @@ impl FlowEdit {
             }
             Message::FlowEdit(win_id, flow_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    handle_flow_edit_message(win, flow_msg);
+                    win.handle_flow_edit_message(flow_msg);
                 }
             }
             Message::NewSubFlow(target_win_id) => {
@@ -814,22 +817,22 @@ impl FlowEdit {
             }
             Message::InitializerTypeChanged(win_id, new_type) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    initializer::handle_type_changed(win, new_type);
+                    win.handle_initializer_type_changed(new_type);
                 }
             }
             Message::InitializerValueChanged(win_id, new_value) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    initializer::handle_value_changed(win, new_value);
+                    win.handle_initializer_value_changed(new_value);
                 }
             }
             Message::InitializerApply(win_id) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    initializer::handle_apply(win);
+                    win.handle_initializer_apply();
                 }
             }
             Message::InitializerCancel(win_id) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    initializer::handle_cancel(win);
+                    win.handle_initializer_cancel();
                 }
             }
             Message::WindowFocused(id) => {
@@ -934,7 +937,7 @@ impl FlowEdit {
             return Self::view_function(window_id, viewer, &win.status, !win.history.is_empty());
         }
 
-        let canvas_with_controls = canvas_view::view_canvas_area(win, window_id);
+        let canvas_with_controls = win.view_canvas_area(window_id);
 
         let hierarchy_panel = win
             .flow_hierarchy
@@ -1810,7 +1813,7 @@ impl FlowEdit {
                 return Task::none();
             };
             let source = pref.source.clone();
-            let path = library_mgmt::resolve_node_source(win, &source);
+            let path = win.resolve_node_source(&source);
             (source, path)
         };
 
@@ -2213,7 +2216,7 @@ impl FlowEdit {
                                 }
                             }
                         }
-                        WindowKind::FlowEditor => file_ops::handle_save(win),
+                        WindowKind::FlowEditor => win.handle_save(),
                     }
                 }
             }
@@ -2232,14 +2235,14 @@ impl FlowEdit {
                                 }
                             }
                         }
-                        WindowKind::FlowEditor => file_ops::handle_save_as(win),
+                        WindowKind::FlowEditor => win.handle_save_as(),
                     }
                 }
             }
             Message::Open => {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
-                        if let Some((lib_refs, _ctx_refs)) = file_ops::perform_open(win) {
+                        if let Some((lib_refs, _ctx_refs)) = win.perform_open() {
                             win.flow_hierarchy =
                                 FlowHierarchy::from_flow_definition(&win.flow_definition);
 
@@ -2254,7 +2257,7 @@ impl FlowEdit {
             }
             Message::New => {
                 if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
-                    file_ops::perform_new(win);
+                    win.perform_new();
                     win.flow_hierarchy = FlowHierarchy::empty();
                     self.library_cache.clear();
                     self.all_definitions.clear();
@@ -2266,7 +2269,7 @@ impl FlowEdit {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
                     if !win.flow_definition.process_refs.is_empty() {
-                        match file_ops::perform_compile(win) {
+                        match win.perform_compile() {
                             Ok(path) => {
                                 win.history.set_compiled_manifest(path.clone());
                                 win.status = format!("Compiled: {}", path.display());

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1060,8 +1060,11 @@ impl FlowEdit {
             Row::new()
                 .spacing(8)
                 .padding([4, 8])
-                .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
-                .push(iced::widget::Space::new().width(Fill))
+                .push(
+                    container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
+                        .width(Fill)
+                        .clip(true),
+                )
                 .push(info_btn)
                 .push(
                     button(Text::new("\u{1F4C1} Libs").size(btn_size).center())
@@ -1077,11 +1080,11 @@ impl FlowEdit {
                 .push(new_func_btn)
                 .push(compile_btn)
         } else {
-            Row::new()
-                .spacing(8)
-                .padding([4, 8])
-                .push(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
-                .push(iced::widget::Space::new().width(Fill))
+            Row::new().spacing(8).padding([4, 8]).push(
+                container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
+                    .width(Fill)
+                    .clip(true),
+            )
         };
 
         container(status_bar).width(Fill).padding(5).into()

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -795,7 +795,7 @@ fn click_build_with_saved_flow() {
     if let Some(win) = app.windows.get_mut(&win_id) {
         win.set_file_path(&path);
         win.flow_definition.name = "test_build".into();
-        file_ops::perform_save(win, &path);
+        win.perform_save(&path);
     }
     click_and_update(&mut app, win_id, "\u{1F528} Build");
     let status = app

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1456,7 +1456,7 @@ fn flow_output_rename_updates_edges() {
 fn new_subflow_clears_context_menu() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.context_menu = Some((100.0, 200.0));
+        win.context_menu = Some(crate::window_state::MenuPosition { x: 100.0, y: 200.0 });
     }
     let _ = app.update(Message::NewSubFlow(win_id));
     assert!(
@@ -1472,7 +1472,7 @@ fn new_subflow_clears_context_menu() {
 fn new_function_clears_context_menu() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.context_menu = Some((100.0, 200.0));
+        win.context_menu = Some(crate::window_state::MenuPosition { x: 100.0, y: 200.0 });
     }
     let _ = app.update(Message::NewFunction(win_id));
     assert!(

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -10,7 +10,6 @@ use flowcore::model::function_definition::FunctionDefinition;
 
 use crate::canvas_view::FlowCanvasState;
 use crate::hierarchy_panel::FlowHierarchy;
-use crate::history;
 use crate::history::EditHistory;
 
 /// State for the initializer editing dialog.
@@ -139,15 +138,5 @@ impl WindowState {
     /// Clear the file path by resetting the source URL to the default.
     pub(crate) fn clear_file_path(&mut self) {
         self.flow_definition.source_url = FlowDefinition::default_url();
-    }
-
-    /// Undo the last edit action.
-    pub(crate) fn handle_undo(&mut self) {
-        history::handle_undo(self);
-    }
-
-    /// Redo the last undone action.
-    pub(crate) fn handle_redo(&mut self) {
-        history::handle_redo(self);
     }
 }

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -12,6 +12,21 @@ use crate::canvas_view::FlowCanvasState;
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history::EditHistory;
 
+/// Tooltip text and screen position for hover display.
+#[derive(Debug, Clone)]
+pub(crate) struct Tooltip {
+    pub(crate) text: String,
+    pub(crate) x: f32,
+    pub(crate) y: f32,
+}
+
+/// Screen position for a right-click context menu.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MenuPosition {
+    pub(crate) x: f32,
+    pub(crate) y: f32,
+}
+
 /// State for the initializer editing dialog.
 pub(crate) struct InitializerEditor {
     /// Index of the node being edited
@@ -73,13 +88,13 @@ pub(crate) struct WindowState {
     /// The original flow definition, used to preserve metadata when saving
     pub(crate) flow_definition: FlowDefinition,
     /// Tooltip text and screen position to display (full source path on hover)
-    pub(crate) tooltip: Option<(String, f32, f32)>,
+    pub(crate) tooltip: Option<Tooltip>,
     /// Active initializer editor dialog, if any
     pub(crate) initializer_editor: Option<InitializerEditor>,
     /// Whether this is the root (main) window
     pub(crate) is_root: bool,
     /// Context menu position (screen coords), if showing
-    pub(crate) context_menu: Option<(f32, f32)>,
+    pub(crate) context_menu: Option<MenuPosition>,
     /// Whether the metadata editor is visible
     pub(crate) show_metadata: bool,
     /// Flow hierarchy tree for this window's navigation panel


### PR DESCRIPTION
## Summary
- Replace two duplicate `NodeKind` enums with flowcore's `Process` enum — `NodeLayout` and `HierarchyNode` now derive color, icon, and openability directly from the `Process` discriminant
- Replace `NodeLayout` duplicate fields (alias, source, description, x/y/width/height, inputs/outputs, initializers) with `ProcessReference` + `Option<Process>` and accessor methods; delete unused `PortInfo` struct and `extract_ports` function
- Convert ~25 free functions that take `&mut WindowState` into methods on `WindowState` (across canvas_view, file_ops, history, initializer, library_mgmt, main); convert `HierarchyNode` and `NodeLayout` free functions to methods
- Tighten field visibility from `pub` to `pub(crate)` on `HierarchyNode`, `FlowHierarchy`, `CategoryEntry`, `LibraryEntry`, `LibraryTree`, `FlowCanvasState`
- Replace tuple types `Option<(String, f32, f32)>` and `Option<(f32, f32)>` with named `Tooltip` and `MenuPosition` structs
- Fix tooltip hovering over cursor (offset +20px) and status bar text pushing buttons off-screen (clip long text)

## Follow-up items
- HierarchyNode tree duplicates FlowDefinition's subprocess tree — could navigate FlowDefinition directly with separate expansion state
- ConnectingState stores cloned node/port strings — could use Route references instead (TODO in code)
- FunctionDefinition.source_url was added for flowedit — investigate using the existing `source` field instead

## Test plan
- [x] All 196 flowedit tests pass
- [x] `make clippy` clean (only pre-existing warnings)
- [x] `make test` passes
- [ ] Manual testing: verify tooltip offset, status bar layout, node colors, port rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal editor operations (save, load, open, new, compile, undo, redo) for improved code structure and maintainability.
  * Refactored hierarchy tree model and initializer editing logic for better internal organization.
  * Enhanced data structure typing for UI elements (tooltips and context menus).
  * Updated tests to reflect internal structural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->