### PR TITLE
flowcore: Skip serialization of runtime-only fields, fix all clippy warnings (#2607)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic
+          args: --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic --deny warnings
 
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build:
 .PHONY: clippy
 clippy:
 	@echo "clippy<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-	cargo clippy --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic
+	cargo clippy --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic --deny warnings
 
 .PHONY: test
 test: build

--- a/flowcore/src/model/datatype.rs
+++ b/flowcore/src/model/datatype.rs
@@ -502,6 +502,7 @@ mod test {
         /// * array/{type}  --> object (`is_array` = false) - values in Array will be serialized
         ///   and sent to input one by one
         #[test]
+        #[allow(clippy::too_many_lines)]
         fn valid_type_conversions() {
             let valid_type_conversions: Vec<(String, String, &str)> = vec![
                 // equal types are compatible (equality)

--- a/flowcore/src/model/function_definition.rs
+++ b/flowcore/src/model/function_definition.rs
@@ -47,31 +47,31 @@ pub struct FunctionDefinition {
     pub outputs: IOSet,
     /// As a function can be used multiple times in a single flow, the repeated instances must
     /// be referred to using an alias to disambiguate which instance is being referred to
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub alias: Name,
     /// `source_url` is where this function definition was read from
-    #[serde(skip_deserializing, default = "FunctionDefinition::default_url")]
+    #[serde(skip, default = "FunctionDefinition::default_url")]
     pub(crate) source_url: Url,
     /// the `route` in the flow hierarchy where this function is located
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub route: Route,
     /// Implementation is the relative path from the lib root to the compiled wasm implementation
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub implementation: String,
     /// Is the function being used part of a library and where is it found
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub lib_reference: Option<Url>,
     /// Is the function a context function and where is it found
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub context_reference: Option<Url>,
     /// The output connections from this function to other processes (functions or flows)
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub output_connections: Vec<OutputConnection>,
     /// A unique `id` assigned to the function as the flow is parsed hierarchically
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub(crate) function_id: usize,
     /// the `id` of the `FlowDefinition` that this `FunctionDefinition` lies within in the hierarchy
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub(crate) flow_id: usize,
 }
 
@@ -678,6 +678,68 @@ mod test {
         assert_eq!(
             *output1.route(),
             Route::from("/flow/test_alias/other_output")
+        );
+    }
+
+    #[test]
+    fn runtime_fields_not_serialized() {
+        let mut func = FunctionDefinition {
+            name: "test".into(),
+            source: "test.rs".into(),
+            ..FunctionDefinition::default()
+        };
+        func.alias = "my_alias".into();
+        func.set_source_url(&Url::parse("file:///tmp/test.toml").expect("valid url"));
+        func.route = Route::from("/flow/my_alias");
+        func.implementation = "test.wasm".into();
+        func.lib_reference = Some(Url::parse("lib://testlib").expect("valid url"));
+        func.context_reference = Some(Url::parse("context://stdio").expect("valid url"));
+        func.set_id(42);
+
+        let serialized = toml::to_string(&func).expect("serialization failed");
+        assert!(
+            !serialized.contains("alias"),
+            "alias should not be serialized"
+        );
+        assert!(
+            !serialized.contains("source_url"),
+            "source_url should not be serialized"
+        );
+        assert!(
+            !serialized.contains("route"),
+            "route should not be serialized"
+        );
+        assert!(
+            !serialized.contains("implementation"),
+            "implementation should not be serialized"
+        );
+        assert!(
+            !serialized.contains("lib_reference"),
+            "lib_reference should not be serialized"
+        );
+        assert!(
+            !serialized.contains("context_reference"),
+            "context_reference should not be serialized"
+        );
+        assert!(
+            !serialized.contains("output_connections"),
+            "output_connections should not be serialized"
+        );
+        assert!(
+            !serialized.contains("function_id"),
+            "function_id should not be serialized"
+        );
+        assert!(
+            !serialized.contains("flow_id"),
+            "flow_id should not be serialized"
+        );
+        assert!(
+            serialized.contains("function = \"test\""),
+            "name should be serialized"
+        );
+        assert!(
+            serialized.contains("source = \"test.rs\""),
+            "source should be serialized"
         );
     }
 }

--- a/flowcore/src/model/io.rs
+++ b/flowcore/src/model/io.rs
@@ -54,16 +54,16 @@ pub struct IO {
     initializer: Option<InputInitializer>,
 
     /// An input initializer that is propagated from a flow's input initializer
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     flow_initializer: Option<InputInitializer>,
 
     /// [Route] where in the full flow hierarchy this IO is located, including it's [Name]
     /// as the last segment
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     route: Route,
 
     /// What type of IO is this, used in making connections between IOs
-    #[serde(skip_deserializing, default = "IOType::default")]
+    #[serde(skip, default = "IOType::default")]
     io_type: IOType,
 }
 
@@ -359,6 +359,7 @@ mod test {
     use crate::deserializers::deserializer::get;
     use crate::errors::Result;
     use crate::model::datatype::{DataType, GENERIC_TYPE, STRING_TYPE};
+    use crate::model::input::InputInitializer;
     use crate::model::io::{IOSet, IOType};
     use crate::model::name::HasName;
     use crate::model::name::Name;
@@ -563,5 +564,32 @@ mod test {
             .find_by_subroute(&Route::from("/0"))
             .expect("Expected to find an IO");
         assert_eq!(*output.name(), Name::default());
+    }
+
+    #[test]
+    fn runtime_fields_not_serialized() {
+        let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), "input0");
+        io.set_route(&Route::from("/flow/func/input0"), &IOType::FunctionInput);
+        io.set_io_type(IOType::FunctionInput);
+        io.set_flow_initializer(Some(InputInitializer::Once(serde_json::json!("hello"))))
+            .expect("set_flow_initializer failed");
+
+        let serialized = toml::to_string(&io).expect("serialization failed");
+        assert!(
+            !serialized.contains("flow_initializer"),
+            "flow_initializer should not be serialized"
+        );
+        assert!(
+            !serialized.contains("route"),
+            "route should not be serialized"
+        );
+        assert!(
+            !serialized.contains("io_type"),
+            "io_type should not be serialized"
+        );
+        assert!(
+            serialized.contains("name = \"input0\""),
+            "name should be serialized"
+        );
     }
 }

--- a/flowcore/src/model/lib_manifest.rs
+++ b/flowcore/src/model/lib_manifest.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_LIB_RUST_MANIFEST_FILENAME: &str = "manifest.rs";
 #[serde(untagged)]
 /// `ImplementationLocator` describes where an implementation can be located.
 pub enum ImplementationLocator {
-    #[serde(skip_deserializing, skip_serializing)]
+    #[serde(skip)]
     /// A `Native` - A reference to a trait object statically linked with the library
     Native(Arc<dyn Implementation>),
     /// A path indicating where the implementation file is located within the Library directory

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -50,26 +50,7 @@ impl WindowState {
     /// operations (e.g. opening a sub-flow in a new editor window).
     pub(crate) fn handle_canvas_message(&mut self, msg: CanvasMessage) -> CanvasAction {
         match msg {
-            CanvasMessage::Selected(idx) => {
-                self.selected_node = idx;
-                self.context_menu = None;
-                if self.selected_connection.is_some() {
-                    self.selected_connection = None;
-                    self.canvas_state.request_redraw();
-                }
-                if let Some(i) = idx {
-                    if let Some(pref) = self.flow_definition.process_refs.get(i) {
-                        let alias = if pref.alias.is_empty() {
-                            derive_short_name(&pref.source)
-                        } else {
-                            pref.alias.clone()
-                        };
-                        self.status = format!("Selected: {alias}");
-                    }
-                } else {
-                    self.status = String::from("Ready");
-                }
-            }
+            CanvasMessage::Selected(idx) => self.handle_selected(idx),
             CanvasMessage::Moved(idx, x, y) => {
                 if let Some(pref) = self.flow_definition.process_refs.get_mut(idx) {
                     pref.x = Some(x);
@@ -110,127 +91,19 @@ impl WindowState {
                 new_w,
                 new_h,
             ) => {
-                if (old_x - new_x).abs() > 0.5
-                    || (old_y - new_y).abs() > 0.5
-                    || (old_w - new_w).abs() > 0.5
-                    || (old_h - new_h).abs() > 0.5
-                {
-                    self.history.record(EditAction::ResizeNode {
-                        index: idx,
-                        old_x,
-                        old_y,
-                        old_w,
-                        old_h,
-                        new_x,
-                        new_y,
-                        new_w,
-                        new_h,
-                    });
-                }
+                self.handle_resize_completed(
+                    idx, old_x, old_y, old_w, old_h, new_x, new_y, new_w, new_h,
+                );
             }
-            CanvasMessage::Deleted(idx) => {
-                if idx < self.flow_definition.process_refs.len() {
-                    let Some(pref) = self.flow_definition.process_refs.get(idx).cloned() else {
-                        return CanvasAction::None;
-                    };
-                    let alias = if pref.alias.is_empty() {
-                        derive_short_name(&pref.source)
-                    } else {
-                        pref.alias.clone()
-                    };
-                    let removed_connections: Vec<Connection> = self
-                        .flow_definition
-                        .connections
-                        .iter()
-                        .filter(|c| connection_references_node(c, &alias))
-                        .cloned()
-                        .collect();
-                    let removed_pref = self.flow_definition.process_refs.remove(idx);
-                    let removed_subprocess = self.flow_definition.subprocesses.remove(&alias);
-                    self.flow_definition
-                        .connections
-                        .retain(|c| !connection_references_node(c, &alias));
-                    self.history.record(EditAction::DeleteNode {
-                        index: idx,
-                        process_ref: removed_pref,
-                        subprocess: removed_subprocess.map(|p| (alias, p)),
-                        removed_connections,
-                    });
-                    self.selected_node = None;
-                    self.selected_connection = None;
-                    self.canvas_state.request_redraw();
-                    let nc = self.flow_definition.process_refs.len();
-                    let ec = self.flow_definition.connections.len();
-                    self.status = format!("Node deleted - {nc} nodes, {ec} connections");
-                    if self.auto_fit_enabled {
-                        self.auto_fit_pending = true;
-                    }
-                }
-            }
+            CanvasMessage::Deleted(idx) => self.handle_deleted(idx),
             CanvasMessage::ConnectionCreated {
                 from_node,
                 from_port,
                 to_node,
                 to_port,
-            } => {
-                let from_route = if from_port.is_empty() {
-                    from_node.clone()
-                } else {
-                    format!("{from_node}/{from_port}")
-                };
-                let to_route = if to_port.is_empty() {
-                    to_node.clone()
-                } else {
-                    format!("{to_node}/{to_port}")
-                };
-                let connection = Connection::new(from_route, to_route);
-                self.history.record(EditAction::CreateConnection {
-                    connection: connection.clone(),
-                });
-                self.flow_definition.connections.push(connection);
-                self.canvas_state.request_redraw();
-                let nc = self.flow_definition.process_refs.len();
-                let ec = self.flow_definition.connections.len();
-                self.status = format!(
-                "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
-            );
-            }
-            CanvasMessage::ConnectionSelected(idx) => {
-                self.selected_connection = idx;
-                self.selected_node = None;
-                self.canvas_state.request_redraw();
-                if let Some(i) = idx {
-                    if let Some(conn) = self.flow_definition.connections.get(i) {
-                        let (from_node, from_port) = split_route(conn.from().as_ref());
-                        let to_str = conn
-                            .to()
-                            .first()
-                            .map_or_else(String::new, ToString::to_string);
-                        let (to_node, to_port) = split_route(&to_str);
-                        self.status = format!(
-                            "Connection: {} -> {}",
-                            file_ops::format_endpoint(&from_node, &from_port),
-                            file_ops::format_endpoint(&to_node, &to_port),
-                        );
-                    }
-                } else {
-                    self.status = String::from("Ready");
-                }
-            }
-            CanvasMessage::ConnectionDeleted(idx) => {
-                if idx < self.flow_definition.connections.len() {
-                    let connection = self.flow_definition.connections.remove(idx);
-                    self.history.record(EditAction::DeleteConnection {
-                        index: idx,
-                        connection,
-                    });
-                    self.selected_connection = None;
-                    self.canvas_state.request_redraw();
-                    let nc = self.flow_definition.process_refs.len();
-                    let ec = self.flow_definition.connections.len();
-                    self.status = format!("Connection deleted - {nc} nodes, {ec} connections");
-                }
-            }
+            } => self.handle_connection_created(&from_node, &from_port, &to_node, &to_port),
+            CanvasMessage::ConnectionSelected(idx) => self.handle_connection_selected(idx),
+            CanvasMessage::ConnectionDeleted(idx) => self.handle_connection_deleted(idx),
             CanvasMessage::HoverChanged(data) => {
                 self.tooltip = data;
             }
@@ -245,14 +118,14 @@ impl WindowState {
                 }
             }
             CanvasMessage::Pan(dx, dy) => {
-                self.auto_fit_enabled = false; // Manual pan disables auto-fit
+                self.auto_fit_enabled = false;
                 self.auto_fit_pending = false;
                 self.canvas_state.scroll_offset.x += dx;
                 self.canvas_state.scroll_offset.y += dy;
                 self.canvas_state.request_redraw();
             }
             CanvasMessage::ZoomBy(factor) => {
-                self.auto_fit_enabled = false; // Manual zoom disables auto-fit
+                self.auto_fit_enabled = false;
                 self.auto_fit_pending = false;
                 self.canvas_state.zoom = (self.canvas_state.zoom * factor).clamp(0.1, 5.0);
                 self.canvas_state.request_redraw();
@@ -260,32 +133,7 @@ impl WindowState {
                 self.status = format!("Zoom: {pct}%");
             }
             CanvasMessage::InitializerEdit(node_idx, port_name) => {
-                // Look up current initializer from the model (flow definition)
-                let (init_type, value_text) = self
-                    .flow_definition
-                    .process_refs
-                    .get(node_idx)
-                    .and_then(|pr| pr.initializations.get(&port_name))
-                    .map_or_else(
-                        || ("none".to_string(), String::new()),
-                        |init| match init {
-                            InputInitializer::Once(v) => (
-                                "once".to_string(),
-                                serde_json::to_string(v).unwrap_or_default(),
-                            ),
-                            InputInitializer::Always(v) => (
-                                "always".to_string(),
-                                serde_json::to_string(v).unwrap_or_default(),
-                            ),
-                        },
-                    );
-
-                self.initializer_editor = Some(InitializerEditor {
-                    node_index: node_idx,
-                    port_name,
-                    init_type,
-                    value_text,
-                });
+                self.handle_initializer_edit(node_idx, port_name);
             }
             CanvasMessage::OpenNode(idx) => {
                 return CanvasAction::OpenNode(idx);
@@ -295,6 +143,195 @@ impl WindowState {
             }
         }
         CanvasAction::None
+    }
+
+    fn handle_selected(&mut self, idx: Option<usize>) {
+        self.selected_node = idx;
+        self.context_menu = None;
+        if self.selected_connection.is_some() {
+            self.selected_connection = None;
+            self.canvas_state.request_redraw();
+        }
+        if let Some(i) = idx {
+            if let Some(pref) = self.flow_definition.process_refs.get(i) {
+                let alias = if pref.alias.is_empty() {
+                    derive_short_name(&pref.source)
+                } else {
+                    pref.alias.clone()
+                };
+                self.status = format!("Selected: {alias}");
+            }
+        } else {
+            self.status = String::from("Ready");
+        }
+    }
+
+    #[allow(clippy::similar_names, clippy::too_many_arguments)]
+    fn handle_resize_completed(
+        &mut self,
+        idx: usize,
+        old_x: f32,
+        old_y: f32,
+        old_w: f32,
+        old_h: f32,
+        new_x: f32,
+        new_y: f32,
+        new_w: f32,
+        new_h: f32,
+    ) {
+        if (old_x - new_x).abs() > 0.5
+            || (old_y - new_y).abs() > 0.5
+            || (old_w - new_w).abs() > 0.5
+            || (old_h - new_h).abs() > 0.5
+        {
+            self.history.record(EditAction::ResizeNode {
+                index: idx,
+                old_x,
+                old_y,
+                old_w,
+                old_h,
+                new_x,
+                new_y,
+                new_w,
+                new_h,
+            });
+        }
+    }
+
+    fn handle_deleted(&mut self, idx: usize) {
+        if idx < self.flow_definition.process_refs.len() {
+            let Some(pref) = self.flow_definition.process_refs.get(idx).cloned() else {
+                return;
+            };
+            let alias = if pref.alias.is_empty() {
+                derive_short_name(&pref.source)
+            } else {
+                pref.alias.clone()
+            };
+            let removed_connections: Vec<Connection> = self
+                .flow_definition
+                .connections
+                .iter()
+                .filter(|c| connection_references_node(c, &alias))
+                .cloned()
+                .collect();
+            let removed_pref = self.flow_definition.process_refs.remove(idx);
+            let removed_subprocess = self.flow_definition.subprocesses.remove(&alias);
+            self.flow_definition
+                .connections
+                .retain(|c| !connection_references_node(c, &alias));
+            self.history.record(EditAction::DeleteNode {
+                index: idx,
+                process_ref: removed_pref,
+                subprocess: removed_subprocess.map(|p| (alias, p)),
+                removed_connections,
+            });
+            self.selected_node = None;
+            self.selected_connection = None;
+            self.canvas_state.request_redraw();
+            let nc = self.flow_definition.process_refs.len();
+            let ec = self.flow_definition.connections.len();
+            self.status = format!("Node deleted - {nc} nodes, {ec} connections");
+            if self.auto_fit_enabled {
+                self.auto_fit_pending = true;
+            }
+        }
+    }
+
+    fn handle_connection_created(
+        &mut self,
+        from_node: &str,
+        from_port: &str,
+        to_node: &str,
+        to_port: &str,
+    ) {
+        let from_route = if from_port.is_empty() {
+            from_node.to_string()
+        } else {
+            format!("{from_node}/{from_port}")
+        };
+        let to_route = if to_port.is_empty() {
+            to_node.to_string()
+        } else {
+            format!("{to_node}/{to_port}")
+        };
+        let connection = Connection::new(from_route, to_route);
+        self.history.record(EditAction::CreateConnection {
+            connection: connection.clone(),
+        });
+        self.flow_definition.connections.push(connection);
+        self.canvas_state.request_redraw();
+        let nc = self.flow_definition.process_refs.len();
+        let ec = self.flow_definition.connections.len();
+        self.status = format!(
+            "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
+        );
+    }
+
+    fn handle_connection_selected(&mut self, idx: Option<usize>) {
+        self.selected_connection = idx;
+        self.selected_node = None;
+        self.canvas_state.request_redraw();
+        if let Some(i) = idx {
+            if let Some(conn) = self.flow_definition.connections.get(i) {
+                let (from_node, from_port) = split_route(conn.from().as_ref());
+                let to_str = conn
+                    .to()
+                    .first()
+                    .map_or_else(String::new, ToString::to_string);
+                let (to_node, to_port) = split_route(&to_str);
+                self.status = format!(
+                    "Connection: {} -> {}",
+                    file_ops::format_endpoint(&from_node, &from_port),
+                    file_ops::format_endpoint(&to_node, &to_port),
+                );
+            }
+        } else {
+            self.status = String::from("Ready");
+        }
+    }
+
+    fn handle_connection_deleted(&mut self, idx: usize) {
+        if idx < self.flow_definition.connections.len() {
+            let connection = self.flow_definition.connections.remove(idx);
+            self.history.record(EditAction::DeleteConnection {
+                index: idx,
+                connection,
+            });
+            self.selected_connection = None;
+            self.canvas_state.request_redraw();
+            let nc = self.flow_definition.process_refs.len();
+            let ec = self.flow_definition.connections.len();
+            self.status = format!("Connection deleted - {nc} nodes, {ec} connections");
+        }
+    }
+
+    fn handle_initializer_edit(&mut self, node_idx: usize, port_name: String) {
+        let (init_type, value_text) = self
+            .flow_definition
+            .process_refs
+            .get(node_idx)
+            .and_then(|pr| pr.initializations.get(&port_name))
+            .map_or_else(
+                || ("none".to_string(), String::new()),
+                |init| match init {
+                    InputInitializer::Once(v) => (
+                        "once".to_string(),
+                        serde_json::to_string(v).unwrap_or_default(),
+                    ),
+                    InputInitializer::Always(v) => (
+                        "always".to_string(),
+                        serde_json::to_string(v).unwrap_or_default(),
+                    ),
+                },
+            );
+
+        self.initializer_editor = Some(InitializerEditor {
+            node_index: node_idx,
+            port_name,
+            init_type,
+            value_text,
+        });
     }
 
     pub(crate) fn handle_view_message(&mut self, msg: &ViewMessage) {
@@ -1499,6 +1536,459 @@ fn resize_cursor(handle: ResizeHandle) -> mouse::Interaction {
     }
 }
 
+fn handle_delete_key(state: &mut CanvasInteractionState) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some(sel_conn) = state.selected_connection {
+        state.selected_connection = None;
+        return Some(
+            canvas::Action::publish(CanvasMessage::ConnectionDeleted(sel_conn)).and_capture(),
+        );
+    }
+    if let Some(sel_idx) = state.selected_node {
+        state.selected_node = None;
+        return Some(canvas::Action::publish(CanvasMessage::Deleted(sel_idx)).and_capture());
+    }
+    None
+}
+
+fn try_start_connection(
+    canvas: &FlowCanvas<'_>,
+    state: &mut CanvasInteractionState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    let (node_idx, port_name, is_output) =
+        hit_test_port(&canvas.nodes, cursor_position, zoom, offset)?;
+    let node = canvas.nodes.get(node_idx)?;
+    let port_world_pos = if is_output {
+        let port_idx = node
+            .outputs()
+            .iter()
+            .position(|p| p.name() == &port_name)
+            .unwrap_or(0);
+        node.output_port_position(port_idx)
+    } else {
+        let port_idx = node
+            .inputs()
+            .iter()
+            .position(|p| p.name() == &port_name)
+            .unwrap_or(0);
+        node.input_port_position(port_idx)
+    };
+    state.connecting = Some(ConnectingState {
+        from_node: node.alias().to_string(),
+        from_port: port_name,
+        from_output: is_output,
+        start_pos: port_world_pos,
+        current_screen_pos: cursor_position,
+    });
+    Some(canvas::Action::request_redraw().and_capture())
+}
+
+fn handle_left_press(
+    canvas: &FlowCanvas<'_>,
+    state: &mut CanvasInteractionState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+    world_pos: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some(sel_idx) = state.selected_node {
+        if let Some(sel_node) = canvas.nodes.get(sel_idx) {
+            if let Some((_idx, handle)) =
+                hit_test_resize_handle(sel_node, sel_idx, cursor_position, zoom, offset)
+            {
+                state.resizing = Some(ResizeState {
+                    node_index: sel_idx,
+                    handle,
+                    start_x: world_pos.x,
+                    start_y: world_pos.y,
+                    start_node_x: sel_node.x(),
+                    start_node_y: sel_node.y(),
+                    start_width: sel_node.width(),
+                    start_height: sel_node.height(),
+                });
+                return Some(canvas::Action::request_redraw().and_capture());
+            }
+        }
+    }
+
+    let on_a_port = hit_test_port(&canvas.nodes, cursor_position, zoom, offset).is_some();
+    if !on_a_port {
+        if let Some(conn_idx) = hit_test_connection(
+            canvas.connections,
+            &canvas.nodes,
+            canvas.flow_inputs,
+            canvas.flow_outputs,
+            cursor_position,
+            zoom,
+            offset,
+        ) {
+            state.selected_connection = Some(conn_idx);
+            state.selected_node = None;
+            state.dragging = None;
+            return Some(
+                canvas::Action::publish(CanvasMessage::ConnectionSelected(Some(conn_idx)))
+                    .and_capture(),
+            );
+        }
+    }
+
+    if let Some(action) = try_start_connection(canvas, state, cursor_position, zoom, offset) {
+        return Some(action);
+    }
+
+    if let Some(idx) = hit_test_open_icon(&canvas.nodes, world_pos) {
+        return Some(canvas::Action::publish(CanvasMessage::OpenNode(idx)).and_capture());
+    }
+
+    if let Some(idx) = hit_test_node(&canvas.nodes, world_pos) {
+        let node = canvas.nodes.get(idx)?;
+        state.selected_node = Some(idx);
+        state.selected_connection = None;
+        state.dragging = Some(DragState {
+            node_index: idx,
+            offset_x: world_pos.x - node.x(),
+            offset_y: world_pos.y - node.y(),
+            start_x: node.x(),
+            start_y: node.y(),
+        });
+        Some(canvas::Action::publish(CanvasMessage::Selected(Some(idx))).and_capture())
+    } else {
+        state.selected_node = None;
+        state.selected_connection = None;
+        state.dragging = None;
+        Some(canvas::Action::publish(CanvasMessage::Selected(None)).and_capture())
+    }
+}
+
+fn handle_right_press(
+    canvas: &FlowCanvas<'_>,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+    world_pos: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some((node_idx, port_name, is_output)) =
+        hit_test_port(&canvas.nodes, cursor_position, zoom, offset)
+    {
+        if !is_output {
+            return Some(
+                canvas::Action::publish(CanvasMessage::InitializerEdit(node_idx, port_name))
+                    .and_capture(),
+            );
+        }
+    }
+    if hit_test_node(&canvas.nodes, world_pos).is_none() {
+        return Some(
+            canvas::Action::publish(CanvasMessage::ContextMenu(
+                cursor_position.x,
+                cursor_position.y,
+            ))
+            .and_capture(),
+        );
+    }
+    None
+}
+
+fn handle_cursor_moved(
+    canvas: &FlowCanvas<'_>,
+    state: &mut CanvasInteractionState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+    world_pos: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some(ref mut connecting) = state.connecting {
+        connecting.current_screen_pos = cursor_position;
+        return Some(canvas::Action::request_redraw().and_capture());
+    }
+    if let Some(ref resize) = state.resizing {
+        return Some(compute_resize(resize, world_pos));
+    }
+    if let Some(ref pan) = state.panning {
+        let dx = (cursor_position.x - pan.last_screen_pos.x) / zoom;
+        let dy = (cursor_position.y - pan.last_screen_pos.y) / zoom;
+        state.panning = Some(PanState {
+            last_screen_pos: cursor_position,
+        });
+        return Some(canvas::Action::publish(CanvasMessage::Pan(dx, dy)).and_capture());
+    }
+    if let Some(ref drag) = state.dragging {
+        let new_x = world_pos.x - drag.offset_x;
+        let new_y = world_pos.y - drag.offset_y;
+        return Some(
+            canvas::Action::publish(CanvasMessage::Moved(drag.node_index, new_x, new_y))
+                .and_capture(),
+        );
+    }
+
+    handle_hover(canvas, state, cursor_position, zoom, offset, world_pos)
+}
+
+fn compute_resize(resize: &ResizeState, world_pos: Point) -> canvas::Action<CanvasMessage> {
+    let dx = world_pos.x - resize.start_x;
+    let dy = world_pos.y - resize.start_y;
+    let (mut new_x, mut new_y, mut new_w, mut new_h) = (
+        resize.start_node_x,
+        resize.start_node_y,
+        resize.start_width,
+        resize.start_height,
+    );
+    match resize.handle {
+        ResizeHandle::TopLeft => {
+            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
+            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
+            new_x = resize.start_node_x + resize.start_width - new_w;
+            new_y = resize.start_node_y + resize.start_height - new_h;
+        }
+        ResizeHandle::Top => {
+            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
+            new_y = resize.start_node_y + resize.start_height - new_h;
+        }
+        ResizeHandle::TopRight => {
+            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
+            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
+            new_y = resize.start_node_y + resize.start_height - new_h;
+        }
+        ResizeHandle::Left => {
+            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
+            new_x = resize.start_node_x + resize.start_width - new_w;
+        }
+        ResizeHandle::Right => {
+            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
+        }
+        ResizeHandle::BottomLeft => {
+            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
+            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
+            new_x = resize.start_node_x + resize.start_width - new_w;
+        }
+        ResizeHandle::Bottom => {
+            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
+        }
+        ResizeHandle::BottomRight => {
+            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
+            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
+        }
+    }
+    canvas::Action::publish(CanvasMessage::Resized(
+        resize.node_index,
+        new_x,
+        new_y,
+        new_w,
+        new_h,
+    ))
+    .and_capture()
+}
+
+fn handle_hover(
+    canvas: &FlowCanvas<'_>,
+    state: &mut CanvasInteractionState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+    world_pos: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some((node_idx, port_name, is_output)) =
+        hit_test_port(&canvas.nodes, cursor_position, zoom, offset)
+    {
+        if let Some(node) = canvas.nodes.get(node_idx) {
+            let ports = if is_output {
+                node.outputs()
+            } else {
+                node.inputs()
+            };
+            let type_text = ports.iter().find(|p| p.name() == &port_name).map_or_else(
+                || port_name.clone(),
+                |p| {
+                    if p.datatypes().is_empty() {
+                        format!("{port_name}: (any)")
+                    } else {
+                        format!(
+                            "{port_name}: {}",
+                            p.datatypes()
+                                .iter()
+                                .map(ToString::to_string)
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    }
+                },
+            );
+            state.hover_node = None;
+            return Some(canvas::Action::publish(CanvasMessage::HoverChanged(Some(
+                crate::window_state::Tooltip {
+                    text: type_text,
+                    x: cursor_position.x,
+                    y: cursor_position.y - 20.0,
+                },
+            ))));
+        }
+    }
+
+    let new_hover = hit_test_node(&canvas.nodes, world_pos);
+    if new_hover != state.hover_node || new_hover.is_some() {
+        state.hover_node = new_hover;
+        let tooltip_data = new_hover
+            .and_then(|idx| canvas.nodes.get(idx))
+            .and_then(|n| {
+                let bottom_center = transform_point(
+                    Point::new(n.x() + n.width() / 2.0, n.y() + n.height()),
+                    zoom,
+                    offset,
+                );
+                if n.is_in_source_text_zone(world_pos) {
+                    Some(crate::window_state::Tooltip {
+                        text: n.source().to_string(),
+                        x: bottom_center.x,
+                        y: bottom_center.y,
+                    })
+                } else if !n.description().is_empty() {
+                    Some(crate::window_state::Tooltip {
+                        text: n.description(),
+                        x: bottom_center.x,
+                        y: bottom_center.y,
+                    })
+                } else {
+                    None
+                }
+            });
+        return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
+            tooltip_data,
+        )));
+    }
+    None
+}
+
+fn handle_left_release(
+    canvas: &FlowCanvas<'_>,
+    state: &mut CanvasInteractionState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some(connecting) = state.connecting.take() {
+        return finish_connecting(canvas, &connecting, cursor_position, zoom, offset);
+    }
+    if let Some(resize) = state.resizing.take() {
+        if let Some(node) = canvas.nodes.get(resize.node_index) {
+            return Some(
+                canvas::Action::publish(CanvasMessage::ResizeCompleted(
+                    resize.node_index,
+                    resize.start_node_x,
+                    resize.start_node_y,
+                    resize.start_width,
+                    resize.start_height,
+                    node.x(),
+                    node.y(),
+                    node.width(),
+                    node.height(),
+                ))
+                .and_capture(),
+            );
+        }
+        Some(canvas::Action::request_redraw().and_capture())
+    } else if let Some(drag) = state.dragging.take() {
+        if let Some(node) = canvas.nodes.get(drag.node_index) {
+            return Some(
+                canvas::Action::publish(CanvasMessage::MoveCompleted(
+                    drag.node_index,
+                    drag.start_x,
+                    drag.start_y,
+                    node.x(),
+                    node.y(),
+                ))
+                .and_capture(),
+            );
+        }
+        Some(canvas::Action::request_redraw().and_capture())
+    } else {
+        None
+    }
+}
+
+fn finish_connecting(
+    canvas: &FlowCanvas<'_>,
+    connecting: &ConnectingState,
+    cursor_position: Point,
+    zoom: f32,
+    offset: Point,
+) -> Option<canvas::Action<CanvasMessage>> {
+    if let Some((target_idx, target_port, target_is_output)) =
+        hit_test_port(&canvas.nodes, cursor_position, zoom, offset)
+    {
+        if connecting.from_output != target_is_output {
+            if let Some(target_node) = canvas.nodes.get(target_idx) {
+                let source_node = canvas
+                    .nodes
+                    .iter()
+                    .find(|n| n.alias() == connecting.from_node);
+                let types_ok = check_port_type_compatibility(
+                    source_node,
+                    &connecting.from_port,
+                    connecting.from_output,
+                    target_node,
+                    &target_port,
+                    target_is_output,
+                );
+
+                if types_ok {
+                    let (from_node, from_port, to_node, to_port) = if connecting.from_output {
+                        (
+                            connecting.from_node.clone(),
+                            connecting.from_port.clone(),
+                            target_node.alias().to_string(),
+                            target_port,
+                        )
+                    } else {
+                        (
+                            target_node.alias().to_string(),
+                            target_port,
+                            connecting.from_node.clone(),
+                            connecting.from_port.clone(),
+                        )
+                    };
+                    return Some(
+                        canvas::Action::publish(CanvasMessage::ConnectionCreated {
+                            from_node,
+                            from_port,
+                            to_node,
+                            to_port,
+                        })
+                        .and_capture(),
+                    );
+                }
+            }
+        }
+    }
+    Some(canvas::Action::request_redraw().and_capture())
+}
+
+fn handle_scroll(
+    state: &CanvasInteractionState,
+    zoom: f32,
+    delta: &mouse::ScrollDelta,
+) -> Option<canvas::Action<CanvasMessage>> {
+    let (dx, dy) = match *delta {
+        mouse::ScrollDelta::Lines { x, y } => (x * SCROLL_SPEED, y * SCROLL_SPEED),
+        mouse::ScrollDelta::Pixels { x, y } => (x, y),
+    };
+
+    if state.modifiers.command() {
+        if dy > 0.0 {
+            Some(canvas::Action::publish(CanvasMessage::ZoomBy(ZOOM_STEP)).and_capture())
+        } else if dy < 0.0 {
+            Some(canvas::Action::publish(CanvasMessage::ZoomBy(1.0 / ZOOM_STEP)).and_capture())
+        } else {
+            None
+        }
+    } else {
+        let pan_x = dx / zoom;
+        let pan_y = dy / zoom;
+        Some(canvas::Action::publish(CanvasMessage::Pan(pan_x, pan_y)).and_capture())
+    }
+}
+
 impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
     type State = CanvasInteractionState;
 
@@ -1509,7 +1999,6 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Option<canvas::Action<CanvasMessage>> {
-        // Trigger auto-fit when pending or when auto-fit is enabled and bounds changed
         let bounds_changed = state.last_bounds.is_none_or(|last| {
             (last.width - bounds.width).abs() > 1.0 || (last.height - bounds.height).abs() > 1.0
         });
@@ -1521,8 +2010,6 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             );
         }
 
-        // Handle keyboard events before cursor position check — keyboard events
-        // should work even when the cursor is off-canvas
         match event {
             Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
                 state.modifiers = *modifiers;
@@ -1532,23 +2019,7 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                 key:
                     keyboard::Key::Named(keyboard::key::Named::Delete | keyboard::key::Named::Backspace),
                 ..
-            }) => {
-                if let Some(sel_conn) = state.selected_connection {
-                    state.selected_connection = None;
-                    return Some(
-                        canvas::Action::publish(CanvasMessage::ConnectionDeleted(sel_conn))
-                            .and_capture(),
-                    );
-                }
-                if let Some(sel_idx) = state.selected_node {
-                    state.selected_node = None;
-                    return Some(
-                        canvas::Action::publish(CanvasMessage::Deleted(sel_idx)).and_capture(),
-                    );
-                }
-                return None;
-            }
-            // Clear stuck drag/resize/connect states when mouse released off-canvas
+            }) => return handle_delete_key(state),
             Event::Mouse(mouse::Event::ButtonReleased(_))
                 if cursor.position_in(bounds).is_none() =>
             {
@@ -1567,398 +2038,24 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         let world_pos = screen_to_world(cursor_position, zoom, offset);
 
         match event {
-            // Left mouse button pressed — check resize handles, ports, connections, nodes, or deselect
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
-                // 1. Check if cursor is on a resize handle of the selected node
-                if let Some(sel_idx) = state.selected_node {
-                    if let Some(sel_node) = self.nodes.get(sel_idx) {
-                        if let Some((_idx, handle)) =
-                            hit_test_resize_handle(sel_node, sel_idx, cursor_position, zoom, offset)
-                        {
-                            state.resizing = Some(ResizeState {
-                                node_index: sel_idx,
-                                handle,
-                                start_x: world_pos.x,
-                                start_y: world_pos.y,
-                                start_node_x: sel_node.x(),
-                                start_node_y: sel_node.y(),
-                                start_width: sel_node.width(),
-                                start_height: sel_node.height(),
-                            });
-                            return Some(canvas::Action::request_redraw().and_capture());
-                        }
-                    }
-                }
-
-                // 2. Check if cursor is near a connection line (but NOT on a port) — select it
-                let on_a_port = hit_test_port(&self.nodes, cursor_position, zoom, offset).is_some();
-                if !on_a_port {
-                    if let Some(conn_idx) = hit_test_connection(
-                        self.connections,
-                        &self.nodes,
-                        self.flow_inputs,
-                        self.flow_outputs,
-                        cursor_position,
-                        zoom,
-                        offset,
-                    ) {
-                        state.selected_connection = Some(conn_idx);
-                        state.selected_node = None;
-                        state.dragging = None;
-                        return Some(
-                            canvas::Action::publish(CanvasMessage::ConnectionSelected(Some(
-                                conn_idx,
-                            )))
-                            .and_capture(),
-                        );
-                    }
-                }
-
-                // 3. Check if cursor is on a port — start connection drag
-                if let Some((node_idx, port_name, is_output)) =
-                    hit_test_port(&self.nodes, cursor_position, zoom, offset)
-                {
-                    if let Some(node) = self.nodes.get(node_idx) {
-                        let port_world_pos = if is_output {
-                            let port_idx = node
-                                .outputs()
-                                .iter()
-                                .position(|p| p.name() == &port_name)
-                                .unwrap_or(0);
-                            node.output_port_position(port_idx)
-                        } else {
-                            let port_idx = node
-                                .inputs()
-                                .iter()
-                                .position(|p| p.name() == &port_name)
-                                .unwrap_or(0);
-                            node.input_port_position(port_idx)
-                        };
-                        state.connecting = Some(ConnectingState {
-                            from_node: node.alias().to_string(),
-                            from_port: port_name,
-                            from_output: is_output,
-                            start_pos: port_world_pos,
-                            current_screen_pos: cursor_position,
-                        });
-                        return Some(canvas::Action::request_redraw().and_capture());
-                    }
-                }
-
-                // 4. Check if cursor is on an openable node's open icon
-                if let Some(idx) = hit_test_open_icon(&self.nodes, world_pos) {
-                    return Some(
-                        canvas::Action::publish(CanvasMessage::OpenNode(idx)).and_capture(),
-                    );
-                }
-
-                // 6. Check if cursor is on a node — select/drag it
-                if let Some(idx) = hit_test_node(&self.nodes, world_pos) {
-                    let node = self.nodes.get(idx)?;
-                    state.selected_node = Some(idx);
-                    state.selected_connection = None;
-                    state.dragging = Some(DragState {
-                        node_index: idx,
-                        offset_x: world_pos.x - node.x(),
-                        offset_y: world_pos.y - node.y(),
-                        start_x: node.x(),
-                        start_y: node.y(),
-                    });
-                    Some(canvas::Action::publish(CanvasMessage::Selected(Some(idx))).and_capture())
-                } else {
-                    // 7. Clicked empty canvas — deselect all
-                    state.selected_node = None;
-                    state.selected_connection = None;
-                    state.dragging = None;
-                    Some(canvas::Action::publish(CanvasMessage::Selected(None)).and_capture())
-                }
+                handle_left_press(self, state, cursor_position, zoom, offset, world_pos)
             }
-
-            // Right mouse button pressed — edit initializer on input port, or context menu
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
-                if let Some((node_idx, port_name, is_output)) =
-                    hit_test_port(&self.nodes, cursor_position, zoom, offset)
-                {
-                    if !is_output {
-                        return Some(
-                            canvas::Action::publish(CanvasMessage::InitializerEdit(
-                                node_idx, port_name,
-                            ))
-                            .and_capture(),
-                        );
-                    }
-                }
-                // Right-click on empty canvas — show context menu
-                if hit_test_node(&self.nodes, world_pos).is_none() {
-                    return Some(
-                        canvas::Action::publish(CanvasMessage::ContextMenu(
-                            cursor_position.x,
-                            cursor_position.y,
-                        ))
-                        .and_capture(),
-                    );
-                }
-                None
+                handle_right_press(self, cursor_position, zoom, offset, world_pos)
             }
-
-            // Middle mouse button pressed — start panning
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Middle)) => {
                 state.panning = Some(PanState {
                     last_screen_pos: cursor_position,
                 });
                 Some(canvas::Action::request_redraw().and_capture())
             }
-
-            // Mouse moved — handle connecting, resize, drag, or pan
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
-                if let Some(ref mut connecting) = state.connecting {
-                    connecting.current_screen_pos = cursor_position;
-                    return Some(canvas::Action::request_redraw().and_capture());
-                }
-                if let Some(ref resize) = state.resizing {
-                    let dx = world_pos.x - resize.start_x;
-                    let dy = world_pos.y - resize.start_y;
-                    let (mut new_x, mut new_y, mut new_w, mut new_h) = (
-                        resize.start_node_x,
-                        resize.start_node_y,
-                        resize.start_width,
-                        resize.start_height,
-                    );
-                    match resize.handle {
-                        ResizeHandle::TopLeft => {
-                            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
-                            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
-                            // Position moves by the amount size didn't change due to clamping
-                            new_x = resize.start_node_x + resize.start_width - new_w;
-                            new_y = resize.start_node_y + resize.start_height - new_h;
-                        }
-                        ResizeHandle::Top => {
-                            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
-                            new_y = resize.start_node_y + resize.start_height - new_h;
-                        }
-                        ResizeHandle::TopRight => {
-                            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
-                            new_h = (resize.start_height - dy).max(MIN_NODE_HEIGHT);
-                            new_y = resize.start_node_y + resize.start_height - new_h;
-                        }
-                        ResizeHandle::Left => {
-                            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
-                            new_x = resize.start_node_x + resize.start_width - new_w;
-                        }
-                        ResizeHandle::Right => {
-                            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
-                        }
-                        ResizeHandle::BottomLeft => {
-                            new_w = (resize.start_width - dx).max(MIN_NODE_WIDTH);
-                            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
-                            new_x = resize.start_node_x + resize.start_width - new_w;
-                        }
-                        ResizeHandle::Bottom => {
-                            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
-                        }
-                        ResizeHandle::BottomRight => {
-                            new_w = (resize.start_width + dx).max(MIN_NODE_WIDTH);
-                            new_h = (resize.start_height + dy).max(MIN_NODE_HEIGHT);
-                        }
-                    }
-                    let idx = resize.node_index;
-                    Some(
-                        canvas::Action::publish(CanvasMessage::Resized(
-                            idx, new_x, new_y, new_w, new_h,
-                        ))
-                        .and_capture(),
-                    )
-                } else if let Some(ref pan) = state.panning {
-                    // Pan: adjust scroll_offset based on screen-space delta
-                    let dx = (cursor_position.x - pan.last_screen_pos.x) / zoom;
-                    let dy = (cursor_position.y - pan.last_screen_pos.y) / zoom;
-                    state.panning = Some(PanState {
-                        last_screen_pos: cursor_position,
-                    });
-                    Some(canvas::Action::publish(CanvasMessage::Pan(dx, dy)).and_capture())
-                } else if let Some(ref drag) = state.dragging {
-                    let new_x = world_pos.x - drag.offset_x;
-                    let new_y = world_pos.y - drag.offset_y;
-                    Some(
-                        canvas::Action::publish(CanvasMessage::Moved(
-                            drag.node_index,
-                            new_x,
-                            new_y,
-                        ))
-                        .and_capture(),
-                    )
-                } else {
-                    // Check port hover for type tooltip
-                    if let Some((node_idx, port_name, is_output)) =
-                        hit_test_port(&self.nodes, cursor_position, zoom, offset)
-                    {
-                        if let Some(node) = self.nodes.get(node_idx) {
-                            let ports = if is_output {
-                                node.outputs()
-                            } else {
-                                node.inputs()
-                            };
-                            let type_text =
-                                ports.iter().find(|p| p.name() == &port_name).map_or_else(
-                                    || port_name.clone(),
-                                    |p| {
-                                        if p.datatypes().is_empty() {
-                                            format!("{port_name}: (any)")
-                                        } else {
-                                            format!(
-                                                "{port_name}: {}",
-                                                p.datatypes()
-                                                    .iter()
-                                                    .map(ToString::to_string)
-                                                    .collect::<Vec<_>>()
-                                                    .join(", ")
-                                            )
-                                        }
-                                    },
-                                );
-                            state.hover_node = None;
-                            return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
-                                Some(crate::window_state::Tooltip {
-                                    text: type_text,
-                                    x: cursor_position.x,
-                                    y: cursor_position.y - 20.0,
-                                }),
-                            )));
-                        }
-                    }
-
-                    // Track hover for two-zone node tooltip
-                    let new_hover = hit_test_node(&self.nodes, world_pos);
-                    if new_hover != state.hover_node || new_hover.is_some() {
-                        state.hover_node = new_hover;
-                        let tooltip_data =
-                            new_hover.and_then(|idx| self.nodes.get(idx)).and_then(|n| {
-                                let bottom_center = transform_point(
-                                    Point::new(n.x() + n.width() / 2.0, n.y() + n.height()),
-                                    zoom,
-                                    offset,
-                                );
-                                if n.is_in_source_text_zone(world_pos) {
-                                    Some(crate::window_state::Tooltip {
-                                        text: n.source().to_string(),
-                                        x: bottom_center.x,
-                                        y: bottom_center.y,
-                                    })
-                                } else if !n.description().is_empty() {
-                                    Some(crate::window_state::Tooltip {
-                                        text: n.description(),
-                                        x: bottom_center.x,
-                                        y: bottom_center.y,
-                                    })
-                                } else {
-                                    None
-                                }
-                            });
-                        return Some(canvas::Action::publish(CanvasMessage::HoverChanged(
-                            tooltip_data,
-                        )));
-                    }
-                    None
-                }
+                handle_cursor_moved(self, state, cursor_position, zoom, offset, world_pos)
             }
-
-            // Left mouse button released — stop connecting, dragging, or resizing
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
-                if let Some(connecting) = state.connecting.take() {
-                    // Check if cursor is on a compatible port
-                    if let Some((target_idx, target_port, target_is_output)) =
-                        hit_test_port(&self.nodes, cursor_position, zoom, offset)
-                    {
-                        // Must connect output→input or input→output
-                        if connecting.from_output != target_is_output {
-                            if let Some(target_node) = self.nodes.get(target_idx) {
-                                // Check type compatibility before creating connection
-                                let source_node = self
-                                    .nodes
-                                    .iter()
-                                    .find(|n| n.alias() == connecting.from_node);
-                                let types_ok = check_port_type_compatibility(
-                                    source_node,
-                                    &connecting.from_port,
-                                    connecting.from_output,
-                                    target_node,
-                                    &target_port,
-                                    target_is_output,
-                                );
-
-                                if types_ok {
-                                    let (from_node, from_port, to_node, to_port) =
-                                        if connecting.from_output {
-                                            (
-                                                connecting.from_node,
-                                                connecting.from_port,
-                                                target_node.alias().to_string(),
-                                                target_port,
-                                            )
-                                        } else {
-                                            (
-                                                target_node.alias().to_string(),
-                                                target_port,
-                                                connecting.from_node,
-                                                connecting.from_port,
-                                            )
-                                        };
-                                    return Some(
-                                        canvas::Action::publish(CanvasMessage::ConnectionCreated {
-                                            from_node,
-                                            from_port,
-                                            to_node,
-                                            to_port,
-                                        })
-                                        .and_capture(),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    // Released on empty area or incompatible port — cancel
-                    return Some(canvas::Action::request_redraw().and_capture());
-                }
-                if let Some(resize) = state.resizing.take() {
-                    // Emit resize completed with old and new geometry
-                    if let Some(node) = self.nodes.get(resize.node_index) {
-                        return Some(
-                            canvas::Action::publish(CanvasMessage::ResizeCompleted(
-                                resize.node_index,
-                                resize.start_node_x,
-                                resize.start_node_y,
-                                resize.start_width,
-                                resize.start_height,
-                                node.x(),
-                                node.y(),
-                                node.width(),
-                                node.height(),
-                            ))
-                            .and_capture(),
-                        );
-                    }
-                    Some(canvas::Action::request_redraw().and_capture())
-                } else if let Some(drag) = state.dragging.take() {
-                    // Emit move completed with old and new position
-                    if let Some(node) = self.nodes.get(drag.node_index) {
-                        return Some(
-                            canvas::Action::publish(CanvasMessage::MoveCompleted(
-                                drag.node_index,
-                                drag.start_x,
-                                drag.start_y,
-                                node.x(),
-                                node.y(),
-                            ))
-                            .and_capture(),
-                        );
-                    }
-                    Some(canvas::Action::request_redraw().and_capture())
-                } else {
-                    None
-                }
+                handle_left_release(self, state, cursor_position, zoom, offset)
             }
-
-            // Middle mouse button released — stop panning
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Middle)) => {
                 if state.panning.is_some() {
                     state.panning = None;
@@ -1967,36 +2064,9 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
                     None
                 }
             }
-
-            // Scroll wheel: pan or zoom depending on modifier keys
             Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                let (dx, dy) = match *delta {
-                    mouse::ScrollDelta::Lines { x, y } => (x * SCROLL_SPEED, y * SCROLL_SPEED),
-                    mouse::ScrollDelta::Pixels { x, y } => (x, y),
-                };
-
-                if state.modifiers.command() {
-                    // Zoom: positive dy = zoom in, negative = zoom out
-                    if dy > 0.0 {
-                        Some(
-                            canvas::Action::publish(CanvasMessage::ZoomBy(ZOOM_STEP)).and_capture(),
-                        )
-                    } else if dy < 0.0 {
-                        Some(
-                            canvas::Action::publish(CanvasMessage::ZoomBy(1.0 / ZOOM_STEP))
-                                .and_capture(),
-                        )
-                    } else {
-                        None
-                    }
-                } else {
-                    // Pan
-                    let pan_x = dx / zoom;
-                    let pan_y = dy / zoom;
-                    Some(canvas::Action::publish(CanvasMessage::Pan(pan_x, pan_y)).and_capture())
-                }
+                handle_scroll(state, zoom, delta)
             }
-
             _ => None,
         }
     }
@@ -2037,8 +2107,6 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
             );
         });
 
-        // Build an overlay for selection highlights, connection previews, tooltips, etc.
-        // (Selected connections are drawn inline by draw_edges, not as an overlay)
         let needs_overlay = state.selected_node.is_some()
             || state.connecting.is_some()
             || state.hover_node.is_some();
@@ -2046,102 +2114,12 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         if needs_overlay {
             let mut overlay = Frame::new(renderer, bounds.size());
 
-            // Draw selected node highlight and resize handles
             if let Some(selected_idx) = state.selected_node {
-                if let Some(node) = self.nodes.get(selected_idx) {
-                    let screen_pos = transform_point(Point::new(node.x(), node.y()), zoom, offset);
-                    let screen_size = Size::new(node.width() * zoom, node.height() * zoom);
-                    let selection_color = Color::from_rgb(1.0, 0.85, 0.0);
-                    let highlight = Path::new(|builder| {
-                        rounded_rect(builder, screen_pos, screen_size, CORNER_RADIUS * zoom);
-                    });
-                    overlay.stroke(
-                        &highlight,
-                        Stroke::default()
-                            .with_width(4.0)
-                            .with_color(selection_color),
-                    );
-
-                    // Draw resize handles at the 8 positions
-                    for (_handle, world_pt) in &node.resize_handle_positions() {
-                        let sp = transform_point(*world_pt, zoom, offset);
-                        let handle_rect = Path::rectangle(
-                            Point::new(sp.x - RESIZE_HANDLE_HALF, sp.y - RESIZE_HANDLE_HALF),
-                            Size::new(RESIZE_HANDLE_HALF * 2.0, RESIZE_HANDLE_HALF * 2.0),
-                        );
-                        overlay.fill(&handle_rect, selection_color);
-                        overlay.stroke(
-                            &handle_rect,
-                            Stroke::default()
-                                .with_width(1.0)
-                                .with_color(Color::from_rgb(0.3, 0.3, 0.0)),
-                        );
-                    }
-                }
+                draw_selection_highlight(&mut overlay, &self.nodes, selected_idx, zoom, offset);
             }
 
-            // Draw connection preview (bezier from start port to cursor)
             if let Some(ref connecting) = state.connecting {
-                let start_screen = transform_point(connecting.start_pos, zoom, offset);
-                let end_screen = connecting.current_screen_pos;
-
-                let preview_color = Color::from_rgb(0.3, 0.9, 0.3);
-                let dx_ctrl = (end_screen.x - start_screen.x).abs().max(60.0 * zoom) * 0.5;
-
-                // Direction of control points depends on whether we started from output or input
-                let (ctrl1, ctrl2) = if connecting.from_output {
-                    (
-                        Point::new(start_screen.x + dx_ctrl, start_screen.y),
-                        Point::new(end_screen.x - dx_ctrl, end_screen.y),
-                    )
-                } else {
-                    (
-                        Point::new(start_screen.x - dx_ctrl, start_screen.y),
-                        Point::new(end_screen.x + dx_ctrl, end_screen.y),
-                    )
-                };
-
-                let preview_path = Path::new(|builder| {
-                    builder.move_to(start_screen);
-                    builder.bezier_curve_to(ctrl1, ctrl2, end_screen);
-                });
-                overlay.stroke(
-                    &preview_path,
-                    Stroke::default()
-                        .with_width(2.0 * zoom)
-                        .with_color(preview_color),
-                );
-
-                // Highlight the target port if hovering over a compatible one
-                if let Some((target_idx, target_port, target_is_output)) =
-                    hit_test_port(&self.nodes, end_screen, zoom, offset)
-                {
-                    if connecting.from_output != target_is_output {
-                        if let Some(target_node) = self.nodes.get(target_idx) {
-                            let port_world = if target_is_output {
-                                let pidx = target_node
-                                    .outputs()
-                                    .iter()
-                                    .position(|p| p.name() == &target_port)
-                                    .unwrap_or(0);
-                                target_node.output_port_position(pidx)
-                            } else {
-                                let pidx = target_node
-                                    .inputs()
-                                    .iter()
-                                    .position(|p| p.name() == &target_port)
-                                    .unwrap_or(0);
-                                target_node.input_port_position(pidx)
-                            };
-                            let port_screen = transform_point(port_world, zoom, offset);
-                            let highlight_circle = Path::circle(port_screen, PORT_HIT_RADIUS);
-                            overlay.stroke(
-                                &highlight_circle,
-                                Stroke::default().with_width(2.0).with_color(preview_color),
-                            );
-                        }
-                    }
-                }
+                draw_connection_preview(&mut overlay, &self.nodes, connecting, zoom, offset);
             }
 
             return vec![content, overlay.into_geometry()];
@@ -2206,6 +2184,111 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
         }
 
         mouse::Interaction::default()
+    }
+}
+
+fn draw_selection_highlight(
+    overlay: &mut Frame,
+    nodes: &[NodeLayout],
+    selected_idx: usize,
+    zoom: f32,
+    offset: Point,
+) {
+    if let Some(node) = nodes.get(selected_idx) {
+        let screen_pos = transform_point(Point::new(node.x(), node.y()), zoom, offset);
+        let screen_size = Size::new(node.width() * zoom, node.height() * zoom);
+        let selection_color = Color::from_rgb(1.0, 0.85, 0.0);
+        let highlight = Path::new(|builder| {
+            rounded_rect(builder, screen_pos, screen_size, CORNER_RADIUS * zoom);
+        });
+        overlay.stroke(
+            &highlight,
+            Stroke::default()
+                .with_width(4.0)
+                .with_color(selection_color),
+        );
+
+        for (_handle, world_pt) in &node.resize_handle_positions() {
+            let sp = transform_point(*world_pt, zoom, offset);
+            let handle_rect = Path::rectangle(
+                Point::new(sp.x - RESIZE_HANDLE_HALF, sp.y - RESIZE_HANDLE_HALF),
+                Size::new(RESIZE_HANDLE_HALF * 2.0, RESIZE_HANDLE_HALF * 2.0),
+            );
+            overlay.fill(&handle_rect, selection_color);
+            overlay.stroke(
+                &handle_rect,
+                Stroke::default()
+                    .with_width(1.0)
+                    .with_color(Color::from_rgb(0.3, 0.3, 0.0)),
+            );
+        }
+    }
+}
+
+fn draw_connection_preview(
+    overlay: &mut Frame,
+    nodes: &[NodeLayout],
+    connecting: &ConnectingState,
+    zoom: f32,
+    offset: Point,
+) {
+    let start_screen = transform_point(connecting.start_pos, zoom, offset);
+    let end_screen = connecting.current_screen_pos;
+
+    let preview_color = Color::from_rgb(0.3, 0.9, 0.3);
+    let dx_ctrl = (end_screen.x - start_screen.x).abs().max(60.0 * zoom) * 0.5;
+
+    let (ctrl1, ctrl2) = if connecting.from_output {
+        (
+            Point::new(start_screen.x + dx_ctrl, start_screen.y),
+            Point::new(end_screen.x - dx_ctrl, end_screen.y),
+        )
+    } else {
+        (
+            Point::new(start_screen.x - dx_ctrl, start_screen.y),
+            Point::new(end_screen.x + dx_ctrl, end_screen.y),
+        )
+    };
+
+    let preview_path = Path::new(|builder| {
+        builder.move_to(start_screen);
+        builder.bezier_curve_to(ctrl1, ctrl2, end_screen);
+    });
+    overlay.stroke(
+        &preview_path,
+        Stroke::default()
+            .with_width(2.0 * zoom)
+            .with_color(preview_color),
+    );
+
+    if let Some((target_idx, target_port, target_is_output)) =
+        hit_test_port(nodes, end_screen, zoom, offset)
+    {
+        if connecting.from_output != target_is_output {
+            if let Some(target_node) = nodes.get(target_idx) {
+                let port_world = if target_is_output {
+                    let pidx = target_node
+                        .outputs()
+                        .iter()
+                        .position(|p| p.name() == &target_port)
+                        .unwrap_or(0);
+                    target_node.output_port_position(pidx)
+                } else {
+                    let pidx = target_node
+                        .inputs()
+                        .iter()
+                        .position(|p| p.name() == &target_port)
+                        .unwrap_or(0);
+                    target_node.input_port_position(pidx)
+                };
+                let port_screen = transform_point(port_world, zoom, offset);
+                let highlight_circle = Path::circle(port_screen, PORT_HIT_RADIUS);
+                overlay.stroke(
+                    &highlight_circle,
+                    Stroke::default().with_width(2.0).with_color(preview_color),
+                );
+            }
+        }
     }
 }
 
@@ -2416,30 +2499,13 @@ fn draw_nodes(frame: &mut Frame, nodes: &[NodeLayout], zoom: f32, offset: Point)
 /// Draw a rounded bounding box around all subprocess nodes with flow I/O
 /// ports on the box edges and bezier connections to internal nodes.
 #[allow(clippy::too_many_arguments)]
-fn draw_flow_io_ports(
-    frame: &mut Frame,
-    flow_name: &str,
+fn flow_io_bounding_box(
+    nodes: &[NodeLayout],
     flow_inputs: &[IO],
     flow_outputs: &[IO],
-    nodes: &[NodeLayout],
-    connections: &[Connection],
-    is_subflow: bool,
-    selected_connection: Option<usize>,
-    zoom: f32,
-    offset: Point,
-) {
-    use std::f32::consts::PI;
-
-    if !is_subflow {
-        return;
-    }
-
-    let port_radius = 6.0;
-    let font_size = 13.0;
+) -> (f32, f32, f32, f32, f32, f32) {
     let spacing = 28.0;
     let padding = 80.0;
-    let corner = 16.0;
-
     let max_ports = flow_inputs.len().max(flow_outputs.len()).max(1) as f32;
     let default_h = max_ports * spacing + 60.0;
     let (min_x, max_x, min_y, max_y) = if nodes.is_empty() {
@@ -2458,13 +2524,38 @@ fn draw_flow_io_ports(
                 .fold(f32::MIN, f32::max),
         )
     };
-
     let box_x = min_x - padding;
     let box_y = min_y - padding;
     let box_w = (max_x - min_x) + 2.0 * padding;
     let box_h = (max_y - min_y) + 2.0 * padding;
+    let center_y = min_y.midpoint(max_y);
+    (box_x, box_y, box_w, box_h, center_y, spacing)
+}
 
-    // Draw the rounded bounding box
+#[allow(clippy::too_many_arguments)]
+fn draw_flow_io_ports(
+    frame: &mut Frame,
+    flow_name: &str,
+    flow_inputs: &[IO],
+    flow_outputs: &[IO],
+    nodes: &[NodeLayout],
+    connections: &[Connection],
+    is_subflow: bool,
+    selected_connection: Option<usize>,
+    zoom: f32,
+    offset: Point,
+) {
+    if !is_subflow {
+        return;
+    }
+
+    let port_radius = 6.0;
+    let font_size = 13.0;
+    let corner = 16.0;
+
+    let (box_x, box_y, box_w, box_h, center_y, spacing) =
+        flow_io_bounding_box(nodes, flow_inputs, flow_outputs);
+
     let top_left = transform_point(Point::new(box_x, box_y), zoom, offset);
     let size = Size::new(box_w * zoom, box_h * zoom);
     let border_path = Path::new(|builder| {
@@ -2477,7 +2568,6 @@ fn draw_flow_io_ports(
             .with_color(Color::from_rgba(0.6, 0.6, 0.6, 0.5)),
     );
 
-    // Draw flow name at top center of the bounding box
     if !flow_name.is_empty() {
         let name_pos = transform_point(Point::new(box_x + box_w / 2.0, box_y + 8.0), zoom, offset);
         frame.fill_text(CanvasText {
@@ -2490,17 +2580,62 @@ fn draw_flow_io_ports(
         });
     }
 
-    let center_y = min_y.midpoint(max_y);
-    let input_color = Color::from_rgb(0.4, 0.8, 1.0);
-    let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+    let input_positions = draw_flow_input_port_labels(
+        frame,
+        flow_inputs,
+        box_x,
+        center_y,
+        spacing,
+        port_radius,
+        font_size,
+        zoom,
+        offset,
+    );
+    let output_positions = draw_flow_output_port_labels(
+        frame,
+        flow_outputs,
+        box_x + box_w,
+        center_y,
+        spacing,
+        port_radius,
+        font_size,
+        zoom,
+        offset,
+    );
 
-    // Compute and draw flow input ports on the left edge
-    let mut input_positions: HashMap<String, Point> = HashMap::new();
-    let input_start_y = center_y - (flow_inputs.len() as f32 - 1.0) * spacing / 2.0;
+    draw_flow_io_connections(
+        frame,
+        connections,
+        nodes,
+        &input_positions,
+        &output_positions,
+        selected_connection,
+        zoom,
+        offset,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_flow_input_port_labels(
+    frame: &mut Frame,
+    flow_inputs: &[IO],
+    left_x: f32,
+    center_y: f32,
+    spacing: f32,
+    port_radius: f32,
+    font_size: f32,
+    zoom: f32,
+    offset: Point,
+) -> HashMap<String, Point> {
+    use std::f32::consts::PI;
+
+    let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+    let mut positions: HashMap<String, Point> = HashMap::new();
+    let start_y = center_y - (flow_inputs.len() as f32 - 1.0) * spacing / 2.0;
     for (i, input) in flow_inputs.iter().enumerate() {
-        let world_y = input_start_y + i as f32 * spacing;
-        let world_pos = Point::new(box_x, world_y);
-        input_positions.insert(input.name().clone(), world_pos);
+        let world_y = start_y + i as f32 * spacing;
+        let world_pos = Point::new(left_x, world_y);
+        positions.insert(input.name().clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
         let semi = Path::new(|builder| {
@@ -2525,15 +2660,30 @@ fn draw_flow_io_ports(
             ..CanvasText::default()
         });
     }
+    positions
+}
 
-    // Compute and draw flow output ports on the right edge
-    let mut output_positions: HashMap<String, Point> = HashMap::new();
-    let right_x = box_x + box_w;
-    let output_start_y = center_y - (flow_outputs.len() as f32 - 1.0) * spacing / 2.0;
+#[allow(clippy::too_many_arguments)]
+fn draw_flow_output_port_labels(
+    frame: &mut Frame,
+    flow_outputs: &[IO],
+    right_x: f32,
+    center_y: f32,
+    spacing: f32,
+    port_radius: f32,
+    font_size: f32,
+    zoom: f32,
+    offset: Point,
+) -> HashMap<String, Point> {
+    use std::f32::consts::PI;
+
+    let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+    let mut positions: HashMap<String, Point> = HashMap::new();
+    let start_y = center_y - (flow_outputs.len() as f32 - 1.0) * spacing / 2.0;
     for (i, output) in flow_outputs.iter().enumerate() {
-        let world_y = output_start_y + i as f32 * spacing;
+        let world_y = start_y + i as f32 * spacing;
         let world_pos = Point::new(right_x, world_y);
-        output_positions.insert(output.name().clone(), world_pos);
+        positions.insert(output.name().clone(), world_pos);
         let screen_pos = transform_point(world_pos, zoom, offset);
         let scaled_r = port_radius * zoom;
         let semi = Path::new(|builder| {
@@ -2557,8 +2707,20 @@ fn draw_flow_io_ports(
             ..CanvasText::default()
         });
     }
+    positions
+}
 
-    // Draw bezier connections from flow inputs/outputs to internal node ports
+#[allow(clippy::too_many_arguments)]
+fn draw_flow_io_connections(
+    frame: &mut Frame,
+    connections: &[Connection],
+    nodes: &[NodeLayout],
+    input_positions: &HashMap<String, Point>,
+    output_positions: &HashMap<String, Point>,
+    selected_connection: Option<usize>,
+    zoom: f32,
+    offset: Point,
+) {
     let conn_color = Color::from_rgba(0.7, 0.7, 0.7, 0.6);
     let sel_color = Color::from_rgb(1.0, 0.85, 0.0);
     for (conn_idx, conn) in connections.iter().enumerate() {
@@ -3042,87 +3204,104 @@ impl WindowState {
         let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
 
         if let Some(ref tip) = self.tooltip {
-            let tooltip_widget = container(
-                container(Text::new(tip.text.clone()).size(20).color(Color::WHITE))
-                    .padding(8)
-                    .style(|_theme: &Theme| container::Style {
-                        background: Some(iced::Background::Color(Color::from_rgb(
-                            0.12, 0.12, 0.12,
-                        ))),
-                        border: iced::Border {
-                            color: Color::WHITE,
-                            width: 1.0,
-                            radius: 6.0.into(),
-                        },
-                        ..Default::default()
-                    }),
-            )
-            .padding(iced::Padding {
-                top: tip.y + 26.0,
-                right: 0.0,
-                bottom: 0.0,
-                left: (tip.x - 80.0).max(0.0),
-            });
-            canvas_stack.push(tooltip_widget.into());
+            canvas_stack.push(Self::build_tooltip_overlay(tip));
         }
 
-        // Initializer editor dialog overlay
         if let Some(ref editor) = self.initializer_editor {
-            let port_label =
-                if let Some(pref) = self.flow_definition.process_refs.get(editor.node_index) {
-                    let alias = if pref.alias.is_empty() {
-                        derive_short_name(&pref.source)
-                    } else {
-                        pref.alias.clone()
-                    };
-                    format!("{}/{}", alias, editor.port_name)
+            canvas_stack.push(self.build_initializer_dialog(window_id, editor));
+        }
+
+        if let Some(menu_pos) = self.context_menu {
+            canvas_stack.push(Self::build_context_menu(window_id, menu_pos));
+        }
+
+        stack(canvas_stack).into()
+    }
+
+    fn build_tooltip_overlay<'a>(tip: &crate::window_state::Tooltip) -> Element<'a, Message> {
+        container(
+            container(Text::new(tip.text.clone()).size(20).color(Color::WHITE))
+                .padding(8)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Background::Color(Color::from_rgb(0.12, 0.12, 0.12))),
+                    border: iced::Border {
+                        color: Color::WHITE,
+                        width: 1.0,
+                        radius: 6.0.into(),
+                    },
+                    ..Default::default()
+                }),
+        )
+        .padding(iced::Padding {
+            top: tip.y + 26.0,
+            right: 0.0,
+            bottom: 0.0,
+            left: (tip.x - 80.0).max(0.0),
+        })
+        .into()
+    }
+
+    fn build_initializer_dialog<'a>(
+        &self,
+        window_id: window::Id,
+        editor: &InitializerEditor,
+    ) -> Element<'a, Message> {
+        let port_label =
+            if let Some(pref) = self.flow_definition.process_refs.get(editor.node_index) {
+                let alias = if pref.alias.is_empty() {
+                    derive_short_name(&pref.source)
                 } else {
-                    editor.port_name.clone()
+                    pref.alias.clone()
                 };
+                format!("{}/{}", alias, editor.port_name)
+            } else {
+                editor.port_name.clone()
+            };
 
-            let init_types = vec!["none", "once", "always"];
-            let selected: Option<&str> =
-                init_types.iter().find(|&&t| t == editor.init_type).copied();
+        let init_types = vec!["none", "once", "always"];
+        let selected: Option<&str> = init_types.iter().find(|&&t| t == editor.init_type).copied();
 
-            let mut dialog_col = Column::new()
-                .spacing(8)
-                .padding(12)
-                .push(Text::new(format!("Initializer: {port_label}")).size(14))
-                .push(
-                    pick_list(init_types, selected, move |s: &str| {
-                        Message::InitializerTypeChanged(window_id, s.to_string())
-                    })
-                    .text_size(12),
-                );
-
-            if editor.init_type != "none" {
-                dialog_col = dialog_col.push(
-                    text_input("JSON value (e.g. 42, \"hello\", true)", &editor.value_text)
-                        .on_input(move |v| Message::InitializerValueChanged(window_id, v))
-                        .size(12)
-                        .padding(6),
-                );
-            }
-
-            dialog_col = dialog_col.push(
-                Row::new()
-                    .spacing(8)
-                    .push(
-                        button(Text::new("Apply").size(12).center())
-                            .on_press(Message::InitializerApply(window_id))
-                            .style(button::primary)
-                            .padding(6),
-                    )
-                    .push(
-                        button(Text::new("Cancel").size(12).center())
-                            .on_press(Message::InitializerCancel(window_id))
-                            .style(button::secondary)
-                            .padding(6),
-                    ),
+        let mut dialog_col = Column::new()
+            .spacing(8)
+            .padding(12)
+            .push(Text::new(format!("Initializer: {port_label}")).size(14))
+            .push(
+                pick_list(init_types, selected, move |s: &str| {
+                    Message::InitializerTypeChanged(window_id, s.to_string())
+                })
+                .text_size(12),
             );
 
-            let dialog = container(container(dialog_col).width(280).style(|_theme: &Theme| {
-                container::Style {
+        if editor.init_type != "none" {
+            dialog_col = dialog_col.push(
+                text_input("JSON value (e.g. 42, \"hello\", true)", &editor.value_text)
+                    .on_input(move |v| Message::InitializerValueChanged(window_id, v))
+                    .size(12)
+                    .padding(6),
+            );
+        }
+
+        dialog_col = dialog_col.push(
+            Row::new()
+                .spacing(8)
+                .push(
+                    button(Text::new("Apply").size(12).center())
+                        .on_press(Message::InitializerApply(window_id))
+                        .style(button::primary)
+                        .padding(6),
+                )
+                .push(
+                    button(Text::new("Cancel").size(12).center())
+                        .on_press(Message::InitializerCancel(window_id))
+                        .style(button::secondary)
+                        .padding(6),
+                ),
+        );
+
+        container(
+            container(dialog_col)
+                .width(280)
+                .style(|_theme: &Theme| container::Style {
                     background: Some(iced::Background::Color(Color::from_rgb(0.15, 0.15, 0.15))),
                     border: iced::Border {
                         color: Color::from_rgb(0.4, 0.4, 0.4),
@@ -3130,55 +3309,54 @@ impl WindowState {
                         radius: 8.0.into(),
                     },
                     ..Default::default()
-                }
-            }))
-            .center(Fill);
+                }),
+        )
+        .center(Fill)
+        .into()
+    }
 
-            canvas_stack.push(dialog.into());
-        }
+    fn build_context_menu(
+        window_id: window::Id,
+        menu_pos: crate::window_state::MenuPosition,
+    ) -> Element<'static, Message> {
+        let menu = container(
+            Column::new()
+                .spacing(2)
+                .push(
+                    button(Text::new("+ New Sub-flow").size(13))
+                        .on_press(Message::NewSubFlow(window_id))
+                        .style(button::text)
+                        .padding([6, 16])
+                        .width(Fill),
+                )
+                .push(
+                    button(Text::new("+ New Function").size(13))
+                        .on_press(Message::NewFunction(window_id))
+                        .style(button::text)
+                        .padding([6, 16])
+                        .width(Fill),
+                ),
+        )
+        .style(|_theme: &Theme| container::Style {
+            background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
+            border: iced::Border {
+                color: Color::from_rgb(0.4, 0.4, 0.4),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(160)
+        .padding(4);
 
-        // Context menu overlay (right-click on empty canvas)
-        if let Some(menu_pos) = self.context_menu {
-            let menu = container(
-                Column::new()
-                    .spacing(2)
-                    .push(
-                        button(Text::new("+ New Sub-flow").size(13))
-                            .on_press(Message::NewSubFlow(window_id))
-                            .style(button::text)
-                            .padding([6, 16])
-                            .width(Fill),
-                    )
-                    .push(
-                        button(Text::new("+ New Function").size(13))
-                            .on_press(Message::NewFunction(window_id))
-                            .style(button::text)
-                            .padding([6, 16])
-                            .width(Fill),
-                    ),
-            )
-            .style(|_theme: &Theme| container::Style {
-                background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
-                border: iced::Border {
-                    color: Color::from_rgb(0.4, 0.4, 0.4),
-                    width: 1.0,
-                    radius: 6.0.into(),
-                },
-                ..Default::default()
-            })
-            .width(160)
-            .padding(4);
-
-            let positioned = container(menu).padding(iced::Padding {
+        container(menu)
+            .padding(iced::Padding {
                 top: menu_pos.y,
                 left: menu_pos.x,
                 right: 0.0,
                 bottom: 0.0,
-            });
-            canvas_stack.push(positioned.into());
-        }
-
-        stack(canvas_stack).into()
+            })
+            .into()
     }
 } // impl WindowState (view)
 

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -269,6 +269,7 @@ impl WindowState {
     }
 
     fn handle_connection_selected(&mut self, idx: Option<usize>) {
+        self.context_menu = None;
         self.selected_connection = idx;
         self.selected_node = None;
         self.canvas_state.request_redraw();
@@ -307,6 +308,7 @@ impl WindowState {
     }
 
     fn handle_initializer_edit(&mut self, node_idx: usize, port_name: String) {
+        self.context_menu = None;
         let (init_type, value_text) = self
             .flow_definition
             .process_refs

--- a/flowedit/src/canvas_view.rs
+++ b/flowedit/src/canvas_view.rs
@@ -1315,12 +1315,12 @@ fn compute_flow_io_positions(
         (150.0, 350.0, 100.0, 100.0 + default_h)
     } else {
         (
-            nodes.iter().map(|n| n.x()).fold(f32::MAX, f32::min),
+            nodes.iter().map(NodeLayout::x).fold(f32::MAX, f32::min),
             nodes
                 .iter()
                 .map(|n| n.x() + n.width())
                 .fold(f32::MIN, f32::max),
-            nodes.iter().map(|n| n.y()).fold(f32::MAX, f32::min),
+            nodes.iter().map(NodeLayout::y).fold(f32::MAX, f32::min),
             nodes
                 .iter()
                 .map(|n| n.y() + n.height())
@@ -1868,7 +1868,13 @@ fn handle_left_release(
     offset: Point,
 ) -> Option<canvas::Action<CanvasMessage>> {
     if let Some(connecting) = state.connecting.take() {
-        return finish_connecting(canvas, &connecting, cursor_position, zoom, offset);
+        return Some(finish_connecting(
+            canvas,
+            &connecting,
+            cursor_position,
+            zoom,
+            offset,
+        ));
     }
     if let Some(resize) = state.resizing.take() {
         if let Some(node) = canvas.nodes.get(resize.node_index) {
@@ -1913,7 +1919,7 @@ fn finish_connecting(
     cursor_position: Point,
     zoom: f32,
     offset: Point,
-) -> Option<canvas::Action<CanvasMessage>> {
+) -> canvas::Action<CanvasMessage> {
     if let Some((target_idx, target_port, target_is_output)) =
         hit_test_port(&canvas.nodes, cursor_position, zoom, offset)
     {
@@ -1948,20 +1954,18 @@ fn finish_connecting(
                             connecting.from_port.clone(),
                         )
                     };
-                    return Some(
-                        canvas::Action::publish(CanvasMessage::ConnectionCreated {
-                            from_node,
-                            from_port,
-                            to_node,
-                            to_port,
-                        })
-                        .and_capture(),
-                    );
+                    return canvas::Action::publish(CanvasMessage::ConnectionCreated {
+                        from_node,
+                        from_port,
+                        to_node,
+                        to_port,
+                    })
+                    .and_capture();
                 }
             }
         }
     }
-    Some(canvas::Action::request_redraw().and_capture())
+    canvas::Action::request_redraw().and_capture()
 }
 
 fn handle_scroll(
@@ -2512,12 +2516,12 @@ fn flow_io_bounding_box(
         (150.0, 350.0, 100.0, 100.0 + default_h)
     } else {
         (
-            nodes.iter().map(|n| n.x()).fold(f32::MAX, f32::min),
+            nodes.iter().map(NodeLayout::x).fold(f32::MAX, f32::min),
             nodes
                 .iter()
                 .map(|n| n.x() + n.width())
                 .fold(f32::MIN, f32::max),
-            nodes.iter().map(|n| n.y()).fold(f32::MAX, f32::min),
+            nodes.iter().map(NodeLayout::y).fold(f32::MAX, f32::min),
             nodes
                 .iter()
                 .map(|n| n.y() + n.height())

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -380,40 +380,12 @@ pub(crate) fn save_flow_toml(flow: &FlowDefinition, path: &PathBuf) -> Result<()
         }
     }
 
-    // Flow-level inputs
     for input in &flow.inputs {
-        out.push_str("\n[[input]]\n");
-        let name = input.name();
-        if !name.is_empty() {
-            let _ = writeln!(out, "name = \"{name}\"");
-        }
-        let types = input.datatypes();
-        if types.len() == 1 {
-            if let Some(t) = types.first() {
-                let _ = writeln!(out, "type = \"{t}\"");
-            }
-        } else if types.len() > 1 {
-            let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
-            let _ = writeln!(out, "type = [{}]", ts.join(", "));
-        }
+        write_io_toml(&mut out, "input", input);
     }
 
-    // Flow-level outputs
     for output in &flow.outputs {
-        out.push_str("\n[[output]]\n");
-        let name = output.name();
-        if !name.is_empty() {
-            let _ = writeln!(out, "name = \"{name}\"");
-        }
-        let types = output.datatypes();
-        if types.len() == 1 {
-            if let Some(t) = types.first() {
-                let _ = writeln!(out, "type = \"{t}\"");
-            }
-        } else if types.len() > 1 {
-            let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
-            let _ = writeln!(out, "type = [{}]", ts.join(", "));
-        }
+        write_io_toml(&mut out, "output", output);
     }
 
     // Processes
@@ -460,6 +432,24 @@ pub(crate) fn save_flow_toml(flow: &FlowDefinition, path: &PathBuf) -> Result<()
     }
 
     std::fs::write(path, out).map_err(|e| format!("Could not write file: {e}"))
+}
+
+fn write_io_toml(out: &mut String, section: &str, io: &flowcore::model::io::IO) {
+    use flowcore::model::name::HasName;
+    let _ = writeln!(out, "\n[[{section}]]");
+    let name = io.name();
+    if !name.is_empty() {
+        let _ = writeln!(out, "name = \"{name}\"");
+    }
+    let types = io.datatypes();
+    if types.len() == 1 {
+        if let Some(t) = types.first() {
+            let _ = writeln!(out, "type = \"{t}\"");
+        }
+    } else if types.len() > 1 {
+        let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
+        let _ = writeln!(out, "type = [{}]", ts.join(", "));
+    }
 }
 
 /// Generate a unique alias for a new node, appending a numeric suffix if needed.
@@ -597,60 +587,73 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
     std::fs::write(&toml_path, &toml)
         .map_err(|e| format!("Could not write {}: {e}", toml_path.display()))?;
 
-    // 2. Generate skeleton .rs if it doesn't exist
-    let rs_path = dir.join(&func.source);
-    if !rs_path.exists() {
-        let input_count = func.inputs.len();
-        let input_bindings = (0..input_count).fold(String::new(), |mut acc, i| {
-            use std::fmt::Write;
-            let _ = writeln!(acc, "    let _input{i} = &inputs[{i}];");
-            acc
-        });
-        let skeleton = format!(
-            "use flowcore::{{RUN_AGAIN, RunAgain}};\n\
-             use flowcore::errors::*;\n\
-             use flowmacro::flow_function;\n\
-             use serde_json::Value;\n\
-             \n\
-             #[flow_function]\n\
-             fn _{name}(inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {{\n\
-             {input_bindings}\
-             \n    // TODO: implement function logic\n\
-             \n    Ok((None, RUN_AGAIN))\n\
-             }}\n",
-            name = func.name,
-        );
-        std::fs::write(&rs_path, &skeleton)
-            .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))?;
-    }
-
-    // 3. Generate function.toml (Cargo manifest) if it doesn't exist
-    let cargo_path = dir.join("function.toml");
-    if !cargo_path.exists() {
-        let stem = func.source.strip_suffix(".rs").unwrap_or(&func.source);
-        let cargo = format!(
-            "[package]\n\
-             name = \"{name}\"\n\
-             version = \"0.1.0\"\n\
-             edition = \"2021\"\n\
-             \n\
-             [lib]\n\
-             name = \"{name}\"\n\
-             crate-type = [\"cdylib\"]\n\
-             path = \"{source}\"\n\
-             \n\
-             [dependencies]\n\
-             flowcore = {{version = \"0\"}}\n\
-             flowmacro = {{version = \"0\"}}\n\
-             serde_json = {{version = \"1.0\", default-features = false}}\n",
-            name = escape_toml_string(&func.name),
-            source = escape_toml_string(stem),
-        );
-        std::fs::write(&cargo_path, &cargo)
-            .map_err(|e| format!("Could not write {}: {e}", cargo_path.display()))?;
-    }
+    generate_skeleton_rs(dir, func)?;
+    generate_cargo_manifest(dir, func)?;
 
     Ok(())
+}
+
+fn generate_skeleton_rs(
+    dir: &Path,
+    func: &flowcore::model::function_definition::FunctionDefinition,
+) -> Result<(), String> {
+    let rs_path = dir.join(&func.source);
+    if rs_path.exists() {
+        return Ok(());
+    }
+    let input_count = func.inputs.len();
+    let input_bindings = (0..input_count).fold(String::new(), |mut acc, i| {
+        use std::fmt::Write;
+        let _ = writeln!(acc, "    let _input{i} = &inputs[{i}];");
+        acc
+    });
+    let skeleton = format!(
+        "use flowcore::{{RUN_AGAIN, RunAgain}};\n\
+         use flowcore::errors::*;\n\
+         use flowmacro::flow_function;\n\
+         use serde_json::Value;\n\
+         \n\
+         #[flow_function]\n\
+         fn _{name}(inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {{\n\
+         {input_bindings}\
+         \n    // TODO: implement function logic\n\
+         \n    Ok((None, RUN_AGAIN))\n\
+         }}\n",
+        name = func.name,
+    );
+    std::fs::write(&rs_path, &skeleton)
+        .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))
+}
+
+fn generate_cargo_manifest(
+    dir: &Path,
+    func: &flowcore::model::function_definition::FunctionDefinition,
+) -> Result<(), String> {
+    let cargo_path = dir.join("function.toml");
+    if cargo_path.exists() {
+        return Ok(());
+    }
+    let stem = func.source.strip_suffix(".rs").unwrap_or(&func.source);
+    let cargo = format!(
+        "[package]\n\
+         name = \"{name}\"\n\
+         version = \"0.1.0\"\n\
+         edition = \"2021\"\n\
+         \n\
+         [lib]\n\
+         name = \"{name}\"\n\
+         crate-type = [\"cdylib\"]\n\
+         path = \"{source}\"\n\
+         \n\
+         [dependencies]\n\
+         flowcore = {{version = \"0\"}}\n\
+         flowmacro = {{version = \"0\"}}\n\
+         serde_json = {{version = \"1.0\", default-features = false}}\n",
+        name = escape_toml_string(&func.name),
+        source = escape_toml_string(stem),
+    );
+    std::fs::write(&cargo_path, &cargo)
+        .map_err(|e| format!("Could not write {}: {e}", cargo_path.display()))
 }
 
 /// Compute the path for the editor preferences file alongside the flow file.

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -213,58 +213,7 @@ impl LibraryTree {
 
                     if cat.expanded {
                         for func_url in &cat.function_urls {
-                            let func_name = func_name_from_url(func_url);
-                            let description =
-                                func_description_from_definitions(func_url, all_definitions);
-                            let source = func_url.to_string();
-
-                            let view_btn = button(text("\u{270E}").size(10))
-                                .on_press(LibraryMessage::ViewFunction(
-                                    source.clone(),
-                                    func_name.clone(),
-                                ))
-                                .style(button::text)
-                                .padding([1, 3]);
-
-                            let func_btn = button(text(func_name.clone()).size(11))
-                                .on_press(LibraryMessage::AddFunction(source, func_name))
-                                .style(button::text)
-                                .padding([2, 4]);
-
-                            let row = Row::new()
-                                .spacing(2)
-                                .align_y(iced::Alignment::Center)
-                                .push(view_btn)
-                                .push(func_btn);
-
-                            let entry_widget: Element<'_, LibraryMessage> = if description
-                                .is_empty()
-                            {
-                                row.into()
-                            } else {
-                                tooltip(row, text(description).size(14), tooltip::Position::Bottom)
-                                    .gap(2)
-                                    .style(|_theme: &iced::Theme| container::Style {
-                                        background: Some(iced::Background::Color(
-                                            iced::Color::from_rgb(0.12, 0.12, 0.12),
-                                        )),
-                                        border: iced::Border {
-                                            color: iced::Color::WHITE,
-                                            width: 1.0,
-                                            radius: 4.0.into(),
-                                        },
-                                        ..Default::default()
-                                    })
-                                    .into()
-                            };
-
-                            content =
-                                content.push(container(entry_widget).padding(iced::Padding {
-                                    top: 0.0,
-                                    right: 0.0,
-                                    bottom: 0.0,
-                                    left: 24.0,
-                                }));
+                            content = content.push(view_function_entry(func_url, all_definitions));
                         }
                     }
                 }
@@ -284,6 +233,62 @@ impl LibraryTree {
             })
             .into()
     }
+}
+
+fn view_function_entry<'a>(
+    func_url: &Url,
+    all_definitions: &'a HashMap<Url, Process>,
+) -> Element<'a, LibraryMessage> {
+    let func_name = func_name_from_url(func_url);
+    let description = func_description_from_definitions(func_url, all_definitions);
+    let source = func_url.to_string();
+
+    let view_btn = button(text("\u{270E}").size(10))
+        .on_press(LibraryMessage::ViewFunction(
+            source.clone(),
+            func_name.clone(),
+        ))
+        .style(button::text)
+        .padding([1, 3]);
+
+    let func_btn = button(text(func_name.clone()).size(11))
+        .on_press(LibraryMessage::AddFunction(source, func_name))
+        .style(button::text)
+        .padding([2, 4]);
+
+    let row = Row::new()
+        .spacing(2)
+        .align_y(iced::Alignment::Center)
+        .push(view_btn)
+        .push(func_btn);
+
+    let entry_widget: Element<'_, LibraryMessage> = if description.is_empty() {
+        row.into()
+    } else {
+        tooltip(row, text(description).size(14), tooltip::Position::Bottom)
+            .gap(2)
+            .style(|_theme: &iced::Theme| container::Style {
+                background: Some(iced::Background::Color(iced::Color::from_rgb(
+                    0.12, 0.12, 0.12,
+                ))),
+                border: iced::Border {
+                    color: iced::Color::WHITE,
+                    width: 1.0,
+                    radius: 4.0.into(),
+                },
+                ..Default::default()
+            })
+            .into()
+    };
+
+    container(entry_widget)
+        .padding(iced::Padding {
+            top: 0.0,
+            right: 0.0,
+            bottom: 0.0,
+            left: 24.0,
+        })
+        .into()
 }
 
 /// Extract a display name for a function from its URL.

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -444,11 +444,11 @@ fn setup_lib_search_path(lib_dirs: &[String]) {
     }
     if lib_search_path.is_empty() {
         if let Ok(home) = std::env::var("HOME") {
-            lib_search_path.add(&format!("{home}/.flow/lib"));
+            let default_lib = format!("{home}/.flow/lib");
+            lib_search_path.add(&default_lib);
+            std::env::set_var("FLOW_LIB_PATH", &default_lib);
         }
-    }
-
-    if !lib_dirs.is_empty() {
+    } else if !lib_dirs.is_empty() {
         let current = std::env::var("FLOW_LIB_PATH").unwrap_or_default();
         let additions = lib_dirs.join(",");
         if current.is_empty() {
@@ -2442,11 +2442,24 @@ impl FlowEdit {
                 } else {
                     &v.func_def.outputs
                 };
+                let duplicate = ports
+                    .iter()
+                    .enumerate()
+                    .any(|(i, io)| i != idx && io.name() == name);
+                if duplicate {
+                    return None;
+                }
                 ports.get(idx).map(|io| io.name().clone())
             } else {
                 None
             }
         });
+        let Some(ref old) = old_name else {
+            return;
+        };
+        if old == name {
+            return;
+        }
         if let Some(win) = self.windows.get_mut(&win_id) {
             if let WindowKind::FunctionViewer(ref mut v) = win.kind {
                 let ports = if is_input {
@@ -2461,9 +2474,7 @@ impl FlowEdit {
             win.history.mark_modified();
         }
         Self::propagate_function_ports(&mut self.windows, win_id);
-        if let Some(old) = old_name {
-            Self::rename_parent_connections_port(&mut self.windows, win_id, &old, name, is_input);
-        }
+        Self::rename_parent_connections_port(&mut self.windows, win_id, old, name, is_input);
     }
 
     /// Handle function definition viewing/editing messages.

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -67,6 +67,63 @@ fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
 }
 
 impl WindowState {
+    fn rename_flow_input(&mut self, idx: usize, name: String) {
+        let duplicate = self
+            .flow_definition
+            .inputs
+            .iter()
+            .enumerate()
+            .any(|(i, io)| i != idx && io.name() == &name);
+        if !duplicate {
+            if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
+                let old_name = io.name().clone();
+                io.set_name(name.clone());
+                let old_route = format!("input/{old_name}");
+                let new_route = format!("input/{name}");
+                for conn in &mut self.flow_definition.connections {
+                    if conn.from().to_string() == old_route {
+                        conn.set_from(Route::from(new_route.as_str()));
+                    }
+                }
+            }
+            self.history.mark_modified();
+            self.canvas_state.request_redraw();
+        }
+    }
+
+    fn rename_flow_output(&mut self, idx: usize, name: String) {
+        let duplicate = self
+            .flow_definition
+            .outputs
+            .iter()
+            .enumerate()
+            .any(|(i, io)| i != idx && io.name() == &name);
+        if !duplicate {
+            if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
+                let old_name = io.name().clone();
+                io.set_name(name.clone());
+                let old_route_str = format!("output/{old_name}");
+                let new_route_str = format!("output/{name}");
+                for conn in &mut self.flow_definition.connections {
+                    let new_to: Vec<Route> = conn
+                        .to()
+                        .iter()
+                        .map(|r| {
+                            if r.to_string() == old_route_str {
+                                Route::from(new_route_str.as_str())
+                            } else {
+                                r.clone()
+                            }
+                        })
+                        .collect();
+                    conn.set_to(new_to);
+                }
+            }
+            self.history.mark_modified();
+            self.canvas_state.request_redraw();
+        }
+    }
+
     /// Handle flow metadata and I/O editing messages.
     fn handle_flow_edit_message(&mut self, msg: FlowEditMessage) {
         match msg {
@@ -113,7 +170,6 @@ impl WindowState {
                 if let Some(io) = self.flow_definition.inputs.get(idx) {
                     let name = io.name().clone();
                     self.flow_definition.inputs.remove(idx);
-                    // Remove connections referencing this flow input
                     self.flow_definition.connections.retain(|c| {
                         let (from_node, from_port) = canvas_view::split_route(c.from().as_ref());
                         !(from_node == "input" && from_port == name)
@@ -146,29 +202,7 @@ impl WindowState {
                     self.canvas_state.request_redraw();
                 }
             }
-            FlowEditMessage::InputNameChanged(idx, name) => {
-                let duplicate = self
-                    .flow_definition
-                    .inputs
-                    .iter()
-                    .enumerate()
-                    .any(|(i, io)| i != idx && io.name() == &name);
-                if !duplicate {
-                    if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
-                        let old_name = io.name().clone();
-                        io.set_name(name.clone());
-                        let old_route = format!("input/{old_name}");
-                        let new_route = format!("input/{name}");
-                        for conn in &mut self.flow_definition.connections {
-                            if conn.from().to_string() == old_route {
-                                conn.set_from(Route::from(new_route.as_str()));
-                            }
-                        }
-                    }
-                    self.history.mark_modified();
-                    self.canvas_state.request_redraw();
-                }
-            }
+            FlowEditMessage::InputNameChanged(idx, name) => self.rename_flow_input(idx, name),
             FlowEditMessage::InputTypeChanged(idx, dtype) => {
                 if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
@@ -176,38 +210,7 @@ impl WindowState {
                 self.history.mark_modified();
                 self.canvas_state.request_redraw();
             }
-            FlowEditMessage::OutputNameChanged(idx, name) => {
-                let duplicate = self
-                    .flow_definition
-                    .outputs
-                    .iter()
-                    .enumerate()
-                    .any(|(i, io)| i != idx && io.name() == &name);
-                if !duplicate {
-                    if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
-                        let old_name = io.name().clone();
-                        io.set_name(name.clone());
-                        let old_route_str = format!("output/{old_name}");
-                        let new_route_str = format!("output/{name}");
-                        for conn in &mut self.flow_definition.connections {
-                            let new_to: Vec<Route> = conn
-                                .to()
-                                .iter()
-                                .map(|r| {
-                                    if r.to_string() == old_route_str {
-                                        Route::from(new_route_str.as_str())
-                                    } else {
-                                        r.clone()
-                                    }
-                                })
-                                .collect();
-                            conn.set_to(new_to);
-                        }
-                    }
-                    self.history.mark_modified();
-                    self.canvas_state.request_redraw();
-                }
-            }
+            FlowEditMessage::OutputNameChanged(idx, name) => self.rename_flow_output(idx, name),
             FlowEditMessage::OutputTypeChanged(idx, dtype) => {
                 if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
@@ -400,101 +403,109 @@ fn main() -> iced::Result {
         .run()
 }
 
+fn parse_cli_args() -> (Vec<String>, Option<String>) {
+    let matches = ClapCommand::new("flowedit")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Visual editor for flow definition files")
+        .arg(
+            Arg::new("flow-file")
+                .required(false)
+                .help("Path to the flow definition file (.toml, .yaml, or .json)"),
+        )
+        .arg(
+            Arg::new("lib_dir")
+                .short('L')
+                .long("libdir")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .value_name("LIB_DIR")
+                .help("Add a directory to the Library Search path"),
+        )
+        .get_matches();
+
+    let lib_dirs: Vec<String> = if matches.contains_id("lib_dir") {
+        matches
+            .get_many::<String>("lib_dir")
+            .map(|dirs| dirs.map(std::string::ToString::to_string).collect())
+            .unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    let flow_file = matches.get_one::<String>("flow-file").cloned();
+    (lib_dirs, flow_file)
+}
+
+fn setup_lib_search_path(lib_dirs: &[String]) {
+    let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
+    for addition in lib_dirs {
+        lib_search_path.add(addition);
+        info!("'{addition}' added to the Library Search Path");
+    }
+    if lib_search_path.is_empty() {
+        if let Ok(home) = std::env::var("HOME") {
+            lib_search_path.add(&format!("{home}/.flow/lib"));
+        }
+    }
+
+    if !lib_dirs.is_empty() {
+        let current = std::env::var("FLOW_LIB_PATH").unwrap_or_default();
+        let additions = lib_dirs.join(",");
+        if current.is_empty() {
+            std::env::set_var("FLOW_LIB_PATH", additions);
+        } else {
+            std::env::set_var("FLOW_LIB_PATH", format!("{current},{additions}"));
+        }
+    }
+}
+
+fn load_initial_flow(flow_file: Option<&str>) -> (String, FlowDefinition, BTreeSet<Url>) {
+    if let Some(flow_path_str) = flow_file {
+        let flow_path = PathBuf::from(flow_path_str);
+        match file_ops::load_flow(&flow_path) {
+            Ok(loaded) => {
+                let nc = loaded.flow_def.process_refs.len();
+                let ec = loaded.flow_def.connections.len();
+                let mut fd = loaded.flow_def;
+                if let Ok(url) = Url::from_file_path(&flow_path) {
+                    fd.source_url = url;
+                }
+                (
+                    format!("Ready - {nc} nodes, {ec} connections"),
+                    fd,
+                    loaded.lib_references,
+                )
+            }
+            Err(e) => {
+                let fd = FlowDefinition {
+                    name: String::from("(error)"),
+                    ..FlowDefinition::default()
+                };
+                (format!("Error loading flow: {e}"), fd, BTreeSet::new())
+            }
+        }
+    } else {
+        let fd = FlowDefinition {
+            name: String::from("(new flow)"),
+            ..FlowDefinition::default()
+        };
+        (String::from("Ready"), fd, BTreeSet::new())
+    }
+}
+
 impl FlowEdit {
     /// Create the application, parsing CLI args and optionally loading a flow file.
     fn new() -> (Self, Task<Message>) {
-        let matches = ClapCommand::new("flowedit")
-            .version(env!("CARGO_PKG_VERSION"))
-            .about("Visual editor for flow definition files")
-            .arg(
-                Arg::new("flow-file")
-                    .required(false)
-                    .help("Path to the flow definition file (.toml, .yaml, or .json)"),
-            )
-            .arg(
-                Arg::new("lib_dir")
-                    .short('L')
-                    .long("libdir")
-                    .num_args(1)
-                    .action(ArgAction::Append)
-                    .value_name("LIB_DIR")
-                    .help("Add a directory to the Library Search path"),
-            )
-            .get_matches();
+        let (lib_dirs, flow_file) = parse_cli_args();
+        setup_lib_search_path(&lib_dirs);
 
-        // Collect -L library directories, same as flowrgui
-        let lib_dirs: Vec<String> = if matches.contains_id("lib_dir") {
-            matches
-                .get_many::<String>("lib_dir")
-                .map(|dirs| dirs.map(std::string::ToString::to_string).collect())
-                .unwrap_or_default()
-        } else {
-            vec![]
-        };
-
-        // Build the library search path from FLOW_LIB_PATH + -L args
-        let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
-        for addition in &lib_dirs {
-            lib_search_path.add(addition);
-            info!("'{addition}' added to the Library Search Path");
-        }
-        if lib_search_path.is_empty() {
-            if let Ok(home) = std::env::var("HOME") {
-                lib_search_path.add(&format!("{home}/.flow/lib"));
-            }
-        }
-
-        // Set FLOW_LIB_PATH with any -L additions so other code can find libraries
-        if !lib_dirs.is_empty() {
-            let current = std::env::var("FLOW_LIB_PATH").unwrap_or_default();
-            let additions = lib_dirs.join(",");
-            if current.is_empty() {
-                std::env::set_var("FLOW_LIB_PATH", additions);
-            } else {
-                std::env::set_var("FLOW_LIB_PATH", format!("{current},{additions}"));
-            }
-        }
-
-        let (status, flow_definition, lib_refs) =
-            if let Some(flow_path_str) = matches.get_one::<String>("flow-file") {
-                let flow_path = PathBuf::from(flow_path_str);
-                match file_ops::load_flow(&flow_path) {
-                    Ok(loaded) => {
-                        let nc = loaded.flow_def.process_refs.len();
-                        let ec = loaded.flow_def.connections.len();
-                        let mut fd = loaded.flow_def;
-                        if let Ok(url) = Url::from_file_path(&flow_path) {
-                            fd.source_url = url;
-                        }
-                        (
-                            format!("Ready - {nc} nodes, {ec} connections"),
-                            fd,
-                            loaded.lib_references,
-                        )
-                    }
-                    Err(e) => {
-                        let fd = FlowDefinition {
-                            name: String::from("(error)"),
-                            ..FlowDefinition::default()
-                        };
-                        (format!("Error loading flow: {e}"), fd, BTreeSet::new())
-                    }
-                }
-            } else {
-                let fd = FlowDefinition {
-                    name: String::from("(new flow)"),
-                    ..FlowDefinition::default()
-                };
-                (String::from("Ready"), fd, BTreeSet::new())
-            };
+        let (status, flow_definition, lib_refs) = load_initial_flow(flow_file.as_deref());
 
         let has_nodes = !flow_definition.process_refs.is_empty();
 
-        // Load full library catalogs from manifests and parse all definitions
         let (library_cache, all_definitions) = library_mgmt::load_library_catalogs(&lib_refs);
         let library_tree = LibraryTree::from_cache(&library_cache, &all_definitions);
 
-        // Open the root window via daemon API
         let file_path = flow_definition.source_url.to_file_path().ok();
         let saved_prefs = file_path
             .as_ref()
@@ -575,209 +586,307 @@ impl FlowEdit {
         }
     }
 
+    fn handle_hierarchy_message(
+        &mut self,
+        hier_win_id: window::Id,
+        hier_msg: &HierarchyMessage,
+    ) -> Task<Message> {
+        let open_result = self
+            .windows
+            .get_mut(&hier_win_id)
+            .and_then(|win| win.flow_hierarchy.update(hier_msg));
+        let Some((_source, path)) = open_result else {
+            return Task::none();
+        };
+        // Check if already open
+        for (&win_id, win) in &self.windows {
+            if win.file_path().as_ref() == Some(&path) {
+                return window::gain_focus(win_id);
+            }
+        }
+        // Open the flow or function
+        if let Ok(loaded) = file_ops::load_flow(&path) {
+            let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
+            let has_nodes = !loaded.flow_def.process_refs.is_empty();
+            let nc = loaded.flow_def.process_refs.len();
+            let ec = loaded.flow_def.connections.len();
+            let mut flow_def = loaded.flow_def;
+            if let Ok(url) = Url::from_file_path(&path) {
+                flow_def.source_url = url;
+            }
+            let child = WindowState {
+                kind: WindowKind::FlowEditor,
+                canvas_state: FlowCanvasState::default(),
+                status: format!("Ready - {nc} nodes, {ec} connections"),
+                selected_node: None,
+                selected_connection: None,
+                history: EditHistory::default(),
+                auto_fit_pending: has_nodes,
+                auto_fit_enabled: true,
+                flow_hierarchy: FlowHierarchy::from_flow_definition(&flow_def),
+                flow_definition: flow_def,
+                tooltip: None,
+                initializer_editor: None,
+                is_root: false,
+                context_menu: None,
+                show_metadata: false,
+                last_size: None,
+                last_position: None,
+            };
+            self.windows.insert(new_id, child);
+            return open_task.discard();
+        }
+        // Try as function definition
+        let abs = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if let Ok(contents) = std::fs::read_to_string(&abs) {
+            if let Ok(url) = Url::from_file_path(&abs) {
+                if let Ok(deser) = get::<Process>(&url) {
+                    if let Ok(Process::FunctionProcess(ref func)) =
+                        deser.deserialize(&contents, Some(&url))
+                    {
+                        return self.open_function_viewer(
+                            hier_win_id,
+                            &path,
+                            func,
+                            &path.to_string_lossy(),
+                        );
+                    }
+                }
+            }
+        }
+        Task::none()
+    }
+
+    fn handle_close_requested(&mut self, target: Option<window::Id>) -> Task<Message> {
+        let Some(id) = target else {
+            return Task::none();
+        };
+        if let Some(win) = self.windows.get(&id) {
+            if !win.history.is_empty() {
+                let dialog = rfd::MessageDialog::new()
+                    .set_title("Unsaved Changes")
+                    .set_description("This window has unsaved changes. Close without saving?")
+                    .set_buttons(rfd::MessageButtons::YesNo)
+                    .set_level(rfd::MessageLevel::Warning);
+                if dialog.show() != rfd::MessageDialogResult::Yes {
+                    return Task::none();
+                }
+            }
+        }
+        self.windows.remove(&id);
+        if self.root_window == Some(id) || self.windows.is_empty() {
+            return iced::exit();
+        }
+        window::close(id)
+    }
+
+    fn handle_quit_all(&self) -> Task<Message> {
+        let has_unsaved = self.windows.values().any(|w| !w.history.is_empty());
+        if has_unsaved {
+            let dialog = rfd::MessageDialog::new()
+                .set_title("Unsaved Changes")
+                .set_description("There are unsaved changes. Quit without saving?")
+                .set_buttons(rfd::MessageButtons::YesNo)
+                .set_level(rfd::MessageLevel::Warning);
+            if dialog.show() != rfd::MessageDialogResult::Yes {
+                return Task::none();
+            }
+        }
+        iced::exit()
+    }
+
+    fn handle_add_library(&mut self, win_id: window::Id) {
+        let dialog = rfd::FileDialog::new();
+        let Some(dir) = dialog.pick_folder() else {
+            return;
+        };
+        let lib_name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let Ok(lib_url) = Url::parse(&format!("lib://{lib_name}")) else {
+            return;
+        };
+        let Some(parent) = dir.parent() else {
+            return;
+        };
+        let Some(parent_str) = parent.to_str() else {
+            return;
+        };
+
+        let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
+        lib_search_path.add_directory(parent_str);
+
+        if let Ok(home) = std::env::var("HOME") {
+            let default_lib = PathBuf::from(&home).join(".flow").join("lib");
+            if default_lib.exists() {
+                if let Some(path_str) = default_lib.to_str() {
+                    lib_search_path.add_directory(path_str);
+                }
+            }
+        }
+
+        let context_root = std::env::var("HOME").map_or_else(
+            |_| PathBuf::from("/"),
+            |h| {
+                PathBuf::from(h)
+                    .join(".flow")
+                    .join("runner")
+                    .join("flowrcli")
+            },
+        );
+        let provider = MetaProvider::new(lib_search_path.clone(), context_root.clone());
+        let arc_provider: Arc<dyn Provider> = Arc::new(provider);
+
+        match LibraryManifest::load(&arc_provider, &lib_url) {
+            Ok((manifest, _manifest_url)) => {
+                info!(
+                    "Loaded library manifest for '{}' with {} locators",
+                    lib_url,
+                    manifest.locators.len()
+                );
+
+                for locator_url in manifest.locators.keys() {
+                    let meta_provider =
+                        MetaProvider::new(lib_search_path.clone(), context_root.clone());
+                    match flowrclib::compiler::parser::parse(locator_url, &meta_provider) {
+                        Ok(process) => {
+                            self.all_definitions.insert(locator_url.clone(), process);
+                        }
+                        Err(e) => {
+                            warn!("Could not parse library definition '{locator_url}': {e}");
+                        }
+                    }
+                }
+
+                self.library_cache.insert(lib_url.clone(), manifest);
+
+                if !self.lib_paths.contains(&parent_str.to_string()) {
+                    self.lib_paths.push(parent_str.to_string());
+                    self.update_lib_paths();
+                }
+
+                self.library_tree =
+                    LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
+
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.status = format!("Added library: {lib_name}");
+                }
+            }
+            Err(e) => {
+                warn!("Could not load library manifest for '{lib_url}': {e}");
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.status = format!("Failed to load library '{lib_name}': {e}");
+                }
+            }
+        }
+    }
+
+    fn handle_library_message(
+        &mut self,
+        win_id: window::Id,
+        lib_msg: &LibraryMessage,
+    ) -> Task<Message> {
+        match self.library_tree.update(lib_msg) {
+            LibraryAction::Add(source, func_name) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.add_library_function(&source, &func_name);
+                }
+            }
+            LibraryAction::View(source, _name) => {
+                return self.open_library_function(&source);
+            }
+            LibraryAction::AddLibrary => {
+                self.handle_add_library(win_id);
+            }
+            LibraryAction::None => {}
+        }
+        Task::none()
+    }
+
+    fn handle_window_event(&mut self, message: &Message) -> Task<Message> {
+        match *message {
+            Message::WindowFocused(id) => {
+                self.focused_window = Some(id);
+            }
+            Message::WindowResized(id, size) => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.last_size = Some(size);
+                }
+            }
+            Message::WindowMoved(id, pos) => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.last_position = Some(pos);
+                }
+            }
+            Message::WindowClosed(id) => {
+                self.windows.remove(&id);
+                if self.focused_window == Some(id) {
+                    self.focused_window = self.root_window;
+                }
+                if self.root_window == Some(id) || self.windows.is_empty() {
+                    return iced::exit();
+                }
+            }
+            _ => {}
+        }
+        Task::none()
+    }
+
+    fn handle_canvas_update(
+        &mut self,
+        win_id: window::Id,
+        canvas_msg: CanvasMessage,
+    ) -> Task<Message> {
+        let Some(win) = self.windows.get_mut(&win_id) else {
+            return Task::none();
+        };
+        match win.handle_canvas_message(canvas_msg) {
+            canvas_view::CanvasAction::OpenNode(idx) => self.open_node(win_id, idx),
+            canvas_view::CanvasAction::None => Task::none(),
+        }
+    }
+
+    fn handle_initializer_message(&mut self, message: &Message) {
+        match *message {
+            Message::InitializerTypeChanged(win_id, ref new_type) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.handle_initializer_type_changed(new_type.clone());
+                }
+            }
+            Message::InitializerValueChanged(win_id, ref new_value) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.handle_initializer_value_changed(new_value.clone());
+                }
+            }
+            Message::InitializerApply(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.handle_initializer_apply();
+                }
+            }
+            Message::InitializerCancel(win_id) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    win.handle_initializer_cancel();
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Handle messages from canvas interactions.
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::WindowCanvas(win_id, canvas_msg) => {
-                let Some(win) = self.windows.get_mut(&win_id) else {
-                    return Task::none();
-                };
-                match win.handle_canvas_message(canvas_msg) {
-                    canvas_view::CanvasAction::OpenNode(idx) => {
-                        return self.open_node(win_id, idx);
-                    }
-                    canvas_view::CanvasAction::None => {}
-                }
+                return self.handle_canvas_update(win_id, canvas_msg);
             }
             Message::Hierarchy(hier_win_id, ref hier_msg) => {
-                let open_result = self
-                    .windows
-                    .get_mut(&hier_win_id)
-                    .and_then(|win| win.flow_hierarchy.update(hier_msg));
-                if let Some((_source, path)) = open_result {
-                    // Check if already open
-                    for (&win_id, win) in &self.windows {
-                        if win.file_path().as_ref() == Some(&path) {
-                            return window::gain_focus(win_id);
-                        }
-                    }
-                    // Open the flow or function
-                    if let Ok(loaded) = file_ops::load_flow(&path) {
-                        let (new_id, open_task) =
-                            window::open(self.child_window_settings(1024.0, 768.0));
-                        let has_nodes = !loaded.flow_def.process_refs.is_empty();
-                        let nc = loaded.flow_def.process_refs.len();
-                        let ec = loaded.flow_def.connections.len();
-                        let mut flow_def = loaded.flow_def;
-                        if let Ok(url) = Url::from_file_path(&path) {
-                            flow_def.source_url = url;
-                        }
-                        let child = WindowState {
-                            kind: WindowKind::FlowEditor,
-
-                            canvas_state: FlowCanvasState::default(),
-                            status: format!("Ready - {nc} nodes, {ec} connections"),
-                            selected_node: None,
-                            selected_connection: None,
-                            history: EditHistory::default(),
-                            auto_fit_pending: has_nodes,
-                            auto_fit_enabled: true,
-                            flow_hierarchy: FlowHierarchy::from_flow_definition(&flow_def),
-                            flow_definition: flow_def,
-                            tooltip: None,
-                            initializer_editor: None,
-                            is_root: false,
-                            context_menu: None,
-                            show_metadata: false,
-                            last_size: None,
-                            last_position: None,
-                        };
-                        self.windows.insert(new_id, child);
-                        return open_task.discard();
-                    }
-                    // Try as function definition
-                    let abs = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                    if let Ok(contents) = std::fs::read_to_string(&abs) {
-                        if let Ok(url) = Url::from_file_path(&abs) {
-                            if let Ok(deser) = get::<Process>(&url) {
-                                if let Ok(Process::FunctionProcess(ref func)) =
-                                    deser.deserialize(&contents, Some(&url))
-                                {
-                                    return self.open_function_viewer(
-                                        hier_win_id,
-                                        &path,
-                                        func,
-                                        &path.to_string_lossy(),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
+                return self.handle_hierarchy_message(hier_win_id, hier_msg);
             }
-            Message::Library(win_id, ref lib_msg) => match self.library_tree.update(lib_msg) {
-                LibraryAction::Add(source, func_name) => {
-                    if let Some(win) = self.windows.get_mut(&win_id) {
-                        win.add_library_function(&source, &func_name);
-                    }
-                }
-                LibraryAction::View(source, _name) => {
-                    return self.open_library_function(&source);
-                }
-                LibraryAction::AddLibrary => {
-                    let dialog = rfd::FileDialog::new();
-                    if let Some(dir) = dialog.pick_folder() {
-                        let lib_name = dir
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("unknown")
-                            .to_string();
-
-                        // Construct lib:// URL from directory name
-                        if let Ok(lib_url) = Url::parse(&format!("lib://{lib_name}")) {
-                            // Add parent directory to provider's search path
-                            if let Some(parent) = dir.parent() {
-                                if let Some(parent_str) = parent.to_str() {
-                                    let mut lib_search_path =
-                                        Simpath::new_with_separator("FLOW_LIB_PATH", ',');
-                                    lib_search_path.add_directory(parent_str);
-
-                                    // Add default lib path if it exists
-                                    if let Ok(home) = std::env::var("HOME") {
-                                        let default_lib =
-                                            PathBuf::from(&home).join(".flow").join("lib");
-                                        if default_lib.exists() {
-                                            if let Some(path_str) = default_lib.to_str() {
-                                                lib_search_path.add_directory(path_str);
-                                            }
-                                        }
-                                    }
-
-                                    let context_root = std::env::var("HOME").map_or_else(
-                                        |_| PathBuf::from("/"),
-                                        |h| {
-                                            PathBuf::from(h)
-                                                .join(".flow")
-                                                .join("runner")
-                                                .join("flowrcli")
-                                        },
-                                    );
-                                    let provider = MetaProvider::new(
-                                        lib_search_path.clone(),
-                                        context_root.clone(),
-                                    );
-                                    let arc_provider: Arc<dyn Provider> = Arc::new(provider);
-
-                                    // Load the library manifest
-                                    match LibraryManifest::load(&arc_provider, &lib_url) {
-                                        Ok((manifest, _manifest_url)) => {
-                                            info!(
-                                                "Loaded library manifest for '{}' with {} locators",
-                                                lib_url,
-                                                manifest.locators.len()
-                                            );
-
-                                            // Parse all definitions in the manifest
-                                            for locator_url in manifest.locators.keys() {
-                                                let meta_provider = MetaProvider::new(
-                                                    lib_search_path.clone(),
-                                                    context_root.clone(),
-                                                );
-                                                match flowrclib::compiler::parser::parse(
-                                                    locator_url,
-                                                    &meta_provider,
-                                                ) {
-                                                    Ok(process) => {
-                                                        self.all_definitions
-                                                            .insert(locator_url.clone(), process);
-                                                    }
-                                                    Err(e) => {
-                                                        warn!(
-                                                            "Could not parse library definition '{locator_url}': {e}"
-                                                        );
-                                                    }
-                                                }
-                                            }
-
-                                            // Add to library cache
-                                            self.library_cache.insert(lib_url.clone(), manifest);
-
-                                            // Persist the parent directory so that
-                                            // subsequent MetaProvider rebuilds can
-                                            // resolve this library.
-                                            if !self.lib_paths.contains(&parent_str.to_string()) {
-                                                self.lib_paths.push(parent_str.to_string());
-                                                self.update_lib_paths();
-                                            }
-
-                                            // Rebuild the library tree
-                                            self.library_tree = LibraryTree::from_cache(
-                                                &self.library_cache,
-                                                &self.all_definitions,
-                                            );
-
-                                            if let Some(win) = self.windows.get_mut(&win_id) {
-                                                win.status = format!("Added library: {lib_name}");
-                                            }
-                                        }
-                                        Err(e) => {
-                                            warn!(
-                                                "Could not load library manifest for '{lib_url}': {e}"
-                                            );
-                                            if let Some(win) = self.windows.get_mut(&win_id) {
-                                                win.status = format!(
-                                                    "Failed to load library '{lib_name}': {e}"
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                LibraryAction::None => {}
-            },
+            Message::Library(win_id, ref lib_msg) => {
+                return self.handle_library_message(win_id, lib_msg);
+            }
             Message::View(win_id, view_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
                     win.handle_view_message(&view_msg);
@@ -815,38 +924,11 @@ impl FlowEdit {
                 }
                 return self.create_new_function(target_win_id);
             }
-            Message::InitializerTypeChanged(win_id, new_type) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_type_changed(new_type);
-                }
-            }
-            Message::InitializerValueChanged(win_id, new_value) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_value_changed(new_value);
-                }
-            }
-            Message::InitializerApply(win_id) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_apply();
-                }
-            }
-            Message::InitializerCancel(win_id) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_cancel();
-                }
-            }
-            Message::WindowFocused(id) => {
-                self.focused_window = Some(id);
-            }
-            Message::WindowResized(id, size) => {
-                if let Some(win) = self.windows.get_mut(&id) {
-                    win.last_size = Some(size);
-                }
-            }
-            Message::WindowMoved(id, pos) => {
-                if let Some(win) = self.windows.get_mut(&id) {
-                    win.last_position = Some(pos);
-                }
+            Message::InitializerTypeChanged(_, _)
+            | Message::InitializerValueChanged(_, _)
+            | Message::InitializerApply(_)
+            | Message::InitializerCancel(_) => {
+                self.handle_initializer_message(&message);
             }
             Message::AddLibraryPath => {
                 let dialog = rfd::FileDialog::new();
@@ -870,14 +952,11 @@ impl FlowEdit {
             Message::FunctionEdit(win_id, func_msg) => {
                 self.handle_function_edit_message(win_id, func_msg);
             }
-            Message::WindowClosed(id) => {
-                self.windows.remove(&id);
-                if self.focused_window == Some(id) {
-                    self.focused_window = self.root_window;
-                }
-                if self.root_window == Some(id) || self.windows.is_empty() {
-                    return iced::exit();
-                }
+            Message::WindowFocused(_)
+            | Message::WindowResized(_, _)
+            | Message::WindowMoved(_, _)
+            | Message::WindowClosed(_) => {
+                return self.handle_window_event(&message);
             }
             Message::CloseRequested(_) | Message::CloseActiveWindow => {
                 let target = match message {
@@ -885,43 +964,10 @@ impl FlowEdit {
                     Message::CloseActiveWindow => self.focused_window.or(self.root_window),
                     _ => None,
                 };
-                let Some(id) = target else {
-                    return Task::none();
-                };
-                if let Some(win) = self.windows.get(&id) {
-                    if !win.history.is_empty() {
-                        let dialog = rfd::MessageDialog::new()
-                            .set_title("Unsaved Changes")
-                            .set_description(
-                                "This window has unsaved changes. Close without saving?",
-                            )
-                            .set_buttons(rfd::MessageButtons::YesNo)
-                            .set_level(rfd::MessageLevel::Warning);
-                        if dialog.show() != rfd::MessageDialogResult::Yes {
-                            return Task::none();
-                        }
-                    }
-                }
-                self.windows.remove(&id);
-                if self.root_window == Some(id) || self.windows.is_empty() {
-                    return iced::exit();
-                }
-                return window::close(id);
+                return self.handle_close_requested(target);
             }
             Message::QuitAll => {
-                // Check for unsaved edits in any window
-                let has_unsaved = self.windows.values().any(|w| !w.history.is_empty());
-                if has_unsaved {
-                    let dialog = rfd::MessageDialog::new()
-                        .set_title("Unsaved Changes")
-                        .set_description("There are unsaved changes. Quit without saving?")
-                        .set_buttons(rfd::MessageButtons::YesNo)
-                        .set_level(rfd::MessageLevel::Warning);
-                    if dialog.show() != rfd::MessageDialogResult::Yes {
-                        return Task::none();
-                    }
-                }
-                return iced::exit();
+                return self.handle_quit_all();
             }
         }
         Task::none()
@@ -1216,12 +1262,10 @@ impl FlowEdit {
         lib_panel.into()
     }
 
-    fn view_flow_io_panel(window_id: window::Id, win: &WindowState) -> Element<'_, Message> {
+    fn view_flow_inputs_column(window_id: window::Id, inputs: &[IO]) -> Column<'_, Message> {
         let input_color = Color::from_rgb(0.4, 0.8, 1.0);
-        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
-
         let mut input_col = Column::new().spacing(4);
-        for (i, port) in win.flow_definition.inputs.iter().enumerate() {
+        for (i, port) in inputs.iter().enumerate() {
             let port_name = port.name().clone();
             let dtype = port
                 .datatypes()
@@ -1261,15 +1305,18 @@ impl FlowEdit {
                 );
             input_col = input_col.push(row);
         }
-        input_col = input_col.push(
+        input_col.push(
             button(Text::new("+ Input").size(11).center())
                 .on_press(Message::FlowEdit(window_id, FlowEditMessage::AddInput))
                 .style(button::secondary)
                 .padding([2, 8]),
-        );
+        )
+    }
 
+    fn view_flow_outputs_column(window_id: window::Id, outputs: &[IO]) -> Column<'_, Message> {
+        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
         let mut output_col = Column::new().spacing(4).align_x(iced::Alignment::End);
-        for (i, port) in win.flow_definition.outputs.iter().enumerate() {
+        for (i, port) in outputs.iter().enumerate() {
             let port_name = port.name().clone();
             let dtype = port
                 .datatypes()
@@ -1309,12 +1356,17 @@ impl FlowEdit {
                 .push(Text::new("\u{25D6}").size(18).color(output_color));
             output_col = output_col.push(row);
         }
-        output_col = output_col.push(
+        output_col.push(
             button(Text::new("+ Output").size(11).center())
                 .on_press(Message::FlowEdit(window_id, FlowEditMessage::AddOutput))
                 .style(button::secondary)
                 .padding([2, 8]),
-        );
+        )
+    }
+
+    fn view_flow_io_panel(window_id: window::Id, win: &WindowState) -> Element<'_, Message> {
+        let input_col = Self::view_flow_inputs_column(window_id, &win.flow_definition.inputs);
+        let output_col = Self::view_flow_outputs_column(window_id, &win.flow_definition.outputs);
 
         let io_box = container(
             Column::new()
@@ -1347,6 +1399,280 @@ impl FlowEdit {
         container(io_box).padding([6, 12]).width(Fill).into()
     }
 
+    fn view_function_definition_tab<'a>(
+        window_id: window::Id,
+        viewer: &'a FunctionViewer,
+    ) -> Element<'a, Message> {
+        let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+        let editable = !viewer.read_only;
+
+        let input_col = Self::view_function_input_ports(window_id, viewer, input_color, editable);
+        let output_col =
+            Self::view_function_output_ports(window_id, viewer, output_color, editable);
+
+        let mut name_widget = text_input("Function name", &viewer.func_def.name)
+            .size(16)
+            .padding(6)
+            .width(250);
+        if editable {
+            name_widget = name_widget.on_input(move |s| {
+                Message::FunctionEdit(window_id, FunctionEditMessage::NameChanged(s))
+            });
+        }
+        let name_input = container(name_widget).center_x(Fill);
+
+        let mut desc_widget = text_input("Description", &viewer.func_def.description)
+            .size(13)
+            .padding(6)
+            .width(480);
+        if editable {
+            let ext = std::path::Path::new(&viewer.func_def.source)
+                .extension()
+                .unwrap_or_default();
+            let is_provided = ext.eq_ignore_ascii_case("rs") || ext.eq_ignore_ascii_case("wasm");
+            if is_provided {
+                desc_widget = desc_widget.on_input(move |s| {
+                    Message::FunctionEdit(window_id, FunctionEditMessage::DescriptionChanged(s))
+                });
+            }
+        }
+        let desc_input = container(desc_widget).center_x(Fill);
+
+        let mut source_row = Row::new().spacing(6).align_y(iced::Alignment::Center).push(
+            button(
+                Text::new(&viewer.func_def.source)
+                    .size(13)
+                    .color(Color::from_rgb(0.6, 0.8, 1.0)),
+            )
+            .on_press(Message::FunctionEdit(
+                window_id,
+                FunctionEditMessage::TabSelected(1),
+            ))
+            .style(button::text)
+            .padding(0),
+        );
+        if editable {
+            source_row = source_row.push(
+                button(Text::new("...").size(12).center())
+                    .on_press(Message::FunctionEdit(
+                        window_id,
+                        FunctionEditMessage::BrowseSource,
+                    ))
+                    .style(button::secondary)
+                    .padding([3, 8]),
+            );
+        }
+        if viewer.docs_content.is_some() {
+            source_row = source_row.push(
+                button(Text::new("Docs").size(12).center())
+                    .on_press(Message::FunctionEdit(
+                        window_id,
+                        FunctionEditMessage::TabSelected(2),
+                    ))
+                    .style(button::secondary)
+                    .padding([3, 8]),
+            );
+        }
+
+        let func_box = container(
+            Column::new()
+                .spacing(20)
+                .padding(iced::Padding {
+                    top: 24.0,
+                    bottom: 24.0,
+                    left: 0.0,
+                    right: 0.0,
+                })
+                .push(name_input)
+                .push(desc_input)
+                .push(
+                    Row::new()
+                        .push(input_col)
+                        .push(iced::widget::Space::new().width(Fill))
+                        .push(output_col),
+                )
+                .push(container(source_row).center_x(Fill)),
+        )
+        .style(|_theme: &Theme| container::Style {
+            background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
+            border: iced::Border {
+                color: Color::from_rgb(0.5, 0.3, 0.7),
+                width: 2.0,
+                radius: 12.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(550);
+
+        container(func_box).center(Fill).padding(40).into()
+    }
+
+    fn view_function_input_ports<'a>(
+        window_id: window::Id,
+        viewer: &'a FunctionViewer,
+        input_color: Color,
+        editable: bool,
+    ) -> Column<'a, Message> {
+        let mut input_col = Column::new().spacing(6);
+        for (i, io) in viewer.func_def.inputs.iter().enumerate() {
+            let port_name = io.name().clone();
+            let dtype = io
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            let mut name_widget = text_input("name", &port_name).size(13).padding(3).width(90);
+            let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
+            if editable {
+                name_widget = name_widget.on_input(move |s| {
+                    Message::FunctionEdit(window_id, FunctionEditMessage::InputNameChanged(i, s))
+                });
+                type_widget = type_widget.on_input(move |s| {
+                    Message::FunctionEdit(window_id, FunctionEditMessage::InputTypeChanged(i, s))
+                });
+            }
+            let mut row = Row::new()
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .push(Text::new("\u{25D7}").size(24).color(input_color))
+                .push(name_widget)
+                .push(type_widget);
+            if editable {
+                row = row.push(
+                    button(Text::new("\u{2715}").size(10).center())
+                        .on_press(Message::FunctionEdit(
+                            window_id,
+                            FunctionEditMessage::DeleteInput(i),
+                        ))
+                        .style(button::danger)
+                        .padding([2, 5]),
+                );
+            }
+            input_col = input_col.push(row);
+        }
+        if editable {
+            input_col = input_col.push(
+                button(Text::new("+ Input").size(11).center())
+                    .on_press(Message::FunctionEdit(
+                        window_id,
+                        FunctionEditMessage::AddInput,
+                    ))
+                    .style(button::secondary)
+                    .padding([2, 8]),
+            );
+        }
+        input_col
+    }
+
+    fn view_function_output_ports<'a>(
+        window_id: window::Id,
+        viewer: &'a FunctionViewer,
+        output_color: Color,
+        editable: bool,
+    ) -> Column<'a, Message> {
+        let mut output_col = Column::new().spacing(6).align_x(iced::Alignment::End);
+        for (i, io) in viewer.func_def.outputs.iter().enumerate() {
+            let port_name = io.name().clone();
+            let dtype = io
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
+            let mut name_widget = text_input("name", &port_name).size(13).padding(3).width(90);
+            if editable {
+                type_widget = type_widget.on_input(move |s| {
+                    Message::FunctionEdit(window_id, FunctionEditMessage::OutputTypeChanged(i, s))
+                });
+                name_widget = name_widget.on_input(move |s| {
+                    Message::FunctionEdit(window_id, FunctionEditMessage::OutputNameChanged(i, s))
+                });
+            }
+            let mut row = Row::new().spacing(4).align_y(iced::Alignment::Center);
+            if editable {
+                row = row.push(
+                    button(Text::new("\u{2715}").size(10).center())
+                        .on_press(Message::FunctionEdit(
+                            window_id,
+                            FunctionEditMessage::DeleteOutput(i),
+                        ))
+                        .style(button::danger)
+                        .padding([2, 5]),
+                );
+            }
+            row = row
+                .push(type_widget)
+                .push(name_widget)
+                .push(Text::new("\u{25D6}").size(24).color(output_color));
+            output_col = output_col.push(row);
+        }
+        if editable {
+            output_col = output_col.push(
+                button(Text::new("+ Output").size(11).center())
+                    .on_press(Message::FunctionEdit(
+                        window_id,
+                        FunctionEditMessage::AddOutput,
+                    ))
+                    .style(button::secondary)
+                    .padding([2, 8]),
+            );
+        }
+        output_col
+    }
+
+    fn view_function_source_tab(window_id: window::Id, rs_content: &str) -> Element<'_, Message> {
+        let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
+            .on_press(Message::FunctionEdit(
+                window_id,
+                FunctionEditMessage::TabSelected(0),
+            ))
+            .style(button::secondary)
+            .padding([6, 14]);
+        Column::new()
+            .push(container(back_btn).padding([8, 12]))
+            .push(
+                container(
+                    iced::widget::scrollable(
+                        Text::new(rs_content).size(14).font(iced::Font::MONOSPACE),
+                    )
+                    .width(Fill)
+                    .height(Fill),
+                )
+                .width(Fill)
+                .height(Fill)
+                .padding(12),
+            )
+            .into()
+    }
+
+    fn view_function_docs_tab(
+        window_id: window::Id,
+        docs_content: Option<&str>,
+    ) -> Element<'_, Message> {
+        let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
+            .on_press(Message::FunctionEdit(
+                window_id,
+                FunctionEditMessage::TabSelected(0),
+            ))
+            .style(button::secondary)
+            .padding([6, 14]);
+        let docs = docs_content.unwrap_or("");
+        Column::new()
+            .push(container(back_btn).padding([8, 12]))
+            .push(
+                container(
+                    iced::widget::scrollable(Text::new(docs).size(14))
+                        .width(Fill)
+                        .height(Fill),
+                )
+                .width(Fill)
+                .height(Fill)
+                .padding(12),
+            )
+            .into()
+    }
+
     fn view_function<'a>(
         window_id: window::Id,
         viewer: &'a FunctionViewer,
@@ -1354,273 +1680,9 @@ impl FlowEdit {
         has_unsaved: bool,
     ) -> Element<'a, Message> {
         let content: Element<'_, Message> = match viewer.active_tab {
-            0 => {
-                let input_color = Color::from_rgb(0.4, 0.8, 1.0);
-                let output_color = Color::from_rgb(1.0, 0.6, 0.3);
-
-                // Input ports inside box: semicircle, name, type, (delete if editable)
-                let editable = !viewer.read_only;
-                let mut input_col = Column::new().spacing(6);
-                for (i, io) in viewer.func_def.inputs.iter().enumerate() {
-                    let port_name = io.name().clone();
-                    let dtype = io
-                        .datatypes()
-                        .first()
-                        .map(ToString::to_string)
-                        .unwrap_or_default();
-                    let mut name_widget =
-                        text_input("name", &port_name).size(13).padding(3).width(90);
-                    let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
-                    if editable {
-                        name_widget = name_widget.on_input(move |s| {
-                            Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::InputNameChanged(i, s),
-                            )
-                        });
-                        type_widget = type_widget.on_input(move |s| {
-                            Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::InputTypeChanged(i, s),
-                            )
-                        });
-                    }
-                    let mut row = Row::new()
-                        .spacing(4)
-                        .align_y(iced::Alignment::Center)
-                        .push(Text::new("\u{25D7}").size(24).color(input_color))
-                        .push(name_widget)
-                        .push(type_widget);
-                    if editable {
-                        row = row.push(
-                            button(Text::new("\u{2715}").size(10).center())
-                                .on_press(Message::FunctionEdit(
-                                    window_id,
-                                    FunctionEditMessage::DeleteInput(i),
-                                ))
-                                .style(button::danger)
-                                .padding([2, 5]),
-                        );
-                    }
-                    input_col = input_col.push(row);
-                }
-                if editable {
-                    input_col = input_col.push(
-                        button(Text::new("+ Input").size(11).center())
-                            .on_press(Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::AddInput,
-                            ))
-                            .style(button::secondary)
-                            .padding([2, 8]),
-                    );
-                }
-
-                // Output ports inside box: (delete if editable), type, name, semicircle
-                let mut output_col = Column::new().spacing(6).align_x(iced::Alignment::End);
-                for (i, io) in viewer.func_def.outputs.iter().enumerate() {
-                    let port_name = io.name().clone();
-                    let dtype = io
-                        .datatypes()
-                        .first()
-                        .map(ToString::to_string)
-                        .unwrap_or_default();
-                    let mut type_widget = text_input("type", &dtype).size(11).padding(3).width(75);
-                    let mut name_widget =
-                        text_input("name", &port_name).size(13).padding(3).width(90);
-                    if editable {
-                        type_widget = type_widget.on_input(move |s| {
-                            Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::OutputTypeChanged(i, s),
-                            )
-                        });
-                        name_widget = name_widget.on_input(move |s| {
-                            Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::OutputNameChanged(i, s),
-                            )
-                        });
-                    }
-                    let mut row = Row::new().spacing(4).align_y(iced::Alignment::Center);
-                    if editable {
-                        row = row.push(
-                            button(Text::new("\u{2715}").size(10).center())
-                                .on_press(Message::FunctionEdit(
-                                    window_id,
-                                    FunctionEditMessage::DeleteOutput(i),
-                                ))
-                                .style(button::danger)
-                                .padding([2, 5]),
-                        );
-                    }
-                    row = row
-                        .push(type_widget)
-                        .push(name_widget)
-                        .push(Text::new("\u{25D6}").size(24).color(output_color));
-                    output_col = output_col.push(row);
-                }
-                if editable {
-                    output_col = output_col.push(
-                        button(Text::new("+ Output").size(11).center())
-                            .on_press(Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::AddOutput,
-                            ))
-                            .style(button::secondary)
-                            .padding([2, 8]),
-                    );
-                }
-
-                let mut name_widget = text_input("Function name", &viewer.func_def.name)
-                    .size(16)
-                    .padding(6)
-                    .width(250);
-                if editable {
-                    name_widget = name_widget.on_input(move |s| {
-                        Message::FunctionEdit(window_id, FunctionEditMessage::NameChanged(s))
-                    });
-                }
-                let name_input = container(name_widget).center_x(Fill);
-
-                let mut desc_widget = text_input("Description", &viewer.func_def.description)
-                    .size(13)
-                    .padding(6)
-                    .width(480);
-                if editable {
-                    let ext = std::path::Path::new(&viewer.func_def.source)
-                        .extension()
-                        .unwrap_or_default();
-                    let is_provided =
-                        ext.eq_ignore_ascii_case("rs") || ext.eq_ignore_ascii_case("wasm");
-                    if is_provided {
-                        desc_widget = desc_widget.on_input(move |s| {
-                            Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::DescriptionChanged(s),
-                            )
-                        });
-                    }
-                }
-                let desc_input = container(desc_widget).center_x(Fill);
-
-                let mut source_row = Row::new().spacing(6).align_y(iced::Alignment::Center).push(
-                    button(
-                        Text::new(&viewer.func_def.source)
-                            .size(13)
-                            .color(Color::from_rgb(0.6, 0.8, 1.0)),
-                    )
-                    .on_press(Message::FunctionEdit(
-                        window_id,
-                        FunctionEditMessage::TabSelected(1),
-                    ))
-                    .style(button::text)
-                    .padding(0),
-                );
-                if editable {
-                    source_row = source_row.push(
-                        button(Text::new("...").size(12).center())
-                            .on_press(Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::BrowseSource,
-                            ))
-                            .style(button::secondary)
-                            .padding([3, 8]),
-                    );
-                }
-                if viewer.docs_content.is_some() {
-                    source_row = source_row.push(
-                        button(Text::new("Docs").size(12).center())
-                            .on_press(Message::FunctionEdit(
-                                window_id,
-                                FunctionEditMessage::TabSelected(2),
-                            ))
-                            .style(button::secondary)
-                            .padding([3, 8]),
-                    );
-                }
-
-                let func_box = container(
-                    Column::new()
-                        .spacing(20)
-                        .padding(iced::Padding {
-                            top: 24.0,
-                            bottom: 24.0,
-                            left: 0.0,
-                            right: 0.0,
-                        })
-                        .push(name_input)
-                        .push(desc_input)
-                        .push(
-                            Row::new()
-                                .push(input_col)
-                                .push(iced::widget::Space::new().width(Fill))
-                                .push(output_col),
-                        )
-                        .push(container(source_row).center_x(Fill)),
-                )
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
-                    border: iced::Border {
-                        color: Color::from_rgb(0.5, 0.3, 0.7),
-                        width: 2.0,
-                        radius: 12.0.into(),
-                    },
-                    ..Default::default()
-                })
-                .width(550);
-
-                container(func_box).center(Fill).padding(40).into()
-            }
-            1 => {
-                let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
-                    .on_press(Message::FunctionEdit(
-                        window_id,
-                        FunctionEditMessage::TabSelected(0),
-                    ))
-                    .style(button::secondary)
-                    .padding([6, 14]);
-                Column::new()
-                    .push(container(back_btn).padding([8, 12]))
-                    .push(
-                        container(
-                            iced::widget::scrollable(
-                                Text::new(&viewer.rs_content)
-                                    .size(14)
-                                    .font(iced::Font::MONOSPACE),
-                            )
-                            .width(Fill)
-                            .height(Fill),
-                        )
-                        .width(Fill)
-                        .height(Fill)
-                        .padding(12),
-                    )
-                    .into()
-            }
-            _ => {
-                let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
-                    .on_press(Message::FunctionEdit(
-                        window_id,
-                        FunctionEditMessage::TabSelected(0),
-                    ))
-                    .style(button::secondary)
-                    .padding([6, 14]);
-                let docs = viewer.docs_content.as_deref().unwrap_or("");
-                Column::new()
-                    .push(container(back_btn).padding([8, 12]))
-                    .push(
-                        container(
-                            iced::widget::scrollable(Text::new(docs).size(14))
-                                .width(Fill)
-                                .height(Fill),
-                        )
-                        .width(Fill)
-                        .height(Fill)
-                        .padding(12),
-                    )
-                    .into()
-            }
+            0 => Self::view_function_definition_tab(window_id, viewer),
+            1 => Self::view_function_source_tab(window_id, &viewer.rs_content),
+            _ => Self::view_function_docs_tab(window_id, viewer.docs_content.as_deref()),
         };
 
         let mut save_btn = button(Text::new("\u{1F4BE} Save").size(14).center())
@@ -2280,7 +2342,212 @@ impl FlowEdit {
         }
     }
 
+    fn handle_func_description_changed(&mut self, win_id: window::Id, new_desc: String) {
+        let parent_info = self.windows.get(&win_id).and_then(|win| {
+            if let WindowKind::FunctionViewer(ref viewer) = win.kind {
+                viewer
+                    .parent_window
+                    .map(|pid| (pid, viewer.node_source.clone()))
+            } else {
+                None
+            }
+        });
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                viewer.func_def.description.clone_from(&new_desc);
+            }
+            win.history.mark_modified();
+        }
+        if let Some((parent_id, node_source)) = parent_info {
+            if let Some(parent_win) = self.windows.get_mut(&parent_id) {
+                for pref in &parent_win.flow_definition.process_refs {
+                    if pref.source == node_source {
+                        let alias = if pref.alias.is_empty() {
+                            canvas_view::derive_short_name(&pref.source)
+                        } else {
+                            pref.alias.clone()
+                        };
+                        if let Some(proc) = parent_win.flow_definition.subprocesses.get_mut(&alias)
+                        {
+                            match proc {
+                                Process::FunctionProcess(ref mut f) => {
+                                    f.description.clone_from(&new_desc);
+                                }
+                                Process::FlowProcess(ref mut f) => {
+                                    f.description.clone_from(&new_desc);
+                                }
+                            }
+                        }
+                    }
+                }
+                parent_win.canvas_state.request_redraw();
+            }
+        }
+    }
+
+    fn handle_func_browse_source(&mut self, win_id: window::Id) {
+        let dialog = rfd::FileDialog::new().add_filter("Rust", &["rs"]);
+        if let Some(selected) = dialog.pick_file() {
+            if let Some(win) = self.windows.get_mut(&win_id) {
+                if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                    let base = viewer
+                        .toml_path()
+                        .as_deref()
+                        .and_then(Path::parent)
+                        .unwrap_or(Path::new("."))
+                        .to_path_buf();
+                    let rel = selected.strip_prefix(&base).map_or_else(
+                        |_| selected.to_string_lossy().to_string(),
+                        |p| p.to_string_lossy().to_string(),
+                    );
+                    viewer.func_def.source = rel;
+                    viewer.rs_content = std::fs::read_to_string(&selected)
+                        .unwrap_or_else(|_| String::from("// Could not read file"));
+                }
+                win.history.mark_modified();
+            }
+        }
+    }
+
+    fn handle_func_save(&mut self, win_id: window::Id) {
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                match file_ops::save_function_definition(v) {
+                    Ok(()) => {
+                        let path_display = v
+                            .toml_path()
+                            .map_or_else(|| String::from("(unknown)"), |p| p.display().to_string());
+                        win.status = format!("Saved: {path_display}");
+                        win.history.clear();
+                    }
+                    Err(e) => {
+                        win.status = format!("Save failed: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_func_io_name_changed(
+        &mut self,
+        win_id: window::Id,
+        idx: usize,
+        name: String,
+        is_input: bool,
+    ) {
+        let old_name = self.windows.get(&win_id).and_then(|win| {
+            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                let ports = if is_input {
+                    &v.func_def.inputs
+                } else {
+                    &v.func_def.outputs
+                };
+                ports.get(idx).map(|io| io.name().clone())
+            } else {
+                None
+            }
+        });
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                let ports = if is_input {
+                    &mut v.func_def.inputs
+                } else {
+                    &mut v.func_def.outputs
+                };
+                if let Some(io) = ports.get_mut(idx) {
+                    io.set_name(name.clone());
+                }
+            }
+            win.history.mark_modified();
+        }
+        Self::propagate_function_ports(&mut self.windows, win_id);
+        if let Some(old) = old_name {
+            Self::rename_parent_connections_port(&mut self.windows, win_id, &old, &name, is_input);
+        }
+    }
+
     /// Handle function definition viewing/editing messages.
+    fn handle_func_add_io(&mut self, win_id: window::Id, is_input: bool) {
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                let (prefix, ports) = if is_input {
+                    ("input", &v.func_def.inputs as &[IO])
+                } else {
+                    ("output", &v.func_def.outputs as &[IO])
+                };
+                let name = next_unique_io_name(prefix, ports);
+                let io = IO::new_named(vec![DataType::from("string")], Route::default(), &name);
+                if is_input {
+                    v.func_def.inputs.push(io);
+                } else {
+                    v.func_def.outputs.push(io);
+                }
+            }
+            win.history.mark_modified();
+        }
+        Self::propagate_function_ports(&mut self.windows, win_id);
+    }
+
+    fn handle_func_delete_io(&mut self, win_id: window::Id, idx: usize, is_input: bool) {
+        let old_name = self.windows.get(&win_id).and_then(|win| {
+            if let WindowKind::FunctionViewer(ref v) = win.kind {
+                let ports = if is_input {
+                    &v.func_def.inputs
+                } else {
+                    &v.func_def.outputs
+                };
+                ports.get(idx).map(|io| io.name().clone())
+            } else {
+                None
+            }
+        });
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                let ports = if is_input {
+                    &mut v.func_def.inputs
+                } else {
+                    &mut v.func_def.outputs
+                };
+                if idx < ports.len() {
+                    ports.remove(idx);
+                }
+            }
+            win.history.mark_modified();
+        }
+        Self::propagate_function_ports(&mut self.windows, win_id);
+        if let Some(port_name) = old_name {
+            Self::remove_parent_connections_to_port(
+                &mut self.windows,
+                win_id,
+                &port_name,
+                is_input,
+            );
+        }
+    }
+
+    fn handle_func_io_type_changed(
+        &mut self,
+        win_id: window::Id,
+        idx: usize,
+        dtype: String,
+        is_input: bool,
+    ) {
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            if let WindowKind::FunctionViewer(ref mut v) = win.kind {
+                let ports = if is_input {
+                    &mut v.func_def.inputs
+                } else {
+                    &mut v.func_def.outputs
+                };
+                if let Some(io) = ports.get_mut(idx) {
+                    io.set_datatypes(&[DataType::from(dtype)]);
+                }
+            }
+            win.history.mark_modified();
+        }
+        Self::propagate_function_ports(&mut self.windows, win_id);
+    }
+
     fn handle_function_edit_message(&mut self, win_id: window::Id, func_msg: FunctionEditMessage) {
         match func_msg {
             FunctionEditMessage::TabSelected(tab) => {
@@ -2299,249 +2566,30 @@ impl FlowEdit {
                 }
             }
             FunctionEditMessage::DescriptionChanged(new_desc) => {
-                // Extract parent info before mutating
-                let parent_info = self.windows.get(&win_id).and_then(|win| {
-                    if let WindowKind::FunctionViewer(ref viewer) = win.kind {
-                        viewer
-                            .parent_window
-                            .map(|pid| (pid, viewer.node_source.clone()))
-                    } else {
-                        None
-                    }
-                });
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                        viewer.func_def.description.clone_from(&new_desc);
-                    }
-                    win.history.mark_modified();
-                }
-                // Propagate description to the parent window's subprocess definitions
-                if let Some((parent_id, node_source)) = parent_info {
-                    if let Some(parent_win) = self.windows.get_mut(&parent_id) {
-                        // Update subprocess definitions with matching source
-                        for pref in &parent_win.flow_definition.process_refs {
-                            if pref.source == node_source {
-                                let alias = if pref.alias.is_empty() {
-                                    canvas_view::derive_short_name(&pref.source)
-                                } else {
-                                    pref.alias.clone()
-                                };
-                                if let Some(proc) =
-                                    parent_win.flow_definition.subprocesses.get_mut(&alias)
-                                {
-                                    match proc {
-                                        Process::FunctionProcess(ref mut f) => {
-                                            f.description.clone_from(&new_desc);
-                                        }
-                                        Process::FlowProcess(ref mut f) => {
-                                            f.description.clone_from(&new_desc);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        parent_win.canvas_state.request_redraw();
-                    }
-                }
+                self.handle_func_description_changed(win_id, new_desc);
             }
-            FunctionEditMessage::BrowseSource => {
-                let dialog = rfd::FileDialog::new().add_filter("Rust", &["rs"]);
-                if let Some(selected) = dialog.pick_file() {
-                    if let Some(win) = self.windows.get_mut(&win_id) {
-                        if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                            let base = viewer
-                                .toml_path()
-                                .as_deref()
-                                .and_then(Path::parent)
-                                .unwrap_or(Path::new("."))
-                                .to_path_buf();
-                            let rel = selected.strip_prefix(&base).map_or_else(
-                                |_| selected.to_string_lossy().to_string(),
-                                |p| p.to_string_lossy().to_string(),
-                            );
-                            viewer.func_def.source = rel;
-                            viewer.rs_content = std::fs::read_to_string(&selected)
-                                .unwrap_or_else(|_| String::from("// Could not read file"));
-                        }
-                        win.history.mark_modified();
-                    }
-                }
-            }
-            FunctionEditMessage::AddInput => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        let name = next_unique_io_name("input", &v.func_def.inputs);
-                        v.func_def.inputs.push(IO::new_named(
-                            vec![DataType::from("string")],
-                            Route::default(),
-                            &name,
-                        ));
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-            }
-            FunctionEditMessage::AddOutput => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        let name = next_unique_io_name("output", &v.func_def.outputs);
-                        v.func_def.outputs.push(IO::new_named(
-                            vec![DataType::from("string")],
-                            Route::default(),
-                            &name,
-                        ));
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-            }
+            FunctionEditMessage::BrowseSource => self.handle_func_browse_source(win_id),
+            FunctionEditMessage::AddInput => self.handle_func_add_io(win_id, true),
+            FunctionEditMessage::AddOutput => self.handle_func_add_io(win_id, false),
             FunctionEditMessage::DeleteInput(idx) => {
-                let old_name = self.windows.get(&win_id).and_then(|win| {
-                    if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        v.func_def.inputs.get(idx).map(|io| io.name().clone())
-                    } else {
-                        None
-                    }
-                });
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if idx < v.func_def.inputs.len() {
-                            v.func_def.inputs.remove(idx);
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-                if let Some(port_name) = old_name {
-                    Self::remove_parent_connections_to_port(
-                        &mut self.windows,
-                        win_id,
-                        &port_name,
-                        true,
-                    );
-                }
+                self.handle_func_delete_io(win_id, idx, true);
             }
             FunctionEditMessage::DeleteOutput(idx) => {
-                let old_name = self.windows.get(&win_id).and_then(|win| {
-                    if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        v.func_def.outputs.get(idx).map(|io| io.name().clone())
-                    } else {
-                        None
-                    }
-                });
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if idx < v.func_def.outputs.len() {
-                            v.func_def.outputs.remove(idx);
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-                if let Some(port_name) = old_name {
-                    Self::remove_parent_connections_to_port(
-                        &mut self.windows,
-                        win_id,
-                        &port_name,
-                        false,
-                    );
-                }
+                self.handle_func_delete_io(win_id, idx, false);
             }
             FunctionEditMessage::InputNameChanged(idx, name) => {
-                let old_name = self.windows.get(&win_id).and_then(|win| {
-                    if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        v.func_def.inputs.get(idx).map(|io| io.name().clone())
-                    } else {
-                        None
-                    }
-                });
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if let Some(io) = v.func_def.inputs.get_mut(idx) {
-                            io.set_name(name.clone());
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-                if let Some(old) = old_name {
-                    Self::rename_parent_connections_port(
-                        &mut self.windows,
-                        win_id,
-                        &old,
-                        &name,
-                        true,
-                    );
-                }
+                self.handle_func_io_name_changed(win_id, idx, name, true);
             }
             FunctionEditMessage::InputTypeChanged(idx, dtype) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if let Some(io) = v.func_def.inputs.get_mut(idx) {
-                            io.set_datatypes(&[DataType::from(dtype)]);
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
+                self.handle_func_io_type_changed(win_id, idx, dtype, true);
             }
             FunctionEditMessage::OutputNameChanged(idx, name) => {
-                let old_name = self.windows.get(&win_id).and_then(|win| {
-                    if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        v.func_def.outputs.get(idx).map(|io| io.name().clone())
-                    } else {
-                        None
-                    }
-                });
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if let Some(io) = v.func_def.outputs.get_mut(idx) {
-                            io.set_name(name.clone());
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
-                if let Some(old) = old_name {
-                    Self::rename_parent_connections_port(
-                        &mut self.windows,
-                        win_id,
-                        &old,
-                        &name,
-                        false,
-                    );
-                }
+                self.handle_func_io_name_changed(win_id, idx, name, false);
             }
             FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref mut v) = win.kind {
-                        if let Some(io) = v.func_def.outputs.get_mut(idx) {
-                            io.set_datatypes(&[DataType::from(dtype)]);
-                        }
-                    }
-                    win.history.mark_modified();
-                }
-                Self::propagate_function_ports(&mut self.windows, win_id);
+                self.handle_func_io_type_changed(win_id, idx, dtype, false);
             }
-            FunctionEditMessage::Save => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    if let WindowKind::FunctionViewer(ref v) = win.kind {
-                        match file_ops::save_function_definition(v) {
-                            Ok(()) => {
-                                let path_display = v.toml_path().map_or_else(
-                                    || String::from("(unknown)"),
-                                    |p| p.display().to_string(),
-                                );
-                                win.status = format!("Saved: {path_display}");
-                                win.history.clear();
-                            }
-                            Err(e) => {
-                                win.status = format!("Save failed: {e}");
-                            }
-                        }
-                    }
-                }
-            }
+            FunctionEditMessage::Save => self.handle_func_save(win_id),
         }
     }
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -67,17 +67,17 @@ fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
 }
 
 impl WindowState {
-    fn rename_flow_input(&mut self, idx: usize, name: String) {
+    fn rename_flow_input(&mut self, idx: usize, name: &str) {
         let duplicate = self
             .flow_definition
             .inputs
             .iter()
             .enumerate()
-            .any(|(i, io)| i != idx && io.name() == &name);
+            .any(|(i, io)| i != idx && io.name() == name);
         if !duplicate {
             if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
                 let old_name = io.name().clone();
-                io.set_name(name.clone());
+                io.set_name(name.into());
                 let old_route = format!("input/{old_name}");
                 let new_route = format!("input/{name}");
                 for conn in &mut self.flow_definition.connections {
@@ -91,17 +91,17 @@ impl WindowState {
         }
     }
 
-    fn rename_flow_output(&mut self, idx: usize, name: String) {
+    fn rename_flow_output(&mut self, idx: usize, name: &str) {
         let duplicate = self
             .flow_definition
             .outputs
             .iter()
             .enumerate()
-            .any(|(i, io)| i != idx && io.name() == &name);
+            .any(|(i, io)| i != idx && io.name() == name);
         if !duplicate {
             if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
                 let old_name = io.name().clone();
-                io.set_name(name.clone());
+                io.set_name(name.into());
                 let old_route_str = format!("output/{old_name}");
                 let new_route_str = format!("output/{name}");
                 for conn in &mut self.flow_definition.connections {
@@ -202,7 +202,7 @@ impl WindowState {
                     self.canvas_state.request_redraw();
                 }
             }
-            FlowEditMessage::InputNameChanged(idx, name) => self.rename_flow_input(idx, name),
+            FlowEditMessage::InputNameChanged(idx, name) => self.rename_flow_input(idx, &name),
             FlowEditMessage::InputTypeChanged(idx, dtype) => {
                 if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
@@ -210,7 +210,7 @@ impl WindowState {
                 self.history.mark_modified();
                 self.canvas_state.request_redraw();
             }
-            FlowEditMessage::OutputNameChanged(idx, name) => self.rename_flow_output(idx, name),
+            FlowEditMessage::OutputNameChanged(idx, name) => self.rename_flow_output(idx, &name),
             FlowEditMessage::OutputTypeChanged(idx, dtype) => {
                 if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
@@ -1399,10 +1399,10 @@ impl FlowEdit {
         container(io_box).padding([6, 12]).width(Fill).into()
     }
 
-    fn view_function_definition_tab<'a>(
+    fn view_function_definition_tab(
         window_id: window::Id,
-        viewer: &'a FunctionViewer,
-    ) -> Element<'a, Message> {
+        viewer: &FunctionViewer,
+    ) -> Element<'_, Message> {
         let input_color = Color::from_rgb(0.4, 0.8, 1.0);
         let output_color = Color::from_rgb(1.0, 0.6, 0.3);
         let editable = !viewer.read_only;
@@ -1508,12 +1508,12 @@ impl FlowEdit {
         container(func_box).center(Fill).padding(40).into()
     }
 
-    fn view_function_input_ports<'a>(
+    fn view_function_input_ports(
         window_id: window::Id,
-        viewer: &'a FunctionViewer,
+        viewer: &FunctionViewer,
         input_color: Color,
         editable: bool,
-    ) -> Column<'a, Message> {
+    ) -> Column<'_, Message> {
         let mut input_col = Column::new().spacing(6);
         for (i, io) in viewer.func_def.inputs.iter().enumerate() {
             let port_name = io.name().clone();
@@ -1565,12 +1565,12 @@ impl FlowEdit {
         input_col
     }
 
-    fn view_function_output_ports<'a>(
+    fn view_function_output_ports(
         window_id: window::Id,
-        viewer: &'a FunctionViewer,
+        viewer: &FunctionViewer,
         output_color: Color,
         editable: bool,
-    ) -> Column<'a, Message> {
+    ) -> Column<'_, Message> {
         let mut output_col = Column::new().spacing(6).align_x(iced::Alignment::End);
         for (i, io) in viewer.func_def.outputs.iter().enumerate() {
             let port_name = io.name().clone();
@@ -1991,7 +1991,7 @@ impl FlowEdit {
             func_flow_def.source_url = url;
         }
         let child = WindowState {
-            kind: WindowKind::FunctionViewer(viewer),
+            kind: WindowKind::FunctionViewer(Box::new(viewer)),
 
             canvas_state: FlowCanvasState::default(),
             status: format!("Function: {func_name}"),
@@ -2230,7 +2230,7 @@ impl FlowEdit {
             func_flow_def.source_url = url;
         }
         let mut child = WindowState {
-            kind: WindowKind::FunctionViewer(viewer),
+            kind: WindowKind::FunctionViewer(Box::new(viewer)),
 
             canvas_state: FlowCanvasState::default(),
             status: String::from("New function — add ports and Save"),
@@ -2342,7 +2342,7 @@ impl FlowEdit {
         }
     }
 
-    fn handle_func_description_changed(&mut self, win_id: window::Id, new_desc: String) {
+    fn handle_func_description_changed(&mut self, win_id: window::Id, new_desc: &str) {
         let parent_info = self.windows.get(&win_id).and_then(|win| {
             if let WindowKind::FunctionViewer(ref viewer) = win.kind {
                 viewer
@@ -2354,7 +2354,7 @@ impl FlowEdit {
         });
         if let Some(win) = self.windows.get_mut(&win_id) {
             if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
-                viewer.func_def.description.clone_from(&new_desc);
+                viewer.func_def.description = new_desc.to_string();
             }
             win.history.mark_modified();
         }
@@ -2371,10 +2371,10 @@ impl FlowEdit {
                         {
                             match proc {
                                 Process::FunctionProcess(ref mut f) => {
-                                    f.description.clone_from(&new_desc);
+                                    f.description = new_desc.to_string();
                                 }
                                 Process::FlowProcess(ref mut f) => {
-                                    f.description.clone_from(&new_desc);
+                                    f.description = new_desc.to_string();
                                 }
                             }
                         }
@@ -2432,7 +2432,7 @@ impl FlowEdit {
         &mut self,
         win_id: window::Id,
         idx: usize,
-        name: String,
+        name: &str,
         is_input: bool,
     ) {
         let old_name = self.windows.get(&win_id).and_then(|win| {
@@ -2455,14 +2455,14 @@ impl FlowEdit {
                     &mut v.func_def.outputs
                 };
                 if let Some(io) = ports.get_mut(idx) {
-                    io.set_name(name.clone());
+                    io.set_name(name.into());
                 }
             }
             win.history.mark_modified();
         }
         Self::propagate_function_ports(&mut self.windows, win_id);
         if let Some(old) = old_name {
-            Self::rename_parent_connections_port(&mut self.windows, win_id, &old, &name, is_input);
+            Self::rename_parent_connections_port(&mut self.windows, win_id, &old, name, is_input);
         }
     }
 
@@ -2566,7 +2566,7 @@ impl FlowEdit {
                 }
             }
             FunctionEditMessage::DescriptionChanged(new_desc) => {
-                self.handle_func_description_changed(win_id, new_desc);
+                self.handle_func_description_changed(win_id, &new_desc);
             }
             FunctionEditMessage::BrowseSource => self.handle_func_browse_source(win_id),
             FunctionEditMessage::AddInput => self.handle_func_add_io(win_id, true),
@@ -2578,13 +2578,13 @@ impl FlowEdit {
                 self.handle_func_delete_io(win_id, idx, false);
             }
             FunctionEditMessage::InputNameChanged(idx, name) => {
-                self.handle_func_io_name_changed(win_id, idx, name, true);
+                self.handle_func_io_name_changed(win_id, idx, &name, true);
             }
             FunctionEditMessage::InputTypeChanged(idx, dtype) => {
                 self.handle_func_io_type_changed(win_id, idx, dtype, true);
             }
             FunctionEditMessage::OutputNameChanged(idx, name) => {
-                self.handle_func_io_name_changed(win_id, idx, name, false);
+                self.handle_func_io_name_changed(win_id, idx, &name, false);
             }
             FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
                 self.handle_func_io_type_changed(win_id, idx, dtype, false);

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -64,10 +64,11 @@ impl FunctionViewer {
 /// What kind of content a window displays.
 pub(crate) enum WindowKind {
     FlowEditor,
-    FunctionViewer(FunctionViewer),
+    FunctionViewer(Box<FunctionViewer>),
 }
 
 /// Per-window state for the flow editor.
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct WindowState {
     /// What this window displays
     pub(crate) kind: WindowKind,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -190,6 +190,7 @@ impl FlowrGui {
         (flowrgui, Task::none())
     }
 
+    #[allow(clippy::unused_self)]
     fn title(&self) -> String {
         String::from("flowrgui")
     }

--- a/flowr/src/lib/discovery.rs
+++ b/flowr/src/lib/discovery.rs
@@ -19,6 +19,10 @@ const DEFAULT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// The returned `ServiceDaemon` must be kept alive by the caller — the service is
 /// unregistered when the daemon is dropped.
+///
+/// # Errors
+///
+/// Returns an error if the mDNS daemon or service registration fails.
 pub fn enable_service_discovery(name: &str, service_port: u16) -> Result<ServiceDaemon> {
     let mdns = ServiceDaemon::new().map_err(|e| format!("Could not create mDNS daemon: {e}"))?;
 
@@ -70,7 +74,9 @@ pub fn discover_service(name: &str) -> Result<String> {
             ));
         }
 
-        if let Ok(ServiceEvent::ServiceResolved(info)) = receiver.recv_timeout(Duration::from_millis(500)) {
+        if let Ok(ServiceEvent::ServiceResolved(info)) =
+            receiver.recv_timeout(Duration::from_millis(500))
+        {
             let instance = info
                 .get_fullname()
                 .strip_suffix(&full_name_suffix)


### PR DESCRIPTION
## Summary
- Change `#[serde(skip_deserializing)]` to `#[serde(skip)]` on all runtime-only fields in `FunctionDefinition`, `IO`, and `ImplementationLocator::Native` so they are also excluded from serialization
- Add tests verifying runtime fields are excluded from serialized output
- Split 15 functions exceeding clippy's 100-line limit into smaller helpers
- Fix all remaining clippy warnings (redundant closures, unnecessary Option wrapping, large enum variant, String-by-value params, lifetime elision, missing error docs)
- Add `--deny warnings` to clippy in both Makefile and CI workflow

## Structs/fields changed

**FunctionDefinition** — 9 fields: `alias`, `source_url`, `route`, `implementation`, `lib_reference`, `context_reference`, `output_connections`, `function_id`, `flow_id`

**IO** — 3 fields: `flow_initializer`, `route`, `io_type`

**ImplementationLocator::Native** — enum variant (was `skip_deserializing, skip_serializing`, now `skip`)

Closes #2607

## Test plan
- [x] All 195 flowedit tests pass
- [x] All flowcore tests pass (including new serialization tests)
- [x] `make clippy` passes with `--deny warnings` (zero warnings)
- [x] `make test` passes (only pre-existing flaky flowr test fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled stricter Clippy lint enforcement to treat all warnings as build errors.

* **Bug Fixes**
  * Enhanced flow input/output rename operations with duplicate-name validation and improved connection routing.

* **Refactor**
  * Improved code organization across canvas interactions, file operations, and UI rendering.
  * Optimized serialization behavior for function definitions and data structures.

* **Documentation**
  * Updated documentation for service discovery error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->