### PR TITLE
flowcore: Add process_from_route for hierarchy lookup, design spec (#2602)

### DIFF
--- a/docs/design/2026-04-25-single-flow-owner-design.md
+++ b/docs/design/2026-04-25-single-flow-owner-design.md
@@ -1,0 +1,120 @@
+# Single FlowDefinition Owner Architecture
+
+Issue: #2602
+
+## Problem
+
+Each editor window currently owns an independent copy of its `FlowDefinition`.
+Edits in one window don't propagate to others. When a sub-flow or function is
+opened in a child window, a fresh copy is loaded from disk, creating divergent
+state. Manual propagation helpers exist but are fragile and incomplete.
+
+## Design
+
+### Data Ownership
+
+`FlowEdit` owns the single root `FlowDefinition`, which contains the complete
+hierarchy of nested flows and functions via `subprocesses: BTreeMap<Name, Process>`.
+This is the single source of truth for all editing windows.
+
+`WindowState` stores a `Route` identifying which `Process` in the hierarchy it
+renders. It does NOT own any flow data. It retains only UI state: canvas zoom/scroll,
+selection, undo history, tooltip, context menu, metadata panel visibility, and
+window size/position.
+
+### Addressing via Route
+
+Windows address their target using flowcore's `Route` type (e.g., `/root/parser/tokenizer`).
+Each `FlowDefinition` and `FunctionDefinition` already has a `route` field populated
+by the parser.
+
+`FlowDefinition::process_from_route(&self, route: &Route) -> Option<&Process>` and
+its `_mut` variant walk the `subprocesses` tree by matching route segments against
+subprocess aliases. These methods are implemented in flowcore.
+
+### Edit Flow
+
+1. Window sends an edit message containing the target `Route` and the edit operation.
+   Messages are self-contained and independent of the originating window.
+2. `FlowEdit::update()` receives the message, uses `process_from_route_mut()` to find
+   the target `Process`, and applies the mutation.
+3. `FlowEdit::update()` marks the target route as dirty (for save tracking).
+4. `FlowEdit::update()` notifies all windows whose stored `Route` is affected
+   (equal to or a sub-route of the changed route) to redraw.
+5. Windows call `borrow()` / read the data via their `Route` during `view()`.
+
+### Window Lifecycle
+
+**Opening a sub-flow or function:** Create a new `WindowState` with the target
+`Route`. No file loading — the data already exists in the root hierarchy from
+the initial parse. The window renders by looking up its `Route` in the hierarchy.
+
+**Closing a window:** Remove the `WindowState`. No data effect — the hierarchy
+is unaffected.
+
+**Deleting a process:** Before removing a process from the hierarchy, iterate
+all open windows and close any whose stored `Route` is equal to or a sub-route
+of the deleted process's route. Then remove the process.
+
+### Undo/Redo
+
+Per-window. Each `WindowState` maintains its own `EditHistory`. Undo/redo is
+triggered by keyboard shortcut or button on the focused window and only affects
+edits made from that window. Undo sends a reverse-edit message to `FlowEdit::update()`
+following the same flow as any other edit.
+
+### Saving
+
+Track modified files by maintaining dirty flags per `Route`. When saving,
+iterate all dirty routes and serialize each `FlowDefinition` or `FunctionDefinition`
+to its file (determined by `source_url`).
+
+Serialization methods for `FlowDefinition` and `FunctionDefinition` need to be
+added to flowcore, moving logic currently in flowedit's `file_ops.rs`.
+
+### Data Flow Diagram
+
+```
+Window A (Route: /root)        Window B (Route: /root/parser)
+     |                              |
+     | edit msg + Route             | edit msg + Route
+     v                              v
++--------------------------------------------------+
+|                FlowEdit::update()                 |
+|                                                   |
+|  process_from_route_mut(route) -> &mut Process    |
+|  apply mutation                                   |
+|  mark route dirty                                 |
+|  notify affected windows                          |
++--------------------------------------------------+
+                      |
+                      v
+            FlowEdit::view()
+                      |
+        +-------------+-------------+
+        |                           |
+        v                           v
+   Window A                    Window B
+   process_from_route(         process_from_route(
+     &root, /root)               &root, /root/parser)
+   -> render root flow         -> render sub-flow
+```
+
+## Prerequisites
+
+1. `process_from_route` / `process_from_route_mut` in flowcore — **done**
+2. Serialization methods for `FlowDefinition` and `FunctionDefinition` in flowcore
+3. Refactor edit messages to carry `Route` instead of relying on window context
+
+## Migration Strategy
+
+This is a large architectural change. Suggested order:
+
+1. Add serialization to flowcore (prerequisite 2)
+2. Add `Route` to `WindowState`, populate alongside existing `flow_definition`
+3. Refactor edit messages to carry `Route`
+4. Move edit logic from `WindowState` methods to `FlowEdit::update()`
+5. Remove `flow_definition` from `WindowState`, use `process_from_route` in `view()`
+6. Implement cascade-close on deletion
+7. Implement dirty-flag save tracking
+8. Remove file loading from child window creation

--- a/docs/design/2026-04-25-single-flow-owner-design.md
+++ b/docs/design/2026-04-25-single-flow-owner-design.md
@@ -74,7 +74,7 @@ added to flowcore, moving logic currently in flowedit's `file_ops.rs`.
 
 ### Data Flow Diagram
 
-```
+```text
 Window A (Route: /root)        Window B (Route: /root/parser)
      |                              |
      | edit msg + Route             | edit msg + Route
@@ -95,8 +95,8 @@ Window A (Route: /root)        Window B (Route: /root/parser)
         |                           |
         v                           v
    Window A                    Window B
-   process_from_route(         process_from_route(
-     &root, /root)               &root, /root/parser)
+   uses &root_flow             process_from_route(
+   directly (root window)        &root, /root/parser)
    -> render root flow         -> render sub-flow
 ```
 

--- a/flowcore/src/lib.rs
+++ b/flowcore/src/lib.rs
@@ -7,6 +7,9 @@ use crate::errors::Result;
 /// serializers to read definition files from various text formats based on file extension
 pub mod deserializers;
 
+/// Serializers for writing flow model types to disk (TOML format)
+pub mod serializers;
+
 /// contains [Error] that other modules in this crate will `use errors::*;`
 /// to get access to everything `error_chain` creates.
 pub mod errors;

--- a/flowcore/src/model/flow_definition.rs
+++ b/flowcore/src/model/flow_definition.rs
@@ -290,15 +290,20 @@ impl FlowDefinition {
         let alias = *segments.first()?;
         let process = self.subprocesses.get(alias)?;
 
-        match (process, segments.get(1..)) {
-            (Process::FlowProcess(sub_flow), Some(rest)) if !rest.is_empty() => {
+        let rest = segments.get(1..).unwrap_or_default();
+        if rest.is_empty() {
+            return Some(process);
+        }
+
+        match process {
+            Process::FlowProcess(sub_flow) => {
                 let remaining = Route::from(rest.join("/"));
                 let mut child_route = self.route.clone();
                 child_route.extend(&Route::from(alias));
                 child_route.extend(&remaining);
                 sub_flow.process_from_route(&child_route)
             }
-            _ => Some(process),
+            Process::FunctionProcess(_) => None,
         }
     }
 

--- a/flowcore/src/model/flow_definition.rs
+++ b/flowcore/src/model/flow_definition.rs
@@ -274,6 +274,63 @@ impl FlowDefinition {
         self.inputs().is_empty() && self.outputs().is_empty()
     }
 
+    /// Find a `Process` in the flow hierarchy by its `Route`.
+    ///
+    /// The route is matched against this flow's own route first. If they match,
+    /// returns `None` (the caller already has the flow). Otherwise, walks the
+    /// `subprocesses` tree by stripping route segments to find the target process.
+    #[must_use]
+    pub fn process_from_route(&self, route: &Route) -> Option<&Process> {
+        let sub = route.sub_route_of(&self.route)?;
+        if sub.is_empty() {
+            return None;
+        }
+
+        let segments: Vec<&str> = sub.as_ref().split('/').collect();
+        let alias = *segments.first()?;
+        let process = self.subprocesses.get(alias)?;
+
+        match (process, segments.get(1..)) {
+            (Process::FlowProcess(sub_flow), Some(rest)) if !rest.is_empty() => {
+                let remaining = Route::from(rest.join("/"));
+                let mut child_route = self.route.clone();
+                child_route.extend(&Route::from(alias));
+                child_route.extend(&remaining);
+                sub_flow.process_from_route(&child_route)
+            }
+            _ => Some(process),
+        }
+    }
+
+    /// Mutable version of [`process_from_route`](Self::process_from_route).
+    pub fn process_from_route_mut(&mut self, route: &Route) -> Option<&mut Process> {
+        let sub = route.sub_route_of(&self.route)?;
+        if sub.is_empty() {
+            return None;
+        }
+
+        let segments: Vec<&str> = sub.as_ref().split('/').collect();
+        let alias = *segments.first()?;
+
+        let Some(rest) = segments.get(1..) else {
+            return self.subprocesses.get_mut(alias);
+        };
+        if rest.is_empty() {
+            return self.subprocesses.get_mut(alias);
+        }
+
+        let process = self.subprocesses.get_mut(alias)?;
+        if let Process::FlowProcess(ref mut sub_flow) = process {
+            let remaining = Route::from(rest.join("/"));
+            let mut child_route = self.route.clone();
+            child_route.extend(&Route::from(alias));
+            child_route.extend(&remaining);
+            sub_flow.process_from_route_mut(&child_route)
+        } else {
+            Some(process)
+        }
+    }
+
     fn get_subprocess_io(
         &mut self,
         subprocess_alias: &Name,
@@ -810,5 +867,129 @@ mod test {
             .deserialize(toml_str, Some(&url))
             .expect("Could not deserialize FlowDefinition without description");
         assert_eq!(flow.description, "");
+    }
+
+    fn nested_test_flow() -> FlowDefinition {
+        let mut inner_func = FunctionDefinition {
+            name: "inner_func".into(),
+            ..Default::default()
+        };
+        inner_func.route = Route::from("/root/sub_flow/inner_func");
+
+        let mut sub_flow = FlowDefinition {
+            name: "sub_flow".into(),
+            alias: "sub_flow".into(),
+            route: Route::from("/root/sub_flow"),
+            ..Default::default()
+        };
+        sub_flow
+            .subprocesses
+            .insert("inner_func".into(), Process::FunctionProcess(inner_func));
+
+        let mut func = FunctionDefinition {
+            name: "top_func".into(),
+            ..Default::default()
+        };
+        func.route = Route::from("/root/top_func");
+
+        let mut root = FlowDefinition {
+            name: "root".into(),
+            alias: "root".into(),
+            route: Route::from("/root"),
+            ..Default::default()
+        };
+        root.subprocesses
+            .insert("sub_flow".into(), Process::FlowProcess(sub_flow));
+        root.subprocesses
+            .insert("top_func".into(), Process::FunctionProcess(func));
+        root
+    }
+
+    #[test]
+    fn process_from_route_finds_top_level_function() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/root/top_func"));
+        assert!(process.is_some());
+        assert!(matches!(
+            process.expect("process not found"),
+            Process::FunctionProcess(_)
+        ));
+    }
+
+    #[test]
+    fn process_from_route_finds_sub_flow() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/root/sub_flow"));
+        assert!(process.is_some());
+        assert!(matches!(
+            process.expect("process not found"),
+            Process::FlowProcess(_)
+        ));
+    }
+
+    #[test]
+    fn process_from_route_finds_nested_function() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/root/sub_flow/inner_func"));
+        assert!(process.is_some());
+        assert!(matches!(
+            process.expect("process not found"),
+            Process::FunctionProcess(_)
+        ));
+    }
+
+    #[test]
+    fn process_from_route_returns_none_for_root() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/root"));
+        assert!(process.is_none());
+    }
+
+    #[test]
+    fn process_from_route_returns_none_for_nonexistent() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/root/nonexistent"));
+        assert!(process.is_none());
+    }
+
+    #[test]
+    fn process_from_route_returns_none_for_unrelated_route() {
+        let root = nested_test_flow();
+        let process = root.process_from_route(&Route::from("/other/path"));
+        assert!(process.is_none());
+    }
+
+    #[test]
+    fn process_from_route_mut_modifies_function() {
+        let mut root = nested_test_flow();
+        if let Some(Process::FunctionProcess(ref mut f)) =
+            root.process_from_route_mut(&Route::from("/root/top_func"))
+        {
+            f.name = "renamed".into();
+        }
+        if let Some(Process::FunctionProcess(f)) =
+            root.process_from_route(&Route::from("/root/top_func"))
+        {
+            assert_eq!(f.name, "renamed");
+        } else {
+            panic!("Expected to find renamed function");
+        }
+    }
+
+    #[test]
+    fn process_from_route_mut_modifies_nested() {
+        let mut root = nested_test_flow();
+        if let Some(Process::FunctionProcess(ref mut f)) =
+            root.process_from_route_mut(&Route::from("/root/sub_flow/inner_func"))
+        {
+            f.name = "deep_rename".into();
+        }
+        if let Some(Process::FunctionProcess(f)) =
+            root.process_from_route(&Route::from("/root/sub_flow/inner_func"))
+        {
+            assert_eq!(f.name, "deep_rename");
+        } else {
+            panic!("Expected to find renamed nested function");
+        }
     }
 }

--- a/flowcore/src/serializers/mod.rs
+++ b/flowcore/src/serializers/mod.rs
@@ -1,0 +1,3 @@
+//! Serializers for flow model types to TOML format.
+
+pub mod toml_serializer;

--- a/flowcore/src/serializers/toml_serializer.rs
+++ b/flowcore/src/serializers/toml_serializer.rs
@@ -1,0 +1,515 @@
+//! TOML serialization for flow and function definitions.
+//!
+//! Hand-built TOML output that matches the format expected by the flow
+//! deserializer. The derived `Serialize` on some flowcore types produces
+//! struct-style output that is not compatible with the flow format.
+
+use std::fmt::Write;
+use std::path::Path;
+
+use crate::model::flow_definition::FlowDefinition;
+use crate::model::function_definition::FunctionDefinition;
+use crate::model::input::InputInitializer;
+use crate::model::io::IO;
+use crate::model::name::HasName;
+
+fn escape_toml_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Serialize a `serde_json::Value` into a TOML-compatible inline value string.
+pub fn value_to_toml(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => {
+            format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+        }
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "\"null\"".to_string(),
+        serde_json::Value::Array(a) => {
+            let items: Vec<String> = a.iter().map(value_to_toml).collect();
+            format!("[{}]", items.join(", "))
+        }
+        serde_json::Value::Object(m) => {
+            let items: Vec<String> = m
+                .iter()
+                .map(|(k, val)| format!("{k} = {}", value_to_toml(val)))
+                .collect();
+            format!("{{ {} }}", items.join(", "))
+        }
+    }
+}
+
+fn initializer_to_toml(init: &InputInitializer) -> String {
+    match init {
+        InputInitializer::Once(v) => format!("{{ once = {} }}", value_to_toml(v)),
+        InputInitializer::Always(v) => format!("{{ always = {} }}", value_to_toml(v)),
+    }
+}
+
+fn write_io_toml(out: &mut String, section: &str, io: &IO) {
+    let _ = writeln!(out, "\n[[{section}]]");
+    let name = io.name();
+    if !name.is_empty() {
+        let _ = writeln!(out, "name = \"{name}\"");
+    }
+    let types = io.datatypes();
+    if types.len() == 1 {
+        if let Some(t) = types.first() {
+            let _ = writeln!(out, "type = \"{t}\"");
+        }
+    } else if types.len() > 1 {
+        let ts: Vec<String> = types.iter().map(|t| format!("\"{t}\"")).collect();
+        let _ = writeln!(out, "type = [{}]", ts.join(", "));
+    }
+}
+
+impl FlowDefinition {
+    /// Serialize this flow definition to TOML format.
+    #[must_use]
+    pub fn to_toml(&self) -> String {
+        let mut out = String::new();
+
+        let _ = writeln!(out, "flow = \"{}\"", escape_toml_string(&self.name));
+
+        if !self.description.is_empty() {
+            let _ = writeln!(
+                out,
+                "description = \"{}\"",
+                escape_toml_string(&self.description)
+            );
+        }
+
+        if !self.docs.is_empty() {
+            let _ = writeln!(out, "docs = \"{}\"", escape_toml_string(&self.docs));
+        }
+
+        let md = &self.metadata;
+        if !md.version.is_empty() || !md.description.is_empty() || !md.authors.is_empty() {
+            out.push_str("\n[metadata]\n");
+            if !md.version.is_empty() {
+                let _ = writeln!(out, "version = \"{}\"", escape_toml_string(&md.version));
+            }
+            if !md.description.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "description = \"{}\"",
+                    escape_toml_string(&md.description)
+                );
+            }
+            if !md.authors.is_empty() {
+                let authors: Vec<String> = md
+                    .authors
+                    .iter()
+                    .map(|a| format!("\"{}\"", escape_toml_string(a)))
+                    .collect();
+                let _ = writeln!(out, "authors = [{}]", authors.join(", "));
+            }
+        }
+
+        for input in &self.inputs {
+            write_io_toml(&mut out, "input", input);
+        }
+
+        for output in &self.outputs {
+            write_io_toml(&mut out, "output", output);
+        }
+
+        for pref in &self.process_refs {
+            out.push_str("\n[[process]]\n");
+            if !pref.alias.is_empty() {
+                let _ = writeln!(out, "alias = \"{}\"", pref.alias);
+            }
+            let _ = writeln!(out, "source = \"{}\"", pref.source);
+
+            if let Some(x) = pref.x {
+                let _ = writeln!(out, "x = {x}");
+            }
+            if let Some(y) = pref.y {
+                let _ = writeln!(out, "y = {y}");
+            }
+            if let Some(w) = pref.width {
+                let _ = writeln!(out, "width = {w}");
+            }
+            if let Some(h) = pref.height {
+                let _ = writeln!(out, "height = {h}");
+            }
+
+            for (port_name, init) in &pref.initializations {
+                let _ = writeln!(out, "input.{port_name} = {}", initializer_to_toml(init));
+            }
+        }
+
+        for conn in &self.connections {
+            let _ = writeln!(out, "\n[[connection]]");
+            if !conn.name().is_empty() {
+                let _ = writeln!(out, "name = \"{}\"", conn.name());
+            }
+            let _ = writeln!(out, "from = \"{}\"", conn.from());
+            if let [single] = conn.to().as_slice() {
+                let _ = writeln!(out, "to = \"{single}\"");
+            } else {
+                let to_strs: Vec<String> = conn.to().iter().map(|r| format!("\"{r}\"")).collect();
+                let _ = writeln!(out, "to = [{}]", to_strs.join(", "));
+            }
+        }
+
+        out
+    }
+
+    /// Save this flow definition to a TOML file at the given path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
+    pub fn save_to_file(&self, path: &Path) -> Result<(), String> {
+        std::fs::write(path, self.to_toml()).map_err(|e| format!("Could not write file: {e}"))
+    }
+}
+
+impl FunctionDefinition {
+    /// Serialize this function definition to TOML format.
+    #[must_use]
+    pub fn to_toml(&self) -> String {
+        let mut out = format!(
+            "function = \"{}\"\nsource = \"{}\"\ntype = \"rust\"\n",
+            escape_toml_string(&self.name),
+            escape_toml_string(&self.source)
+        );
+
+        if !self.description.is_empty() {
+            let _ = writeln!(
+                out,
+                "description = \"{}\"",
+                escape_toml_string(&self.description)
+            );
+        }
+
+        for input in &self.inputs {
+            let dtype = input
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            let name = input.name();
+            if name.is_empty() || name == "input" || name == "name" {
+                let _ = write!(out, "\n[[input]]\ntype = \"{dtype}\"\n");
+            } else {
+                let _ = write!(out, "\n[[input]]\nname = \"{name}\"\ntype = \"{dtype}\"\n");
+            }
+        }
+
+        for output in &self.outputs {
+            let dtype = output
+                .datatypes()
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            let name = output.name();
+            if name.is_empty() || name == "output" || name == "name" {
+                let _ = write!(out, "\n[[output]]\ntype = \"{dtype}\"\n");
+            } else {
+                let _ = write!(out, "\n[[output]]\nname = \"{name}\"\ntype = \"{dtype}\"\n");
+            }
+        }
+
+        out
+    }
+
+    /// Save this function definition to a TOML file at the given path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
+    pub fn save_to_file(&self, path: &Path) -> Result<(), String> {
+        std::fs::write(path, self.to_toml()).map_err(|e| format!("Could not write file: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::model::connection::Connection;
+    use crate::model::datatype::DataType;
+    use crate::model::io::IO;
+    use crate::model::metadata::MetaData;
+    use crate::model::name::Name;
+    use crate::model::process_reference::ProcessReference;
+    use crate::model::route::Route;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn flow_to_toml_minimal() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("flow = \"test\""));
+    }
+
+    #[test]
+    fn flow_to_toml_with_description() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            description: "A test flow".into(),
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("description = \"A test flow\""));
+    }
+
+    #[test]
+    fn flow_to_toml_with_metadata() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            metadata: MetaData {
+                name: String::new(),
+                version: "1.0.0".into(),
+                description: String::new(),
+                authors: vec!["Author".into()],
+            },
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("[metadata]"));
+        assert!(toml.contains("version = \"1.0.0\""));
+        assert!(toml.contains("authors = [\"Author\"]"));
+    }
+
+    #[test]
+    fn flow_to_toml_with_io() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            inputs: vec![IO::new_named(
+                vec![DataType::from("string")],
+                Route::default(),
+                "in0",
+            )],
+            outputs: vec![IO::new_named(
+                vec![DataType::from("number")],
+                Route::default(),
+                "out0",
+            )],
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("[[input]]"));
+        assert!(toml.contains("name = \"in0\""));
+        assert!(toml.contains("[[output]]"));
+        assert!(toml.contains("name = \"out0\""));
+    }
+
+    #[test]
+    fn flow_to_toml_with_process() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            process_refs: vec![ProcessReference {
+                alias: Name::from("add"),
+                source: "lib://flowstdlib/math/add".into(),
+                initializations: BTreeMap::new(),
+                x: Some(100.0),
+                y: Some(200.0),
+                width: None,
+                height: None,
+            }],
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("[[process]]"));
+        assert!(toml.contains("alias = \"add\""));
+        assert!(toml.contains("source = \"lib://flowstdlib/math/add\""));
+        assert!(toml.contains("x = 100"));
+        assert!(toml.contains("y = 200"));
+    }
+
+    #[test]
+    fn flow_to_toml_with_connection() {
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            connections: vec![Connection::new("input/string", "print")],
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("[[connection]]"));
+        assert!(toml.contains("from = \"input/string\""));
+        assert!(toml.contains("to = \"print\""));
+    }
+
+    #[test]
+    fn flow_to_toml_with_initializer() {
+        let mut inits = BTreeMap::new();
+        inits.insert(
+            "start".into(),
+            InputInitializer::Once(serde_json::json!(42)),
+        );
+        let flow = FlowDefinition {
+            name: Name::from("test"),
+            process_refs: vec![ProcessReference {
+                alias: Name::from("seq"),
+                source: "lib://flowstdlib/control/tap".into(),
+                initializations: inits,
+                x: None,
+                y: None,
+                width: None,
+                height: None,
+            }],
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+        assert!(toml.contains("input.start = { once = 42 }"));
+    }
+
+    #[test]
+    fn flow_roundtrip() {
+        let flow = FlowDefinition {
+            name: Name::from("roundtrip"),
+            description: "Test roundtrip".into(),
+            inputs: vec![IO::new_named(
+                vec![DataType::from("string")],
+                Route::default(),
+                "input0",
+            )],
+            process_refs: vec![ProcessReference {
+                alias: Name::from("func"),
+                source: "func.toml".into(),
+                initializations: BTreeMap::new(),
+                x: Some(100.0),
+                y: Some(200.0),
+                width: Some(180.0),
+                height: Some(120.0),
+            }],
+            connections: vec![Connection::new("input/input0", "func")],
+            ..FlowDefinition::default()
+        };
+        let toml = flow.to_toml();
+
+        let url = url::Url::parse("file:///fake.toml").expect("valid url");
+        let deserializer =
+            crate::deserializers::deserializer::get::<FlowDefinition>(&url).expect("deserializer");
+        let parsed = deserializer
+            .deserialize(&toml, Some(&url))
+            .expect("roundtrip parse failed");
+        assert_eq!(parsed.name, "roundtrip");
+        assert_eq!(parsed.description, "Test roundtrip");
+        assert_eq!(parsed.inputs.len(), 1);
+        assert_eq!(parsed.process_refs.len(), 1);
+        assert_eq!(parsed.connections.len(), 1);
+    }
+
+    #[test]
+    fn function_to_toml_minimal() {
+        let func = FunctionDefinition {
+            name: Name::from("myfunc"),
+            source: "myfunc.rs".into(),
+            ..FunctionDefinition::default()
+        };
+        let toml = func.to_toml();
+        assert!(toml.contains("function = \"myfunc\""));
+        assert!(toml.contains("source = \"myfunc.rs\""));
+        assert!(toml.contains("type = \"rust\""));
+    }
+
+    #[test]
+    fn function_to_toml_with_ports() {
+        let func = FunctionDefinition {
+            name: Name::from("add"),
+            source: "add.rs".into(),
+            inputs: vec![
+                IO::new_named(vec![DataType::from("number")], Route::default(), "a"),
+                IO::new_named(vec![DataType::from("number")], Route::default(), "b"),
+            ],
+            outputs: vec![IO::new_named(
+                vec![DataType::from("number")],
+                Route::default(),
+                "sum",
+            )],
+            ..FunctionDefinition::default()
+        };
+        let toml = func.to_toml();
+        assert!(toml.contains("name = \"a\""));
+        assert!(toml.contains("name = \"b\""));
+        assert!(toml.contains("name = \"sum\""));
+        assert_eq!(toml.matches("[[input]]").count(), 2);
+        assert_eq!(toml.matches("[[output]]").count(), 1);
+    }
+
+    #[test]
+    fn function_roundtrip() {
+        let func = FunctionDefinition {
+            name: Name::from("roundtrip"),
+            source: "roundtrip.rs".into(),
+            description: "Test func".into(),
+            inputs: vec![IO::new_named(
+                vec![DataType::from("string")],
+                Route::default(),
+                "input0",
+            )],
+            outputs: vec![IO::new_named(
+                vec![DataType::from("number")],
+                Route::default(),
+                "output0",
+            )],
+            ..FunctionDefinition::default()
+        };
+        let toml = func.to_toml();
+
+        let url = url::Url::parse("file:///fake.toml").expect("valid url");
+        let deserializer =
+            crate::deserializers::deserializer::get::<crate::model::process::Process>(&url)
+                .expect("deserializer");
+        let parsed = deserializer
+            .deserialize(&toml, Some(&url))
+            .expect("roundtrip parse failed");
+        if let crate::model::process::Process::FunctionProcess(f) = parsed {
+            assert_eq!(f.name, "roundtrip");
+            assert_eq!(f.source, "roundtrip.rs");
+            assert_eq!(f.inputs.len(), 1);
+            assert_eq!(f.outputs.len(), 1);
+        } else {
+            panic!("Expected FunctionProcess");
+        }
+    }
+
+    #[test]
+    fn escape_special_chars() {
+        assert_eq!(escape_toml_string("hello"), "hello");
+        assert_eq!(escape_toml_string("a\"b"), "a\\\"b");
+        assert_eq!(escape_toml_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_toml_string("a\nb"), "a\\nb");
+    }
+
+    #[test]
+    fn value_to_toml_types() {
+        assert_eq!(value_to_toml(&serde_json::json!("hello")), "\"hello\"");
+        assert_eq!(value_to_toml(&serde_json::json!(42)), "42");
+        assert_eq!(value_to_toml(&serde_json::json!(true)), "true");
+        assert_eq!(value_to_toml(&serde_json::json!(null)), "\"null\"");
+        assert_eq!(value_to_toml(&serde_json::json!([1, 2])), "[1, 2]");
+    }
+
+    #[test]
+    fn initializer_to_toml_once() {
+        let init = InputInitializer::Once(serde_json::json!(42));
+        assert_eq!(initializer_to_toml(&init), "{ once = 42 }");
+    }
+
+    #[test]
+    fn initializer_to_toml_always() {
+        let init = InputInitializer::Always(serde_json::json!("hello"));
+        assert_eq!(initializer_to_toml(&init), "{ always = \"hello\" }");
+    }
+}

--- a/flowcore/src/serializers/toml_serializer.rs
+++ b/flowcore/src/serializers/toml_serializer.rs
@@ -34,7 +34,7 @@ fn escape_toml_string(s: &str) -> String {
 pub fn value_to_toml(v: &serde_json::Value) -> String {
     match v {
         serde_json::Value::String(s) => {
-            format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+            format!("\"{}\"", escape_toml_string(s))
         }
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
@@ -199,31 +199,11 @@ impl FunctionDefinition {
         }
 
         for input in &self.inputs {
-            let dtype = input
-                .datatypes()
-                .first()
-                .map(ToString::to_string)
-                .unwrap_or_default();
-            let name = input.name();
-            if name.is_empty() || name == "input" || name == "name" {
-                let _ = write!(out, "\n[[input]]\ntype = \"{dtype}\"\n");
-            } else {
-                let _ = write!(out, "\n[[input]]\nname = \"{name}\"\ntype = \"{dtype}\"\n");
-            }
+            write_io_toml(&mut out, "input", input);
         }
 
         for output in &self.outputs {
-            let dtype = output
-                .datatypes()
-                .first()
-                .map(ToString::to_string)
-                .unwrap_or_default();
-            let name = output.name();
-            if name.is_empty() || name == "output" || name == "name" {
-                let _ = write!(out, "\n[[output]]\ntype = \"{dtype}\"\n");
-            } else {
-                let _ = write!(out, "\n[[output]]\nname = \"{name}\"\ntype = \"{dtype}\"\n");
-            }
+            write_io_toml(&mut out, "output", output);
         }
 
         out

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -33,11 +33,11 @@ pub(crate) struct EditorPrefs {
 }
 
 impl WindowState {
-    pub(crate) fn perform_save(&mut self, path: &PathBuf) {
-        match save_flow_toml(&self.flow_definition, path) {
+    pub(crate) fn perform_save(&mut self, flow_def: &mut FlowDefinition, path: &PathBuf) {
+        match save_flow_toml(flow_def, path) {
             Ok(()) => {
                 self.history.clear();
-                self.set_file_path(path);
+                Self::set_file_path_on(flow_def, path);
                 save_editor_prefs(path, self.last_size, self.last_position);
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                     self.status = format!("Saved to {name}");
@@ -52,41 +52,44 @@ impl WindowState {
     }
 
     /// Prompt the user with a save dialog and save to the chosen path.
-    pub(crate) fn perform_save_as(&mut self) {
+    pub(crate) fn perform_save_as(&mut self, flow_def: &mut FlowDefinition) {
         let dialog = rfd::FileDialog::new()
             .add_filter("Flow", &["toml"])
-            .set_file_name(format!("{}.toml", self.flow_definition.name));
+            .set_file_name(format!("{}.toml", flow_def.name));
         if let Some(path) = dialog.save_file() {
-            self.perform_save(&path);
+            self.perform_save(flow_def, &path);
         }
     }
 
     /// Handle save message -- saves to existing path or prompts with save dialog.
-    pub(crate) fn handle_save(&mut self) {
-        if let Some(path) = self.file_path() {
-            self.perform_save(&path);
+    pub(crate) fn handle_save(&mut self, flow_def: &mut FlowDefinition) {
+        if let Some(path) = Self::file_path_of(flow_def) {
+            self.perform_save(flow_def, &path);
         } else {
-            self.perform_save_as();
+            self.perform_save_as(flow_def);
         }
     }
 
     /// Handle save-as message -- prompts with save dialog.
-    pub(crate) fn handle_save_as(&mut self) {
-        self.perform_save_as();
+    pub(crate) fn handle_save_as(&mut self, flow_def: &mut FlowDefinition) {
+        self.perform_save_as(flow_def);
     }
 
     /// Prompt the user with an open dialog and load the selected flow file.
     /// Open a flow file and update the window state.
-    /// Returns the lib and context references if successful, for rebuilding the library cache.
-    pub(crate) fn perform_open(&mut self) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
+    /// Returns the loaded flow definition and lib/context references if successful.
+    pub(crate) fn perform_open(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+    ) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
         let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
         if let Some(path) = dialog.pick_file() {
             match load_flow(&path) {
                 Ok(loaded) => {
                     let nc = loaded.flow_def.process_refs.len();
                     let ec = loaded.flow_def.connections.len();
-                    self.flow_definition = loaded.flow_def;
-                    self.set_file_path(&path);
+                    *flow_def = loaded.flow_def;
+                    Self::set_file_path_on(flow_def, &path);
                     self.selected_node = None;
                     self.selected_connection = None;
                     self.tooltip = None;
@@ -109,10 +112,10 @@ impl WindowState {
     }
 
     /// Clear the canvas and reset to an empty flow state.
-    pub(crate) fn perform_new(&mut self) {
-        self.flow_definition = FlowDefinition::default();
-        self.flow_definition.name = String::from("(new flow)");
-        self.clear_file_path();
+    pub(crate) fn perform_new(&mut self, flow_def: &mut FlowDefinition) {
+        *flow_def = FlowDefinition::default();
+        flow_def.name = String::from("(new flow)");
+        Self::clear_file_path_on(flow_def);
         self.selected_node = None;
         self.selected_connection = None;
         self.tooltip = None;
@@ -133,18 +136,21 @@ impl WindowState {
     ///
     /// Returns the path to the generated manifest on success, or a human-readable
     /// error message on failure.
-    pub(crate) fn perform_compile(&mut self) -> Result<PathBuf, String> {
+    pub(crate) fn perform_compile(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+    ) -> Result<PathBuf, String> {
         // New flows must be saved first so the compiler has a real file path
-        if self.file_path().is_none() {
-            self.perform_save_as();
+        if Self::file_path_of(flow_def).is_none() {
+            self.perform_save_as(flow_def);
         }
-        let Some(flow_path) = self.file_path() else {
+        let Some(flow_path) = Self::file_path_of(flow_def) else {
             return Err("Flow must be saved before compiling".to_string());
         };
 
         // Save any unsaved edits so the file on disk matches the editor state
         if !self.history.is_empty() {
-            self.perform_save(&flow_path);
+            self.perform_save(flow_def, &flow_path);
             if !self.history.is_empty() {
                 return Err("Save failed — cannot compile stale content".to_string());
             }
@@ -723,11 +729,6 @@ mod test {
     use flowcore::model::process_reference::ProcessReference;
     use flowcore::model::route::Route;
 
-    use crate::hierarchy_panel::FlowHierarchy;
-    use crate::history::EditHistory;
-    use crate::window_state::FlowCanvasState;
-    use crate::WindowKind;
-
     fn test_pref(alias: &str, source: &str) -> ProcessReference {
         ProcessReference {
             alias: alias.into(),
@@ -1144,34 +1145,14 @@ mod test {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    fn test_win_state() -> WindowState {
-        let flow_def = FlowDefinition {
+    fn test_flow_def() -> FlowDefinition {
+        FlowDefinition {
             name: String::from("test"),
             process_refs: vec![
                 test_pref("add", "lib://flowstdlib/math/add"),
                 test_pref("stdout", "context://stdio/stdout"),
             ],
             ..FlowDefinition::default()
-        };
-        WindowState {
-            route: flowcore::model::route::Route::default(),
-            kind: WindowKind::FlowEditor,
-            canvas_state: FlowCanvasState::default(),
-            status: String::new(),
-            selected_node: None,
-            selected_connection: None,
-            history: EditHistory::default(),
-            auto_fit_pending: false,
-            auto_fit_enabled: false,
-            flow_definition: flow_def,
-            tooltip: None,
-            initializer_editor: None,
-            is_root: true,
-            context_menu: None,
-            show_metadata: false,
-            flow_hierarchy: FlowHierarchy::empty(),
-            last_size: None,
-            last_position: None,
         }
     }
 
@@ -1180,14 +1161,15 @@ mod test {
         let dir = temp_dir("perform_save");
         let path = dir.join("saved.toml");
 
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         win.history.mark_modified();
-        win.flow_definition.name = "saved_flow".into();
+        flow_def.name = "saved_flow".into();
 
-        win.perform_save(&path);
+        win.perform_save(&mut flow_def, &path);
         assert!(win.history.is_empty());
         let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
-        assert_eq!(win.file_path(), Some(canonical));
+        assert_eq!(WindowState::file_path_of(&flow_def), Some(canonical));
 
         let contents = std::fs::read_to_string(&path).expect("read failed");
         assert!(contents.contains("flow = \"saved_flow\""));

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -1154,6 +1154,7 @@ mod test {
             ..FlowDefinition::default()
         };
         WindowState {
+            route: flowcore::model::route::Route::default(),
             kind: WindowKind::FlowEditor,
             canvas_state: FlowCanvasState::default(),
             status: String::new(),

--- a/flowedit/src/history.rs
+++ b/flowedit/src/history.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use flowcore::model::connection::Connection;
+use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::input::InputInitializer;
 use flowcore::model::name::Name;
 use flowcore::model::process::Process;
@@ -180,7 +181,7 @@ impl EditHistory {
 }
 
 impl WindowState {
-    fn apply_undo(&mut self) {
+    fn apply_undo(&mut self, flow_def: &mut FlowDefinition) {
         if let Some(action) = self.history.undo() {
             match action {
                 EditAction::MoveNode {
@@ -189,7 +190,7 @@ impl WindowState {
                     old_y,
                     ..
                 } => {
-                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                    if let Some(pref) = flow_def.process_refs.get_mut(index) {
                         pref.x = Some(old_x);
                         pref.y = Some(old_y);
                     }
@@ -203,7 +204,7 @@ impl WindowState {
                     old_h,
                     ..
                 } => {
-                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                    if let Some(pref) = flow_def.process_refs.get_mut(index) {
                         pref.x = Some(old_x);
                         pref.y = Some(old_y);
                         pref.width = Some(old_w);
@@ -221,10 +222,10 @@ impl WindowState {
                     } else {
                         process_ref.alias.clone()
                     };
-                    if index < self.flow_definition.process_refs.len() {
-                        self.flow_definition.process_refs.remove(index);
-                        self.flow_definition.subprocesses.remove(&alias);
-                        self.flow_definition
+                    if index < flow_def.process_refs.len() {
+                        flow_def.process_refs.remove(index);
+                        flow_def.subprocesses.remove(&alias);
+                        flow_def
                             .connections
                             .retain(|c| !crate::utils::connection_references_node(c, &alias));
                     }
@@ -236,25 +237,25 @@ impl WindowState {
                     subprocess,
                     removed_connections,
                 } => {
-                    self.flow_definition.process_refs.insert(index, process_ref);
+                    flow_def.process_refs.insert(index, process_ref);
                     if let Some((name, proc)) = subprocess {
-                        self.flow_definition.subprocesses.insert(name, proc);
+                        flow_def.subprocesses.insert(name, proc);
                     }
-                    self.flow_definition.connections.extend(removed_connections);
+                    flow_def.connections.extend(removed_connections);
                     self.status = String::from("Undo: delete node");
                 }
                 EditAction::CreateConnection { connection } => {
                     let from_str = connection.from().to_string();
                     let to_strs: Vec<String> =
                         connection.to().iter().map(ToString::to_string).collect();
-                    self.flow_definition.connections.retain(|c| {
+                    flow_def.connections.retain(|c| {
                         c.from().to_string() != from_str
                             || c.to().iter().map(ToString::to_string).collect::<Vec<_>>() != to_strs
                     });
                     self.status = String::from("Undo: create connection");
                 }
                 EditAction::DeleteConnection { index, connection } => {
-                    self.flow_definition.connections.insert(index, connection);
+                    flow_def.connections.insert(index, connection);
                     self.status = String::from("Undo: delete connection");
                 }
                 EditAction::EditInitializer {
@@ -263,7 +264,12 @@ impl WindowState {
                     ref old_init,
                     ..
                 } => {
-                    self.apply_initializer_state(node_index, port_name, old_init.as_ref());
+                    self.apply_initializer_state(
+                        flow_def,
+                        node_index,
+                        port_name,
+                        old_init.as_ref(),
+                    );
                     self.status = String::from("Undo: initializer");
                 }
             }
@@ -272,7 +278,7 @@ impl WindowState {
         }
     }
 
-    fn apply_redo(&mut self) {
+    fn apply_redo(&mut self, flow_def: &mut FlowDefinition) {
         if let Some(action) = self.history.redo() {
             match action {
                 EditAction::MoveNode {
@@ -281,7 +287,7 @@ impl WindowState {
                     new_y,
                     ..
                 } => {
-                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                    if let Some(pref) = flow_def.process_refs.get_mut(index) {
                         pref.x = Some(new_x);
                         pref.y = Some(new_y);
                     }
@@ -295,7 +301,7 @@ impl WindowState {
                     new_h,
                     ..
                 } => {
-                    if let Some(pref) = self.flow_definition.process_refs.get_mut(index) {
+                    if let Some(pref) = flow_def.process_refs.get_mut(index) {
                         pref.x = Some(new_x);
                         pref.y = Some(new_y);
                         pref.width = Some(new_w);
@@ -308,10 +314,10 @@ impl WindowState {
                     process_ref,
                     subprocess,
                 } => {
-                    let idx = index.min(self.flow_definition.process_refs.len());
-                    self.flow_definition.process_refs.insert(idx, process_ref);
+                    let idx = index.min(flow_def.process_refs.len());
+                    flow_def.process_refs.insert(idx, process_ref);
                     if let Some((name, proc)) = subprocess {
-                        self.flow_definition.subprocesses.insert(name, proc);
+                        flow_def.subprocesses.insert(name, proc);
                     }
                     self.status = String::from("Redo: create node");
                 }
@@ -321,24 +327,24 @@ impl WindowState {
                     removed_connections,
                     ..
                 } => {
-                    if index < self.flow_definition.process_refs.len() {
-                        let removed = self.flow_definition.process_refs.remove(index);
+                    if index < flow_def.process_refs.len() {
+                        let removed = flow_def.process_refs.remove(index);
                         let alias = if removed.alias.is_empty() {
                             crate::utils::derive_short_name(&removed.source)
                         } else {
                             removed.alias.clone()
                         };
-                        self.flow_definition.subprocesses.remove(&alias);
+                        flow_def.subprocesses.remove(&alias);
                     }
                     // Also remove re-inserted subprocess if it was restored during undo
                     if let Some((ref name, _)) = subprocess {
-                        self.flow_definition.subprocesses.remove(name);
+                        flow_def.subprocesses.remove(name);
                     }
                     for conn in &removed_connections {
                         let from_str = conn.from().to_string();
                         let to_strs: Vec<String> =
                             conn.to().iter().map(ToString::to_string).collect();
-                        self.flow_definition.connections.retain(|c| {
+                        flow_def.connections.retain(|c| {
                             c.from().to_string() != from_str
                                 || c.to().iter().map(ToString::to_string).collect::<Vec<_>>()
                                     != to_strs
@@ -347,12 +353,12 @@ impl WindowState {
                     self.status = String::from("Redo: delete node");
                 }
                 EditAction::CreateConnection { connection } => {
-                    self.flow_definition.connections.push(connection);
+                    flow_def.connections.push(connection);
                     self.status = String::from("Redo: create connection");
                 }
                 EditAction::DeleteConnection { index, .. } => {
-                    if index < self.flow_definition.connections.len() {
-                        self.flow_definition.connections.remove(index);
+                    if index < flow_def.connections.len() {
+                        flow_def.connections.remove(index);
                     }
                     self.status = String::from("Redo: delete connection");
                 }
@@ -362,7 +368,12 @@ impl WindowState {
                     ref new_init,
                     ..
                 } => {
-                    self.apply_initializer_state(node_index, port_name, new_init.as_ref());
+                    self.apply_initializer_state(
+                        flow_def,
+                        node_index,
+                        port_name,
+                        new_init.as_ref(),
+                    );
                     self.status = String::from("Redo: initializer");
                 }
             }
@@ -371,12 +382,12 @@ impl WindowState {
         }
     }
 
-    pub(crate) fn handle_undo(&mut self) {
-        self.apply_undo();
+    pub(crate) fn handle_undo(&mut self, flow_def: &mut FlowDefinition) {
+        self.apply_undo(flow_def);
     }
 
-    pub(crate) fn handle_redo(&mut self) {
-        self.apply_redo();
+    pub(crate) fn handle_redo(&mut self, flow_def: &mut FlowDefinition) {
+        self.apply_redo(flow_def);
     }
 }
 
@@ -557,11 +568,10 @@ mod test {
 
     // --- Tests moved from ui_test.rs (direct function calls, no message routing) ---
 
-    fn test_win_state() -> WindowState {
-        use flowcore::model::flow_definition::FlowDefinition;
+    fn test_flow_def() -> FlowDefinition {
         use flowcore::model::name::Name;
 
-        let flow = FlowDefinition {
+        FlowDefinition {
             name: Name::from("test"),
             process_refs: vec![
                 ProcessReference {
@@ -584,20 +594,14 @@ mod test {
                 },
             ],
             ..FlowDefinition::default()
-        };
-
-        WindowState {
-            flow_definition: flow,
-            is_root: true,
-            ..Default::default()
         }
     }
 
     #[test]
     fn record_and_undo_edit() {
-        let mut flow_def = flowcore::model::flow_definition::FlowDefinition {
+        let mut flow_def = FlowDefinition {
             name: String::from("test"),
-            ..flowcore::model::flow_definition::FlowDefinition::default()
+            ..FlowDefinition::default()
         };
         flow_def.process_refs.push(ProcessReference {
             alias: "a".into(),
@@ -609,13 +613,12 @@ mod test {
             height: Some(120.0),
         });
         let mut win = WindowState {
-            flow_definition: flow_def,
             is_root: true,
             ..Default::default()
         };
 
         // Move node
-        if let Some(pref) = win.flow_definition.process_refs.first_mut() {
+        if let Some(pref) = flow_def.process_refs.first_mut() {
             pref.x = Some(200.0);
             pref.y = Some(300.0);
         }
@@ -629,23 +632,24 @@ mod test {
         assert!(!win.history.is_empty());
 
         // Undo
-        win.handle_undo();
-        let pref = win.flow_definition.process_refs.first();
+        win.handle_undo(&mut flow_def);
+        let pref = flow_def.process_refs.first();
         assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 100.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 100.0).abs() < 0.01));
 
         // Redo
-        win.handle_redo();
-        let pref = win.flow_definition.process_refs.first();
+        win.handle_redo(&mut flow_def);
+        let pref = flow_def.process_refs.first();
         assert!(pref.is_some_and(|p| (p.x.unwrap_or(0.0) - 200.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.y.unwrap_or(0.0) - 300.0).abs() < 0.01));
     }
 
     #[test]
     fn undo_redo_resize_node() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         // Simulate resize
-        if let Some(pref) = win.flow_definition.process_refs.first_mut() {
+        if let Some(pref) = flow_def.process_refs.first_mut() {
             pref.width = Some(250.0);
             pref.height = Some(180.0);
         }
@@ -662,85 +666,89 @@ mod test {
         });
 
         // Undo
-        win.handle_undo();
-        let pref = win.flow_definition.process_refs.first();
+        win.handle_undo(&mut flow_def);
+        let pref = flow_def.process_refs.first();
         assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 180.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 120.0).abs() < 0.01));
 
         // Redo
-        win.handle_redo();
-        let pref = win.flow_definition.process_refs.first();
+        win.handle_redo(&mut flow_def);
+        let pref = flow_def.process_refs.first();
         assert!(pref.is_some_and(|p| (p.width.unwrap_or(0.0) - 250.0).abs() < 0.01));
         assert!(pref.is_some_and(|p| (p.height.unwrap_or(0.0) - 180.0).abs() < 0.01));
     }
 
     #[test]
     fn undo_redo_delete_node() {
-        let mut win = test_win_state();
-        assert_eq!(win.flow_definition.process_refs.len(), 2);
-        let removed_pref = win.flow_definition.process_refs.remove(0);
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
+        assert_eq!(flow_def.process_refs.len(), 2);
+        let removed_pref = flow_def.process_refs.remove(0);
         win.history.record(EditAction::DeleteNode {
             index: 0,
             process_ref: removed_pref,
             subprocess: None,
             removed_connections: Vec::new(),
         });
-        assert_eq!(win.flow_definition.process_refs.len(), 1);
+        assert_eq!(flow_def.process_refs.len(), 1);
 
         // Undo restores
-        win.handle_undo();
-        assert_eq!(win.flow_definition.process_refs.len(), 2);
+        win.handle_undo(&mut flow_def);
+        assert_eq!(flow_def.process_refs.len(), 2);
 
         // Redo removes again
-        win.handle_redo();
-        assert_eq!(win.flow_definition.process_refs.len(), 1);
+        win.handle_redo(&mut flow_def);
+        assert_eq!(flow_def.process_refs.len(), 1);
     }
 
     #[test]
     fn undo_redo_create_connection() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let connection = Connection::new("add/out", "stdout/in");
-        win.flow_definition.connections.push(connection.clone());
+        flow_def.connections.push(connection.clone());
         win.history
             .record(EditAction::CreateConnection { connection });
-        assert_eq!(win.flow_definition.connections.len(), 1);
+        assert_eq!(flow_def.connections.len(), 1);
 
         // Undo removes
-        win.handle_undo();
-        assert_eq!(win.flow_definition.connections.len(), 0);
+        win.handle_undo(&mut flow_def);
+        assert_eq!(flow_def.connections.len(), 0);
 
         // Redo re-adds
-        win.handle_redo();
-        assert_eq!(win.flow_definition.connections.len(), 1);
+        win.handle_redo(&mut flow_def);
+        assert_eq!(flow_def.connections.len(), 1);
     }
 
     #[test]
     fn undo_redo_delete_connection() {
-        let mut win = test_win_state();
-        win.flow_definition
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
+        flow_def
             .connections
             .push(Connection::new("add/out", "stdout/in"));
-        let removed_conn = win.flow_definition.connections.remove(0);
+        let removed_conn = flow_def.connections.remove(0);
         win.history.record(EditAction::DeleteConnection {
             index: 0,
             connection: removed_conn,
         });
-        assert_eq!(win.flow_definition.connections.len(), 0);
+        assert_eq!(flow_def.connections.len(), 0);
 
         // Undo restores
-        win.handle_undo();
-        assert_eq!(win.flow_definition.connections.len(), 1);
+        win.handle_undo(&mut flow_def);
+        assert_eq!(flow_def.connections.len(), 1);
 
         // Redo removes again
-        win.handle_redo();
-        assert_eq!(win.flow_definition.connections.len(), 0);
+        win.handle_redo(&mut flow_def);
+        assert_eq!(flow_def.connections.len(), 0);
     }
 
     #[test]
     fn undo_redo_edit_initializer() {
         use flowcore::model::input::InputInitializer;
 
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         // Record an initializer edit
         win.history.record(EditAction::EditInitializer {
             node_index: 0,
@@ -751,30 +759,28 @@ mod test {
 
         // Apply the new state manually (record only records, doesn't apply)
         win.apply_initializer_state(
+            &mut flow_def,
             0,
             "input",
             Some(&InputInitializer::Once(serde_json::json!(42))),
         );
-        assert!(win
-            .flow_definition
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
             .is_some());
 
         // Undo
-        win.handle_undo();
-        assert!(win
-            .flow_definition
+        win.handle_undo(&mut flow_def);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
             .is_none());
 
         // Redo
-        win.handle_redo();
-        assert!(win
-            .flow_definition
+        win.handle_redo(&mut flow_def);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))

--- a/flowedit/src/initializer.rs
+++ b/flowedit/src/initializer.rs
@@ -1,5 +1,6 @@
 //! Initializer editor logic for applying and syncing initializer edits.
 
+use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::input::InputInitializer;
 
 use crate::history::EditAction;
@@ -7,9 +8,12 @@ use crate::utils::derive_short_name;
 use crate::{InitializerEditor, WindowState};
 
 impl WindowState {
-    pub(crate) fn apply_initializer_edit(&mut self, editor: &InitializerEditor) {
-        let alias = self
-            .flow_definition
+    pub(crate) fn apply_initializer_edit(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+        editor: &InitializerEditor,
+    ) {
+        let alias = flow_def
             .process_refs
             .get(editor.node_index)
             .map(|pr| {
@@ -21,8 +25,7 @@ impl WindowState {
             })
             .unwrap_or_default();
 
-        let old_init = self
-            .flow_definition
+        let old_init = flow_def
             .process_refs
             .get(editor.node_index)
             .and_then(|pr| pr.initializations.get(&editor.port_name).cloned());
@@ -42,7 +45,7 @@ impl WindowState {
             _ => return,
         };
 
-        let Some(pref) = self.flow_definition.process_refs.get_mut(editor.node_index) else {
+        let Some(pref) = flow_def.process_refs.get_mut(editor.node_index) else {
             return;
         };
         match &new_init {
@@ -65,13 +68,15 @@ impl WindowState {
         self.status = format!("Initializer updated on {}/{}", alias, editor.port_name);
     }
 
+    #[allow(clippy::unused_self)]
     pub(crate) fn apply_initializer_state(
         &mut self,
+        flow_def: &mut FlowDefinition,
         node_index: usize,
         port_name: &str,
         init: Option<&InputInitializer>,
     ) {
-        if let Some(pref) = self.flow_definition.process_refs.get_mut(node_index) {
+        if let Some(pref) = flow_def.process_refs.get_mut(node_index) {
             match init {
                 Some(i) => {
                     pref.initializations
@@ -96,9 +101,9 @@ impl WindowState {
         }
     }
 
-    pub(crate) fn handle_initializer_apply(&mut self) {
+    pub(crate) fn handle_initializer_apply(&mut self, flow_def: &mut FlowDefinition) {
         if let Some(editor) = self.initializer_editor.take() {
-            self.apply_initializer_edit(&editor);
+            self.apply_initializer_edit(flow_def, &editor);
         }
     }
 
@@ -115,8 +120,8 @@ mod test {
     use flowcore::model::process_reference::ProcessReference;
     use std::collections::BTreeMap;
 
-    fn test_win_state() -> WindowState {
-        let flow = FlowDefinition {
+    fn test_flow_def() -> FlowDefinition {
+        FlowDefinition {
             name: Name::from("test"),
             process_refs: vec![
                 ProcessReference {
@@ -139,28 +144,22 @@ mod test {
                 },
             ],
             ..FlowDefinition::default()
-        };
-
-        WindowState {
-            flow_definition: flow,
-            is_root: true,
-            ..Default::default()
         }
     }
 
     #[test]
     fn initializer_apply_once() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
             init_type: "once".into(),
             value_text: "42".into(),
         };
-        win.apply_initializer_edit(&editor);
+        win.apply_initializer_edit(&mut flow_def, &editor);
         assert!(!win.history.is_empty());
-        assert!(win
-            .flow_definition
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
@@ -169,16 +168,16 @@ mod test {
 
     #[test]
     fn initializer_apply_always() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
             init_type: "always".into(),
             value_text: "\"hello\"".into(),
         };
-        win.apply_initializer_edit(&editor);
-        assert!(win
-            .flow_definition
+        win.apply_initializer_edit(&mut flow_def, &editor);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
@@ -187,16 +186,16 @@ mod test {
 
     #[test]
     fn initializer_apply_none_removes() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let editor = InitializerEditor {
             node_index: 0,
             port_name: "input".into(),
             init_type: "once".into(),
             value_text: "42".into(),
         };
-        win.apply_initializer_edit(&editor);
-        assert!(win
-            .flow_definition
+        win.apply_initializer_edit(&mut flow_def, &editor);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
@@ -208,9 +207,8 @@ mod test {
             init_type: "none".into(),
             value_text: String::new(),
         };
-        win.apply_initializer_edit(&editor);
-        assert!(win
-            .flow_definition
+        win.apply_initializer_edit(&mut flow_def, &editor);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("input"))
@@ -219,19 +217,18 @@ mod test {
 
     #[test]
     fn initializer_apply_state_set_and_remove() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let init = InputInitializer::Once(serde_json::json!(99));
-        win.apply_initializer_state(0, "port", Some(&init));
-        assert!(win
-            .flow_definition
+        win.apply_initializer_state(&mut flow_def, 0, "port", Some(&init));
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("port"))
             .is_some());
 
-        win.apply_initializer_state(0, "port", None);
-        assert!(win
-            .flow_definition
+        win.apply_initializer_state(&mut flow_def, 0, "port", None);
+        assert!(flow_def
             .process_refs
             .first()
             .and_then(|p| p.initializations.get("port"))
@@ -240,7 +237,8 @@ mod test {
 
     #[test]
     fn initializer_apply_invalid_type_no_change() {
-        let mut win = test_win_state();
+        let mut flow_def = test_flow_def();
+        let mut win = WindowState::default();
         let empty_before = win.history.is_empty();
         let editor = InitializerEditor {
             node_index: 0,
@@ -248,7 +246,7 @@ mod test {
             init_type: "bogus".into(),
             value_text: "42".into(),
         };
-        win.apply_initializer_edit(&editor);
+        win.apply_initializer_edit(&mut flow_def, &editor);
         assert_eq!(
             win.history.is_empty(),
             empty_before,

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -259,6 +259,7 @@ mod test {
             ..flowcore::model::flow_definition::FlowDefinition::default()
         };
         WindowState {
+            route: flowcore::model::route::Route::default(),
             kind: WindowKind::FlowEditor,
             canvas_state: FlowCanvasState::default(),
             status: String::new(),

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use log::{info, warn};
 use url::Url;
 
+use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::lib_manifest::LibraryManifest;
 use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
@@ -133,12 +134,17 @@ pub(crate) fn load_library_catalogs(
 
 impl WindowState {
     /// Add a library function as a new node on the canvas.
-    pub(crate) fn add_library_function(&mut self, source: &str, func_name: &str) {
+    pub(crate) fn add_library_function(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+        source: &str,
+        func_name: &str,
+    ) {
         // Generate a unique alias: if the name already exists, append a number
-        let alias = file_ops::generate_unique_alias(func_name, &self.flow_definition.process_refs);
+        let alias = file_ops::generate_unique_alias(func_name, &flow_def.process_refs);
 
         // Place the new node at a default position offset from existing nodes
-        let (x, y) = file_ops::next_node_position(&self.flow_definition.process_refs);
+        let (x, y) = file_ops::next_node_position(&flow_def.process_refs);
 
         // Resolve the subprocess definition by parsing the function/flow
         let resolved_process = match Url::parse(source) {
@@ -168,21 +174,18 @@ impl WindowState {
             height: Some(120.0),
         };
 
-        let index = self.flow_definition.process_refs.len();
-        self.flow_definition.process_refs.push(pref.clone());
+        let index = flow_def.process_refs.len();
+        flow_def.process_refs.push(pref.clone());
 
         // Add the resolved subprocess definition if we have one
         if let Some(proc) = resolved_process {
-            self.flow_definition
-                .subprocesses
-                .insert(alias.clone(), proc);
+            flow_def.subprocesses.insert(alias.clone(), proc);
         }
 
         self.history.record(EditAction::CreateNode {
             index,
             process_ref: pref,
-            subprocess: self
-                .flow_definition
+            subprocess: flow_def
                 .subprocesses
                 .get(&alias)
                 .map(|p| (alias.clone(), p.clone())),
@@ -194,13 +197,18 @@ impl WindowState {
         if self.auto_fit_enabled {
             self.auto_fit_pending = true;
         }
-        let nc = self.flow_definition.process_refs.len();
+        let nc = flow_def.process_refs.len();
         self.status = format!("Added {alias} from library - {nc} nodes");
     }
 
     /// Resolve a node's source path relative to the current flow file.
-    pub(crate) fn resolve_node_source(&self, source: &str) -> Option<PathBuf> {
-        let base_dir = self.file_path()?.parent()?.to_path_buf();
+    #[allow(clippy::unused_self)]
+    pub(crate) fn resolve_node_source(
+        &self,
+        flow_def: &FlowDefinition,
+        source: &str,
+    ) -> Option<PathBuf> {
+        let base_dir = Self::file_path_of(flow_def)?.parent()?.to_path_buf();
         let base_dir = &base_dir;
         let canonicalize = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
         let candidate = base_dir.join(source);
@@ -225,16 +233,12 @@ mod test {
     use std::path::Path;
 
     use super::*;
-    use crate::hierarchy_panel::FlowHierarchy;
-    use crate::history::EditHistory;
-    use crate::window_state::FlowCanvasState;
-    use crate::WindowKind;
 
-    fn test_win_state() -> WindowState {
+    fn test_flow_def() -> FlowDefinition {
         use flowcore::model::process_reference::ProcessReference;
         use std::collections::BTreeMap;
 
-        let flow_def = flowcore::model::flow_definition::FlowDefinition {
+        FlowDefinition {
             name: String::from("test"),
             process_refs: vec![
                 ProcessReference {
@@ -256,27 +260,7 @@ mod test {
                     height: Some(120.0),
                 },
             ],
-            ..flowcore::model::flow_definition::FlowDefinition::default()
-        };
-        WindowState {
-            route: flowcore::model::route::Route::default(),
-            kind: WindowKind::FlowEditor,
-            canvas_state: FlowCanvasState::default(),
-            status: String::new(),
-            selected_node: None,
-            selected_connection: None,
-            history: EditHistory::default(),
-            auto_fit_pending: false,
-            auto_fit_enabled: false,
-            flow_definition: flow_def,
-            tooltip: None,
-            initializer_editor: None,
-            is_root: true,
-            context_menu: None,
-            show_metadata: false,
-            flow_hierarchy: FlowHierarchy::empty(),
-            last_size: None,
-            last_position: None,
+            ..FlowDefinition::default()
         }
     }
 
@@ -294,10 +278,11 @@ mod test {
         let sub_path = dir.join("sub.toml");
         std::fs::write(&sub_path, "flow = \"sub\"").expect("write");
 
-        let mut win = test_win_state();
-        win.set_file_path(&flow_path);
+        let mut flow_def = test_flow_def();
+        let win = WindowState::default();
+        WindowState::set_file_path_on(&mut flow_def, &flow_path);
 
-        let resolved = win.resolve_node_source("sub");
+        let resolved = win.resolve_node_source(&flow_def, "sub");
         assert!(resolved.is_some());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -305,9 +290,13 @@ mod test {
 
     #[test]
     fn resolve_node_source_not_found() {
-        let mut win = test_win_state();
-        win.set_file_path(Path::new("/tmp/flowedit_tests/nonexistent/root.toml"));
-        let resolved = win.resolve_node_source("missing");
+        let mut flow_def = test_flow_def();
+        let win = WindowState::default();
+        WindowState::set_file_path_on(
+            &mut flow_def,
+            Path::new("/tmp/flowedit_tests/nonexistent/root.toml"),
+        );
+        let resolved = win.resolve_node_source(&flow_def, "missing");
         assert!(resolved.is_none());
     }
 }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -70,20 +70,19 @@ fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
 }
 
 impl WindowState {
-    fn rename_flow_input(&mut self, idx: usize, name: &str) {
-        let duplicate = self
-            .flow_definition
+    fn rename_flow_input(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) {
+        let duplicate = flow_def
             .inputs
             .iter()
             .enumerate()
             .any(|(i, io)| i != idx && io.name() == name);
         if !duplicate {
-            if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
+            if let Some(io) = flow_def.inputs.get_mut(idx) {
                 let old_name = io.name().clone();
                 io.set_name(name.into());
                 let old_route = format!("input/{old_name}");
                 let new_route = format!("input/{name}");
-                for conn in &mut self.flow_definition.connections {
+                for conn in &mut flow_def.connections {
                     if conn.from().to_string() == old_route {
                         conn.set_from(Route::from(new_route.as_str()));
                     }
@@ -94,20 +93,19 @@ impl WindowState {
         }
     }
 
-    fn rename_flow_output(&mut self, idx: usize, name: &str) {
-        let duplicate = self
-            .flow_definition
+    fn rename_flow_output(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) {
+        let duplicate = flow_def
             .outputs
             .iter()
             .enumerate()
             .any(|(i, io)| i != idx && io.name() == name);
         if !duplicate {
-            if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
+            if let Some(io) = flow_def.outputs.get_mut(idx) {
                 let old_name = io.name().clone();
                 io.set_name(name.into());
                 let old_route_str = format!("output/{old_name}");
                 let new_route_str = format!("output/{name}");
-                for conn in &mut self.flow_definition.connections {
+                for conn in &mut flow_def.connections {
                     let new_to: Vec<Route> = conn
                         .to()
                         .iter()
@@ -128,22 +126,22 @@ impl WindowState {
     }
 
     /// Handle flow metadata and I/O editing messages.
-    fn handle_flow_edit_message(&mut self, msg: FlowEditMessage) {
+    fn handle_flow_edit_message(&mut self, flow_def: &mut FlowDefinition, msg: FlowEditMessage) {
         match msg {
             FlowEditMessage::NameChanged(new_name) => {
-                self.flow_definition.name = new_name;
+                flow_def.name = new_name;
                 self.history.mark_modified();
             }
             FlowEditMessage::VersionChanged(version) => {
-                self.flow_definition.metadata.version = version;
+                flow_def.metadata.version = version;
                 self.history.mark_modified();
             }
             FlowEditMessage::DescriptionChanged(desc) => {
-                self.flow_definition.metadata.description = desc;
+                flow_def.metadata.description = desc;
                 self.history.mark_modified();
             }
             FlowEditMessage::AuthorsChanged(authors_str) => {
-                self.flow_definition.metadata.authors = authors_str
+                flow_def.metadata.authors = authors_str
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
@@ -154,28 +152,28 @@ impl WindowState {
                 self.show_metadata = !self.show_metadata;
             }
             FlowEditMessage::AddInput => {
-                let name = next_unique_io_name("input", &self.flow_definition.inputs);
+                let name = next_unique_io_name("input", &flow_def.inputs);
                 let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
                 io.set_io_type(IOType::FlowInput);
-                self.flow_definition.inputs.push(io);
+                flow_def.inputs.push(io);
                 self.history.mark_modified();
                 self.canvas_state.request_redraw();
                 self.trigger_auto_fit_if_enabled();
             }
             FlowEditMessage::AddOutput => {
-                let name = next_unique_io_name("output", &self.flow_definition.outputs);
+                let name = next_unique_io_name("output", &flow_def.outputs);
                 let mut io = IO::new_named(vec![DataType::from("string")], Route::default(), name);
                 io.set_io_type(IOType::FlowOutput);
-                self.flow_definition.outputs.push(io);
+                flow_def.outputs.push(io);
                 self.history.mark_modified();
                 self.canvas_state.request_redraw();
                 self.trigger_auto_fit_if_enabled();
             }
             FlowEditMessage::DeleteInput(idx) => {
-                if let Some(io) = self.flow_definition.inputs.get(idx) {
+                if let Some(io) = flow_def.inputs.get(idx) {
                     let name = io.name().clone();
-                    self.flow_definition.inputs.remove(idx);
-                    self.flow_definition.connections.retain(|c| {
+                    flow_def.inputs.remove(idx);
+                    flow_def.connections.retain(|c| {
                         let (from_node, from_port) = utils::split_route(c.from().as_ref());
                         !(from_node == "input" && from_port == name)
                     });
@@ -185,10 +183,10 @@ impl WindowState {
                 }
             }
             FlowEditMessage::DeleteOutput(idx) => {
-                if let Some(io) = self.flow_definition.outputs.get(idx) {
+                if let Some(io) = flow_def.outputs.get(idx) {
                     let name = io.name().clone();
-                    self.flow_definition.outputs.remove(idx);
-                    for conn in &mut self.flow_definition.connections {
+                    flow_def.outputs.remove(idx);
+                    for conn in &mut flow_def.connections {
                         let new_to: Vec<Route> = conn
                             .to()
                             .iter()
@@ -200,26 +198,28 @@ impl WindowState {
                             .collect();
                         conn.set_to(new_to);
                     }
-                    self.flow_definition
-                        .connections
-                        .retain(|c| !c.to().is_empty());
+                    flow_def.connections.retain(|c| !c.to().is_empty());
                     self.history.mark_modified();
                     self.canvas_state.request_redraw();
                     self.trigger_auto_fit_if_enabled();
                 }
             }
-            FlowEditMessage::InputNameChanged(idx, name) => self.rename_flow_input(idx, &name),
+            FlowEditMessage::InputNameChanged(idx, name) => {
+                self.rename_flow_input(flow_def, idx, &name);
+            }
             FlowEditMessage::InputTypeChanged(idx, dtype) => {
-                if let Some(io) = self.flow_definition.inputs.get_mut(idx) {
+                if let Some(io) = flow_def.inputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
                 }
                 self.history.mark_modified();
                 self.canvas_state.request_redraw();
                 self.trigger_auto_fit_if_enabled();
             }
-            FlowEditMessage::OutputNameChanged(idx, name) => self.rename_flow_output(idx, &name),
+            FlowEditMessage::OutputNameChanged(idx, name) => {
+                self.rename_flow_output(flow_def, idx, &name);
+            }
             FlowEditMessage::OutputTypeChanged(idx, dtype) => {
-                if let Some(io) = self.flow_definition.outputs.get_mut(idx) {
+                if let Some(io) = flow_def.outputs.get_mut(idx) {
                     io.set_datatypes(&[DataType::from(dtype)]);
                 }
                 self.history.mark_modified();
@@ -585,16 +585,12 @@ impl FlowEdit {
     fn title(&self, window_id: window::Id) -> String {
         if let Some(win) = self.windows.get(&window_id) {
             let modified = if win.history.is_empty() { "" } else { " *" };
-            let file = win
-                .file_path()
+            let file = WindowState::file_path_of(&self.root_flow)
                 .as_ref()
                 .and_then(|p| p.file_name().map(ToOwned::to_owned))
                 .and_then(|n| n.to_str().map(String::from))
                 .unwrap_or_else(|| String::from("untitled"));
-            format!(
-                "flowedit - {} ({}){modified}",
-                win.flow_definition.name, file
-            )
+            format!("flowedit - {} ({}){modified}", self.root_flow.name, file)
         } else {
             String::from("flowedit")
         }
@@ -807,7 +803,7 @@ impl FlowEdit {
         match self.library_tree.update(lib_msg) {
             LibraryAction::Add(source, func_name) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.add_library_function(&source, &func_name);
+                    win.add_library_function(&mut self.root_flow, &source, &func_name);
                 }
             }
             LibraryAction::View(source, _name) => {
@@ -858,7 +854,8 @@ impl FlowEdit {
         let Some(win) = self.windows.get_mut(&win_id) else {
             return Task::none();
         };
-        match win.handle_canvas_message(canvas_msg) {
+        let action = win.handle_canvas_message(&mut self.root_flow, canvas_msg);
+        match action {
             CanvasAction::OpenNode(idx) => self.open_node(win_id, idx),
             CanvasAction::None => Task::none(),
         }
@@ -878,7 +875,7 @@ impl FlowEdit {
             }
             Message::InitializerApply(win_id) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_apply();
+                    win.handle_initializer_apply(&mut self.root_flow);
                 }
             }
             Message::InitializerCancel(win_id) => {
@@ -910,13 +907,13 @@ impl FlowEdit {
             Message::Undo => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    win.handle_undo();
+                    win.handle_undo(&mut self.root_flow);
                 }
             }
             Message::Redo => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    win.handle_redo();
+                    win.handle_redo(&mut self.root_flow);
                 }
             }
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
@@ -924,7 +921,7 @@ impl FlowEdit {
             }
             Message::FlowEdit(win_id, flow_msg) => {
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_flow_edit_message(flow_msg);
+                    win.handle_flow_edit_message(&mut self.root_flow, flow_msg);
                 }
             }
             Message::NewSubFlow(target_win_id) => {
@@ -998,11 +995,11 @@ impl FlowEdit {
             return Self::view_function(window_id, viewer, &win.status, !win.history.is_empty());
         }
 
-        let canvas_with_controls = win.view_canvas_area(window_id);
+        let canvas_with_controls = win.view_canvas_area(&self.root_flow, window_id);
 
         let hierarchy_panel = win
             .flow_hierarchy
-            .view(&win.flow_definition)
+            .view(&self.root_flow)
             .map(move |msg| Message::Hierarchy(window_id, msg));
 
         let library_panel = self
@@ -1020,12 +1017,12 @@ impl FlowEdit {
 
         // Flow I/O editor panel for sub-flow windows
         if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(Self::view_flow_io_panel(window_id, win));
+            right_col = right_col.push(Self::view_flow_io_panel(window_id, &self.root_flow));
         }
 
         // Metadata editor panel (toggled by Info button)
         if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(Self::view_metadata_panel(win, window_id));
+            right_col = right_col.push(Self::view_metadata_panel(&self.root_flow, window_id));
         }
 
         // Library paths panel (toggled by Libs button)
@@ -1033,7 +1030,7 @@ impl FlowEdit {
             right_col = right_col.push(self.view_lib_paths_panel());
         }
 
-        right_col = right_col.push(self.view_toolbar(win, window_id));
+        right_col = right_col.push(self.view_toolbar(win, &self.root_flow, window_id));
 
         let layout = Row::new().push(left_panel).push(right_col.width(Fill));
         layout.into()
@@ -1043,6 +1040,7 @@ impl FlowEdit {
     fn view_toolbar<'a>(
         &'a self,
         win: &'a WindowState,
+        flow_def: &'a FlowDefinition,
         window_id: window::Id,
     ) -> Element<'a, Message> {
         let edit_indicator = if win.history.is_empty() {
@@ -1092,7 +1090,7 @@ impl FlowEdit {
             let mut compile_btn = button(Text::new("\u{1F528} Build").size(btn_size).center())
                 .padding(btn_pad)
                 .style(toolbar_btn);
-            if !win.flow_definition.process_refs.is_empty() {
+            if !flow_def.process_refs.is_empty() {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
@@ -1152,8 +1150,11 @@ impl FlowEdit {
     }
 
     /// Build the metadata editor panel.
-    fn view_metadata_panel(win: &WindowState, window_id: window::Id) -> Element<'_, Message> {
-        let authors_str = win.flow_definition.metadata.authors.join(", ");
+    fn view_metadata_panel(
+        flow_def: &FlowDefinition,
+        window_id: window::Id,
+    ) -> Element<'_, Message> {
+        let authors_str = flow_def.metadata.authors.join(", ");
         let meta_panel = container(
             Column::new()
                 .spacing(6)
@@ -1164,7 +1165,7 @@ impl FlowEdit {
                         .align_y(iced::Alignment::Center)
                         .push(Text::new("Name:").size(12).width(70))
                         .push(
-                            text_input("Flow name", &win.flow_definition.name)
+                            text_input("Flow name", &flow_def.name)
                                 .on_input(move |s| {
                                     Message::FlowEdit(window_id, FlowEditMessage::NameChanged(s))
                                 })
@@ -1179,7 +1180,7 @@ impl FlowEdit {
                         .align_y(iced::Alignment::Center)
                         .push(Text::new("Version:").size(12).width(70))
                         .push(
-                            text_input("0.1.0", &win.flow_definition.metadata.version)
+                            text_input("0.1.0", &flow_def.metadata.version)
                                 .on_input(move |s| {
                                     Message::FlowEdit(window_id, FlowEditMessage::VersionChanged(s))
                                 })
@@ -1194,16 +1195,16 @@ impl FlowEdit {
                         .align_y(iced::Alignment::Center)
                         .push(Text::new("Description:").size(12).width(70))
                         .push(
-                            text_input(
-                                "A short description",
-                                &win.flow_definition.metadata.description,
-                            )
-                            .on_input(move |s| {
-                                Message::FlowEdit(window_id, FlowEditMessage::DescriptionChanged(s))
-                            })
-                            .size(13)
-                            .padding(4)
-                            .width(Fill),
+                            text_input("A short description", &flow_def.metadata.description)
+                                .on_input(move |s| {
+                                    Message::FlowEdit(
+                                        window_id,
+                                        FlowEditMessage::DescriptionChanged(s),
+                                    )
+                                })
+                                .size(13)
+                                .padding(4)
+                                .width(Fill),
                         ),
                 )
                 .push(
@@ -1379,9 +1380,12 @@ impl FlowEdit {
         )
     }
 
-    fn view_flow_io_panel(window_id: window::Id, win: &WindowState) -> Element<'_, Message> {
-        let input_col = Self::view_flow_inputs_column(window_id, &win.flow_definition.inputs);
-        let output_col = Self::view_flow_outputs_column(window_id, &win.flow_definition.outputs);
+    fn view_flow_io_panel(
+        window_id: window::Id,
+        flow_def: &FlowDefinition,
+    ) -> Element<'_, Message> {
+        let input_col = Self::view_flow_inputs_column(window_id, &flow_def.inputs);
+        let output_col = Self::view_flow_outputs_column(window_id, &flow_def.outputs);
 
         let io_box = container(
             Column::new()
@@ -1849,12 +1853,8 @@ impl FlowEdit {
         std::env::set_var("FLOW_LIB_PATH", &path_str);
 
         // Reload library catalogs with the updated search paths.
-        // Gather lib_references from the root window's flow.
-        let lib_refs = self
-            .root_window
-            .and_then(|id| self.windows.get(&id))
-            .map(|win| win.flow_definition.lib_references.clone())
-            .unwrap_or_default();
+        // Gather lib_references from the root flow.
+        let lib_refs = self.root_flow.lib_references.clone();
         let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
         self.library_cache = lc;
         self.all_definitions = ad;
@@ -1879,14 +1879,14 @@ impl FlowEdit {
     fn open_node(&mut self, parent_win_id: window::Id, idx: usize) -> Task<Message> {
         // Extract source and resolved path from the parent window (immutable borrow)
         let (source, resolved_path) = {
-            let Some(win) = self.windows.get(&parent_win_id) else {
-                return Task::none();
-            };
-            let Some(pref) = win.flow_definition.process_refs.get(idx) else {
+            let Some(pref) = self.root_flow.process_refs.get(idx) else {
                 return Task::none();
             };
             let source = pref.source.clone();
-            let path = win.resolve_node_source(&source);
+            let Some(win) = self.windows.get(&parent_win_id) else {
+                return Task::none();
+            };
+            let path = win.resolve_node_source(&self.root_flow, &source);
             (source, path)
         };
 
@@ -2047,10 +2047,7 @@ impl FlowEdit {
         };
 
         // Get the parent flow's directory for relative path resolution
-        let base_dir = self
-            .windows
-            .get(&target_id)
-            .and_then(WindowState::file_path)
+        let base_dir = WindowState::file_path_of(&self.root_flow)
             .as_ref()
             .and_then(|p| p.parent())
             .map(Path::to_path_buf);
@@ -2104,13 +2101,12 @@ impl FlowEdit {
         // Strip .toml extension for the source reference
         let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
 
-        // Add a process reference in the target flow
-        if let Some(win) = self.windows.get_mut(&target_id) {
-            let alias =
-                file_ops::generate_unique_alias(&flow_name, &win.flow_definition.process_refs);
-            let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
+        // Add a process reference in the root flow
+        {
+            let alias = file_ops::generate_unique_alias(&flow_name, &self.root_flow.process_refs);
+            let (x, y) = file_ops::next_node_position(&self.root_flow.process_refs);
 
-            win.flow_definition.process_refs.push(ProcessReference {
+            self.root_flow.process_refs.push(ProcessReference {
                 alias: alias.clone(),
                 source,
                 initializations: std::collections::BTreeMap::new(),
@@ -2119,10 +2115,12 @@ impl FlowEdit {
                 width: Some(180.0),
                 height: Some(120.0),
             });
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
-            win.trigger_auto_fit_if_enabled();
-            win.status = format!("Created sub-flow: {alias}");
+            if let Some(win) = self.windows.get_mut(&target_id) {
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+                win.trigger_auto_fit_if_enabled();
+                win.status = format!("Created sub-flow: {alias}");
+            }
         }
 
         // Open the new sub-flow in a child window
@@ -2164,10 +2162,7 @@ impl FlowEdit {
             return Task::none();
         };
 
-        let base_dir = self
-            .windows
-            .get(&target_id)
-            .and_then(WindowState::file_path)
+        let base_dir = WindowState::file_path_of(&self.root_flow)
             .as_ref()
             .and_then(|p| p.parent())
             .map(Path::to_path_buf);
@@ -2203,13 +2198,12 @@ impl FlowEdit {
         );
         let source = source.strip_suffix(".toml").unwrap_or(&source).to_string();
 
-        // Add process reference in the target flow
-        if let Some(win) = self.windows.get_mut(&target_id) {
-            let alias =
-                file_ops::generate_unique_alias(&func_name, &win.flow_definition.process_refs);
-            let (x, y) = file_ops::next_node_position(&win.flow_definition.process_refs);
+        // Add process reference in the root flow
+        {
+            let alias = file_ops::generate_unique_alias(&func_name, &self.root_flow.process_refs);
+            let (x, y) = file_ops::next_node_position(&self.root_flow.process_refs);
 
-            win.flow_definition.process_refs.push(ProcessReference {
+            self.root_flow.process_refs.push(ProcessReference {
                 alias: alias.clone(),
                 source: source.clone(),
                 initializations: std::collections::BTreeMap::new(),
@@ -2218,10 +2212,12 @@ impl FlowEdit {
                 width: Some(180.0),
                 height: Some(120.0),
             });
-            win.history.mark_modified();
-            win.canvas_state.request_redraw();
-            win.trigger_auto_fit_if_enabled();
-            win.status = format!("Created function: {alias}");
+            if let Some(win) = self.windows.get_mut(&target_id) {
+                win.history.mark_modified();
+                win.canvas_state.request_redraw();
+                win.trigger_auto_fit_if_enabled();
+                win.status = format!("Created function: {alias}");
+            }
         }
 
         let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
@@ -2280,7 +2276,7 @@ impl FlowEdit {
                                 }
                             }
                         }
-                        WindowKind::FlowEditor => win.handle_save(),
+                        WindowKind::FlowEditor => win.handle_save(&mut self.root_flow),
                     }
                 }
             }
@@ -2299,16 +2295,16 @@ impl FlowEdit {
                                 }
                             }
                         }
-                        WindowKind::FlowEditor => win.handle_save_as(),
+                        WindowKind::FlowEditor => win.handle_save_as(&mut self.root_flow),
                     }
                 }
             }
             Message::Open => {
                 if let Some(root_id) = self.root_window {
                     if let Some(win) = self.windows.get_mut(&root_id) {
-                        if let Some((lib_refs, _ctx_refs)) = win.perform_open() {
+                        if let Some((lib_refs, _ctx_refs)) = win.perform_open(&mut self.root_flow) {
                             win.flow_hierarchy =
-                                FlowHierarchy::from_flow_definition(&win.flow_definition);
+                                FlowHierarchy::from_flow_definition(&self.root_flow);
 
                             let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
                             self.library_cache = lc;
@@ -2321,7 +2317,7 @@ impl FlowEdit {
             }
             Message::New => {
                 if let Some(win) = self.root_window.and_then(|id| self.windows.get_mut(&id)) {
-                    win.perform_new();
+                    win.perform_new(&mut self.root_flow);
                     win.flow_hierarchy = FlowHierarchy::empty();
                     self.library_cache.clear();
                     self.all_definitions.clear();
@@ -2332,8 +2328,8 @@ impl FlowEdit {
             Message::Compile => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    if !win.flow_definition.process_refs.is_empty() {
-                        match win.perform_compile() {
+                    if !self.root_flow.process_refs.is_empty() {
+                        match win.perform_compile(&mut self.root_flow) {
                             Ok(path) => {
                                 win.history.set_compiled_manifest(path.clone());
                                 win.status = format!("Compiled: {}", path.display());
@@ -2366,27 +2362,26 @@ impl FlowEdit {
             win.history.mark_modified();
         }
         if let Some((parent_id, node_source)) = parent_info {
-            if let Some(parent_win) = self.windows.get_mut(&parent_id) {
-                for pref in &parent_win.flow_definition.process_refs {
-                    if pref.source == node_source {
-                        let alias = if pref.alias.is_empty() {
-                            utils::derive_short_name(&pref.source)
-                        } else {
-                            pref.alias.clone()
-                        };
-                        if let Some(proc) = parent_win.flow_definition.subprocesses.get_mut(&alias)
-                        {
-                            match proc {
-                                Process::FunctionProcess(ref mut f) => {
-                                    f.description = new_desc.to_string();
-                                }
-                                Process::FlowProcess(ref mut f) => {
-                                    f.description = new_desc.to_string();
-                                }
+            for pref in &self.root_flow.process_refs {
+                if pref.source == node_source {
+                    let alias = if pref.alias.is_empty() {
+                        utils::derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    if let Some(proc) = self.root_flow.subprocesses.get_mut(&alias) {
+                        match proc {
+                            Process::FunctionProcess(ref mut f) => {
+                                f.description = new_desc.to_string();
+                            }
+                            Process::FlowProcess(ref mut f) => {
+                                f.description = new_desc.to_string();
                             }
                         }
                     }
                 }
+            }
+            if let Some(parent_win) = self.windows.get_mut(&parent_id) {
                 parent_win.canvas_state.request_redraw();
             }
         }
@@ -2480,8 +2475,15 @@ impl FlowEdit {
             }
             win.history.mark_modified();
         }
-        Self::propagate_function_ports(&mut self.windows, win_id);
-        Self::rename_parent_connections_port(&mut self.windows, win_id, old, name, is_input);
+        Self::propagate_function_ports(&mut self.windows, &mut self.root_flow, win_id);
+        Self::rename_parent_connections_port(
+            &mut self.windows,
+            &mut self.root_flow,
+            win_id,
+            old,
+            name,
+            is_input,
+        );
     }
 
     /// Handle function definition viewing/editing messages.
@@ -2503,7 +2505,7 @@ impl FlowEdit {
             }
             win.history.mark_modified();
         }
-        Self::propagate_function_ports(&mut self.windows, win_id);
+        Self::propagate_function_ports(&mut self.windows, &mut self.root_flow, win_id);
     }
 
     fn handle_func_delete_io(&mut self, win_id: window::Id, idx: usize, is_input: bool) {
@@ -2532,10 +2534,11 @@ impl FlowEdit {
             }
             win.history.mark_modified();
         }
-        Self::propagate_function_ports(&mut self.windows, win_id);
+        Self::propagate_function_ports(&mut self.windows, &mut self.root_flow, win_id);
         if let Some(port_name) = old_name {
             Self::remove_parent_connections_to_port(
                 &mut self.windows,
+                &mut self.root_flow,
                 win_id,
                 &port_name,
                 is_input,
@@ -2563,7 +2566,7 @@ impl FlowEdit {
             }
             win.history.mark_modified();
         }
-        Self::propagate_function_ports(&mut self.windows, win_id);
+        Self::propagate_function_ports(&mut self.windows, &mut self.root_flow, win_id);
     }
 
     fn build_new_function_viewer(
@@ -2640,6 +2643,7 @@ impl FlowEdit {
     /// display in sync when ports are added, deleted, or renamed in the function viewer.
     fn propagate_function_ports(
         windows: &mut HashMap<window::Id, WindowState>,
+        root_flow: &mut FlowDefinition,
         viewer_win_id: window::Id,
     ) {
         // Extract parent info and current ports from the viewer window
@@ -2659,30 +2663,29 @@ impl FlowEdit {
         });
 
         if let Some((parent_id, node_source, new_inputs, new_outputs)) = propagation_data {
-            if let Some(parent_win) = windows.get_mut(&parent_id) {
-                // Update subprocess definitions for all process refs with matching source
-                for pref in &parent_win.flow_definition.process_refs {
-                    if pref.source == node_source {
-                        let alias = if pref.alias.is_empty() {
-                            utils::derive_short_name(&pref.source)
-                        } else {
-                            pref.alias.clone()
-                        };
-                        if let Some(proc) = parent_win.flow_definition.subprocesses.get_mut(&alias)
-                        {
-                            match proc {
-                                Process::FunctionProcess(ref mut f) => {
-                                    f.inputs.clone_from(&new_inputs);
-                                    f.outputs.clone_from(&new_outputs);
-                                }
-                                Process::FlowProcess(ref mut f) => {
-                                    f.inputs.clone_from(&new_inputs);
-                                    f.outputs.clone_from(&new_outputs);
-                                }
+            // Update subprocess definitions in root_flow for all process refs with matching source
+            for pref in &root_flow.process_refs {
+                if pref.source == node_source {
+                    let alias = if pref.alias.is_empty() {
+                        utils::derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    if let Some(proc) = root_flow.subprocesses.get_mut(&alias) {
+                        match proc {
+                            Process::FunctionProcess(ref mut f) => {
+                                f.inputs.clone_from(&new_inputs);
+                                f.outputs.clone_from(&new_outputs);
+                            }
+                            Process::FlowProcess(ref mut f) => {
+                                f.inputs.clone_from(&new_inputs);
+                                f.outputs.clone_from(&new_outputs);
                             }
                         }
                     }
                 }
+            }
+            if let Some(parent_win) = windows.get_mut(&parent_id) {
                 parent_win.canvas_state.request_redraw();
             }
         }
@@ -2690,6 +2693,7 @@ impl FlowEdit {
 
     fn remove_parent_connections_to_port(
         windows: &mut HashMap<window::Id, WindowState>,
+        root_flow: &mut FlowDefinition,
         viewer_win_id: window::Id,
         port_name: &str,
         is_input: bool,
@@ -2702,38 +2706,32 @@ impl FlowEdit {
             }
         });
         if let Some((parent_id, node_source)) = info {
-            if let Some(parent_win) = windows.get_mut(&parent_id) {
-                for pref in &parent_win.flow_definition.process_refs {
-                    if pref.source != node_source {
-                        continue;
-                    }
-                    let alias = if pref.alias.is_empty() {
-                        utils::derive_short_name(&pref.source)
-                    } else {
-                        pref.alias.clone()
-                    };
-                    let route = format!("{alias}/{port_name}");
-                    if is_input {
-                        for conn in &mut parent_win.flow_definition.connections {
-                            let new_to: Vec<Route> = conn
-                                .to()
-                                .iter()
-                                .filter(|r| r.as_ref() != route)
-                                .cloned()
-                                .collect();
-                            conn.set_to(new_to);
-                        }
-                        parent_win
-                            .flow_definition
-                            .connections
-                            .retain(|c| !c.to().is_empty());
-                    } else {
-                        parent_win
-                            .flow_definition
-                            .connections
-                            .retain(|c| c.from().as_ref() != route);
-                    }
+            for pref in &root_flow.process_refs {
+                if pref.source != node_source {
+                    continue;
                 }
+                let alias = if pref.alias.is_empty() {
+                    utils::derive_short_name(&pref.source)
+                } else {
+                    pref.alias.clone()
+                };
+                let route = format!("{alias}/{port_name}");
+                if is_input {
+                    for conn in &mut root_flow.connections {
+                        let new_to: Vec<Route> = conn
+                            .to()
+                            .iter()
+                            .filter(|r| r.as_ref() != route)
+                            .cloned()
+                            .collect();
+                        conn.set_to(new_to);
+                    }
+                    root_flow.connections.retain(|c| !c.to().is_empty());
+                } else {
+                    root_flow.connections.retain(|c| c.from().as_ref() != route);
+                }
+            }
+            if let Some(parent_win) = windows.get_mut(&parent_id) {
                 parent_win.canvas_state.request_redraw();
             }
         }
@@ -2741,6 +2739,7 @@ impl FlowEdit {
 
     fn rename_parent_connections_port(
         windows: &mut HashMap<window::Id, WindowState>,
+        root_flow: &mut FlowDefinition,
         viewer_win_id: window::Id,
         old_port: &str,
         new_port: &str,
@@ -2754,37 +2753,37 @@ impl FlowEdit {
             }
         });
         if let Some((parent_id, node_source)) = info {
-            if let Some(parent_win) = windows.get_mut(&parent_id) {
-                for pref in &parent_win.flow_definition.process_refs {
-                    if pref.source != node_source {
-                        continue;
-                    }
-                    let alias = if pref.alias.is_empty() {
-                        utils::derive_short_name(&pref.source)
-                    } else {
-                        pref.alias.clone()
-                    };
-                    let old_route = format!("{alias}/{old_port}");
-                    let new_route = format!("{alias}/{new_port}");
-                    for conn in &mut parent_win.flow_definition.connections {
-                        if is_input {
-                            let new_to: Vec<Route> = conn
-                                .to()
-                                .iter()
-                                .map(|r| {
-                                    if r.as_ref() == old_route {
-                                        Route::from(new_route.as_str())
-                                    } else {
-                                        r.clone()
-                                    }
-                                })
-                                .collect();
-                            conn.set_to(new_to);
-                        } else if conn.from().as_ref() == old_route {
-                            conn.set_from(new_route.as_str());
-                        }
+            for pref in &root_flow.process_refs {
+                if pref.source != node_source {
+                    continue;
+                }
+                let alias = if pref.alias.is_empty() {
+                    utils::derive_short_name(&pref.source)
+                } else {
+                    pref.alias.clone()
+                };
+                let old_route = format!("{alias}/{old_port}");
+                let new_route = format!("{alias}/{new_port}");
+                for conn in &mut root_flow.connections {
+                    if is_input {
+                        let new_to: Vec<Route> = conn
+                            .to()
+                            .iter()
+                            .map(|r| {
+                                if r.as_ref() == old_route {
+                                    Route::from(new_route.as_str())
+                                } else {
+                                    r.clone()
+                                }
+                            })
+                            .collect();
+                        conn.set_to(new_to);
+                    } else if conn.from().as_ref() == old_route {
+                        conn.set_from(new_route.as_str());
                     }
                 }
+            }
+            if let Some(parent_win) = windows.get_mut(&parent_id) {
                 parent_win.canvas_state.request_redraw();
             }
         }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -370,6 +370,8 @@ enum Message {
 struct FlowEdit {
     /// Per-window states, keyed by window ID
     windows: HashMap<window::Id, WindowState>,
+    /// The single source of truth for the flow hierarchy
+    root_flow: FlowDefinition,
     /// The ID of the root (main) window, if known
     root_window: Option<window::Id>,
     /// The ID of the currently focused window (updated on focus events)
@@ -388,6 +390,7 @@ impl Default for FlowEdit {
     fn default() -> Self {
         Self {
             windows: HashMap::new(),
+            root_flow: FlowDefinition::default(),
             root_window: None,
             focused_window: None,
             library_tree: LibraryTree { libraries: vec![] },
@@ -536,6 +539,7 @@ impl FlowEdit {
         });
 
         let flow_hierarchy = FlowHierarchy::from_flow_definition(&flow_definition);
+        let root_flow = flow_definition.clone();
 
         let win_state = WindowState {
             route: flow_definition.route.clone(),
@@ -564,6 +568,7 @@ impl FlowEdit {
         let lib_paths = file_ops::resolve_lib_paths();
         let app = FlowEdit {
             windows,
+            root_flow,
             root_window: Some(root_id),
             focused_window: Some(root_id),
             library_tree,

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -538,6 +538,7 @@ impl FlowEdit {
         let flow_hierarchy = FlowHierarchy::from_flow_definition(&flow_definition);
 
         let win_state = WindowState {
+            route: flow_definition.route.clone(),
             kind: WindowKind::FlowEditor,
             canvas_state: FlowCanvasState::default(),
             status,
@@ -623,6 +624,7 @@ impl FlowEdit {
                 flow_def.source_url = url;
             }
             let child = WindowState {
+                route: flow_def.route.clone(),
                 kind: WindowKind::FlowEditor,
                 canvas_state: FlowCanvasState::default(),
                 status: format!("Ready - {nc} nodes, {ec} connections"),
@@ -1808,6 +1810,7 @@ impl FlowEdit {
                         flow_def.source_url = url;
                     }
                     let child = WindowState {
+                        route: flow_def.route.clone(),
                         kind: WindowKind::FlowEditor,
 
                         canvas_state: FlowCanvasState::default(),
@@ -1925,6 +1928,7 @@ impl FlowEdit {
                     flow_def.source_url = url;
                 }
                 let child = WindowState {
+                    route: flow_def.route.clone(),
                     kind: WindowKind::FlowEditor,
 
                     canvas_state: FlowCanvasState::default(),
@@ -1999,6 +2003,7 @@ impl FlowEdit {
             func_flow_def.source_url = url;
         }
         let child = WindowState {
+            route: func_flow_def.route.clone(),
             kind: WindowKind::FunctionViewer(Box::new(viewer)),
 
             canvas_state: FlowCanvasState::default(),
@@ -2119,6 +2124,7 @@ impl FlowEdit {
         let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
 
         let child = WindowState {
+            route: flow_def.route.clone(),
             kind: WindowKind::FlowEditor,
 
             canvas_state: FlowCanvasState::default(),
@@ -2225,6 +2231,7 @@ impl FlowEdit {
             func_flow_def.source_url = url;
         }
         let mut child = WindowState {
+            route: func_flow_def.route.clone(),
             kind: WindowKind::FunctionViewer(Box::new(viewer)),
 
             canvas_state: FlowCanvasState::default(),

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -6,32 +6,7 @@ use iced_test::simulator::{self, simulator};
 use std::collections::HashMap;
 
 fn test_win_state() -> WindowState {
-    let flow_def = FlowDefinition {
-        name: String::from("test"),
-        process_refs: vec![
-            ProcessReference {
-                alias: "add".into(),
-                source: "lib://flowstdlib/math/add".into(),
-                initializations: std::collections::BTreeMap::new(),
-                x: Some(100.0),
-                y: Some(100.0),
-                width: Some(180.0),
-                height: Some(120.0),
-            },
-            ProcessReference {
-                alias: "stdout".into(),
-                source: "context://stdio/stdout".into(),
-                initializations: std::collections::BTreeMap::new(),
-                x: Some(400.0),
-                y: Some(100.0),
-                width: Some(180.0),
-                height: Some(120.0),
-            },
-        ],
-        ..FlowDefinition::default()
-    };
     WindowState {
-        flow_definition: flow_def,
         is_root: true,
         ..Default::default()
     }
@@ -40,13 +15,13 @@ fn test_win_state() -> WindowState {
 fn test_app_with_flow(flow: FlowDefinition) -> (FlowEdit, window::Id) {
     let win_id = window::Id::unique();
     let win_state = WindowState {
-        flow_definition: flow,
         is_root: true,
         ..Default::default()
     };
 
     let app = FlowEdit {
         windows: HashMap::from([(win_id, win_state)]),
+        root_flow: flow,
         root_window: Some(win_id),
         focused_window: Some(win_id),
         library_tree: LibraryTree {
@@ -170,10 +145,7 @@ fn update_canvas_move_node() {
         win_id,
         CanvasMessage::Moved(0, 200.0, 300.0),
     ));
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
     assert!((node.map_or(0.0, |n| n.y.unwrap_or(0.0)) - 300.0).abs() < 0.01);
 }
@@ -194,19 +166,9 @@ fn update_canvas_move_completed_records_history() {
 #[test]
 fn update_canvas_delete_node() {
     let (mut app, win_id) = test_app();
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(2)
-    );
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(2));
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(1));
     assert!(app
         .windows
         .get(&win_id)
@@ -225,12 +187,7 @@ fn update_canvas_create_connection() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(1));
     assert!(app
         .windows
         .get(&win_id)
@@ -241,11 +198,9 @@ fn update_canvas_create_connection() {
 fn update_canvas_select_connection() {
     let (mut app, win_id) = test_app();
     // Add a connection first
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("add", "stdout"));
-    }
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "stdout"));
     let _ = app.update(Message::WindowCanvas(
         win_id,
         CanvasMessage::ConnectionSelected(Some(0)),
@@ -259,21 +214,14 @@ fn update_canvas_select_connection() {
 #[test]
 fn update_canvas_delete_connection() {
     let (mut app, win_id) = test_app();
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("add", "stdout"));
-    }
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "stdout"));
     let _ = app.update(Message::WindowCanvas(
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(0)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(0));
 }
 
 #[test]
@@ -295,18 +243,12 @@ fn update_undo_redo_cycle() {
 
     // Undo
     let _ = app.update(Message::Undo);
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 100.0).abs() < 0.01);
 
     // Redo
     let _ = app.update(Message::Redo);
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
 }
 
@@ -327,12 +269,7 @@ fn update_flow_name_changed() {
         win_id,
         FlowEditMessage::NameChanged("new_name".into()),
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.name.as_str()),
-        Some("new_name")
-    );
+    assert_eq!(Some(app.root_flow.name.as_str()), Some("new_name"));
     assert!(app
         .windows
         .get(&win_id)
@@ -346,12 +283,7 @@ fn update_flow_version_changed() {
         win_id,
         FlowEditMessage::VersionChanged("2.0.0".into()),
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.metadata.version.as_str()),
-        Some("2.0.0")
-    );
+    assert_eq!(Some(app.root_flow.metadata.version.as_str()), Some("2.0.0"));
 }
 
 #[test]
@@ -362,9 +294,7 @@ fn update_flow_description_changed() {
         FlowEditMessage::DescriptionChanged("A test flow".into()),
     ));
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.metadata.description.as_str()),
+        Some(app.root_flow.metadata.description.as_str()),
         Some("A test flow")
     );
 }
@@ -376,11 +306,7 @@ fn update_flow_authors_changed() {
         win_id,
         FlowEditMessage::AuthorsChanged("Alice, Bob".into()),
     ));
-    let authors = app
-        .windows
-        .get(&win_id)
-        .map(|w| w.flow_definition.metadata.authors.clone())
-        .unwrap_or_default();
+    let authors = app.root_flow.metadata.authors.clone();
     assert_eq!(authors, vec!["Alice", "Bob"]);
 }
 
@@ -388,12 +314,7 @@ fn update_flow_authors_changed() {
 fn update_flow_add_input() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.inputs.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.inputs.len()), Some(1));
     assert!(app
         .windows
         .get(&win_id)
@@ -404,12 +325,7 @@ fn update_flow_add_input() {
 fn update_flow_add_output() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.outputs.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.outputs.len()), Some(1));
 }
 
 #[test]
@@ -417,12 +333,7 @@ fn update_flow_delete_input() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.inputs.len()),
-        Some(0)
-    );
+    assert_eq!(Some(app.root_flow.inputs.len()), Some(0));
 }
 
 #[test]
@@ -434,11 +345,7 @@ fn update_flow_input_name_changed() {
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
     assert_eq!(
-        app.windows.get(&win_id).and_then(|w| w
-            .flow_definition
-            .inputs
-            .first()
-            .map(|io| io.name().as_str())),
+        app.root_flow.inputs.first().map(|io| io.name().as_str()),
         Some("data")
     );
 }
@@ -509,10 +416,7 @@ fn update_canvas_resize_node() {
         win_id,
         CanvasMessage::Resized(0, 50.0, 50.0, 200.0, 150.0),
     ));
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.width.unwrap_or(0.0)) - 200.0).abs() < 0.01);
     assert!((node.map_or(0.0, |n| n.height.unwrap_or(0.0)) - 150.0).abs() < 0.01);
 }
@@ -792,11 +696,10 @@ fn click_build_with_saved_flow() {
     let dir = temp_dir("ui_build");
     let path = dir.join("test.toml");
     let (mut app, win_id) = test_app();
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.set_file_path(&path);
-        win.flow_definition.name = "test_build".into();
-        win.perform_save(&path);
-    }
+    WindowState::set_file_path_on(&mut app.root_flow, &path);
+    app.root_flow.name = "test_build".into();
+    // Save through the message handler which properly borrows root_flow
+    let _ = app.update(Message::Save);
     click_and_update(&mut app, win_id, "\u{1F528} Build");
     let status = app
         .windows
@@ -829,12 +732,7 @@ fn helper_right_click_sets_context_menu() {
 #[test]
 fn helper_send_key_delete() {
     let (mut app, win_id) = test_app();
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(2)
-    );
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(2));
 
     // First, select a node via direct canvas click so the canvas internal state
     // has selected_node set. Then send Delete in the same simulator cycle.
@@ -859,9 +757,7 @@ fn helper_send_key_delete() {
     // The canvas should have emitted Selected(Some(0)) from the click,
     // then Deleted(0) from the Delete key
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
+        Some(app.root_flow.process_refs.len()),
         Some(1),
         "Delete key after selecting a node should remove it"
     );
@@ -888,10 +784,7 @@ fn helper_drag_via_direct_messages() {
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 250.0, 350.0),
     ));
 
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!(
         (node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 250.0).abs() < 0.01,
         "Node x should be 250 after drag"
@@ -916,9 +809,9 @@ fn helper_drag_simulator_smoke_test() {
     // the app state remains consistent.
     let (mut app, win_id) = test_app();
     let original_x = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first())
+        .root_flow
+        .process_refs
+        .first()
         .map_or(0.0, |n| n.x.unwrap_or(0.0));
 
     drag(
@@ -936,9 +829,9 @@ fn helper_drag_simulator_smoke_test() {
         "Window state should still exist after drag"
     );
     let _current_x = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first())
+        .root_flow
+        .process_refs
+        .first()
         .map_or(0.0, |n| n.x.unwrap_or(0.0));
     // Note: if current_x == original_x, the simulator drag didn't produce
     // canvas events. This is expected due to the limitation documented above.
@@ -951,29 +844,15 @@ fn helper_drag_simulator_smoke_test() {
 fn ui_delete_node_removes_connected_edges() {
     let (mut app, win_id) = test_app();
     // Add a connection between the two nodes
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("add/out", "stdout/in"));
-    }
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(1)
-    );
+    app.root_flow
+        .connections
+        .push(Connection::new("add/out", "stdout/in"));
+    assert_eq!(Some(app.root_flow.connections.len()), Some(1));
     // Delete node 0 ("add")
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(1));
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(1)
-    );
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
+        Some(app.root_flow.connections.len()),
         Some(0),
         "Edge should be removed when connected node is deleted"
     );
@@ -982,10 +861,7 @@ fn ui_delete_node_removes_connected_edges() {
 #[test]
 fn ui_delete_with_nothing_selected_no_change() {
     let (mut app, win_id) = test_app();
-    let count_before = app
-        .windows
-        .get(&win_id)
-        .map(|w| w.flow_definition.process_refs.len());
+    let count_before = app.root_flow.process_refs.len();
     // Deselect — no node is selected
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Selected(None)));
     // Send Delete key — should not change anything with nothing selected
@@ -994,12 +870,7 @@ fn ui_delete_with_nothing_selected_no_change() {
         win_id,
         iced::keyboard::Key::Named(iced::keyboard::key::Named::Delete),
     );
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        count_before
-    );
+    assert_eq!(app.root_flow.process_refs.len(), count_before);
 }
 
 // ---- Group 2: Connection Selection/Deletion ----
@@ -1016,12 +887,7 @@ fn ui_select_and_delete_connection() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(1));
     // Select
     let _ = app.update(Message::WindowCanvas(
         win_id,
@@ -1036,19 +902,14 @@ fn ui_select_and_delete_connection() {
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(0)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(0));
 }
 
 #[test]
 fn ui_connection_deselect_on_canvas_click() {
     let (mut app, win_id) = test_app();
     if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
+        app.root_flow
             .connections
             .push(Connection::new("add", "stdout"));
         win.selected_connection = Some(0);
@@ -1065,24 +926,12 @@ fn ui_connection_deselect_on_canvas_click() {
 #[test]
 fn ui_undo_node_deletion() {
     let (mut app, win_id) = test_app();
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(2)
-    );
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(2));
     let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.process_refs.len()), Some(1));
     let _ = app.update(Message::Undo);
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.process_refs.len()),
+        Some(app.root_flow.process_refs.len()),
         Some(2),
         "Undo should restore deleted node"
     );
@@ -1100,27 +949,15 @@ fn ui_undo_connection_deletion() {
             to_port: String::new(),
         },
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(1)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(1));
     let _ = app.update(Message::WindowCanvas(
         win_id,
         CanvasMessage::ConnectionDeleted(0),
     ));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
-        Some(0)
-    );
+    assert_eq!(Some(app.root_flow.connections.len()), Some(0));
     let _ = app.update(Message::Undo);
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map(|w| w.flow_definition.connections.len()),
+        Some(app.root_flow.connections.len()),
         Some(1),
         "Undo should restore deleted connection"
     );
@@ -1151,10 +988,7 @@ fn undo_restores_move() {
         CanvasMessage::MoveCompleted(0, 100.0, 100.0, 200.0, 300.0),
     ));
     let _ = app.update(Message::Undo);
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 100.0).abs() < 0.01);
 }
 
@@ -1171,10 +1005,7 @@ fn redo_reapplies_move() {
     ));
     let _ = app.update(Message::Undo);
     let _ = app.update(Message::Redo);
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!((node.map_or(0.0, |n| n.x.unwrap_or(0.0)) - 200.0).abs() < 0.01);
 }
 
@@ -1219,18 +1050,12 @@ fn ui_initializer_editor_open_and_cancel() {
 #[test]
 fn ui_library_add_function_creates_node() {
     let (mut app, win_id) = test_app();
-    let count_before = app
-        .windows
-        .get(&win_id)
-        .map_or(0, |w| w.flow_definition.process_refs.len());
+    let count_before = app.root_flow.process_refs.len();
     let _ = app.update(Message::Library(
         win_id,
         library_panel::LibraryMessage::AddFunction("lib://test_lib/math/add".into(), "add".into()),
     ));
-    let count_after = app
-        .windows
-        .get(&win_id)
-        .map_or(0, |w| w.flow_definition.process_refs.len());
+    let count_after = app.root_flow.process_refs.len();
     assert_eq!(
         count_after,
         count_before + 1,
@@ -1334,10 +1159,7 @@ fn ui_resize_node_records_history() {
             .is_some_and(|w| !w.history.is_empty()),
         "Resize should record an edit"
     );
-    let node = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.process_refs.first());
+    let node = app.root_flow.process_refs.first();
     assert!(
         (node.map_or(0.0, |n| n.width.unwrap_or(0.0)) - 250.0).abs() < 0.01,
         "Node width should be 250 after resize"
@@ -1356,23 +1178,14 @@ fn flow_delete_input_removes_edges() {
     // Add a flow input
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     // Add a connection referencing "input" node
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("input/input0", "add"));
-    }
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.connections.len()),
-        1
-    );
+    app.root_flow
+        .connections
+        .push(Connection::new("input/input0", "add"));
+    assert_eq!(app.root_flow.connections.len(), 1);
     // Delete the input — edge should be removed
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.connections.len()),
+        app.root_flow.connections.len(),
         0,
         "Edge should be removed when flow input is deleted"
     );
@@ -1384,23 +1197,14 @@ fn flow_delete_output_removes_edges() {
     // Add a flow output
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     // Add a connection referencing "output" node
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("add", "output/output0"));
-    }
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.connections.len()),
-        1
-    );
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "output/output0"));
+    assert_eq!(app.root_flow.connections.len(), 1);
     // Delete the output — edge should be removed
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
     assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.connections.len()),
+        app.root_flow.connections.len(),
         0,
         "Edge should be removed when flow output is deleted"
     );
@@ -1410,20 +1214,18 @@ fn flow_delete_output_removes_edges() {
 fn flow_input_rename_updates_edges() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("input/input0", "add"));
-    }
+    app.root_flow
+        .connections
+        .push(Connection::new("input/input0", "add"));
     let _ = app.update(Message::FlowEdit(
         win_id,
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
     // Connection from-route should now reference "input/data" instead of "input/input0"
     let from_route = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.connections.first())
+        .root_flow
+        .connections
+        .first()
         .map(|c| c.from().to_string());
     assert_eq!(from_route, Some("input/data".into()));
 }
@@ -1432,20 +1234,18 @@ fn flow_input_rename_updates_edges() {
 fn flow_output_rename_updates_edges() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
-    if let Some(win) = app.windows.get_mut(&win_id) {
-        win.flow_definition
-            .connections
-            .push(Connection::new("add", "output/output0"));
-    }
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "output/output0"));
     let _ = app.update(Message::FlowEdit(
         win_id,
         FlowEditMessage::OutputNameChanged(0, "result".into()),
     ));
     // Connection to-route should now reference "output/result" instead of "output/output0"
     let to_route = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.connections.first())
+        .root_flow
+        .connections
+        .first()
         .and_then(|c| c.to().first().map(ToString::to_string));
     assert_eq!(to_route, Some("output/result".into()));
 }
@@ -1498,19 +1298,9 @@ fn flow_edit_toggle_metadata() {
 fn flow_edit_add_delete_output() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.outputs.len()),
-        1
-    );
+    assert_eq!(app.root_flow.outputs.len(), 1);
     let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
-    assert_eq!(
-        app.windows
-            .get(&win_id)
-            .map_or(0, |w| w.flow_definition.outputs.len()),
-        0
-    );
+    assert_eq!(app.root_flow.outputs.len(), 0);
 }
 
 #[test]
@@ -1522,9 +1312,9 @@ fn flow_edit_input_type_changed() {
         FlowEditMessage::InputTypeChanged(0, "number".into()),
     ));
     let dtype = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.inputs.first())
+        .root_flow
+        .inputs
+        .first()
         .and_then(|io| io.datatypes().first())
         .map(ToString::to_string);
     assert_eq!(dtype.as_deref(), Some("number"));
@@ -1539,9 +1329,9 @@ fn flow_edit_output_type_changed() {
         FlowEditMessage::OutputTypeChanged(0, "boolean".into()),
     ));
     let dtype = app
-        .windows
-        .get(&win_id)
-        .and_then(|w| w.flow_definition.outputs.first())
+        .root_flow
+        .outputs
+        .first()
         .and_then(|io| io.datatypes().first())
         .map(ToString::to_string);
     assert_eq!(dtype.as_deref(), Some("boolean"));

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -292,8 +292,13 @@ impl WindowState {
         self.flow_definition.source_url.to_file_path().ok()
     }
 
-    /// Set the file path by updating the flow definition's source URL.
-    pub(crate) fn set_file_path(&mut self, path: &Path) {
+    /// Get the file path from a given flow definition's source URL.
+    pub(crate) fn file_path_of(flow_def: &FlowDefinition) -> Option<PathBuf> {
+        flow_def.source_url.to_file_path().ok()
+    }
+
+    /// Set the file path on a given flow definition.
+    pub(crate) fn set_file_path_on(flow_def: &mut FlowDefinition, path: &Path) {
         let abs = path.canonicalize().unwrap_or_else(|_| {
             if path.is_absolute() {
                 path.to_path_buf()
@@ -302,13 +307,13 @@ impl WindowState {
             }
         });
         if let Ok(url) = Url::from_file_path(&abs) {
-            self.flow_definition.source_url = url;
+            flow_def.source_url = url;
         }
     }
 
-    /// Clear the file path by resetting the source URL to the default.
-    pub(crate) fn clear_file_path(&mut self) {
-        self.flow_definition.source_url = FlowDefinition::default_url();
+    /// Clear the file path on a given flow definition.
+    pub(crate) fn clear_file_path_on(flow_def: &mut FlowDefinition) {
+        flow_def.source_url = FlowDefinition::default_url();
     }
 }
 impl WindowState {
@@ -316,18 +321,23 @@ impl WindowState {
     ///
     /// Returns a [`CanvasAction`] when the caller needs to perform cross-window
     /// operations (e.g. opening a sub-flow in a new editor window).
-    pub(crate) fn handle_canvas_message(&mut self, msg: CanvasMessage) -> CanvasAction {
+    #[allow(clippy::too_many_lines)]
+    pub(crate) fn handle_canvas_message(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+        msg: CanvasMessage,
+    ) -> CanvasAction {
         match msg {
-            CanvasMessage::Selected(idx) => self.handle_selected(idx),
+            CanvasMessage::Selected(idx) => self.handle_selected(flow_def, idx),
             CanvasMessage::Moved(idx, x, y) => {
-                if let Some(pref) = self.flow_definition.process_refs.get_mut(idx) {
+                if let Some(pref) = flow_def.process_refs.get_mut(idx) {
                     pref.x = Some(x);
                     pref.y = Some(y);
                     self.canvas_state.request_redraw();
                 }
             }
             CanvasMessage::Resized(idx, x, y, w, h) => {
-                if let Some(pref) = self.flow_definition.process_refs.get_mut(idx) {
+                if let Some(pref) = flow_def.process_refs.get_mut(idx) {
                     pref.x = Some(x);
                     pref.y = Some(y);
                     pref.width = Some(w);
@@ -364,26 +374,34 @@ impl WindowState {
                     idx, old_x, old_y, old_w, old_h, new_x, new_y, new_w, new_h,
                 );
             }
-            CanvasMessage::Deleted(idx) => self.handle_deleted(idx),
+            CanvasMessage::Deleted(idx) => self.handle_deleted(flow_def, idx),
             CanvasMessage::ConnectionCreated {
                 from_node,
                 from_port,
                 to_node,
                 to_port,
-            } => self.handle_connection_created(&from_node, &from_port, &to_node, &to_port),
-            CanvasMessage::ConnectionSelected(idx) => self.handle_connection_selected(idx),
-            CanvasMessage::ConnectionDeleted(idx) => self.handle_connection_deleted(idx),
+            } => {
+                self.handle_connection_created(
+                    flow_def, &from_node, &from_port, &to_node, &to_port,
+                );
+            }
+            CanvasMessage::ConnectionSelected(idx) => {
+                self.handle_connection_selected(flow_def, idx);
+            }
+            CanvasMessage::ConnectionDeleted(idx) => {
+                self.handle_connection_deleted(flow_def, idx);
+            }
             CanvasMessage::HoverChanged(data) => {
                 self.tooltip = data;
             }
             CanvasMessage::AutoFitViewport(viewport) => {
                 if self.auto_fit_enabled || self.auto_fit_pending {
-                    let render_nodes = NodeLayout::build_from_flow(&self.flow_definition);
+                    let render_nodes = NodeLayout::build_from_flow(flow_def);
                     let is_subflow = !self.is_root;
                     self.canvas_state.auto_fit(
                         &render_nodes,
-                        &self.flow_definition.inputs,
-                        &self.flow_definition.outputs,
+                        &flow_def.inputs,
+                        &flow_def.outputs,
                         is_subflow,
                         viewport,
                     );
@@ -406,7 +424,7 @@ impl WindowState {
                 self.status = format!("Zoom: {pct}%");
             }
             CanvasMessage::InitializerEdit(node_idx, port_name) => {
-                self.handle_initializer_edit(node_idx, port_name);
+                self.handle_initializer_edit(flow_def, node_idx, port_name);
             }
             CanvasMessage::OpenNode(idx) => {
                 return CanvasAction::OpenNode(idx);
@@ -425,7 +443,7 @@ impl WindowState {
         }
     }
 
-    fn handle_selected(&mut self, idx: Option<usize>) {
+    fn handle_selected(&mut self, flow_def: &FlowDefinition, idx: Option<usize>) {
         self.selected_node = idx;
         self.context_menu = None;
         if self.selected_connection.is_some() {
@@ -433,7 +451,7 @@ impl WindowState {
             self.canvas_state.request_redraw();
         }
         if let Some(i) = idx {
-            if let Some(pref) = self.flow_definition.process_refs.get(i) {
+            if let Some(pref) = flow_def.process_refs.get(i) {
                 let alias = if pref.alias.is_empty() {
                     derive_short_name(&pref.source)
                 } else {
@@ -479,9 +497,9 @@ impl WindowState {
         }
     }
 
-    fn handle_deleted(&mut self, idx: usize) {
-        if idx < self.flow_definition.process_refs.len() {
-            let Some(pref) = self.flow_definition.process_refs.get(idx).cloned() else {
+    fn handle_deleted(&mut self, flow_def: &mut FlowDefinition, idx: usize) {
+        if idx < flow_def.process_refs.len() {
+            let Some(pref) = flow_def.process_refs.get(idx).cloned() else {
                 return;
             };
             let alias = if pref.alias.is_empty() {
@@ -489,16 +507,15 @@ impl WindowState {
             } else {
                 pref.alias.clone()
             };
-            let removed_connections: Vec<Connection> = self
-                .flow_definition
+            let removed_connections: Vec<Connection> = flow_def
                 .connections
                 .iter()
                 .filter(|c| connection_references_node(c, &alias))
                 .cloned()
                 .collect();
-            let removed_pref = self.flow_definition.process_refs.remove(idx);
-            let removed_subprocess = self.flow_definition.subprocesses.remove(&alias);
-            self.flow_definition
+            let removed_pref = flow_def.process_refs.remove(idx);
+            let removed_subprocess = flow_def.subprocesses.remove(&alias);
+            flow_def
                 .connections
                 .retain(|c| !connection_references_node(c, &alias));
             self.history.record(EditAction::DeleteNode {
@@ -510,8 +527,8 @@ impl WindowState {
             self.selected_node = None;
             self.selected_connection = None;
             self.canvas_state.request_redraw();
-            let nc = self.flow_definition.process_refs.len();
-            let ec = self.flow_definition.connections.len();
+            let nc = flow_def.process_refs.len();
+            let ec = flow_def.connections.len();
             self.status = format!("Node deleted - {nc} nodes, {ec} connections");
             self.trigger_auto_fit_if_enabled();
         }
@@ -519,6 +536,7 @@ impl WindowState {
 
     fn handle_connection_created(
         &mut self,
+        flow_def: &mut FlowDefinition,
         from_node: &str,
         from_port: &str,
         to_node: &str,
@@ -538,23 +556,23 @@ impl WindowState {
         self.history.record(EditAction::CreateConnection {
             connection: connection.clone(),
         });
-        self.flow_definition.connections.push(connection);
+        flow_def.connections.push(connection);
         self.canvas_state.request_redraw();
-        let nc = self.flow_definition.process_refs.len();
-        let ec = self.flow_definition.connections.len();
+        let nc = flow_def.process_refs.len();
+        let ec = flow_def.connections.len();
         self.status = format!(
             "Connection created: {from_node}/{from_port} -> {to_node}/{to_port} - {nc} nodes, {ec} connections"
         );
         self.trigger_auto_fit_if_enabled();
     }
 
-    fn handle_connection_selected(&mut self, idx: Option<usize>) {
+    fn handle_connection_selected(&mut self, flow_def: &FlowDefinition, idx: Option<usize>) {
         self.context_menu = None;
         self.selected_connection = idx;
         self.selected_node = None;
         self.canvas_state.request_redraw();
         if let Some(i) = idx {
-            if let Some(conn) = self.flow_definition.connections.get(i) {
+            if let Some(conn) = flow_def.connections.get(i) {
                 let (from_node, from_port) = split_route(conn.from().as_ref());
                 let to_str = conn
                     .to()
@@ -572,26 +590,30 @@ impl WindowState {
         }
     }
 
-    fn handle_connection_deleted(&mut self, idx: usize) {
-        if idx < self.flow_definition.connections.len() {
-            let connection = self.flow_definition.connections.remove(idx);
+    fn handle_connection_deleted(&mut self, flow_def: &mut FlowDefinition, idx: usize) {
+        if idx < flow_def.connections.len() {
+            let connection = flow_def.connections.remove(idx);
             self.history.record(EditAction::DeleteConnection {
                 index: idx,
                 connection,
             });
             self.selected_connection = None;
             self.canvas_state.request_redraw();
-            let nc = self.flow_definition.process_refs.len();
-            let ec = self.flow_definition.connections.len();
+            let nc = flow_def.process_refs.len();
+            let ec = flow_def.connections.len();
             self.status = format!("Connection deleted - {nc} nodes, {ec} connections");
             self.trigger_auto_fit_if_enabled();
         }
     }
 
-    fn handle_initializer_edit(&mut self, node_idx: usize, port_name: String) {
+    fn handle_initializer_edit(
+        &mut self,
+        flow_def: &FlowDefinition,
+        node_idx: usize,
+        port_name: String,
+    ) {
         self.context_menu = None;
-        let (init_type, value_text) = self
-            .flow_definition
+        let (init_type, value_text) = flow_def
             .process_refs
             .get(node_idx)
             .and_then(|pr| pr.initializations.get(&port_name))
@@ -647,15 +669,19 @@ impl WindowState {
     }
 }
 impl WindowState {
-    pub(crate) fn view_canvas_area(&self, window_id: window::Id) -> Element<'_, Message> {
+    pub(crate) fn view_canvas_area<'a>(
+        &'a self,
+        flow_def: &'a FlowDefinition,
+        window_id: window::Id,
+    ) -> Element<'a, Message> {
         let canvas = self
             .canvas_state
             .view(
-                &self.flow_definition,
-                &self.flow_definition.connections,
-                &self.flow_definition.name,
-                &self.flow_definition.inputs,
-                &self.flow_definition.outputs,
+                flow_def,
+                &flow_def.connections,
+                &flow_def.name,
+                &flow_def.inputs,
+                &flow_def.outputs,
                 !self.is_root,
                 self.auto_fit_pending,
                 self.auto_fit_enabled,
@@ -734,7 +760,7 @@ impl WindowState {
         }
 
         if let Some(ref editor) = self.initializer_editor {
-            canvas_stack.push(self.build_initializer_dialog(window_id, editor));
+            canvas_stack.push(self.build_initializer_dialog(flow_def, window_id, editor));
         }
 
         if let Some(menu_pos) = self.context_menu {
@@ -767,22 +793,23 @@ impl WindowState {
         .into()
     }
 
+    #[allow(clippy::unused_self)]
     fn build_initializer_dialog<'a>(
         &self,
+        flow_def: &FlowDefinition,
         window_id: window::Id,
         editor: &InitializerEditor,
     ) -> Element<'a, Message> {
-        let port_label =
-            if let Some(pref) = self.flow_definition.process_refs.get(editor.node_index) {
-                let alias = if pref.alias.is_empty() {
-                    derive_short_name(&pref.source)
-                } else {
-                    pref.alias.clone()
-                };
-                format!("{}/{}", alias, editor.port_name)
+        let port_label = if let Some(pref) = flow_def.process_refs.get(editor.node_index) {
+            let alias = if pref.alias.is_empty() {
+                derive_short_name(&pref.source)
             } else {
-                editor.port_name.clone()
+                pref.alias.clone()
             };
+            format!("{}/{}", alias, editor.port_name)
+        } else {
+            editor.port_name.clone()
+        };
 
         let init_types = vec!["none", "once", "always"];
         let selected: Option<&str> = init_types.iter().find(|&&t| t == editor.init_type).copied();

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -19,6 +19,7 @@ use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::function_definition::FunctionDefinition;
 use flowcore::model::input::InputInitializer;
 use flowcore::model::io::IO;
+use flowcore::model::route::Route;
 
 use crate::file_ops;
 use crate::flow_canvas::{content_extents, CanvasAction, CanvasMessage, FlowCanvas};
@@ -220,6 +221,9 @@ pub(crate) enum WindowKind {
 /// Per-window state for the flow editor.
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct WindowState {
+    /// Route in the flow hierarchy that this window is editing
+    #[allow(dead_code)]
+    pub(crate) route: Route,
     /// What this window displays
     pub(crate) kind: WindowKind,
     /// Canvas state for caching rendered geometry
@@ -259,6 +263,7 @@ pub(crate) struct WindowState {
 impl Default for WindowState {
     fn default() -> Self {
         Self {
+            route: Route::default(),
             kind: WindowKind::FlowEditor,
             canvas_state: FlowCanvasState::default(),
             status: String::new(),


### PR DESCRIPTION
## Summary
- Add `process_from_route` and `process_from_route_mut` methods to `FlowDefinition` in flowcore — walks the subprocesses tree by Route to find a Process at any depth in the hierarchy
- Add design spec for single FlowDefinition owner architecture (`docs/design/2026-04-25-single-flow-owner-design.md`)

This is the first step toward #2602. The Route-based lookup is a prerequisite for the architecture change where windows address their data by Route instead of owning copies.

## Test plan
- [x] 8 new tests covering: top-level function, sub-flow, nested function, root returns None, nonexistent returns None, unrelated route returns None, mutable modification at top level and nested
- [x] `make clippy` clean with `--deny warnings`
- [x] All existing flowcore tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architectural design documentation for centralized flow editing and window route management.

* **New Features**
  * Centralized flow model across windows for consistent editing and UI updates.
  * Per-window undo/redo histories that operate against the shared flow.
  * New TOML-based save/export for flows and functions.

* **Internal Improvements**
  * Route-based process lookup and window routing to reduce disk I/O and improve save/close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->