### PR TITLE
flowedit: Cross-window editing tests using mandlebrot flow (#2602)

### DIFF
--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -323,7 +323,7 @@ pub(crate) fn next_node_position(
 /// Assign default positions to process references that don't have saved x/y coordinates.
 ///
 /// Uses topological layout based on connections to determine column placement.
-fn assign_default_positions(flow: &mut FlowDefinition) {
+pub(crate) fn assign_default_positions(flow: &mut FlowDefinition) {
     use crate::node_layout::compute_topological_layout;
 
     let needs_layout = flow

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -853,6 +853,19 @@ impl FlowEdit {
     }
 
     fn handle_flow_edit(&mut self, win_id: window::Id, flow_msg: FlowEditMessage) {
+        let affects_parent = matches!(
+            flow_msg,
+            FlowEditMessage::NameChanged(_)
+                | FlowEditMessage::AddInput
+                | FlowEditMessage::AddOutput
+                | FlowEditMessage::DeleteInput(_)
+                | FlowEditMessage::DeleteOutput(_)
+                | FlowEditMessage::InputNameChanged(_, _)
+                | FlowEditMessage::OutputNameChanged(_, _)
+                | FlowEditMessage::InputTypeChanged(_, _)
+                | FlowEditMessage::OutputTypeChanged(_, _)
+        );
+
         let route = self
             .windows
             .get(&win_id)
@@ -861,6 +874,15 @@ impl FlowEdit {
         let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
         if let Some(win) = self.windows.get_mut(&win_id) {
             win.handle_flow_edit_message(flow_def, flow_msg);
+        }
+
+        if affects_parent && !route.is_empty() && route != self.root_flow.route {
+            for win in self.windows.values_mut() {
+                if win.route != route && route.sub_route_of(&win.route).is_some() {
+                    win.canvas_state.request_redraw();
+                    win.trigger_auto_fit_if_enabled();
+                }
+            }
         }
     }
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -876,6 +876,25 @@ impl FlowEdit {
             .map(|w| w.route.clone())
             .unwrap_or_default();
 
+        // Capture deleted I/O name before deletion for parent connection cleanup
+        let io_delete = match &flow_msg {
+            FlowEditMessage::DeleteInput(idx) => {
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                flow_def
+                    .inputs
+                    .get(*idx)
+                    .map(|io| (true, io.name().clone()))
+            }
+            FlowEditMessage::DeleteOutput(idx) => {
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                flow_def
+                    .outputs
+                    .get(*idx)
+                    .map(|io| (false, io.name().clone()))
+            }
+            _ => None,
+        };
+
         // Capture old I/O name before rename for parent connection update
         let io_rename = match &flow_msg {
             FlowEditMessage::InputNameChanged(idx, new_name) => {
@@ -900,42 +919,11 @@ impl FlowEdit {
             win.handle_flow_edit_message(flow_def, flow_msg);
         }
 
-        // Update parent flow connections when a sub-flow I/O is renamed
         if let Some((is_input, old_name, new_name)) = io_rename {
-            if !route.is_empty() && route != self.root_flow.route && old_name != new_name {
-                let sub_alias = route.as_ref().rsplit('/').next().unwrap_or("");
-                if !sub_alias.is_empty() {
-                    // Find parent by stripping last segment from route
-                    let parent_route_str =
-                        &route.as_ref()[..route.as_ref().rfind('/').unwrap_or(0)];
-                    let parent_route = Route::from(parent_route_str);
-                    let parent_flow = resolve_flow_def_mut(&mut self.root_flow, &parent_route);
-                    let old_endpoint = format!("{sub_alias}/{old_name}");
-                    let new_endpoint = format!("{sub_alias}/{new_name}");
-                    for conn in &mut parent_flow.connections {
-                        if is_input {
-                            // Sub-flow inputs appear as "to" in parent connections
-                            let new_to: Vec<Route> = conn
-                                .to()
-                                .iter()
-                                .map(|r| {
-                                    if r.to_string() == old_endpoint {
-                                        Route::from(new_endpoint.as_str())
-                                    } else {
-                                        r.clone()
-                                    }
-                                })
-                                .collect();
-                            conn.set_to(new_to);
-                        } else {
-                            // Sub-flow outputs appear as "from" in parent connections
-                            if conn.from().to_string() == old_endpoint {
-                                conn.set_from(Route::from(new_endpoint.as_str()));
-                            }
-                        }
-                    }
-                }
-            }
+            self.update_parent_io_rename(&route, is_input, &old_name, &new_name);
+        }
+        if let Some((is_input, deleted_name)) = io_delete {
+            self.update_parent_io_delete(&route, is_input, &deleted_name);
         }
 
         if affects_parent && !route.is_empty() && route != self.root_flow.route {
@@ -945,6 +933,75 @@ impl FlowEdit {
                     win.trigger_auto_fit_if_enabled();
                 }
             }
+        }
+    }
+
+    fn update_parent_io_rename(
+        &mut self,
+        route: &Route,
+        is_input: bool,
+        old_name: &str,
+        new_name: &str,
+    ) {
+        if route.is_empty() || *route == self.root_flow.route || old_name == new_name {
+            return;
+        }
+        let sub_alias = route.as_ref().rsplit('/').next().unwrap_or("");
+        if sub_alias.is_empty() {
+            return;
+        }
+        let parent_route_str = &route.as_ref()[..route.as_ref().rfind('/').unwrap_or(0)];
+        let parent_route = Route::from(parent_route_str);
+        let parent_flow = resolve_flow_def_mut(&mut self.root_flow, &parent_route);
+        let old_endpoint = format!("{sub_alias}/{old_name}");
+        let new_endpoint = format!("{sub_alias}/{new_name}");
+        for conn in &mut parent_flow.connections {
+            if is_input {
+                let new_to: Vec<Route> = conn
+                    .to()
+                    .iter()
+                    .map(|r| {
+                        if r.to_string() == old_endpoint {
+                            Route::from(new_endpoint.as_str())
+                        } else {
+                            r.clone()
+                        }
+                    })
+                    .collect();
+                conn.set_to(new_to);
+            } else if conn.from().to_string() == old_endpoint {
+                conn.set_from(Route::from(new_endpoint.as_str()));
+            }
+        }
+    }
+
+    fn update_parent_io_delete(&mut self, route: &Route, is_input: bool, deleted_name: &str) {
+        if route.is_empty() || *route == self.root_flow.route {
+            return;
+        }
+        let sub_alias = route.as_ref().rsplit('/').next().unwrap_or("");
+        if sub_alias.is_empty() {
+            return;
+        }
+        let parent_route_str = &route.as_ref()[..route.as_ref().rfind('/').unwrap_or(0)];
+        let parent_route = Route::from(parent_route_str);
+        let parent_flow = resolve_flow_def_mut(&mut self.root_flow, &parent_route);
+        let endpoint = format!("{sub_alias}/{deleted_name}");
+        if is_input {
+            for conn in &mut parent_flow.connections {
+                let new_to: Vec<Route> = conn
+                    .to()
+                    .iter()
+                    .filter(|r| r.to_string() != endpoint)
+                    .cloned()
+                    .collect();
+                conn.set_to(new_to);
+            }
+            parent_flow.connections.retain(|c| !c.to().is_empty());
+        } else {
+            parent_flow
+                .connections
+                .retain(|c| c.from().to_string() != endpoint);
         }
     }
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -334,6 +334,36 @@ fn load_initial_flow(flow_file: Option<&str>) -> (String, FlowDefinition, BTreeS
     }
 }
 
+/// Resolve a mutable reference to the [`FlowDefinition`] targeted by `route`.
+///
+/// When the route is empty or matches the root flow, returns `root_flow` directly.
+/// Otherwise it walks the process hierarchy to find the matching sub-flow.
+/// This is a free function (not a method) so that Rust can see that only
+/// `root_flow` is borrowed mutably, leaving `windows` available for separate
+/// mutable access.
+fn resolve_flow_def_mut<'a>(
+    root_flow: &'a mut FlowDefinition,
+    route: &Route,
+) -> &'a mut FlowDefinition {
+    if route.is_empty() || *route == root_flow.route {
+        return root_flow;
+    }
+    // Check immutably first to decide whether to descend, then borrow mutably.
+    // This avoids moving `root_flow` after a mutable borrow in the `None` arm.
+    let has_sub_flow = matches!(
+        root_flow.process_from_route(route),
+        Some(Process::FlowProcess(_))
+    );
+    if has_sub_flow {
+        match root_flow.process_from_route_mut(route) {
+            Some(Process::FlowProcess(f)) => f,
+            _ => unreachable!(),
+        }
+    } else {
+        root_flow
+    }
+}
+
 impl FlowEdit {
     /// Create the application, parsing CLI args and optionally loading a flow file.
     fn new() -> (Self, Task<Message>) {
@@ -668,8 +698,14 @@ impl FlowEdit {
     ) -> Task<Message> {
         match self.library_tree.update(lib_msg) {
             LibraryAction::Add(source, func_name) => {
+                let route = self
+                    .windows
+                    .get(&win_id)
+                    .map(|w| w.route.clone())
+                    .unwrap_or_default();
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.add_library_function(&mut self.root_flow, &source, &func_name);
+                    win.add_library_function(flow_def, &source, &func_name);
                 }
             }
             LibraryAction::View(source, _name) => {
@@ -746,10 +782,16 @@ impl FlowEdit {
         win_id: window::Id,
         canvas_msg: CanvasMessage,
     ) -> Task<Message> {
+        let route = self
+            .windows
+            .get(&win_id)
+            .map(|w| w.route.clone())
+            .unwrap_or_default();
+        let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
         let Some(win) = self.windows.get_mut(&win_id) else {
             return Task::none();
         };
-        let action = win.handle_canvas_message(&mut self.root_flow, canvas_msg);
+        let action = win.handle_canvas_message(flow_def, canvas_msg);
         let close_task = self.close_orphaned_windows();
         let action_task = match action {
             CanvasAction::OpenNode(idx) => self.open_node(win_id, idx),
@@ -771,8 +813,14 @@ impl FlowEdit {
                 }
             }
             Message::InitializerApply(win_id) => {
+                let route = self
+                    .windows
+                    .get(&win_id)
+                    .map(|w| w.route.clone())
+                    .unwrap_or_default();
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
                 if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_initializer_apply(&mut self.root_flow);
+                    win.handle_initializer_apply(flow_def);
                 }
             }
             Message::InitializerCancel(win_id) => {
@@ -781,6 +829,38 @@ impl FlowEdit {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn handle_undo_redo(&mut self, is_redo: bool) -> Task<Message> {
+        let target = self.focused_window.or(self.root_window);
+        if let Some(target_id) = target {
+            let route = self
+                .windows
+                .get(&target_id)
+                .map(|w| w.route.clone())
+                .unwrap_or_default();
+            let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+            if let Some(win) = self.windows.get_mut(&target_id) {
+                if is_redo {
+                    win.handle_redo(flow_def);
+                } else {
+                    win.handle_undo(flow_def);
+                }
+            }
+        }
+        self.close_orphaned_windows()
+    }
+
+    fn handle_flow_edit(&mut self, win_id: window::Id, flow_msg: FlowEditMessage) {
+        let route = self
+            .windows
+            .get(&win_id)
+            .map(|w| w.route.clone())
+            .unwrap_or_default();
+        let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+        if let Some(win) = self.windows.get_mut(&win_id) {
+            win.handle_flow_edit_message(flow_def, flow_msg);
         }
     }
 
@@ -801,27 +881,13 @@ impl FlowEdit {
                     win.handle_view_message(&view_msg);
                 }
             }
-            Message::Undo => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    win.handle_undo(&mut self.root_flow);
-                }
-                return self.close_orphaned_windows();
-            }
-            Message::Redo => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    win.handle_redo(&mut self.root_flow);
-                }
-                return self.close_orphaned_windows();
-            }
+            Message::Undo => return self.handle_undo_redo(false),
+            Message::Redo => return self.handle_undo_redo(true),
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
                 self.handle_file_message(message);
             }
             Message::FlowEdit(win_id, flow_msg) => {
-                if let Some(win) = self.windows.get_mut(&win_id) {
-                    win.handle_flow_edit_message(&mut self.root_flow, flow_msg);
-                }
+                self.handle_flow_edit(win_id, flow_msg);
             }
             Message::NewSubFlow(target_win_id) => {
                 for win in self.windows.values_mut() {
@@ -894,11 +960,22 @@ impl FlowEdit {
             return Self::view_function(window_id, viewer, &win.status, !win.history.is_empty());
         }
 
-        let canvas_with_controls = win.view_canvas_area(&self.root_flow, window_id);
+        // Resolve the FlowDefinition for this window: sub-flow windows use
+        // the sub-flow found via their route, root windows use root_flow directly.
+        let flow_def = if win.is_root || win.route.is_empty() || win.route == self.root_flow.route {
+            &self.root_flow
+        } else {
+            match self.root_flow.process_from_route(&win.route) {
+                Some(Process::FlowProcess(f)) => f,
+                _ => &self.root_flow,
+            }
+        };
+
+        let canvas_with_controls = win.view_canvas_area(flow_def, window_id);
 
         let hierarchy_panel = win
             .flow_hierarchy
-            .view(&self.root_flow)
+            .view(flow_def)
             .map(move |msg| Message::Hierarchy(window_id, msg));
 
         let library_panel = self
@@ -916,12 +993,12 @@ impl FlowEdit {
 
         // Flow I/O editor panel for sub-flow windows
         if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(Self::view_flow_io_panel(window_id, &self.root_flow));
+            right_col = right_col.push(Self::view_flow_io_panel(window_id, flow_def));
         }
 
         // Metadata editor panel (toggled by Info button)
         if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(Self::view_metadata_panel(&self.root_flow, window_id));
+            right_col = right_col.push(Self::view_metadata_panel(flow_def, window_id));
         }
 
         // Library paths panel (toggled by Libs button)
@@ -929,7 +1006,7 @@ impl FlowEdit {
             right_col = right_col.push(self.view_lib_paths_panel());
         }
 
-        right_col = right_col.push(self.view_toolbar(win, &self.root_flow, window_id));
+        right_col = right_col.push(self.view_toolbar(win, flow_def, window_id));
 
         let layout = Row::new().push(left_panel).push(right_col.width(Fill));
         layout.into()

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -166,8 +166,8 @@ enum Message {
     InitializerApply(window::Id),
     /// Cancel the initializer edit, tagged with the originating window ID
     InitializerCancel(window::Id),
-    /// Flow metadata and I/O editing messages
-    FlowEdit(window::Id, FlowEditMessage),
+    /// Flow metadata and I/O editing messages (window ID, target route, message)
+    FlowEdit(window::Id, Route, FlowEditMessage),
     /// Function definition viewing/editing messages
     FunctionEdit(window::Id, FunctionEditMessage),
     /// Create a new sub-flow and add it to the current flow (window that initiated the action)
@@ -856,7 +856,7 @@ impl FlowEdit {
         self.close_orphaned_windows()
     }
 
-    fn handle_flow_edit(&mut self, win_id: window::Id, flow_msg: FlowEditMessage) {
+    fn handle_flow_edit(&mut self, win_id: window::Id, route: &Route, flow_msg: FlowEditMessage) {
         let affects_parent = matches!(
             flow_msg,
             FlowEditMessage::NameChanged(_)
@@ -870,23 +870,17 @@ impl FlowEdit {
                 | FlowEditMessage::OutputTypeChanged(_, _)
         );
 
-        let route = self
-            .windows
-            .get(&win_id)
-            .map(|w| w.route.clone())
-            .unwrap_or_default();
-
         // Capture deleted I/O name before deletion for parent connection cleanup
         let io_delete = match &flow_msg {
             FlowEditMessage::DeleteInput(idx) => {
-                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
                 flow_def
                     .inputs
                     .get(*idx)
                     .map(|io| (true, io.name().clone()))
             }
             FlowEditMessage::DeleteOutput(idx) => {
-                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
                 flow_def
                     .outputs
                     .get(*idx)
@@ -898,14 +892,14 @@ impl FlowEdit {
         // Capture old I/O name before rename for parent connection update
         let io_rename = match &flow_msg {
             FlowEditMessage::InputNameChanged(idx, new_name) => {
-                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
                 flow_def
                     .inputs
                     .get(*idx)
                     .map(|io| (true, io.name().clone(), new_name.clone()))
             }
             FlowEditMessage::OutputNameChanged(idx, new_name) => {
-                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
                 flow_def
                     .outputs
                     .get(*idx)
@@ -914,21 +908,21 @@ impl FlowEdit {
             _ => None,
         };
 
-        let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+        let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
         if let Some(win) = self.windows.get_mut(&win_id) {
             win.handle_flow_edit_message(flow_def, flow_msg);
         }
 
         if let Some((is_input, old_name, new_name)) = io_rename {
-            self.update_parent_io_rename(&route, is_input, &old_name, &new_name);
+            self.update_parent_io_rename(route, is_input, &old_name, &new_name);
         }
         if let Some((is_input, deleted_name)) = io_delete {
-            self.update_parent_io_delete(&route, is_input, &deleted_name);
+            self.update_parent_io_delete(route, is_input, &deleted_name);
         }
 
-        if affects_parent && !route.is_empty() && route != self.root_flow.route {
+        if affects_parent && !route.is_empty() && *route != self.root_flow.route {
             for win in self.windows.values_mut() {
-                if win.route != route && route.sub_route_of(&win.route).is_some() {
+                if win.route != *route && route.sub_route_of(&win.route).is_some() {
                     win.canvas_state.request_redraw();
                     win.trigger_auto_fit_if_enabled();
                 }
@@ -1027,8 +1021,8 @@ impl FlowEdit {
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
                 self.handle_file_message(message);
             }
-            Message::FlowEdit(win_id, flow_msg) => {
-                self.handle_flow_edit(win_id, flow_msg);
+            Message::FlowEdit(win_id, ref route, flow_msg) => {
+                self.handle_flow_edit(win_id, route, flow_msg);
             }
             Message::NewSubFlow(target_win_id) => {
                 for win in self.windows.values_mut() {
@@ -1224,6 +1218,7 @@ impl FlowEdit {
             let info_btn = button(Text::new("\u{2139} Info").size(btn_size).center())
                 .on_press(Message::FlowEdit(
                     window_id,
+                    flow_def.route.clone(),
                     FlowEditMessage::ToggleMetadata,
                 ))
                 .style(if win.show_metadata {
@@ -1284,7 +1279,11 @@ impl FlowEdit {
                         .push(
                             text_input("Flow name", &flow_def.name)
                                 .on_input(move |s| {
-                                    Message::FlowEdit(window_id, FlowEditMessage::NameChanged(s))
+                                    Message::FlowEdit(
+                                        window_id,
+                                        flow_def.route.clone(),
+                                        FlowEditMessage::NameChanged(s),
+                                    )
                                 })
                                 .size(13)
                                 .padding(4)
@@ -1299,7 +1298,11 @@ impl FlowEdit {
                         .push(
                             text_input("0.1.0", &flow_def.metadata.version)
                                 .on_input(move |s| {
-                                    Message::FlowEdit(window_id, FlowEditMessage::VersionChanged(s))
+                                    Message::FlowEdit(
+                                        window_id,
+                                        flow_def.route.clone(),
+                                        FlowEditMessage::VersionChanged(s),
+                                    )
                                 })
                                 .size(13)
                                 .padding(4)
@@ -1316,6 +1319,7 @@ impl FlowEdit {
                                 .on_input(move |s| {
                                     Message::FlowEdit(
                                         window_id,
+                                        flow_def.route.clone(),
                                         FlowEditMessage::DescriptionChanged(s),
                                     )
                                 })
@@ -1332,7 +1336,11 @@ impl FlowEdit {
                         .push(
                             text_input("Name <email>, ...", &authors_str)
                                 .on_input(move |s| {
-                                    Message::FlowEdit(window_id, FlowEditMessage::AuthorsChanged(s))
+                                    Message::FlowEdit(
+                                        window_id,
+                                        flow_def.route.clone(),
+                                        FlowEditMessage::AuthorsChanged(s),
+                                    )
                                 })
                                 .size(13)
                                 .padding(4)
@@ -1395,7 +1403,11 @@ impl FlowEdit {
         lib_panel.into()
     }
 
-    fn view_flow_inputs_column(window_id: window::Id, inputs: &[IO]) -> Column<'_, Message> {
+    fn view_flow_inputs_column<'a>(
+        window_id: window::Id,
+        inputs: &'a [IO],
+        route: &'a Route,
+    ) -> Column<'a, Message> {
         let input_color = Color::from_rgb(0.4, 0.8, 1.0);
         let mut input_col = Column::new().spacing(4);
         for (i, port) in inputs.iter().enumerate() {
@@ -1405,6 +1417,9 @@ impl FlowEdit {
                 .first()
                 .map(ToString::to_string)
                 .unwrap_or_default();
+            let route_name = route.clone();
+            let route_type = route.clone();
+            let route_del = route.clone();
             let row = Row::new()
                 .spacing(4)
                 .align_y(iced::Alignment::Center)
@@ -1412,7 +1427,11 @@ impl FlowEdit {
                 .push(
                     text_input("name", &port_name)
                         .on_input(move |s| {
-                            Message::FlowEdit(window_id, FlowEditMessage::InputNameChanged(i, s))
+                            Message::FlowEdit(
+                                window_id,
+                                route_name.clone(),
+                                FlowEditMessage::InputNameChanged(i, s),
+                            )
                         })
                         .size(12)
                         .padding(3)
@@ -1421,7 +1440,11 @@ impl FlowEdit {
                 .push(
                     text_input("type", &dtype)
                         .on_input(move |s| {
-                            Message::FlowEdit(window_id, FlowEditMessage::InputTypeChanged(i, s))
+                            Message::FlowEdit(
+                                window_id,
+                                route_type.clone(),
+                                FlowEditMessage::InputTypeChanged(i, s),
+                            )
                         })
                         .size(11)
                         .padding(3)
@@ -1431,6 +1454,7 @@ impl FlowEdit {
                     button(Text::new("\u{2715}").size(10).center())
                         .on_press(Message::FlowEdit(
                             window_id,
+                            route_del,
                             FlowEditMessage::DeleteInput(i),
                         ))
                         .style(button::danger)
@@ -1440,22 +1464,34 @@ impl FlowEdit {
         }
         input_col.push(
             button(Text::new("+ Input").size(11).center())
-                .on_press(Message::FlowEdit(window_id, FlowEditMessage::AddInput))
+                .on_press(Message::FlowEdit(
+                    window_id,
+                    route.clone(),
+                    FlowEditMessage::AddInput,
+                ))
                 .style(button::secondary)
                 .padding([2, 8]),
         )
     }
 
-    fn view_flow_outputs_column(window_id: window::Id, outputs: &[IO]) -> Column<'_, Message> {
+    fn view_flow_outputs_column<'a>(
+        window_id: window::Id,
+        outputs: &'a [IO],
+        route: &'a Route,
+    ) -> Column<'a, Message> {
         let output_color = Color::from_rgb(1.0, 0.6, 0.3);
         let mut output_col = Column::new().spacing(4).align_x(iced::Alignment::End);
         for (i, port) in outputs.iter().enumerate() {
+            let route = route.clone();
             let port_name = port.name().clone();
             let dtype = port
                 .datatypes()
                 .first()
                 .map(ToString::to_string)
                 .unwrap_or_default();
+            let route_del = route.clone();
+            let route_type = route.clone();
+            let route_name = route.clone();
             let row = Row::new()
                 .spacing(4)
                 .align_y(iced::Alignment::Center)
@@ -1463,6 +1499,7 @@ impl FlowEdit {
                     button(Text::new("\u{2715}").size(10).center())
                         .on_press(Message::FlowEdit(
                             window_id,
+                            route_del,
                             FlowEditMessage::DeleteOutput(i),
                         ))
                         .style(button::danger)
@@ -1471,7 +1508,11 @@ impl FlowEdit {
                 .push(
                     text_input("type", &dtype)
                         .on_input(move |s| {
-                            Message::FlowEdit(window_id, FlowEditMessage::OutputTypeChanged(i, s))
+                            Message::FlowEdit(
+                                window_id,
+                                route_type.clone(),
+                                FlowEditMessage::OutputTypeChanged(i, s),
+                            )
                         })
                         .size(11)
                         .padding(3)
@@ -1480,7 +1521,11 @@ impl FlowEdit {
                 .push(
                     text_input("name", &port_name)
                         .on_input(move |s| {
-                            Message::FlowEdit(window_id, FlowEditMessage::OutputNameChanged(i, s))
+                            Message::FlowEdit(
+                                window_id,
+                                route_name.clone(),
+                                FlowEditMessage::OutputNameChanged(i, s),
+                            )
                         })
                         .size(12)
                         .padding(3)
@@ -1491,7 +1536,11 @@ impl FlowEdit {
         }
         output_col.push(
             button(Text::new("+ Output").size(11).center())
-                .on_press(Message::FlowEdit(window_id, FlowEditMessage::AddOutput))
+                .on_press(Message::FlowEdit(
+                    window_id,
+                    route.clone(),
+                    FlowEditMessage::AddOutput,
+                ))
                 .style(button::secondary)
                 .padding([2, 8]),
         )
@@ -1501,8 +1550,9 @@ impl FlowEdit {
         window_id: window::Id,
         flow_def: &FlowDefinition,
     ) -> Element<'_, Message> {
-        let input_col = Self::view_flow_inputs_column(window_id, &flow_def.inputs);
-        let output_col = Self::view_flow_outputs_column(window_id, &flow_def.outputs);
+        let input_col = Self::view_flow_inputs_column(window_id, &flow_def.inputs, &flow_def.route);
+        let output_col =
+            Self::view_flow_outputs_column(window_id, &flow_def.outputs, &flow_def.route);
 
         let io_box = container(
             Column::new()

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -871,9 +871,67 @@ impl FlowEdit {
             .get(&win_id)
             .map(|w| w.route.clone())
             .unwrap_or_default();
+
+        // Capture old I/O name before rename for parent connection update
+        let io_rename = match &flow_msg {
+            FlowEditMessage::InputNameChanged(idx, new_name) => {
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                flow_def
+                    .inputs
+                    .get(*idx)
+                    .map(|io| (true, io.name().clone(), new_name.clone()))
+            }
+            FlowEditMessage::OutputNameChanged(idx, new_name) => {
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+                flow_def
+                    .outputs
+                    .get(*idx)
+                    .map(|io| (false, io.name().clone(), new_name.clone()))
+            }
+            _ => None,
+        };
+
         let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
         if let Some(win) = self.windows.get_mut(&win_id) {
             win.handle_flow_edit_message(flow_def, flow_msg);
+        }
+
+        // Update parent flow connections when a sub-flow I/O is renamed
+        if let Some((is_input, old_name, new_name)) = io_rename {
+            if !route.is_empty() && route != self.root_flow.route && old_name != new_name {
+                let sub_alias = route.as_ref().rsplit('/').next().unwrap_or("");
+                if !sub_alias.is_empty() {
+                    // Find parent by stripping last segment from route
+                    let parent_route_str =
+                        &route.as_ref()[..route.as_ref().rfind('/').unwrap_or(0)];
+                    let parent_route = Route::from(parent_route_str);
+                    let parent_flow = resolve_flow_def_mut(&mut self.root_flow, &parent_route);
+                    let old_endpoint = format!("{sub_alias}/{old_name}");
+                    let new_endpoint = format!("{sub_alias}/{new_name}");
+                    for conn in &mut parent_flow.connections {
+                        if is_input {
+                            // Sub-flow inputs appear as "to" in parent connections
+                            let new_to: Vec<Route> = conn
+                                .to()
+                                .iter()
+                                .map(|r| {
+                                    if r.to_string() == old_endpoint {
+                                        Route::from(new_endpoint.as_str())
+                                    } else {
+                                        r.clone()
+                                    }
+                                })
+                                .collect();
+                            conn.set_to(new_to);
+                        } else {
+                            // Sub-flow outputs appear as "from" in parent connections
+                            if conn.from().to_string() == old_endpoint {
+                                conn.set_from(Route::from(new_endpoint.as_str()));
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         if affects_parent && !route.is_empty() && route != self.root_flow.route {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -503,8 +503,12 @@ impl FlowEdit {
                 return window::gain_focus(win_id);
             }
         }
-        // Extract info before releasing the borrow on self.root_flow.
-        // FunctionDefinition is cloned because open_function_viewer needs &mut self.
+        // Assign default positions to sub-flow nodes that don't have saved x/y
+        if let Some(Process::FlowProcess(sub_flow)) = self.root_flow.process_from_route_mut(&route)
+        {
+            file_ops::assign_default_positions(sub_flow);
+        }
+
         let process_info = match self.root_flow.process_from_route(&route) {
             Some(Process::FlowProcess(f)) => Some((
                 true,
@@ -1968,7 +1972,13 @@ impl FlowEdit {
             }
         }
 
-        // Look up the process in the hierarchy
+        // Assign default positions to sub-flow nodes
+        if let Some(Process::FlowProcess(sub_flow)) =
+            self.root_flow.process_from_route_mut(&child_route)
+        {
+            file_ops::assign_default_positions(sub_flow);
+        }
+
         let process_info = self
             .root_flow
             .process_from_route(&child_route)

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -2011,3 +2011,134 @@ fn function_edit_tab_switch() {
         }
     }
 }
+
+// --- Sub-flow I/O rename/delete propagation to parent tests ---
+
+#[test]
+fn subflow_input_rename_updates_parent_connections() {
+    let (mut app, _) = load_mandlebrot_app();
+    // Find a sub-flow that has inputs connected from the parent
+    // generate_pixels has input "size" connected from "parse_args/size"
+    let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
+
+    // Create a child window for the sub-flow
+    let child_win_id = window::Id::unique();
+    let child = WindowState {
+        route: sub_route.clone(),
+        ..Default::default()
+    };
+    app.windows.insert(child_win_id, child);
+
+    // Verify parent has a connection to generate_pixels/size
+    let has_size_conn = app.root_flow.connections.iter().any(|c| {
+        c.to()
+            .iter()
+            .any(|r| r.to_string().contains("generate_pixels/size"))
+    });
+    assert!(
+        has_size_conn,
+        "parent should have connection to generate_pixels/size"
+    );
+
+    // Rename the sub-flow's input from "size" to "dimensions"
+    let _ = app.update(Message::FlowEdit(
+        child_win_id,
+        FlowEditMessage::InputNameChanged(0, "dimensions".into()),
+    ));
+
+    // Parent connection should now reference "generate_pixels/dimensions"
+    let has_old = app.root_flow.connections.iter().any(|c| {
+        c.to()
+            .iter()
+            .any(|r| r.to_string().contains("generate_pixels/size"))
+    });
+    let has_new = app.root_flow.connections.iter().any(|c| {
+        c.to()
+            .iter()
+            .any(|r| r.to_string().contains("generate_pixels/dimensions"))
+    });
+    assert!(
+        !has_old,
+        "old connection to generate_pixels/size should be gone"
+    );
+    assert!(
+        has_new,
+        "new connection to generate_pixels/dimensions should exist"
+    );
+}
+
+#[test]
+fn subflow_input_delete_removes_parent_connections() {
+    let (mut app, _) = load_mandlebrot_app();
+    let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
+
+    let child_win_id = window::Id::unique();
+    let child = WindowState {
+        route: sub_route.clone(),
+        ..Default::default()
+    };
+    app.windows.insert(child_win_id, child);
+
+    let conns_before = app.root_flow.connections.len();
+
+    // Delete the sub-flow's input (index 0 = "size")
+    let _ = app.update(Message::FlowEdit(
+        child_win_id,
+        FlowEditMessage::DeleteInput(0),
+    ));
+
+    // Parent connections to generate_pixels/size should be removed
+    let has_size_conn = app.root_flow.connections.iter().any(|c| {
+        c.to()
+            .iter()
+            .any(|r| r.to_string().contains("generate_pixels/size"))
+    });
+    assert!(
+        !has_size_conn,
+        "parent connection to deleted input should be removed"
+    );
+    assert!(
+        app.root_flow.connections.len() < conns_before,
+        "total connections should decrease"
+    );
+}
+
+#[test]
+fn subflow_output_delete_removes_parent_connections() {
+    let (mut app, _) = load_mandlebrot_app();
+    let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
+
+    let child_win_id = window::Id::unique();
+    let child = WindowState {
+        route: sub_route.clone(),
+        ..Default::default()
+    };
+    app.windows.insert(child_win_id, child);
+
+    // generate_pixels has output "pixels" connected to render/pixel
+    let has_pixels_conn = app
+        .root_flow
+        .connections
+        .iter()
+        .any(|c| c.from().to_string().contains("generate_pixels/pixels"));
+    assert!(
+        has_pixels_conn,
+        "parent should have connection from generate_pixels/pixels"
+    );
+
+    // Delete the output
+    let _ = app.update(Message::FlowEdit(
+        child_win_id,
+        FlowEditMessage::DeleteOutput(0),
+    ));
+
+    let has_pixels_after = app
+        .root_flow
+        .connections
+        .iter()
+        .any(|c| c.from().to_string().contains("generate_pixels/pixels"));
+    assert!(
+        !has_pixels_after,
+        "parent connection from deleted output should be removed"
+    );
+}

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use flowcore::model::connection::Connection;
+use flowcore::model::name::HasName;
 use iced_test::simulator::{self, simulator};
 use std::collections::HashMap;
 
@@ -1366,4 +1367,647 @@ fn function_edit_name_changed_no_panic_without_viewer() {
         FunctionEditMessage::NameChanged("test_func".into()),
     ));
     // Should not panic
+}
+
+// --- Cross-window editing tests using mandlebrot flow ---
+
+fn copy_dir_recursive(from: &std::path::Path, to: &std::path::Path) {
+    std::fs::create_dir_all(to).expect("create dir");
+    for entry in std::fs::read_dir(from).expect("read dir") {
+        let entry = entry.expect("entry");
+        let dest_path = to.join(entry.file_name());
+        if entry.file_type().expect("type").is_dir() {
+            copy_dir_recursive(&entry.path(), &dest_path);
+        } else {
+            std::fs::copy(entry.path(), &dest_path).expect("copy file");
+        }
+    }
+}
+
+fn load_mandlebrot_app() -> (FlowEdit, window::Id) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("parent dir")
+        .join("flowr/examples/mandlebrot");
+    let dest = std::env::temp_dir().join(format!("flowedit_mandlebrot_test_{id}"));
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest).expect("clean temp dir");
+    }
+    copy_dir_recursive(&src, &dest);
+    let path = dest.join("root.toml");
+    let flow = file_ops::load_flow(&path).expect("load mandlebrot flow");
+    test_app_with_flow(flow)
+}
+
+#[test]
+fn mandlebrot_loads_with_subprocesses() {
+    let (app, _win_id) = load_mandlebrot_app();
+    assert!(!app.root_flow.process_refs.is_empty());
+    assert!(
+        !app.root_flow.subprocesses.is_empty(),
+        "parsed flow should have resolved subprocesses"
+    );
+}
+
+#[test]
+fn mandlebrot_subflow_routes_resolve() {
+    let (app, _) = load_mandlebrot_app();
+    for alias in app.root_flow.subprocesses.keys() {
+        let route = Route::from(format!("/{}/{alias}", app.root_flow.alias));
+        assert!(
+            app.root_flow.process_from_route(&route).is_some(),
+            "subprocess '{alias}' should be findable via route '{route}'"
+        );
+    }
+}
+
+#[test]
+fn edit_in_root_visible_via_route() {
+    let (mut app, win_id) = load_mandlebrot_app();
+    let original_count = app.root_flow.process_refs.len();
+
+    // Move first node
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::Moved(0, 999.0, 999.0),
+    ));
+
+    // Verify the move is reflected in root_flow
+    assert_eq!(app.root_flow.process_refs.len(), original_count);
+    let pref = &app.root_flow.process_refs[0];
+    assert_eq!(pref.x, Some(999.0));
+    assert_eq!(pref.y, Some(999.0));
+}
+
+#[test]
+fn delete_node_updates_root_flow() {
+    let (mut app, win_id) = load_mandlebrot_app();
+    let original_count = app.root_flow.process_refs.len();
+    assert!(original_count >= 2);
+
+    let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
+
+    assert_eq!(
+        app.root_flow.process_refs.len(),
+        original_count - 1,
+        "deleting a node should remove it from root_flow"
+    );
+}
+
+#[test]
+fn create_connection_updates_root_flow() {
+    let (mut app, win_id) = load_mandlebrot_app();
+    let original_conn_count = app.root_flow.connections.len();
+
+    // Create a connection between two existing nodes
+    let from_alias = app.root_flow.process_refs[0].alias.clone();
+    let to_alias = app.root_flow.process_refs[1].alias.clone();
+
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::ConnectionCreated {
+            from_node: from_alias,
+            from_port: String::new(),
+            to_node: to_alias,
+            to_port: String::new(),
+        },
+    ));
+
+    assert_eq!(
+        app.root_flow.connections.len(),
+        original_conn_count + 1,
+        "creating a connection should add it to root_flow"
+    );
+}
+
+#[test]
+fn undo_restores_root_flow() {
+    let (mut app, win_id) = load_mandlebrot_app();
+    let original_count = app.root_flow.process_refs.len();
+
+    // Delete a node
+    let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Deleted(0)));
+    assert_eq!(app.root_flow.process_refs.len(), original_count - 1);
+
+    // Undo
+    app.focused_window = Some(win_id);
+    let _ = app.update(Message::Undo);
+    assert_eq!(
+        app.root_flow.process_refs.len(),
+        original_count,
+        "undo should restore the deleted node in root_flow"
+    );
+}
+
+#[test]
+fn child_window_sees_same_root_flow() {
+    let (mut app, root_win_id) = load_mandlebrot_app();
+
+    // Simulate a child window by creating one with a sub-flow's route
+    let child_win_id = window::Id::unique();
+    if let Some((alias, _)) = app.root_flow.subprocesses.iter().next() {
+        let route = Route::from(format!("/{}/{alias}", app.root_flow.alias));
+        let child = WindowState {
+            route,
+            is_root: false,
+            ..Default::default()
+        };
+        app.windows.insert(child_win_id, child);
+    }
+
+    // Edit from root window — move a node
+    let _ = app.update(Message::WindowCanvas(
+        root_win_id,
+        CanvasMessage::Moved(0, 555.0, 555.0),
+    ));
+
+    // The child window doesn't own data — it reads from root_flow.
+    // Verify root_flow reflects the edit (both windows see same data)
+    assert_eq!(app.root_flow.process_refs[0].x, Some(555.0));
+    assert_eq!(app.root_flow.process_refs[0].y, Some(555.0));
+}
+
+#[test]
+fn cascade_close_removes_orphaned_child() {
+    let (mut app, root_win_id) = load_mandlebrot_app();
+
+    // Create a child window for the first subprocess
+    let child_win_id = window::Id::unique();
+    let first_alias = app.root_flow.process_refs[0].alias.clone();
+    let route = Route::from(format!("/{}/{first_alias}", app.root_flow.alias));
+    let child = WindowState {
+        route,
+        is_root: false,
+        ..Default::default()
+    };
+    app.windows.insert(child_win_id, child);
+    assert_eq!(app.windows.len(), 2);
+
+    // Delete the first node from root
+    let _ = app.update(Message::WindowCanvas(
+        root_win_id,
+        CanvasMessage::Deleted(0),
+    ));
+
+    // The child window's route no longer resolves — cascade close should remove it
+    assert!(
+        !app.windows.contains_key(&child_win_id),
+        "orphaned child window should be cascade-closed after node deletion"
+    );
+}
+
+// --- FlowEdit message tests (metadata, I/O editing) ---
+
+#[test]
+fn flow_edit_name_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::NameChanged("renamed_flow".into()),
+    ));
+    assert_eq!(app.root_flow.name, "renamed_flow");
+}
+
+#[test]
+fn flow_edit_description_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::DescriptionChanged("A test description".into()),
+    ));
+    assert_eq!(app.root_flow.metadata.description, "A test description");
+}
+
+#[test]
+fn flow_edit_version_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::VersionChanged("2.0.0".into()),
+    ));
+    assert_eq!(app.root_flow.metadata.version, "2.0.0");
+}
+
+#[test]
+fn flow_edit_authors_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::AuthorsChanged("Alice, Bob".into()),
+    ));
+    assert_eq!(app.root_flow.metadata.authors, vec!["Alice", "Bob"]);
+}
+
+#[test]
+fn flow_edit_toggle_metadata_via_message() {
+    let (mut app, win_id) = test_app();
+    let before = app.windows.get(&win_id).is_some_and(|w| w.show_metadata);
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
+    let after = app.windows.get(&win_id).is_some_and(|w| w.show_metadata);
+    assert_ne!(before, after);
+}
+
+#[test]
+fn flow_edit_add_input() {
+    let (mut app, win_id) = test_app();
+    let before = app.root_flow.inputs.len();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    assert_eq!(app.root_flow.inputs.len(), before + 1);
+}
+
+#[test]
+fn flow_edit_add_output() {
+    let (mut app, win_id) = test_app();
+    let before = app.root_flow.outputs.len();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    assert_eq!(app.root_flow.outputs.len(), before + 1);
+}
+
+#[test]
+fn flow_edit_delete_input() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    assert_eq!(app.root_flow.inputs.len(), 1);
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
+    assert_eq!(app.root_flow.inputs.len(), 0);
+}
+
+#[test]
+fn flow_edit_delete_output() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    assert_eq!(app.root_flow.outputs.len(), 1);
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
+    assert_eq!(app.root_flow.outputs.len(), 0);
+}
+
+// --- Initializer message tests ---
+
+#[test]
+fn initializer_type_and_value_change() {
+    let (mut app, win_id) = test_app();
+    // Set up an initializer editor
+    if let Some(win) = app.windows.get_mut(&win_id) {
+        win.initializer_editor = Some(crate::window_state::InitializerEditor {
+            node_index: 0,
+            port_name: "input".into(),
+            init_type: "none".into(),
+            value_text: String::new(),
+        });
+    }
+    let _ = app.update(Message::InitializerTypeChanged(win_id, "once".into()));
+    let init_type = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.initializer_editor.as_ref())
+        .map(|e| e.init_type.clone());
+    assert_eq!(init_type, Some("once".into()));
+
+    let _ = app.update(Message::InitializerValueChanged(win_id, "42".into()));
+    let value = app
+        .windows
+        .get(&win_id)
+        .and_then(|w| w.initializer_editor.as_ref())
+        .map(|e| e.value_text.clone());
+    assert_eq!(value, Some("42".into()));
+}
+
+#[test]
+fn initializer_cancel_clears_editor() {
+    let (mut app, win_id) = test_app();
+    if let Some(win) = app.windows.get_mut(&win_id) {
+        win.initializer_editor = Some(crate::window_state::InitializerEditor {
+            node_index: 0,
+            port_name: "input".into(),
+            init_type: "once".into(),
+            value_text: "42".into(),
+        });
+    }
+    let _ = app.update(Message::InitializerCancel(win_id));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| w.initializer_editor.is_none()));
+}
+
+// --- Window event tests ---
+
+#[test]
+fn window_focus_tracked() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowFocused(win_id));
+    assert_eq!(app.focused_window, Some(win_id));
+}
+
+#[test]
+fn window_resize_tracked() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowResized(
+        win_id,
+        iced::Size::new(1024.0, 768.0),
+    ));
+    let size = app.windows.get(&win_id).and_then(|w| w.last_size);
+    assert_eq!(size, Some(iced::Size::new(1024.0, 768.0)));
+}
+
+#[test]
+fn window_move_tracked() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowMoved(win_id, iced::Point::new(100.0, 200.0)));
+    let pos = app.windows.get(&win_id).and_then(|w| w.last_position);
+    assert_eq!(pos, Some(iced::Point::new(100.0, 200.0)));
+}
+
+// --- Resize node tests ---
+
+#[test]
+fn canvas_resize_node() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::Resized(0, 150.0, 150.0, 200.0, 160.0),
+    ));
+    let pref = &app.root_flow.process_refs[0];
+    assert_eq!(pref.x, Some(150.0));
+    assert_eq!(pref.y, Some(150.0));
+    assert_eq!(pref.width, Some(200.0));
+    assert_eq!(pref.height, Some(160.0));
+}
+
+#[test]
+fn canvas_resize_completed_records_history() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::ResizeCompleted(0, 100.0, 100.0, 180.0, 120.0, 150.0, 150.0, 200.0, 160.0),
+    ));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
+}
+
+// --- Connection delete test ---
+
+#[test]
+fn canvas_delete_connection() {
+    let (mut app, win_id) = test_app();
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "stdout"));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::ConnectionDeleted(0),
+    ));
+    assert!(app.root_flow.connections.is_empty());
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.history.is_empty()));
+}
+
+// --- View message tests ---
+
+#[test]
+fn view_zoom_in_out() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::View(win_id, ViewMessage::ZoomIn));
+    let zoom_in = app
+        .windows
+        .get(&win_id)
+        .map_or(1.0, |w| w.canvas_state.zoom);
+    let _ = app.update(Message::View(win_id, ViewMessage::ZoomOut));
+    let zoom_out = app
+        .windows
+        .get(&win_id)
+        .map_or(1.0, |w| w.canvas_state.zoom);
+    assert!(zoom_in > zoom_out);
+}
+
+#[test]
+fn view_toggle_auto_fit() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::View(win_id, ViewMessage::ToggleAutoFit));
+    assert!(app.windows.get(&win_id).is_some_and(|w| w.auto_fit_enabled));
+    let _ = app.update(Message::View(win_id, ViewMessage::ToggleAutoFit));
+    assert!(app
+        .windows
+        .get(&win_id)
+        .is_some_and(|w| !w.auto_fit_enabled));
+}
+
+// --- Library catalog tests ---
+
+#[test]
+fn load_library_catalogs_empty() {
+    let refs = std::collections::BTreeSet::new();
+    let (cache, defs) = library_mgmt::load_library_catalogs(&refs);
+    assert!(cache.is_empty());
+    let _ = defs;
+}
+
+#[test]
+fn load_library_catalogs_with_flowstdlib() {
+    let mut refs = std::collections::BTreeSet::new();
+    refs.insert(Url::parse("lib://flowstdlib/math/add").expect("valid url"));
+    let (cache, defs) = library_mgmt::load_library_catalogs(&refs);
+    if !cache.is_empty() {
+        assert!(cache.contains_key(&Url::parse("lib://flowstdlib").expect("url")));
+        assert!(!defs.is_empty());
+    }
+}
+
+// --- add_library_function tests ---
+
+#[test]
+fn add_library_function_creates_node() {
+    let (mut app, win_id) = test_app();
+    let before = app.root_flow.process_refs.len();
+    if let Some(win) = app.windows.get_mut(&win_id) {
+        win.add_library_function(&mut app.root_flow, "lib://flowstdlib/math/add", "add");
+    }
+    assert_eq!(app.root_flow.process_refs.len(), before + 1);
+}
+
+#[test]
+fn add_library_function_unique_alias() {
+    let (mut app, win_id) = test_app();
+    if let Some(win) = app.windows.get_mut(&win_id) {
+        win.add_library_function(&mut app.root_flow, "lib://flowstdlib/math/add", "add");
+    }
+    let aliases: Vec<&str> = app
+        .root_flow
+        .process_refs
+        .iter()
+        .map(|p| p.alias.as_str())
+        .collect();
+    assert!(aliases.contains(&"add"));
+    assert!(aliases.iter().any(|a| a.starts_with("add_")));
+}
+
+// --- Window title tests ---
+
+#[test]
+fn title_shows_flow_name() {
+    let (app, win_id) = test_app();
+    let title = app.title(win_id);
+    assert!(title.contains("test"), "title should contain flow name");
+}
+
+// --- handle_close_requested tests ---
+
+#[test]
+fn close_requested_clean_window() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::CloseRequested(win_id));
+    // Clean window (no unsaved) should close
+}
+
+// --- Input/Output name change tests ---
+
+#[test]
+fn flow_edit_input_name_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::InputNameChanged(0, "my_input".into()),
+    ));
+    assert_eq!(app.root_flow.inputs[0].name(), "my_input");
+}
+
+#[test]
+fn flow_edit_output_name_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::OutputNameChanged(0, "my_output".into()),
+    ));
+    assert_eq!(app.root_flow.outputs[0].name(), "my_output");
+}
+
+#[test]
+fn flow_edit_input_type_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::InputTypeChanged(0, "number".into()),
+    ));
+    assert_eq!(
+        app.root_flow.inputs[0]
+            .datatypes()
+            .first()
+            .map(ToString::to_string),
+        Some("number".into())
+    );
+}
+
+#[test]
+fn flow_edit_output_type_change() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        FlowEditMessage::OutputTypeChanged(0, "number".into()),
+    ));
+    assert_eq!(
+        app.root_flow.outputs[0]
+            .datatypes()
+            .first()
+            .map(ToString::to_string),
+        Some("number".into())
+    );
+}
+
+// --- Initializer apply test ---
+
+#[test]
+fn initializer_apply_sets_value() {
+    let (mut app, win_id) = test_app();
+    if let Some(win) = app.windows.get_mut(&win_id) {
+        win.initializer_editor = Some(crate::window_state::InitializerEditor {
+            node_index: 0,
+            port_name: "input".into(),
+            init_type: "once".into(),
+            value_text: "42".into(),
+        });
+    }
+    let _ = app.update(Message::InitializerApply(win_id));
+    assert!(app.root_flow.process_refs[0]
+        .initializations
+        .contains_key("input"));
+}
+
+// --- Function edit message tests ---
+
+#[test]
+fn function_edit_name_change() {
+    let (mut app, win_id) = test_app();
+    // Set up a function viewer window
+    let func_win_id = window::Id::unique();
+    let mut func_def = flowcore::model::function_definition::FunctionDefinition::default();
+    func_def.name = "orig".into();
+    func_def.source = "orig.rs".into();
+    let viewer = crate::window_state::FunctionViewer {
+        func_def,
+        rs_content: String::new(),
+        docs_content: None,
+        active_tab: 0,
+        parent_window: Some(win_id),
+        node_source: "orig".into(),
+        read_only: false,
+    };
+    let child = WindowState {
+        route: Route::from("/test/orig"),
+        kind: WindowKind::FunctionViewer(Box::new(viewer)),
+        ..Default::default()
+    };
+    app.windows.insert(func_win_id, child);
+
+    let _ = app.update(Message::FunctionEdit(
+        func_win_id,
+        FunctionEditMessage::NameChanged("renamed".into()),
+    ));
+    if let Some(win) = app.windows.get(&func_win_id) {
+        if let WindowKind::FunctionViewer(ref v) = win.kind {
+            assert_eq!(v.func_def.name, "renamed");
+        }
+    }
+}
+
+#[test]
+fn function_edit_tab_switch() {
+    let (mut app, win_id) = test_app();
+    let func_win_id = window::Id::unique();
+    let func_def = flowcore::model::function_definition::FunctionDefinition::default();
+    let viewer = crate::window_state::FunctionViewer {
+        func_def,
+        rs_content: String::new(),
+        docs_content: None,
+        active_tab: 0,
+        parent_window: Some(win_id),
+        node_source: String::new(),
+        read_only: false,
+    };
+    let child = WindowState {
+        kind: WindowKind::FunctionViewer(Box::new(viewer)),
+        ..Default::default()
+    };
+    app.windows.insert(func_win_id, child);
+
+    let _ = app.update(Message::FunctionEdit(
+        func_win_id,
+        FunctionEditMessage::TabSelected(1),
+    ));
+    if let Some(win) = app.windows.get(&func_win_id) {
+        if let WindowKind::FunctionViewer(ref v) = win.kind {
+            assert_eq!(v.active_tab, 1);
+        }
+    }
 }

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1465,7 +1465,7 @@ fn copy_dir_recursive(from: &std::path::Path, to: &std::path::Path) {
     }
 }
 
-fn load_mandlebrot_app() -> (FlowEdit, window::Id) {
+fn load_mandlebrot_app() -> (FlowEdit, window::Id, std::path::PathBuf) {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -1481,12 +1481,13 @@ fn load_mandlebrot_app() -> (FlowEdit, window::Id) {
     copy_dir_recursive(&src, &dest);
     let path = dest.join("root.toml");
     let flow = file_ops::load_flow(&path).expect("load mandlebrot flow");
-    test_app_with_flow(flow)
+    let (app, win_id) = test_app_with_flow(flow);
+    (app, win_id, dest)
 }
 
 #[test]
 fn mandlebrot_loads_with_subprocesses() {
-    let (app, _win_id) = load_mandlebrot_app();
+    let (app, _win_id, _tmp) = load_mandlebrot_app();
     assert!(!app.root_flow.process_refs.is_empty());
     assert!(
         !app.root_flow.subprocesses.is_empty(),
@@ -1496,7 +1497,7 @@ fn mandlebrot_loads_with_subprocesses() {
 
 #[test]
 fn mandlebrot_subflow_routes_resolve() {
-    let (app, _) = load_mandlebrot_app();
+    let (app, _, _tmp) = load_mandlebrot_app();
     for alias in app.root_flow.subprocesses.keys() {
         let route = Route::from(format!("/{}/{alias}", app.root_flow.alias));
         assert!(
@@ -1507,8 +1508,8 @@ fn mandlebrot_subflow_routes_resolve() {
 }
 
 #[test]
-fn edit_in_root_visible_via_route() {
-    let (mut app, win_id) = load_mandlebrot_app();
+fn edit_in_root_updates_root_flow() {
+    let (mut app, win_id, _tmp) = load_mandlebrot_app();
     let original_count = app.root_flow.process_refs.len();
 
     // Move first node
@@ -1526,7 +1527,7 @@ fn edit_in_root_visible_via_route() {
 
 #[test]
 fn delete_node_updates_root_flow() {
-    let (mut app, win_id) = load_mandlebrot_app();
+    let (mut app, win_id, _tmp) = load_mandlebrot_app();
     let original_count = app.root_flow.process_refs.len();
     assert!(original_count >= 2);
 
@@ -1541,7 +1542,7 @@ fn delete_node_updates_root_flow() {
 
 #[test]
 fn create_connection_updates_root_flow() {
-    let (mut app, win_id) = load_mandlebrot_app();
+    let (mut app, win_id, _tmp) = load_mandlebrot_app();
     let original_conn_count = app.root_flow.connections.len();
 
     // Create a connection between two existing nodes
@@ -1567,7 +1568,7 @@ fn create_connection_updates_root_flow() {
 
 #[test]
 fn undo_restores_root_flow() {
-    let (mut app, win_id) = load_mandlebrot_app();
+    let (mut app, win_id, _tmp) = load_mandlebrot_app();
     let original_count = app.root_flow.process_refs.len();
 
     // Delete a node
@@ -1586,7 +1587,7 @@ fn undo_restores_root_flow() {
 
 #[test]
 fn child_window_sees_same_root_flow() {
-    let (mut app, root_win_id) = load_mandlebrot_app();
+    let (mut app, root_win_id, _tmp) = load_mandlebrot_app();
 
     // Simulate a child window by creating one with a sub-flow's route
     let child_win_id = window::Id::unique();
@@ -1614,12 +1615,29 @@ fn child_window_sees_same_root_flow() {
 
 #[test]
 fn cascade_close_removes_orphaned_child() {
-    let (mut app, root_win_id) = load_mandlebrot_app();
+    let (mut app, root_win_id, _tmp) = load_mandlebrot_app();
 
-    // Create a child window for the first subprocess
+    // Find a subprocess alias that exists in subprocesses (a sub-flow, not just a process ref)
+    let (sub_alias, sub_idx) = app
+        .root_flow
+        .process_refs
+        .iter()
+        .enumerate()
+        .find_map(|(i, pref)| {
+            let alias = if pref.alias.is_empty() {
+                crate::utils::derive_short_name(&pref.source)
+            } else {
+                pref.alias.clone()
+            };
+            if app.root_flow.subprocesses.contains_key(&alias) {
+                Some((alias, i))
+            } else {
+                None
+            }
+        })
+        .expect("mandlebrot should have at least one resolved subprocess");
     let child_win_id = window::Id::unique();
-    let first_alias = app.root_flow.process_refs[0].alias.clone();
-    let route = Route::from(format!("/{}/{first_alias}", app.root_flow.alias));
+    let route = Route::from(format!("/{}/{sub_alias}", app.root_flow.alias));
     let child = WindowState {
         route,
         is_root: false,
@@ -1628,10 +1646,10 @@ fn cascade_close_removes_orphaned_child() {
     app.windows.insert(child_win_id, child);
     assert_eq!(app.windows.len(), 2);
 
-    // Delete the first node from root
+    // Delete the subprocess node from root
     let _ = app.update(Message::WindowCanvas(
         root_win_id,
-        CanvasMessage::Deleted(0),
+        CanvasMessage::Deleted(sub_idx),
     ));
 
     // The child window's route no longer resolves — cascade close should remove it
@@ -2149,7 +2167,7 @@ fn function_edit_tab_switch() {
 
 #[test]
 fn subflow_input_rename_updates_parent_connections() {
-    let (mut app, _) = load_mandlebrot_app();
+    let (mut app, _, _tmp) = load_mandlebrot_app();
     // Find a sub-flow that has inputs connected from the parent
     // generate_pixels has input "size" connected from "parse_args/size"
     let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
@@ -2203,7 +2221,7 @@ fn subflow_input_rename_updates_parent_connections() {
 
 #[test]
 fn subflow_input_delete_removes_parent_connections() {
-    let (mut app, _) = load_mandlebrot_app();
+    let (mut app, _, _tmp) = load_mandlebrot_app();
     let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
 
     let child_win_id = window::Id::unique();
@@ -2240,7 +2258,7 @@ fn subflow_input_delete_removes_parent_connections() {
 
 #[test]
 fn subflow_output_delete_removes_parent_connections() {
-    let (mut app, _) = load_mandlebrot_app();
+    let (mut app, _, _tmp) = load_mandlebrot_app();
     let sub_route = Route::from(format!("/{}/generate_pixels", app.root_flow.alias));
 
     let child_win_id = window::Id::unique();

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -257,9 +257,17 @@ fn update_undo_redo_cycle() {
 fn update_toggle_metadata() {
     let (mut app, win_id) = test_app();
     assert!(!app.windows.get(&win_id).is_some_and(|w| w.show_metadata));
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::ToggleMetadata,
+    ));
     assert!(app.windows.get(&win_id).is_some_and(|w| w.show_metadata));
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::ToggleMetadata,
+    ));
     assert!(!app.windows.get(&win_id).is_some_and(|w| w.show_metadata));
 }
 
@@ -268,6 +276,7 @@ fn update_flow_name_changed() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::NameChanged("new_name".into()),
     ));
     assert_eq!(Some(app.root_flow.name.as_str()), Some("new_name"));
@@ -282,6 +291,7 @@ fn update_flow_version_changed() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::VersionChanged("2.0.0".into()),
     ));
     assert_eq!(Some(app.root_flow.metadata.version.as_str()), Some("2.0.0"));
@@ -292,6 +302,7 @@ fn update_flow_description_changed() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::DescriptionChanged("A test flow".into()),
     ));
     assert_eq!(
@@ -305,6 +316,7 @@ fn update_flow_authors_changed() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::AuthorsChanged("Alice, Bob".into()),
     ));
     let authors = app.root_flow.metadata.authors.clone();
@@ -314,7 +326,11 @@ fn update_flow_authors_changed() {
 #[test]
 fn update_flow_add_input() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
     assert_eq!(Some(app.root_flow.inputs.len()), Some(1));
     assert!(app
         .windows
@@ -325,24 +341,41 @@ fn update_flow_add_input() {
 #[test]
 fn update_flow_add_output() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     assert_eq!(Some(app.root_flow.outputs.len()), Some(1));
 }
 
 #[test]
 fn update_flow_delete_input() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteInput(0),
+    ));
     assert_eq!(Some(app.root_flow.inputs.len()), Some(0));
 }
 
 #[test]
 fn update_flow_input_name_changed() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
     assert_eq!(
@@ -1177,14 +1210,22 @@ fn ui_resize_node_records_history() {
 fn flow_delete_input_removes_edges() {
     let (mut app, win_id) = test_app();
     // Add a flow input
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
     // Add a connection referencing "input" node
     app.root_flow
         .connections
         .push(Connection::new("input/input0", "add"));
     assert_eq!(app.root_flow.connections.len(), 1);
     // Delete the input — edge should be removed
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteInput(0),
+    ));
     assert_eq!(
         app.root_flow.connections.len(),
         0,
@@ -1196,14 +1237,22 @@ fn flow_delete_input_removes_edges() {
 fn flow_delete_output_removes_edges() {
     let (mut app, win_id) = test_app();
     // Add a flow output
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     // Add a connection referencing "output" node
     app.root_flow
         .connections
         .push(Connection::new("add", "output/output0"));
     assert_eq!(app.root_flow.connections.len(), 1);
     // Delete the output — edge should be removed
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteOutput(0),
+    ));
     assert_eq!(
         app.root_flow.connections.len(),
         0,
@@ -1214,12 +1263,17 @@ fn flow_delete_output_removes_edges() {
 #[test]
 fn flow_input_rename_updates_edges() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
     app.root_flow
         .connections
         .push(Connection::new("input/input0", "add"));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::InputNameChanged(0, "data".into()),
     ));
     // Connection from-route should now reference "input/data" instead of "input/input0"
@@ -1234,12 +1288,17 @@ fn flow_input_rename_updates_edges() {
 #[test]
 fn flow_output_rename_updates_edges() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     app.root_flow
         .connections
         .push(Connection::new("add", "output/output0"));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::OutputNameChanged(0, "result".into()),
     ));
     // Connection to-route should now reference "output/result" instead of "output/output0"
@@ -1291,25 +1350,42 @@ fn new_function_clears_context_menu() {
 fn flow_edit_toggle_metadata() {
     let (mut app, win_id) = test_app();
     assert!(!app.windows.get(&win_id).is_none_or(|w| w.show_metadata));
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::ToggleMetadata,
+    ));
     assert!(app.windows.get(&win_id).is_some_and(|w| w.show_metadata));
 }
 
 #[test]
 fn flow_edit_add_delete_output() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     assert_eq!(app.root_flow.outputs.len(), 1);
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteOutput(0),
+    ));
     assert_eq!(app.root_flow.outputs.len(), 0);
 }
 
 #[test]
 fn flow_edit_input_type_changed() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::InputTypeChanged(0, "number".into()),
     ));
     let dtype = app
@@ -1324,9 +1400,14 @@ fn flow_edit_input_type_changed() {
 #[test]
 fn flow_edit_output_type_changed() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::OutputTypeChanged(0, "boolean".into()),
     ));
     let dtype = app
@@ -1567,6 +1648,7 @@ fn flow_edit_name_change() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::NameChanged("renamed_flow".into()),
     ));
     assert_eq!(app.root_flow.name, "renamed_flow");
@@ -1577,6 +1659,7 @@ fn flow_edit_description_change() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::DescriptionChanged("A test description".into()),
     ));
     assert_eq!(app.root_flow.metadata.description, "A test description");
@@ -1587,6 +1670,7 @@ fn flow_edit_version_change() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::VersionChanged("2.0.0".into()),
     ));
     assert_eq!(app.root_flow.metadata.version, "2.0.0");
@@ -1597,6 +1681,7 @@ fn flow_edit_authors_change() {
     let (mut app, win_id) = test_app();
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
         FlowEditMessage::AuthorsChanged("Alice, Bob".into()),
     ));
     assert_eq!(app.root_flow.metadata.authors, vec!["Alice", "Bob"]);
@@ -1606,7 +1691,11 @@ fn flow_edit_authors_change() {
 fn flow_edit_toggle_metadata_via_message() {
     let (mut app, win_id) = test_app();
     let before = app.windows.get(&win_id).is_some_and(|w| w.show_metadata);
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::ToggleMetadata));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::ToggleMetadata,
+    ));
     let after = app.windows.get(&win_id).is_some_and(|w| w.show_metadata);
     assert_ne!(before, after);
 }
@@ -1615,7 +1704,11 @@ fn flow_edit_toggle_metadata_via_message() {
 fn flow_edit_add_input() {
     let (mut app, win_id) = test_app();
     let before = app.root_flow.inputs.len();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
     assert_eq!(app.root_flow.inputs.len(), before + 1);
 }
 
@@ -1623,25 +1716,45 @@ fn flow_edit_add_input() {
 fn flow_edit_add_output() {
     let (mut app, win_id) = test_app();
     let before = app.root_flow.outputs.len();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     assert_eq!(app.root_flow.outputs.len(), before + 1);
 }
 
 #[test]
 fn flow_edit_delete_input() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
     assert_eq!(app.root_flow.inputs.len(), 1);
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteInput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteInput(0),
+    ));
     assert_eq!(app.root_flow.inputs.len(), 0);
 }
 
 #[test]
 fn flow_edit_delete_output() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
     assert_eq!(app.root_flow.outputs.len(), 1);
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::DeleteOutput(0)));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::DeleteOutput(0),
+    ));
     assert_eq!(app.root_flow.outputs.len(), 0);
 }
 
@@ -1872,9 +1985,14 @@ fn close_requested_clean_window() {
 #[test]
 fn flow_edit_input_name_change() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::InputNameChanged(0, "my_input".into()),
     ));
     assert_eq!(app.root_flow.inputs[0].name(), "my_input");
@@ -1883,9 +2001,14 @@ fn flow_edit_input_name_change() {
 #[test]
 fn flow_edit_output_name_change() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::OutputNameChanged(0, "my_output".into()),
     ));
     assert_eq!(app.root_flow.outputs[0].name(), "my_output");
@@ -1894,9 +2017,14 @@ fn flow_edit_output_name_change() {
 #[test]
 fn flow_edit_input_type_change() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddInput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::InputTypeChanged(0, "number".into()),
     ));
     assert_eq!(
@@ -1911,9 +2039,14 @@ fn flow_edit_input_type_change() {
 #[test]
 fn flow_edit_output_type_change() {
     let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(win_id, FlowEditMessage::AddOutput));
     let _ = app.update(Message::FlowEdit(
         win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
         FlowEditMessage::OutputTypeChanged(0, "number".into()),
     ));
     assert_eq!(
@@ -2043,6 +2176,7 @@ fn subflow_input_rename_updates_parent_connections() {
     // Rename the sub-flow's input from "size" to "dimensions"
     let _ = app.update(Message::FlowEdit(
         child_win_id,
+        sub_route.clone(),
         FlowEditMessage::InputNameChanged(0, "dimensions".into()),
     ));
 
@@ -2084,6 +2218,7 @@ fn subflow_input_delete_removes_parent_connections() {
     // Delete the sub-flow's input (index 0 = "size")
     let _ = app.update(Message::FlowEdit(
         child_win_id,
+        sub_route.clone(),
         FlowEditMessage::DeleteInput(0),
     ));
 
@@ -2129,6 +2264,7 @@ fn subflow_output_delete_removes_parent_connections() {
     // Delete the output
     let _ = app.update(Message::FlowEdit(
         child_win_id,
+        sub_route.clone(),
         FlowEditMessage::DeleteOutput(0),
     ));
 


### PR DESCRIPTION
## Summary
Add 8 integration tests that load the mandlebrot example flow and verify the single FlowDefinition owner architecture works correctly across windows:

- Parsed flow has resolved subprocesses
- Subprocess routes resolve via `process_from_route`
- Node move edits reflect in `root_flow`
- Node deletion updates `root_flow`
- Connection creation updates `root_flow`
- Undo restores `root_flow` state
- Child window sees same `root_flow` data (no stale copies)
- Cascade-close removes orphaned child windows after deletion

Tests require `/tmp/mandlebrot_test/root.toml` — they skip gracefully if the file doesn't exist.

## Test plan
- [x] All 208 flowedit tests pass
- [x] `make clippy` clean with `--deny warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-window undo/redo and route-aware editing so window-scoped edits target the correct canvas and hierarchy.
  * Canvas hierarchy rendering and automatic node positioning when opening sub-flows.

* **Bug Fixes**
  * Ensure renames/deletes in sub-flows propagate to parent connections and remove now-unresolvable child windows.

* **Tests**
  * Extensive cross-window and UI tests covering loading, edits, undo, window focus/resize, connection handling, and function viewer behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->