### PR TITLE
flowedit: Inline I/O editing on canvas for sub-flows (#2618)

### DIFF
--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -182,6 +182,8 @@ pub(crate) struct CanvasInteractionState {
     last_bounds: Option<Size>,
     /// Index of the node currently under the cursor (for hover tooltip)
     hover_node: Option<usize>,
+    /// Whether a port tooltip is currently being shown
+    hover_port: bool,
 }
 
 /// Tracks a middle-mouse-button pan in progress.
@@ -577,6 +579,7 @@ fn draw_flow_input_port_labels(
     font_size: f32,
     zoom: f32,
     offset: Point,
+    draw_labels: bool,
 ) -> HashMap<String, Point> {
     use std::f32::consts::PI;
 
@@ -600,16 +603,18 @@ fn draw_flow_input_port_labels(
         });
         frame.fill(&semi, input_color);
 
-        let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
-        frame.fill_text(CanvasText {
-            content: input.name().clone(),
-            position: label_pos,
-            color: input_color,
-            size: (font_size * zoom).into(),
-            align_x: iced::alignment::Horizontal::Right.into(),
-            align_y: iced::alignment::Vertical::Center,
-            ..CanvasText::default()
-        });
+        if draw_labels {
+            let label_pos = Point::new(screen_pos.x - scaled_r - 4.0, screen_pos.y);
+            frame.fill_text(CanvasText {
+                content: input.name().clone(),
+                position: label_pos,
+                color: input_color,
+                size: (font_size * zoom).into(),
+                align_x: iced::alignment::Horizontal::Right.into(),
+                align_y: iced::alignment::Vertical::Center,
+                ..CanvasText::default()
+            });
+        }
     }
     positions
 }
@@ -625,6 +630,7 @@ fn draw_flow_output_port_labels(
     font_size: f32,
     zoom: f32,
     offset: Point,
+    draw_labels: bool,
 ) -> HashMap<String, Point> {
     use std::f32::consts::PI;
 
@@ -648,15 +654,17 @@ fn draw_flow_output_port_labels(
         });
         frame.fill(&semi, output_color);
 
-        let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
-        frame.fill_text(CanvasText {
-            content: output.name().clone(),
-            position: label_pos,
-            color: output_color,
-            size: (font_size * zoom).into(),
-            align_y: iced::alignment::Vertical::Center,
-            ..CanvasText::default()
-        });
+        if draw_labels {
+            let label_pos = Point::new(screen_pos.x + scaled_r + 4.0, screen_pos.y);
+            frame.fill_text(CanvasText {
+                content: output.name().clone(),
+                position: label_pos,
+                color: output_color,
+                size: (font_size * zoom).into(),
+                align_y: iced::alignment::Vertical::Center,
+                ..CanvasText::default()
+            });
+        }
     }
     positions
 }
@@ -756,6 +764,41 @@ impl FlowCanvas<'_> {
                 }
             }
         }
+        None
+    }
+
+    fn hit_test_flow_io_port(
+        &self,
+        screen_pos: Point,
+        zoom: f32,
+        offset: Point,
+    ) -> Option<(Route, bool, Point)> {
+        if !self.is_subflow {
+            return None;
+        }
+        let (input_positions, output_positions) =
+            compute_flow_io_positions(&self.nodes, &self.flow_def.inputs, &self.flow_def.outputs);
+
+        for (name, &world_pos) in &input_positions {
+            let port_screen = transform_point(world_pos, zoom, offset);
+            let dx = screen_pos.x - port_screen.x;
+            let dy = screen_pos.y - port_screen.y;
+            if dx * dx + dy * dy <= PORT_HIT_RADIUS * PORT_HIT_RADIUS {
+                let route = Route::from(format!("input/{name}"));
+                return Some((route, true, world_pos));
+            }
+        }
+
+        for (name, &world_pos) in &output_positions {
+            let port_screen = transform_point(world_pos, zoom, offset);
+            let dx = screen_pos.x - port_screen.x;
+            let dy = screen_pos.y - port_screen.y;
+            if dx * dx + dy * dy <= PORT_HIT_RADIUS * PORT_HIT_RADIUS {
+                let route = Route::from(format!("output/{name}"));
+                return Some((route, false, world_pos));
+            }
+        }
+
         None
     }
 
@@ -892,35 +935,52 @@ impl FlowCanvas<'_> {
         zoom: f32,
         offset: Point,
     ) -> Option<canvas::Action<CanvasMessage>> {
-        let (node_idx, port_name, is_output) = self.hit_test_port(cursor_position, zoom, offset)?;
-        let node = self.nodes.get(node_idx)?;
-        let port_world_pos = if is_output {
-            let port_idx = node
-                .outputs()
-                .iter()
-                .position(|p| p.name() == &port_name)
-                .unwrap_or(0);
-            node.output_port_position(port_idx)
-        } else {
-            let port_idx = node
-                .inputs()
-                .iter()
-                .position(|p| p.name() == &port_name)
-                .unwrap_or(0);
-            node.input_port_position(port_idx)
-        };
-        let from_route = if port_name.is_empty() {
-            Route::from(node.alias())
-        } else {
-            Route::from(format!("{}/{}", node.alias(), port_name))
-        };
-        state.connecting = Some(ConnectingState {
-            from_route,
-            from_output: is_output,
-            start_pos: port_world_pos,
-            current_screen_pos: cursor_position,
-        });
-        Some(canvas::Action::request_redraw().and_capture())
+        if let Some((node_idx, port_name, is_output)) =
+            self.hit_test_port(cursor_position, zoom, offset)
+        {
+            let node = self.nodes.get(node_idx)?;
+            let port_world_pos = if is_output {
+                let port_idx = node
+                    .outputs()
+                    .iter()
+                    .position(|p| p.name() == &port_name)
+                    .unwrap_or(0);
+                node.output_port_position(port_idx)
+            } else {
+                let port_idx = node
+                    .inputs()
+                    .iter()
+                    .position(|p| p.name() == &port_name)
+                    .unwrap_or(0);
+                node.input_port_position(port_idx)
+            };
+            let from_route = if port_name.is_empty() {
+                Route::from(node.alias())
+            } else {
+                Route::from(format!("{}/{}", node.alias(), port_name))
+            };
+            state.connecting = Some(ConnectingState {
+                from_route,
+                from_output: is_output,
+                start_pos: port_world_pos,
+                current_screen_pos: cursor_position,
+            });
+            return Some(canvas::Action::request_redraw().and_capture());
+        }
+
+        if let Some((route, is_output, world_pos)) =
+            self.hit_test_flow_io_port(cursor_position, zoom, offset)
+        {
+            state.connecting = Some(ConnectingState {
+                from_route: route,
+                from_output: is_output,
+                start_pos: world_pos,
+                current_screen_pos: cursor_position,
+            });
+            return Some(canvas::Action::request_redraw().and_capture());
+        }
+
+        None
     }
 
     fn handle_left_press(
@@ -951,7 +1011,10 @@ impl FlowCanvas<'_> {
             }
         }
 
-        let on_a_port = self.hit_test_port(cursor_position, zoom, offset).is_some();
+        let on_a_port = self.hit_test_port(cursor_position, zoom, offset).is_some()
+            || self
+                .hit_test_flow_io_port(cursor_position, zoom, offset)
+                .is_some();
         if !on_a_port {
             if let Some(conn_idx) = self.hit_test_connection(cursor_position, zoom, offset) {
                 state.selected_connection = Some(conn_idx);
@@ -1091,6 +1154,7 @@ impl FlowCanvas<'_> {
                     },
                 );
                 state.hover_node = None;
+                state.hover_port = true;
                 return Some(canvas::Action::publish(CanvasMessage::HoverChanged(Some(
                     crate::window_state::Tooltip {
                         text: type_text,
@@ -1101,8 +1165,11 @@ impl FlowCanvas<'_> {
             }
         }
 
+        let was_on_port = state.hover_port;
+        state.hover_port = false;
+
         let new_hover = self.hit_test_node(world_pos);
-        if new_hover != state.hover_node || new_hover.is_some() {
+        if new_hover != state.hover_node || new_hover.is_some() || was_on_port {
             state.hover_node = new_hover;
             let tooltip_data = new_hover.and_then(|idx| self.nodes.get(idx)).and_then(|n| {
                 let bottom_center = transform_point(
@@ -1187,13 +1254,13 @@ impl FlowCanvas<'_> {
         zoom: f32,
         offset: Point,
     ) -> canvas::Action<CanvasMessage> {
+        let (conn_from_node, conn_from_port) = split_route(connecting.from_route.as_ref());
+
         if let Some((target_idx, target_port, target_is_output)) =
             self.hit_test_port(cursor_position, zoom, offset)
         {
             if connecting.from_output != target_is_output {
                 if let Some(target_node) = self.nodes.get(target_idx) {
-                    let (conn_from_node, conn_from_port) =
-                        split_route(connecting.from_route.as_ref());
                     let source_node = self.nodes.iter().find(|n| n.alias() == conn_from_node);
                     let types_ok = check_port_type_compatibility(
                         source_node,
@@ -1231,6 +1298,27 @@ impl FlowCanvas<'_> {
                 }
             }
         }
+
+        if let Some((target_route, target_is_output, _)) =
+            self.hit_test_flow_io_port(cursor_position, zoom, offset)
+        {
+            if connecting.from_output != target_is_output {
+                let (target_node, target_port) = split_route(target_route.as_ref());
+                let (from_node, from_port, to_node, to_port) = if connecting.from_output {
+                    (conn_from_node, conn_from_port, target_node, target_port)
+                } else {
+                    (target_node, target_port, conn_from_node, conn_from_port)
+                };
+                return canvas::Action::publish(CanvasMessage::ConnectionCreated {
+                    from_node,
+                    from_port,
+                    to_node,
+                    to_port,
+                })
+                .and_capture();
+            }
+        }
+
         canvas::Action::request_redraw().and_capture()
     }
 
@@ -1335,6 +1423,17 @@ impl FlowCanvas<'_> {
                         Stroke::default().with_width(2.0).with_color(preview_color),
                     );
                 }
+            }
+        } else if let Some((_, target_is_output, world_pos)) =
+            self.hit_test_flow_io_port(end_screen, zoom, offset)
+        {
+            if connecting.from_output != target_is_output {
+                let port_screen = transform_point(world_pos, zoom, offset);
+                let highlight_circle = Path::circle(port_screen, PORT_HIT_RADIUS);
+                overlay.stroke(
+                    &highlight_circle,
+                    Stroke::default().with_width(2.0).with_color(preview_color),
+                );
             }
         }
     }
@@ -1499,6 +1598,7 @@ impl FlowCanvas<'_> {
             font_size,
             zoom,
             offset,
+            false,
         );
         let output_positions = draw_flow_output_port_labels(
             frame,
@@ -1510,6 +1610,7 @@ impl FlowCanvas<'_> {
             font_size,
             zoom,
             offset,
+            false,
         );
 
         self.draw_flow_io_connections(

--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -802,6 +802,80 @@ impl FlowCanvas<'_> {
         None
     }
 
+    /// Check type compatibility when one endpoint is a flow I/O port and the other is a node port.
+    ///
+    /// Looks up the flow IO's datatypes from `self.flow_def.inputs`/`outputs` and the
+    /// node port's datatypes from its `NodeLayout`, then rejects if both have non-empty
+    /// datatypes that don't overlap.
+    fn check_flow_io_type_compatibility(
+        &self,
+        from_node: &str,
+        from_port: &str,
+        from_is_output: bool,
+        to_node: &str,
+        to_port: &str,
+        to_is_output: bool,
+    ) -> bool {
+        // Determine which side is the flow I/O and which is the node port
+        let (io_datatypes, node_alias, node_port, node_is_output) =
+            if from_node == "input" || from_node == "output" {
+                // from side is flow I/O
+                let io_list = if from_node == "input" {
+                    &self.flow_def.inputs
+                } else {
+                    &self.flow_def.outputs
+                };
+                let io_types = io_list
+                    .iter()
+                    .find(|io| io.name() == from_port)
+                    .map(IO::datatypes);
+                (io_types, to_node, to_port, to_is_output)
+            } else {
+                // to side is flow I/O
+                let io_list = if to_node == "input" {
+                    &self.flow_def.inputs
+                } else {
+                    &self.flow_def.outputs
+                };
+                let io_types = io_list
+                    .iter()
+                    .find(|io| io.name() == to_port)
+                    .map(IO::datatypes);
+                (io_types, from_node, from_port, from_is_output)
+            };
+
+        // Look up the node port's datatypes
+        let node_layout = self.nodes.iter().find(|n| n.alias() == node_alias);
+        let node_port_types = node_layout.and_then(|n| {
+            let ports = if node_is_output {
+                n.outputs()
+            } else {
+                n.inputs()
+            };
+            ports
+                .iter()
+                .find(|p| p.name() == node_port)
+                .map(IO::datatypes)
+        });
+
+        match (io_datatypes, node_port_types) {
+            (Some(io_types), Some(node_types)) => {
+                let io_untyped =
+                    io_types.is_empty() || io_types.iter().all(|d| d.to_string().is_empty());
+                let node_untyped =
+                    node_types.is_empty() || node_types.iter().all(|d| d.to_string().is_empty());
+                if io_untyped || node_untyped {
+                    return true;
+                }
+                io_types
+                    .iter()
+                    .any(|it| node_types.iter().any(|nt| it == nt))
+            }
+            // Unknown port or no type info -- allow
+            _ => true,
+        }
+    }
+
     /// Hit test connections by sampling points along each connection's bezier curve.
     ///
     /// Returns the connection index if the cursor is within [`CONNECTION_HIT_DISTANCE`]
@@ -1304,18 +1378,31 @@ impl FlowCanvas<'_> {
         {
             if connecting.from_output != target_is_output {
                 let (target_node, target_port) = split_route(target_route.as_ref());
-                let (from_node, from_port, to_node, to_port) = if connecting.from_output {
-                    (conn_from_node, conn_from_port, target_node, target_port)
-                } else {
-                    (target_node, target_port, conn_from_node, conn_from_port)
-                };
-                return canvas::Action::publish(CanvasMessage::ConnectionCreated {
-                    from_node,
-                    from_port,
-                    to_node,
-                    to_port,
-                })
-                .and_capture();
+
+                // Type-check: one side is a flow I/O port, the other is a node port.
+                let types_ok = self.check_flow_io_type_compatibility(
+                    &conn_from_node,
+                    &conn_from_port,
+                    connecting.from_output,
+                    &target_node,
+                    &target_port,
+                    target_is_output,
+                );
+
+                if types_ok {
+                    let (from_node, from_port, to_node, to_port) = if connecting.from_output {
+                        (conn_from_node, conn_from_port, target_node, target_port)
+                    } else {
+                        (target_node, target_port, conn_from_node, conn_from_port)
+                    };
+                    return canvas::Action::publish(CanvasMessage::ConnectionCreated {
+                        from_node,
+                        from_port,
+                        to_node,
+                        to_port,
+                    })
+                    .and_capture();
+                }
             }
         }
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -41,9 +41,7 @@ use flowcore::provider::Provider;
 
 use flow_canvas::{CanvasAction, CanvasMessage};
 use hierarchy_panel::{FlowHierarchy, HierarchyMessage};
-use history::EditHistory;
 use library_panel::{LibraryAction, LibraryMessage, LibraryTree};
-use window_state::FlowCanvasState;
 
 mod file_ops;
 mod flow_canvas;
@@ -399,22 +397,12 @@ impl FlowEdit {
 
         let win_state = WindowState {
             route: flow_definition.route.clone(),
-            kind: WindowKind::FlowEditor,
-            canvas_state: FlowCanvasState::default(),
             status,
-            selected_node: None,
-            selected_connection: None,
             auto_fit_pending: has_nodes,
             auto_fit_enabled: true,
-            history: EditHistory::default(),
-            tooltip: None,
-            initializer_editor: None,
             is_root: true,
-            context_menu: None,
-            show_metadata: false,
             flow_hierarchy,
-            last_size: None,
-            last_position: None,
+            ..Default::default()
         };
 
         let mut windows = HashMap::new();
@@ -532,22 +520,11 @@ impl FlowEdit {
             let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
             let child = WindowState {
                 route,
-                kind: WindowKind::FlowEditor,
-                canvas_state: FlowCanvasState::default(),
                 status: format!("Ready - {nc} nodes, {ec} connections"),
-                selected_node: None,
-                selected_connection: None,
-                history: EditHistory::default(),
                 auto_fit_pending: has_nodes,
                 auto_fit_enabled: true,
                 flow_hierarchy: FlowHierarchy::from_flow_definition(&self.root_flow),
-                tooltip: None,
-                initializer_editor: None,
-                is_root: false,
-                context_menu: None,
-                show_metadata: false,
-                last_size: None,
-                last_position: None,
+                ..Default::default()
             };
             self.windows.insert(new_id, child);
             open_task.discard()
@@ -1799,22 +1776,11 @@ impl FlowEdit {
                     }
                     let child = WindowState {
                         route: flow_def.route.clone(),
-                        kind: WindowKind::FlowEditor,
-                        canvas_state: FlowCanvasState::default(),
                         status: format!("Library flow - {nc} nodes, {ec} connections"),
-                        selected_node: None,
-                        selected_connection: None,
-                        history: EditHistory::default(),
                         auto_fit_pending: has_nodes,
                         auto_fit_enabled: true,
                         flow_hierarchy: FlowHierarchy::from_flow_definition(&flow_def),
-                        tooltip: None,
-                        initializer_editor: None,
-                        is_root: false,
-                        context_menu: None,
-                        show_metadata: false,
-                        last_size: None,
-                        last_position: None,
+                        ..Default::default()
                     };
                     self.windows.insert(new_id, child);
                     open_task.discard()
@@ -1926,22 +1892,11 @@ impl FlowEdit {
             let (new_id, open_task) = window::open(self.child_window_settings(1024.0, 768.0));
             let child = WindowState {
                 route: child_route,
-                kind: WindowKind::FlowEditor,
-                canvas_state: FlowCanvasState::default(),
                 status: format!("Ready - {nc} nodes, {ec} connections"),
-                selected_node: None,
-                selected_connection: None,
-                history: EditHistory::default(),
                 auto_fit_pending: has_nodes,
                 auto_fit_enabled: true,
                 flow_hierarchy: FlowHierarchy::from_flow_definition(&self.root_flow),
-                tooltip: None,
-                initializer_editor: None,
-                is_root: false,
-                context_menu: None,
-                show_metadata: false,
-                last_size: None,
-                last_position: None,
+                ..Default::default()
             };
             self.windows.insert(new_id, child);
             if let Some(win) = self.windows.get_mut(&parent_win_id) {
@@ -1998,21 +1953,9 @@ impl FlowEdit {
         let child = WindowState {
             route,
             kind: WindowKind::FunctionViewer(Box::new(viewer)),
-            canvas_state: FlowCanvasState::default(),
             status: format!("Function: {func_name}"),
-            selected_node: None,
-            selected_connection: None,
-            history: EditHistory::default(),
-            auto_fit_pending: false,
-            auto_fit_enabled: false,
             flow_hierarchy: FlowHierarchy::from_flow_definition(&func_flow_def),
-            tooltip: None,
-            initializer_editor: None,
-            is_root: false,
-            context_menu: None,
-            show_metadata: false,
-            last_size: None,
-            last_position: None,
+            ..Default::default()
         };
 
         self.windows.insert(new_id, child);
@@ -2114,22 +2057,10 @@ impl FlowEdit {
 
         let child = WindowState {
             route: flow_def.route.clone(),
-            kind: WindowKind::FlowEditor,
-            canvas_state: FlowCanvasState::default(),
             status: format!("New sub-flow: {flow_name}"),
-            selected_node: None,
-            selected_connection: None,
-            history: EditHistory::default(),
-            auto_fit_pending: false,
             auto_fit_enabled: true,
             flow_hierarchy: FlowHierarchy::from_flow_definition(&flow_def),
-            tooltip: None,
-            initializer_editor: None,
-            is_root: false,
-            context_menu: None,
-            show_metadata: false,
-            last_size: None,
-            last_position: None,
+            ..Default::default()
         };
 
         self.windows.insert(new_id, child);
@@ -2218,21 +2149,9 @@ impl FlowEdit {
         let mut child = WindowState {
             route: func_flow_def.route.clone(),
             kind: WindowKind::FunctionViewer(Box::new(viewer)),
-            canvas_state: FlowCanvasState::default(),
             status: String::from("New function — add ports and Save"),
-            selected_node: None,
-            selected_connection: None,
-            history: EditHistory::default(),
-            auto_fit_pending: false,
-            auto_fit_enabled: false,
             flow_hierarchy: FlowHierarchy::from_flow_definition(&func_flow_def),
-            tooltip: None,
-            initializer_editor: None,
-            is_root: false,
-            context_menu: None,
-            show_metadata: false,
-            last_size: None,
-            last_position: None,
+            ..Default::default()
         };
         child.history.mark_modified(); // New function starts dirty
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -86,12 +86,8 @@ pub(crate) enum FlowEditMessage {
     DeleteOutput(usize),
     /// Flow input port name changed
     InputNameChanged(usize, String),
-    /// Flow input port type changed
-    InputTypeChanged(usize, String),
     /// Flow output port name changed
     OutputNameChanged(usize, String),
-    /// Flow output port type changed
-    OutputTypeChanged(usize, String),
 }
 
 /// Messages for function definition viewing/editing, tagged by window
@@ -866,8 +862,6 @@ impl FlowEdit {
                 | FlowEditMessage::DeleteOutput(_)
                 | FlowEditMessage::InputNameChanged(_, _)
                 | FlowEditMessage::OutputNameChanged(_, _)
-                | FlowEditMessage::InputTypeChanged(_, _)
-                | FlowEditMessage::OutputTypeChanged(_, _)
         );
 
         // Capture deleted I/O name before deletion for parent connection cleanup
@@ -1125,11 +1119,6 @@ impl FlowEdit {
 
         let mut right_col: Column<'_, Message> =
             Column::new().push(container(canvas_with_controls).width(Fill).height(Fill));
-
-        // Flow I/O editor panel for sub-flow windows
-        if !win.is_root && matches!(win.kind, WindowKind::FlowEditor) {
-            right_col = right_col.push(Self::view_flow_io_panel(window_id, flow_def));
-        }
 
         // Metadata editor panel (toggled by Info button)
         if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
@@ -1401,188 +1390,6 @@ impl FlowEdit {
             .width(Fill);
 
         lib_panel.into()
-    }
-
-    fn view_flow_inputs_column<'a>(
-        window_id: window::Id,
-        inputs: &'a [IO],
-        route: &'a Route,
-    ) -> Column<'a, Message> {
-        let input_color = Color::from_rgb(0.4, 0.8, 1.0);
-        let mut input_col = Column::new().spacing(4);
-        for (i, port) in inputs.iter().enumerate() {
-            let port_name = port.name().clone();
-            let dtype = port
-                .datatypes()
-                .first()
-                .map(ToString::to_string)
-                .unwrap_or_default();
-            let route_name = route.clone();
-            let route_type = route.clone();
-            let route_del = route.clone();
-            let row = Row::new()
-                .spacing(4)
-                .align_y(iced::Alignment::Center)
-                .push(Text::new("\u{25D7}").size(18).color(input_color))
-                .push(
-                    text_input("name", &port_name)
-                        .on_input(move |s| {
-                            Message::FlowEdit(
-                                window_id,
-                                route_name.clone(),
-                                FlowEditMessage::InputNameChanged(i, s),
-                            )
-                        })
-                        .size(12)
-                        .padding(3)
-                        .width(80),
-                )
-                .push(
-                    text_input("type", &dtype)
-                        .on_input(move |s| {
-                            Message::FlowEdit(
-                                window_id,
-                                route_type.clone(),
-                                FlowEditMessage::InputTypeChanged(i, s),
-                            )
-                        })
-                        .size(11)
-                        .padding(3)
-                        .width(70),
-                )
-                .push(
-                    button(Text::new("\u{2715}").size(10).center())
-                        .on_press(Message::FlowEdit(
-                            window_id,
-                            route_del,
-                            FlowEditMessage::DeleteInput(i),
-                        ))
-                        .style(button::danger)
-                        .padding([2, 5]),
-                );
-            input_col = input_col.push(row);
-        }
-        input_col.push(
-            button(Text::new("+ Input").size(11).center())
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    route.clone(),
-                    FlowEditMessage::AddInput,
-                ))
-                .style(button::secondary)
-                .padding([2, 8]),
-        )
-    }
-
-    fn view_flow_outputs_column<'a>(
-        window_id: window::Id,
-        outputs: &'a [IO],
-        route: &'a Route,
-    ) -> Column<'a, Message> {
-        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
-        let mut output_col = Column::new().spacing(4).align_x(iced::Alignment::End);
-        for (i, port) in outputs.iter().enumerate() {
-            let route = route.clone();
-            let port_name = port.name().clone();
-            let dtype = port
-                .datatypes()
-                .first()
-                .map(ToString::to_string)
-                .unwrap_or_default();
-            let route_del = route.clone();
-            let route_type = route.clone();
-            let route_name = route.clone();
-            let row = Row::new()
-                .spacing(4)
-                .align_y(iced::Alignment::Center)
-                .push(
-                    button(Text::new("\u{2715}").size(10).center())
-                        .on_press(Message::FlowEdit(
-                            window_id,
-                            route_del,
-                            FlowEditMessage::DeleteOutput(i),
-                        ))
-                        .style(button::danger)
-                        .padding([2, 5]),
-                )
-                .push(
-                    text_input("type", &dtype)
-                        .on_input(move |s| {
-                            Message::FlowEdit(
-                                window_id,
-                                route_type.clone(),
-                                FlowEditMessage::OutputTypeChanged(i, s),
-                            )
-                        })
-                        .size(11)
-                        .padding(3)
-                        .width(70),
-                )
-                .push(
-                    text_input("name", &port_name)
-                        .on_input(move |s| {
-                            Message::FlowEdit(
-                                window_id,
-                                route_name.clone(),
-                                FlowEditMessage::OutputNameChanged(i, s),
-                            )
-                        })
-                        .size(12)
-                        .padding(3)
-                        .width(80),
-                )
-                .push(Text::new("\u{25D6}").size(18).color(output_color));
-            output_col = output_col.push(row);
-        }
-        output_col.push(
-            button(Text::new("+ Output").size(11).center())
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    route.clone(),
-                    FlowEditMessage::AddOutput,
-                ))
-                .style(button::secondary)
-                .padding([2, 8]),
-        )
-    }
-
-    fn view_flow_io_panel(
-        window_id: window::Id,
-        flow_def: &FlowDefinition,
-    ) -> Element<'_, Message> {
-        let input_col = Self::view_flow_inputs_column(window_id, &flow_def.inputs, &flow_def.route);
-        let output_col =
-            Self::view_flow_outputs_column(window_id, &flow_def.outputs, &flow_def.route);
-
-        let io_box = container(
-            Column::new()
-                .spacing(12)
-                .padding(iced::Padding {
-                    top: 8.0,
-                    bottom: 8.0,
-                    left: 0.0,
-                    right: 0.0,
-                })
-                .push(
-                    Row::new()
-                        .push(input_col)
-                        .push(iced::widget::Space::new().width(Fill))
-                        .push(output_col),
-                ),
-        )
-        .style(|_theme: &Theme| container::Style {
-            background: Some(iced::Background::Color(Color::from_rgb(0.18, 0.18, 0.22))),
-            border: iced::Border {
-                color: Color::from_rgb(0.9, 0.6, 0.2),
-                width: 2.0,
-                radius: 12.0.into(),
-            },
-            ..Default::default()
-        })
-        .width(Fill)
-        .padding([0, 8]);
-
-        container(io_box).padding([6, 12]).width(Fill).into()
     }
 
     fn view_function_definition_tab(

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1551,7 +1551,6 @@ fn child_window_sees_same_root_flow() {
         let route = Route::from(format!("/{}/{alias}", app.root_flow.alias));
         let child = WindowState {
             route,
-            is_root: false,
             ..Default::default()
         };
         app.windows.insert(child_win_id, child);
@@ -1596,7 +1595,6 @@ fn cascade_close_removes_orphaned_child() {
     let route = Route::from(format!("/{}/{sub_alias}", app.root_flow.alias));
     let child = WindowState {
         route,
-        is_root: false,
         ..Default::default()
     };
     app.windows.insert(child_win_id, child);

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1375,50 +1375,6 @@ fn flow_edit_add_delete_output() {
     assert_eq!(app.root_flow.outputs.len(), 0);
 }
 
-#[test]
-fn flow_edit_input_type_changed() {
-    let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::AddInput,
-    ));
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::InputTypeChanged(0, "number".into()),
-    ));
-    let dtype = app
-        .root_flow
-        .inputs
-        .first()
-        .and_then(|io| io.datatypes().first())
-        .map(ToString::to_string);
-    assert_eq!(dtype.as_deref(), Some("number"));
-}
-
-#[test]
-fn flow_edit_output_type_changed() {
-    let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::AddOutput,
-    ));
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::OutputTypeChanged(0, "boolean".into()),
-    ));
-    let dtype = app
-        .root_flow
-        .outputs
-        .first()
-        .and_then(|io| io.datatypes().first())
-        .map(ToString::to_string);
-    assert_eq!(dtype.as_deref(), Some("boolean"));
-}
-
 // ---- Group 14: PR #2599 Coverage — FunctionEditMessage sub-enum routing ----
 
 #[test]
@@ -2030,50 +1986,6 @@ fn flow_edit_output_name_change() {
         FlowEditMessage::OutputNameChanged(0, "my_output".into()),
     ));
     assert_eq!(app.root_flow.outputs[0].name(), "my_output");
-}
-
-#[test]
-fn flow_edit_input_type_change() {
-    let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::AddInput,
-    ));
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::InputTypeChanged(0, "number".into()),
-    ));
-    assert_eq!(
-        app.root_flow.inputs[0]
-            .datatypes()
-            .first()
-            .map(ToString::to_string),
-        Some("number".into())
-    );
-}
-
-#[test]
-fn flow_edit_output_type_change() {
-    let (mut app, win_id) = test_app();
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::AddOutput,
-    ));
-    let _ = app.update(Message::FlowEdit(
-        win_id,
-        Route::default(),
-        FlowEditMessage::OutputTypeChanged(0, "number".into()),
-    ));
-    assert_eq!(
-        app.root_flow.outputs[0]
-            .datatypes()
-            .first()
-            .map(ToString::to_string),
-        Some("number".into())
-    );
 }
 
 // --- Initializer apply test ---

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -27,7 +27,9 @@ use flowcore::model::process_reference::ProcessReference;
 use flowcore::model::route::Route;
 
 use crate::file_ops;
-use crate::flow_canvas::{flow_io_bounding_box, CanvasAction, CanvasMessage, FlowCanvas};
+use crate::flow_canvas::{
+    flow_io_bounding_box, transform_point, CanvasAction, CanvasMessage, FlowCanvas,
+};
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history::{EditAction, EditHistory};
 use crate::node_layout::NodeLayout;
@@ -815,9 +817,6 @@ impl WindowState {
         canvas_state: &FlowCanvasState,
         window_id: window::Id,
     ) -> Element<'a, Message> {
-        use crate::flow_canvas::flow_io_bounding_box;
-        use crate::node_layout::NodeLayout;
-
         let nodes = NodeLayout::build_from_flow(flow_def);
         let (box_x, _, box_w, _, center_y, spacing) =
             flow_io_bounding_box(&nodes, &flow_def.inputs, &flow_def.outputs);
@@ -828,7 +827,7 @@ impl WindowState {
 
         let mut layers: Vec<Element<'_, Message>> = Vec::new();
 
-        Self::build_input_layers(
+        Self::build_io_layers(
             &mut layers,
             &flow_def.inputs,
             box_x,
@@ -838,8 +837,9 @@ impl WindowState {
             offset,
             &route,
             window_id,
+            true,
         );
-        Self::build_output_layers(
+        Self::build_io_layers(
             &mut layers,
             &flow_def.outputs,
             right_x,
@@ -849,61 +849,75 @@ impl WindowState {
             offset,
             &route,
             window_id,
+            false,
         );
 
         stack(layers).into()
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_input_layers<'a>(
+    fn build_io_layers<'a>(
         layers: &mut Vec<Element<'a, Message>>,
-        inputs: &'a [IO],
-        left_x: f32,
+        ports: &'a [IO],
+        port_x: f32,
         center_y: f32,
         spacing: f32,
         zoom: f32,
         offset: Point,
         route: &Route,
         window_id: window::Id,
+        is_input: bool,
     ) {
-        use crate::flow_canvas::transform_point;
-
-        let port_font_size = 12.0;
         let row_height = 24.0;
-        let input_start_y = center_y - (inputs.len() as f32 - 1.0) * spacing / 2.0;
+        let (row_x_offset, add_x_offset) = if is_input {
+            (-100.0, -60.0)
+        } else {
+            (8.0, 8.0)
+        };
+        let start_y = center_y - (ports.len() as f32 - 1.0) * spacing / 2.0;
 
-        for (i, input) in inputs.iter().enumerate() {
-            let world_y = input_start_y + i as f32 * spacing;
-            let screen_pos = transform_point(Point::new(left_x, world_y), zoom, offset);
+        for (i, port) in ports.iter().enumerate() {
+            let world_y = start_y + i as f32 * spacing;
+            let screen_pos = transform_point(Point::new(port_x, world_y), zoom, offset);
             let route_clone = route.clone();
 
-            let name_input = text_input("name", input.name())
+            let name_input = text_input("name", port.name())
                 .on_input(move |s| {
-                    Message::FlowEdit(
-                        window_id,
-                        route_clone.clone(),
-                        FlowEditMessage::InputNameChanged(i, s),
-                    )
+                    let msg = if is_input {
+                        FlowEditMessage::InputNameChanged(i, s)
+                    } else {
+                        FlowEditMessage::OutputNameChanged(i, s)
+                    };
+                    Message::FlowEdit(window_id, route_clone.clone(), msg)
                 })
-                .size(port_font_size)
+                .size(PORT_FONT_SIZE)
                 .padding(2)
                 .width(80);
 
             let route_del = route.clone();
+            let del_msg = if is_input {
+                FlowEditMessage::DeleteInput(i)
+            } else {
+                FlowEditMessage::DeleteOutput(i)
+            };
             let del_btn = button(Text::new("\u{2715}").size(9))
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    route_del,
-                    FlowEditMessage::DeleteInput(i),
-                ))
+                .on_press(Message::FlowEdit(window_id, route_del, del_msg))
                 .style(button::text)
                 .padding([1, 3]);
 
-            let row = Row::new()
-                .spacing(2)
-                .align_y(iced::Alignment::Center)
-                .push(del_btn)
-                .push(name_input);
+            let row = if is_input {
+                Row::new()
+                    .spacing(2)
+                    .align_y(iced::Alignment::Center)
+                    .push(del_btn)
+                    .push(name_input)
+            } else {
+                Row::new()
+                    .spacing(2)
+                    .align_y(iced::Alignment::Center)
+                    .push(name_input)
+                    .push(del_btn)
+            };
 
             layers.push(
                 container(row)
@@ -911,7 +925,7 @@ impl WindowState {
                     .height(Fill)
                     .padding(iced::Padding {
                         top: (screen_pos.y - row_height / 2.0).max(0.0),
-                        left: (screen_pos.x - 100.0).max(0.0),
+                        left: (screen_pos.x + row_x_offset).max(0.0),
                         right: 0.0,
                         bottom: 0.0,
                     })
@@ -919,18 +933,18 @@ impl WindowState {
             );
         }
 
-        // "+ Input" button layer
-        let input_bottom_y = input_start_y + inputs.len() as f32 * spacing;
-        let add_screen = transform_point(Point::new(left_x, input_bottom_y), zoom, offset);
+        let add_y = start_y + ports.len() as f32 * spacing;
+        let add_screen = transform_point(Point::new(port_x, add_y), zoom, offset);
         let route_add = route.clone();
+        let (add_label, add_msg) = if is_input {
+            ("+ Input", FlowEditMessage::AddInput)
+        } else {
+            ("+ Output", FlowEditMessage::AddOutput)
+        };
         layers.push(
             container(
-                button(Text::new("+ Input").size(10))
-                    .on_press(Message::FlowEdit(
-                        window_id,
-                        route_add,
-                        FlowEditMessage::AddInput,
-                    ))
+                button(Text::new(add_label).size(10))
+                    .on_press(Message::FlowEdit(window_id, route_add, add_msg))
                     .style(button::text)
                     .padding([2, 4]),
             )
@@ -938,99 +952,7 @@ impl WindowState {
             .height(Fill)
             .padding(iced::Padding {
                 top: (add_screen.y - row_height / 2.0).max(0.0),
-                left: (add_screen.x - 60.0).max(0.0),
-                right: 0.0,
-                bottom: 0.0,
-            })
-            .into(),
-        );
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn build_output_layers<'a>(
-        layers: &mut Vec<Element<'a, Message>>,
-        outputs: &'a [IO],
-        right_x: f32,
-        center_y: f32,
-        spacing: f32,
-        zoom: f32,
-        offset: Point,
-        route: &Route,
-        window_id: window::Id,
-    ) {
-        use crate::flow_canvas::transform_point;
-
-        let port_font_size = 12.0;
-        let row_height = 24.0;
-        let output_start_y = center_y - (outputs.len() as f32 - 1.0) * spacing / 2.0;
-
-        for (i, output) in outputs.iter().enumerate() {
-            let world_y = output_start_y + i as f32 * spacing;
-            let screen_pos = transform_point(Point::new(right_x, world_y), zoom, offset);
-            let route_clone = route.clone();
-
-            let name_input = text_input("name", output.name())
-                .on_input(move |s| {
-                    Message::FlowEdit(
-                        window_id,
-                        route_clone.clone(),
-                        FlowEditMessage::OutputNameChanged(i, s),
-                    )
-                })
-                .size(port_font_size)
-                .padding(2)
-                .width(80);
-
-            let route_del = route.clone();
-            let del_btn = button(Text::new("\u{2715}").size(9))
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    route_del,
-                    FlowEditMessage::DeleteOutput(i),
-                ))
-                .style(button::text)
-                .padding([1, 3]);
-
-            let row = Row::new()
-                .spacing(2)
-                .align_y(iced::Alignment::Center)
-                .push(name_input)
-                .push(del_btn);
-
-            layers.push(
-                container(row)
-                    .width(Fill)
-                    .height(Fill)
-                    .padding(iced::Padding {
-                        top: (screen_pos.y - row_height / 2.0).max(0.0),
-                        left: (screen_pos.x + 8.0).max(0.0),
-                        right: 0.0,
-                        bottom: 0.0,
-                    })
-                    .into(),
-            );
-        }
-
-        // "+ Output" button layer
-        let output_bottom_y = output_start_y + outputs.len() as f32 * spacing;
-        let add_screen = transform_point(Point::new(right_x, output_bottom_y), zoom, offset);
-        let route_add = route.clone();
-        layers.push(
-            container(
-                button(Text::new("+ Output").size(10))
-                    .on_press(Message::FlowEdit(
-                        window_id,
-                        route_add,
-                        FlowEditMessage::AddOutput,
-                    ))
-                    .style(button::text)
-                    .padding([2, 4]),
-            )
-            .width(Fill)
-            .height(Fill)
-            .padding(iced::Padding {
-                top: (add_screen.y - row_height / 2.0).max(0.0),
-                left: (add_screen.x + 8.0).max(0.0),
+                left: (add_screen.x + add_x_offset).max(0.0),
                 right: 0.0,
                 bottom: 0.0,
             })
@@ -1728,21 +1650,24 @@ impl WindowState {
             .iter()
             .enumerate()
             .any(|(i, io)| i != idx && io.name() == name);
-        if !duplicate {
-            if let Some(io) = flow_def.inputs.get_mut(idx) {
-                let old_name = io.name().clone();
-                io.set_name(name.into());
-                let old_route = format!("input/{old_name}");
-                let new_route = format!("input/{name}");
-                for conn in &mut flow_def.connections {
-                    if conn.from().to_string() == old_route {
-                        conn.set_from(Route::from(new_route.as_str()));
-                    }
+        if duplicate {
+            self.status = format!("Input name \"{name}\" already in use");
+            return;
+        }
+        if let Some(io) = flow_def.inputs.get_mut(idx) {
+            let old_name = io.name().clone();
+            io.set_name(name.into());
+            let old_route = format!("input/{old_name}");
+            let new_route = format!("input/{name}");
+            for conn in &mut flow_def.connections {
+                if conn.from().to_string() == old_route {
+                    conn.set_from(Route::from(new_route.as_str()));
                 }
             }
-            self.history.mark_modified();
-            self.canvas_state.request_redraw();
         }
+        self.status = String::new();
+        self.history.mark_modified();
+        self.canvas_state.request_redraw();
     }
 
     fn rename_flow_output(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) {
@@ -1751,30 +1676,33 @@ impl WindowState {
             .iter()
             .enumerate()
             .any(|(i, io)| i != idx && io.name() == name);
-        if !duplicate {
-            if let Some(io) = flow_def.outputs.get_mut(idx) {
-                let old_name = io.name().clone();
-                io.set_name(name.into());
-                let old_route_str = format!("output/{old_name}");
-                let new_route_str = format!("output/{name}");
-                for conn in &mut flow_def.connections {
-                    let new_to: Vec<Route> = conn
-                        .to()
-                        .iter()
-                        .map(|r| {
-                            if r.to_string() == old_route_str {
-                                Route::from(new_route_str.as_str())
-                            } else {
-                                r.clone()
-                            }
-                        })
-                        .collect();
-                    conn.set_to(new_to);
-                }
-            }
-            self.history.mark_modified();
-            self.canvas_state.request_redraw();
+        if duplicate {
+            self.status = format!("Output name \"{name}\" already in use");
+            return;
         }
+        if let Some(io) = flow_def.outputs.get_mut(idx) {
+            let old_name = io.name().clone();
+            io.set_name(name.into());
+            let old_route_str = format!("output/{old_name}");
+            let new_route_str = format!("output/{name}");
+            for conn in &mut flow_def.connections {
+                let new_to: Vec<Route> = conn
+                    .to()
+                    .iter()
+                    .map(|r| {
+                        if r.to_string() == old_route_str {
+                            Route::from(new_route_str.as_str())
+                        } else {
+                            r.clone()
+                        }
+                    })
+                    .collect();
+                conn.set_to(new_to);
+            }
+        }
+        self.status = String::new();
+        self.history.mark_modified();
+        self.canvas_state.request_redraw();
     }
 
     /// Handle flow metadata and I/O editing messages.

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use iced::widget::canvas::{self, Canvas};
 use iced::widget::{button, container, pick_list, stack, text_input, Column, Row, Text};
-use iced::{window, Color, Element, Fill, Point, Size, Theme};
+use iced::{window, Color, Element, Fill, Length, Point, Size, Theme};
 use log::info;
 use url::Url;
 
@@ -787,7 +787,7 @@ impl WindowState {
         let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
 
         // Inline I/O editing overlays for sub-flow windows
-        if !self.is_root && (!flow_def.inputs.is_empty() || !flow_def.outputs.is_empty()) {
+        if !self.is_root {
             canvas_stack.push(Self::build_flow_io_overlays(
                 flow_def,
                 &self.canvas_state,
@@ -816,6 +816,7 @@ impl WindowState {
         window_id: window::Id,
     ) -> Element<'a, Message> {
         use crate::flow_canvas::flow_io_bounding_box;
+        use crate::flow_canvas::transform_point;
         use crate::node_layout::NodeLayout;
 
         let nodes = NodeLayout::build_from_flow(flow_def);
@@ -825,14 +826,9 @@ impl WindowState {
         let offset = canvas_state.scroll_offset;
         let route = flow_def.route.clone();
 
-        let input_color = Color::from_rgb(0.4, 0.8, 1.0);
-        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
         let port_font_size = 12.0;
 
-        let mut overlays: Vec<Element<'_, Message>> = Vec::new();
-
-        Self::build_input_overlays(
-            &mut overlays,
+        let input_col = Self::build_input_column(
             &flow_def.inputs,
             box_x,
             center_y,
@@ -842,30 +838,48 @@ impl WindowState {
             &route,
             window_id,
             port_font_size,
-            input_color,
         );
+
+        let output_col =
+            Self::build_output_column(&flow_def.outputs, &route, window_id, port_font_size);
 
         let right_x = box_x + box_w;
-        Self::build_output_overlays(
-            &mut overlays,
-            &flow_def.outputs,
-            right_x,
-            center_y,
-            spacing,
-            zoom,
-            offset,
-            &route,
-            window_id,
-            port_font_size,
-            output_color,
-        );
+        let input_screen = transform_point(Point::new(box_x, center_y), zoom, offset);
+        let output_screen = transform_point(Point::new(right_x, center_y), zoom, offset);
 
-        stack(overlays).into()
+        let input_positioned =
+            container(input_col)
+                .width(Fill)
+                .height(Fill)
+                .padding(iced::Padding {
+                    top: (input_screen.y
+                        - (flow_def.inputs.len().max(1) as f32 - 1.0) * spacing * zoom / 2.0
+                        - 12.0)
+                        .max(0.0),
+                    left: 0.0,
+                    right: 0.0,
+                    bottom: 0.0,
+                });
+
+        let output_positioned = container(output_col)
+            .width(Fill)
+            .height(Fill)
+            .align_right(Fill)
+            .padding(iced::Padding {
+                top: (output_screen.y
+                    - (flow_def.outputs.len().max(1) as f32 - 1.0) * spacing * zoom / 2.0
+                    - 12.0)
+                    .max(0.0),
+                left: 0.0,
+                right: 0.0,
+                bottom: 0.0,
+            });
+
+        stack(vec![input_positioned.into(), output_positioned.into()]).into()
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_input_overlays<'a>(
-        overlays: &mut Vec<Element<'a, Message>>,
+    fn build_input_column<'a>(
         inputs: &'a [IO],
         left_x: f32,
         center_y: f32,
@@ -875,9 +889,10 @@ impl WindowState {
         route: &Route,
         window_id: window::Id,
         port_font_size: f32,
-        input_color: Color,
-    ) {
+    ) -> Column<'a, Message> {
         use crate::flow_canvas::transform_point;
+
+        let mut col = Column::new().spacing(4).width(Length::Shrink);
 
         let input_start_y = center_y - (inputs.len() as f32 - 1.0) * spacing / 2.0;
         for (i, input) in inputs.iter().enumerate() {
@@ -907,27 +922,27 @@ impl WindowState {
                 .style(button::text)
                 .padding([1, 3]);
 
-            let row = Row::new()
-                .spacing(2)
-                .align_y(iced::Alignment::Center)
-                .push(del_btn)
-                .push(name_input)
-                .push(Text::new("\u{25D7}").size(14).color(input_color));
-
-            let positioned = container(row).padding(iced::Padding {
-                top: (screen_pos.y - 12.0).max(0.0),
-                left: (screen_pos.x - 110.0).max(0.0),
+            let row = container(
+                Row::new()
+                    .spacing(2)
+                    .align_y(iced::Alignment::Center)
+                    .push(del_btn)
+                    .push(name_input),
+            )
+            .padding(iced::Padding {
+                top: 0.0,
+                left: (screen_pos.x - 100.0).max(0.0),
                 right: 0.0,
                 bottom: 0.0,
             });
-            overlays.push(positioned.into());
+
+            col = col.push(row);
         }
 
-        // Add input "+" button
         let input_bottom_y = input_start_y + inputs.len() as f32 * spacing;
         let screen_pos = transform_point(Point::new(left_x, input_bottom_y), zoom, offset);
         let route_add = route.clone();
-        overlays.push(
+        col = col.push(
             container(
                 button(Text::new("+ Input").size(10))
                     .on_press(Message::FlowEdit(
@@ -939,35 +954,28 @@ impl WindowState {
                     .padding([2, 4]),
             )
             .padding(iced::Padding {
-                top: (screen_pos.y - 8.0).max(0.0),
-                left: (screen_pos.x - 80.0).max(0.0),
+                top: 0.0,
+                left: (screen_pos.x - 60.0).max(0.0),
                 right: 0.0,
                 bottom: 0.0,
-            })
-            .into(),
+            }),
         );
+
+        col
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn build_output_overlays<'a>(
-        overlays: &mut Vec<Element<'a, Message>>,
+    fn build_output_column<'a>(
         outputs: &'a [IO],
-        right_x: f32,
-        center_y: f32,
-        spacing: f32,
-        zoom: f32,
-        offset: Point,
         route: &Route,
         window_id: window::Id,
         port_font_size: f32,
-        output_color: Color,
-    ) {
-        use crate::flow_canvas::transform_point;
+    ) -> Column<'a, Message> {
+        let mut col = Column::new()
+            .spacing(4)
+            .width(Length::Shrink)
+            .align_x(iced::Alignment::End);
 
-        let output_start_y = center_y - (outputs.len() as f32 - 1.0) * spacing / 2.0;
         for (i, output) in outputs.iter().enumerate() {
-            let world_y = output_start_y + i as f32 * spacing;
-            let screen_pos = transform_point(Point::new(right_x, world_y), zoom, offset);
             let route_clone = route.clone();
 
             let name_input = text_input("name", output.name())
@@ -995,45 +1003,25 @@ impl WindowState {
             let row = Row::new()
                 .spacing(2)
                 .align_y(iced::Alignment::Center)
-                .push(Text::new("\u{25D6}").size(14).color(output_color))
                 .push(name_input)
                 .push(del_btn);
 
-            overlays.push(
-                container(row)
-                    .padding(iced::Padding {
-                        top: (screen_pos.y - 12.0).max(0.0),
-                        left: screen_pos.x + 8.0,
-                        right: 0.0,
-                        bottom: 0.0,
-                    })
-                    .into(),
-            );
+            col = col.push(row);
         }
 
-        // Add output "+" button
-        let output_bottom_y = output_start_y + outputs.len() as f32 * spacing;
-        let screen_pos = transform_point(Point::new(right_x, output_bottom_y), zoom, offset);
         let route_add = route.clone();
-        overlays.push(
-            container(
-                button(Text::new("+ Output").size(10))
-                    .on_press(Message::FlowEdit(
-                        window_id,
-                        route_add,
-                        FlowEditMessage::AddOutput,
-                    ))
-                    .style(button::text)
-                    .padding([2, 4]),
-            )
-            .padding(iced::Padding {
-                top: (screen_pos.y - 8.0).max(0.0),
-                left: screen_pos.x + 8.0,
-                right: 0.0,
-                bottom: 0.0,
-            })
-            .into(),
+        col = col.push(
+            button(Text::new("+ Output").size(10))
+                .on_press(Message::FlowEdit(
+                    window_id,
+                    route_add,
+                    FlowEditMessage::AddOutput,
+                ))
+                .style(button::text)
+                .padding([2, 4]),
         );
+
+        col
     }
 
     fn build_tooltip_overlay<'a>(tip: &crate::window_state::Tooltip) -> Element<'a, Message> {
@@ -1861,24 +1849,8 @@ impl WindowState {
             FlowEditMessage::InputNameChanged(idx, name) => {
                 self.rename_flow_input(flow_def, idx, &name);
             }
-            FlowEditMessage::InputTypeChanged(idx, dtype) => {
-                if let Some(io) = flow_def.inputs.get_mut(idx) {
-                    io.set_datatypes(&[DataType::from(dtype)]);
-                }
-                self.history.mark_modified();
-                self.canvas_state.request_redraw();
-                self.trigger_auto_fit_if_enabled();
-            }
             FlowEditMessage::OutputNameChanged(idx, name) => {
                 self.rename_flow_output(flow_def, idx, &name);
-            }
-            FlowEditMessage::OutputTypeChanged(idx, dtype) => {
-                if let Some(io) = flow_def.outputs.get_mut(idx) {
-                    io.set_datatypes(&[DataType::from(dtype)]);
-                }
-                self.history.mark_modified();
-                self.canvas_state.request_redraw();
-                self.trigger_auto_fit_if_enabled();
             }
         }
     }

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use iced::widget::canvas::{self, Canvas};
 use iced::widget::{button, container, pick_list, stack, text_input, Column, Row, Text};
-use iced::{window, Color, Element, Fill, Length, Point, Size, Theme};
+use iced::{window, Color, Element, Fill, Point, Size, Theme};
 use log::info;
 use url::Url;
 
@@ -816,7 +816,6 @@ impl WindowState {
         window_id: window::Id,
     ) -> Element<'a, Message> {
         use crate::flow_canvas::flow_io_bounding_box;
-        use crate::flow_canvas::transform_point;
         use crate::node_layout::NodeLayout;
 
         let nodes = NodeLayout::build_from_flow(flow_def);
@@ -825,10 +824,12 @@ impl WindowState {
         let zoom = canvas_state.zoom;
         let offset = canvas_state.scroll_offset;
         let route = flow_def.route.clone();
+        let right_x = box_x + box_w;
 
-        let port_font_size = 12.0;
+        let mut layers: Vec<Element<'_, Message>> = Vec::new();
 
-        let input_col = Self::build_input_column(
+        Self::build_input_layers(
+            &mut layers,
             &flow_def.inputs,
             box_x,
             center_y,
@@ -837,49 +838,25 @@ impl WindowState {
             offset,
             &route,
             window_id,
-            port_font_size,
+        );
+        Self::build_output_layers(
+            &mut layers,
+            &flow_def.outputs,
+            right_x,
+            center_y,
+            spacing,
+            zoom,
+            offset,
+            &route,
+            window_id,
         );
 
-        let output_col =
-            Self::build_output_column(&flow_def.outputs, &route, window_id, port_font_size);
-
-        let right_x = box_x + box_w;
-        let input_screen = transform_point(Point::new(box_x, center_y), zoom, offset);
-        let output_screen = transform_point(Point::new(right_x, center_y), zoom, offset);
-
-        let input_positioned =
-            container(input_col)
-                .width(Fill)
-                .height(Fill)
-                .padding(iced::Padding {
-                    top: (input_screen.y
-                        - (flow_def.inputs.len().max(1) as f32 - 1.0) * spacing * zoom / 2.0
-                        - 12.0)
-                        .max(0.0),
-                    left: 0.0,
-                    right: 0.0,
-                    bottom: 0.0,
-                });
-
-        let output_positioned = container(output_col)
-            .width(Fill)
-            .height(Fill)
-            .align_right(Fill)
-            .padding(iced::Padding {
-                top: (output_screen.y
-                    - (flow_def.outputs.len().max(1) as f32 - 1.0) * spacing * zoom / 2.0
-                    - 12.0)
-                    .max(0.0),
-                left: 0.0,
-                right: 0.0,
-                bottom: 0.0,
-            });
-
-        stack(vec![input_positioned.into(), output_positioned.into()]).into()
+        stack(layers).into()
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_input_column<'a>(
+    fn build_input_layers<'a>(
+        layers: &mut Vec<Element<'a, Message>>,
         inputs: &'a [IO],
         left_x: f32,
         center_y: f32,
@@ -888,13 +865,13 @@ impl WindowState {
         offset: Point,
         route: &Route,
         window_id: window::Id,
-        port_font_size: f32,
-    ) -> Column<'a, Message> {
+    ) {
         use crate::flow_canvas::transform_point;
 
-        let mut col = Column::new().spacing(4).width(Length::Shrink);
-
+        let port_font_size = 12.0;
+        let row_height = 24.0;
         let input_start_y = center_y - (inputs.len() as f32 - 1.0) * spacing / 2.0;
+
         for (i, input) in inputs.iter().enumerate() {
             let world_y = input_start_y + i as f32 * spacing;
             let screen_pos = transform_point(Point::new(left_x, world_y), zoom, offset);
@@ -922,27 +899,31 @@ impl WindowState {
                 .style(button::text)
                 .padding([1, 3]);
 
-            let row = container(
-                Row::new()
-                    .spacing(2)
-                    .align_y(iced::Alignment::Center)
-                    .push(del_btn)
-                    .push(name_input),
-            )
-            .padding(iced::Padding {
-                top: 0.0,
-                left: (screen_pos.x - 100.0).max(0.0),
-                right: 0.0,
-                bottom: 0.0,
-            });
+            let row = Row::new()
+                .spacing(2)
+                .align_y(iced::Alignment::Center)
+                .push(del_btn)
+                .push(name_input);
 
-            col = col.push(row);
+            layers.push(
+                container(row)
+                    .width(Fill)
+                    .height(Fill)
+                    .padding(iced::Padding {
+                        top: (screen_pos.y - row_height / 2.0).max(0.0),
+                        left: (screen_pos.x - 100.0).max(0.0),
+                        right: 0.0,
+                        bottom: 0.0,
+                    })
+                    .into(),
+            );
         }
 
+        // "+ Input" button layer
         let input_bottom_y = input_start_y + inputs.len() as f32 * spacing;
-        let screen_pos = transform_point(Point::new(left_x, input_bottom_y), zoom, offset);
+        let add_screen = transform_point(Point::new(left_x, input_bottom_y), zoom, offset);
         let route_add = route.clone();
-        col = col.push(
+        layers.push(
             container(
                 button(Text::new("+ Input").size(10))
                     .on_press(Message::FlowEdit(
@@ -953,29 +934,39 @@ impl WindowState {
                     .style(button::text)
                     .padding([2, 4]),
             )
+            .width(Fill)
+            .height(Fill)
             .padding(iced::Padding {
-                top: 0.0,
-                left: (screen_pos.x - 60.0).max(0.0),
+                top: (add_screen.y - row_height / 2.0).max(0.0),
+                left: (add_screen.x - 60.0).max(0.0),
                 right: 0.0,
                 bottom: 0.0,
-            }),
+            })
+            .into(),
         );
-
-        col
     }
 
-    fn build_output_column<'a>(
+    #[allow(clippy::too_many_arguments)]
+    fn build_output_layers<'a>(
+        layers: &mut Vec<Element<'a, Message>>,
         outputs: &'a [IO],
+        right_x: f32,
+        center_y: f32,
+        spacing: f32,
+        zoom: f32,
+        offset: Point,
         route: &Route,
         window_id: window::Id,
-        port_font_size: f32,
-    ) -> Column<'a, Message> {
-        let mut col = Column::new()
-            .spacing(4)
-            .width(Length::Shrink)
-            .align_x(iced::Alignment::End);
+    ) {
+        use crate::flow_canvas::transform_point;
+
+        let port_font_size = 12.0;
+        let row_height = 24.0;
+        let output_start_y = center_y - (outputs.len() as f32 - 1.0) * spacing / 2.0;
 
         for (i, output) in outputs.iter().enumerate() {
+            let world_y = output_start_y + i as f32 * spacing;
+            let screen_pos = transform_point(Point::new(right_x, world_y), zoom, offset);
             let route_clone = route.clone();
 
             let name_input = text_input("name", output.name())
@@ -1006,22 +997,45 @@ impl WindowState {
                 .push(name_input)
                 .push(del_btn);
 
-            col = col.push(row);
+            layers.push(
+                container(row)
+                    .width(Fill)
+                    .height(Fill)
+                    .padding(iced::Padding {
+                        top: (screen_pos.y - row_height / 2.0).max(0.0),
+                        left: (screen_pos.x + 8.0).max(0.0),
+                        right: 0.0,
+                        bottom: 0.0,
+                    })
+                    .into(),
+            );
         }
 
+        // "+ Output" button layer
+        let output_bottom_y = output_start_y + outputs.len() as f32 * spacing;
+        let add_screen = transform_point(Point::new(right_x, output_bottom_y), zoom, offset);
         let route_add = route.clone();
-        col = col.push(
-            button(Text::new("+ Output").size(10))
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    route_add,
-                    FlowEditMessage::AddOutput,
-                ))
-                .style(button::text)
-                .padding([2, 4]),
+        layers.push(
+            container(
+                button(Text::new("+ Output").size(10))
+                    .on_press(Message::FlowEdit(
+                        window_id,
+                        route_add,
+                        FlowEditMessage::AddOutput,
+                    ))
+                    .style(button::text)
+                    .padding([2, 4]),
+            )
+            .width(Fill)
+            .height(Fill)
+            .padding(iced::Padding {
+                top: (add_screen.y - row_height / 2.0).max(0.0),
+                left: (add_screen.x + 8.0).max(0.0),
+                right: 0.0,
+                bottom: 0.0,
+            })
+            .into(),
         );
-
-        col
     }
 
     fn build_tooltip_overlay<'a>(tip: &crate::window_state::Tooltip) -> Element<'a, Message> {

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -786,6 +786,15 @@ impl WindowState {
 
         let mut canvas_stack: Vec<Element<'_, Message>> = vec![canvas, zoom_controls.into()];
 
+        // Inline I/O editing overlays for sub-flow windows
+        if !self.is_root && (!flow_def.inputs.is_empty() || !flow_def.outputs.is_empty()) {
+            canvas_stack.push(Self::build_flow_io_overlays(
+                flow_def,
+                &self.canvas_state,
+                window_id,
+            ));
+        }
+
         if let Some(ref tip) = self.tooltip {
             canvas_stack.push(Self::build_tooltip_overlay(tip));
         }
@@ -799,6 +808,232 @@ impl WindowState {
         }
 
         stack(canvas_stack).into()
+    }
+
+    fn build_flow_io_overlays<'a>(
+        flow_def: &'a FlowDefinition,
+        canvas_state: &FlowCanvasState,
+        window_id: window::Id,
+    ) -> Element<'a, Message> {
+        use crate::flow_canvas::flow_io_bounding_box;
+        use crate::node_layout::NodeLayout;
+
+        let nodes = NodeLayout::build_from_flow(flow_def);
+        let (box_x, _, box_w, _, center_y, spacing) =
+            flow_io_bounding_box(&nodes, &flow_def.inputs, &flow_def.outputs);
+        let zoom = canvas_state.zoom;
+        let offset = canvas_state.scroll_offset;
+        let route = flow_def.route.clone();
+
+        let input_color = Color::from_rgb(0.4, 0.8, 1.0);
+        let output_color = Color::from_rgb(1.0, 0.6, 0.3);
+        let port_font_size = 12.0;
+
+        let mut overlays: Vec<Element<'_, Message>> = Vec::new();
+
+        Self::build_input_overlays(
+            &mut overlays,
+            &flow_def.inputs,
+            box_x,
+            center_y,
+            spacing,
+            zoom,
+            offset,
+            &route,
+            window_id,
+            port_font_size,
+            input_color,
+        );
+
+        let right_x = box_x + box_w;
+        Self::build_output_overlays(
+            &mut overlays,
+            &flow_def.outputs,
+            right_x,
+            center_y,
+            spacing,
+            zoom,
+            offset,
+            &route,
+            window_id,
+            port_font_size,
+            output_color,
+        );
+
+        stack(overlays).into()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_input_overlays<'a>(
+        overlays: &mut Vec<Element<'a, Message>>,
+        inputs: &'a [IO],
+        left_x: f32,
+        center_y: f32,
+        spacing: f32,
+        zoom: f32,
+        offset: Point,
+        route: &Route,
+        window_id: window::Id,
+        port_font_size: f32,
+        input_color: Color,
+    ) {
+        use crate::flow_canvas::transform_point;
+
+        let input_start_y = center_y - (inputs.len() as f32 - 1.0) * spacing / 2.0;
+        for (i, input) in inputs.iter().enumerate() {
+            let world_y = input_start_y + i as f32 * spacing;
+            let screen_pos = transform_point(Point::new(left_x, world_y), zoom, offset);
+            let route_clone = route.clone();
+
+            let name_input = text_input("name", input.name())
+                .on_input(move |s| {
+                    Message::FlowEdit(
+                        window_id,
+                        route_clone.clone(),
+                        FlowEditMessage::InputNameChanged(i, s),
+                    )
+                })
+                .size(port_font_size)
+                .padding(2)
+                .width(80);
+
+            let route_del = route.clone();
+            let del_btn = button(Text::new("\u{2715}").size(9))
+                .on_press(Message::FlowEdit(
+                    window_id,
+                    route_del,
+                    FlowEditMessage::DeleteInput(i),
+                ))
+                .style(button::text)
+                .padding([1, 3]);
+
+            let row = Row::new()
+                .spacing(2)
+                .align_y(iced::Alignment::Center)
+                .push(del_btn)
+                .push(name_input)
+                .push(Text::new("\u{25D7}").size(14).color(input_color));
+
+            let positioned = container(row).padding(iced::Padding {
+                top: (screen_pos.y - 12.0).max(0.0),
+                left: (screen_pos.x - 110.0).max(0.0),
+                right: 0.0,
+                bottom: 0.0,
+            });
+            overlays.push(positioned.into());
+        }
+
+        // Add input "+" button
+        let input_bottom_y = input_start_y + inputs.len() as f32 * spacing;
+        let screen_pos = transform_point(Point::new(left_x, input_bottom_y), zoom, offset);
+        let route_add = route.clone();
+        overlays.push(
+            container(
+                button(Text::new("+ Input").size(10))
+                    .on_press(Message::FlowEdit(
+                        window_id,
+                        route_add,
+                        FlowEditMessage::AddInput,
+                    ))
+                    .style(button::text)
+                    .padding([2, 4]),
+            )
+            .padding(iced::Padding {
+                top: (screen_pos.y - 8.0).max(0.0),
+                left: (screen_pos.x - 80.0).max(0.0),
+                right: 0.0,
+                bottom: 0.0,
+            })
+            .into(),
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_output_overlays<'a>(
+        overlays: &mut Vec<Element<'a, Message>>,
+        outputs: &'a [IO],
+        right_x: f32,
+        center_y: f32,
+        spacing: f32,
+        zoom: f32,
+        offset: Point,
+        route: &Route,
+        window_id: window::Id,
+        port_font_size: f32,
+        output_color: Color,
+    ) {
+        use crate::flow_canvas::transform_point;
+
+        let output_start_y = center_y - (outputs.len() as f32 - 1.0) * spacing / 2.0;
+        for (i, output) in outputs.iter().enumerate() {
+            let world_y = output_start_y + i as f32 * spacing;
+            let screen_pos = transform_point(Point::new(right_x, world_y), zoom, offset);
+            let route_clone = route.clone();
+
+            let name_input = text_input("name", output.name())
+                .on_input(move |s| {
+                    Message::FlowEdit(
+                        window_id,
+                        route_clone.clone(),
+                        FlowEditMessage::OutputNameChanged(i, s),
+                    )
+                })
+                .size(port_font_size)
+                .padding(2)
+                .width(80);
+
+            let route_del = route.clone();
+            let del_btn = button(Text::new("\u{2715}").size(9))
+                .on_press(Message::FlowEdit(
+                    window_id,
+                    route_del,
+                    FlowEditMessage::DeleteOutput(i),
+                ))
+                .style(button::text)
+                .padding([1, 3]);
+
+            let row = Row::new()
+                .spacing(2)
+                .align_y(iced::Alignment::Center)
+                .push(Text::new("\u{25D6}").size(14).color(output_color))
+                .push(name_input)
+                .push(del_btn);
+
+            overlays.push(
+                container(row)
+                    .padding(iced::Padding {
+                        top: (screen_pos.y - 12.0).max(0.0),
+                        left: screen_pos.x + 8.0,
+                        right: 0.0,
+                        bottom: 0.0,
+                    })
+                    .into(),
+            );
+        }
+
+        // Add output "+" button
+        let output_bottom_y = output_start_y + outputs.len() as f32 * spacing;
+        let screen_pos = transform_point(Point::new(right_x, output_bottom_y), zoom, offset);
+        let route_add = route.clone();
+        overlays.push(
+            container(
+                button(Text::new("+ Output").size(10))
+                    .on_press(Message::FlowEdit(
+                        window_id,
+                        route_add,
+                        FlowEditMessage::AddOutput,
+                    ))
+                    .style(button::text)
+                    .padding([2, 4]),
+            )
+            .padding(iced::Padding {
+                top: (screen_pos.y - 8.0).max(0.0),
+                left: screen_pos.x + 8.0,
+                right: 0.0,
+                bottom: 0.0,
+            })
+            .into(),
+        );
     }
 
     fn build_tooltip_overlay<'a>(tip: &crate::window_state::Tooltip) -> Element<'a, Message> {


### PR DESCRIPTION
## Summary
- Replace bottom I/O panel with inline widget overlays directly on the canvas for sub-flow windows
- Add flow I/O port hit testing so connections can be dragged from/to flow input and output semicircles
- Fix sticky tooltip when hovering process ports — tooltip now clears when cursor moves away
- Suppress canvas-drawn text labels for flow I/O ports to avoid double-rendering with widget overlays
- Remove dead code: `FlowEditMessage::InputTypeChanged`/`OutputTypeChanged` variants and associated bottom panel functions

## Test plan
- [x] `make clippy` passes
- [x] `make test` passes (239 flowedit tests)
- [ ] Open mandlebrot example, edit generate_pixels sub-flow
- [ ] Verify input/output text fields render inline on canvas without double labels
- [ ] Verify connections can be created from flow input semicircles to process inputs
- [ ] Verify connections can be created from process outputs to flow output semicircles
- [ ] Verify tooltips clear when mouse moves away from ports

Closes #2618

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sub-flow I/O ports show port hover tooltips and can be connected directly from the canvas.
  * Inline overlays in sub-flow editor windows let you add, rename, and delete I/O ports.

* **Improvements**
  * Connection preview highlights sub-flow I/O targets and respects port compatibility when completing connections.

* **Removed**
  * Flow-level input/output datatype editing has been removed from the UI.

* **Tests**
  * Related UI/unit tests for I/O datatype changes were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->