### PR TITLE
flowedit: Add Open, Save, Save As buttons to root toolbar (#2616)

### DIFF
--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -992,8 +992,8 @@ mod test {
         win.history.mark_modified();
         flow_def.name = "saved_flow".into();
 
-        win.perform_save(&mut flow_def, &path);
-        assert!(win.history.is_empty());
+        let saved = win.perform_save(&mut flow_def, &path);
+        assert!(saved);
         let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
         assert_eq!(WindowState::file_path_of(&flow_def), Some(canonical));
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -359,12 +359,23 @@ fn resolve_flow_def_mut<'a>(
 }
 
 fn toolbar_btn(_theme: &Theme, status: button::Status) -> button::Style {
+    let is_disabled = matches!(status, button::Status::Disabled);
     let is_hovered = matches!(status, button::Status::Hovered);
     button::Style {
-        background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
-        text_color: Color::WHITE,
+        background: Some(iced::Background::Color(if is_disabled {
+            Color::from_rgb(0.20, 0.20, 0.22)
+        } else {
+            Color::from_rgb(0.25, 0.25, 0.30)
+        })),
+        text_color: if is_disabled {
+            Color::from_rgb(0.5, 0.5, 0.55)
+        } else {
+            Color::WHITE
+        },
         border: iced::Border {
-            color: if is_hovered {
+            color: if is_disabled {
+                Color::from_rgb(0.3, 0.3, 0.32)
+            } else if is_hovered {
                 Color::WHITE
             } else {
                 Color::from_rgb(0.4, 0.4, 0.45)

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -2203,12 +2203,11 @@ impl FlowEdit {
         let Some(win) = root_win else {
             return;
         };
-        if save_as {
-            win.handle_save_as(&mut self.root_flow);
+        let saved = if save_as {
+            win.handle_save_as(&mut self.root_flow)
         } else {
-            win.handle_save(&mut self.root_flow);
-        }
-        let saved = win.history.is_empty();
+            win.handle_save(&mut self.root_flow)
+        };
         if saved {
             for w in self.windows.values_mut() {
                 if matches!(w.kind, WindowKind::FlowEditor) {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1167,16 +1167,34 @@ impl FlowEdit {
         flow_def: &'a FlowDefinition,
         window_id: window::Id,
     ) -> Element<'a, Message> {
-        let edit_indicator = if win.history.is_empty() {
-            "  |  saved"
-        } else {
+        let has_unsaved = self.has_unsaved_flow_edits();
+        let edit_indicator = if has_unsaved {
             "  |  unsaved edit(s)"
+        } else {
+            "  |  saved"
         };
 
         let btn_pad = [6, 14];
         let btn_size = 13;
 
-        let status_bar: Row<'_, Message> = if win.is_root {
+        let mut save_btn = button(Text::new("\u{1F4BE} Save").size(btn_size).center())
+            .style(toolbar_btn)
+            .padding(btn_pad);
+        if has_unsaved {
+            save_btn = save_btn.on_press(Message::Save);
+        }
+
+        let mut status_row = Row::new()
+            .spacing(8)
+            .padding([4, 8])
+            .push(
+                container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
+                    .width(Fill)
+                    .clip(true),
+            )
+            .push(save_btn);
+
+        if win.is_root {
             let mut compile_btn = button(Text::new("\u{1F528} Build").size(btn_size).center())
                 .padding(btn_pad)
                 .style(toolbar_btn);
@@ -1184,34 +1202,19 @@ impl FlowEdit {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
-            let open_btn = button(Text::new("\u{1F4C2} Open").size(btn_size).center())
-                .on_press(Message::Open)
-                .style(toolbar_btn)
-                .padding(btn_pad);
-
-            let mut save_btn = button(Text::new("\u{1F4BE} Save").size(btn_size).center())
-                .style(toolbar_btn)
-                .padding(btn_pad);
-            if !win.history.is_empty() {
-                save_btn = save_btn.on_press(Message::Save);
-            }
-
-            let save_as_btn = button(Text::new("Save As\u{2026}").size(btn_size).center())
-                .on_press(Message::SaveAs)
-                .style(toolbar_btn)
-                .padding(btn_pad);
-
-            Row::new()
-                .spacing(8)
-                .padding([4, 8])
+            status_row = status_row
                 .push(
-                    container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
-                        .width(Fill)
-                        .clip(true),
+                    button(Text::new("\u{1F4C2} Open").size(btn_size).center())
+                        .on_press(Message::Open)
+                        .style(toolbar_btn)
+                        .padding(btn_pad),
                 )
-                .push(open_btn)
-                .push(save_btn)
-                .push(save_as_btn)
+                .push(
+                    button(Text::new("Save As\u{2026}").size(btn_size).center())
+                        .on_press(Message::SaveAs)
+                        .style(toolbar_btn)
+                        .padding(btn_pad),
+                )
                 .push(
                     button(Text::new("\u{2139} Info").size(btn_size).center())
                         .on_press(Message::FlowEdit(
@@ -1248,16 +1251,10 @@ impl FlowEdit {
                         .style(toolbar_btn)
                         .padding(btn_pad),
                 )
-                .push(compile_btn)
-        } else {
-            Row::new().spacing(8).padding([4, 8]).push(
-                container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
-                    .width(Fill)
-                    .clip(true),
-            )
-        };
+                .push(compile_btn);
+        }
 
-        container(status_bar).width(Fill).padding(5).into()
+        container(status_row).width(Fill).padding(5).into()
     }
 
     /// Build the metadata editor panel.
@@ -2192,46 +2189,69 @@ impl FlowEdit {
         open_task.discard()
     }
 
+    fn has_unsaved_flow_edits(&self) -> bool {
+        self.windows
+            .values()
+            .any(|w| matches!(w.kind, WindowKind::FlowEditor) && !w.history.is_empty())
+    }
+
+    fn save_root_flow(&mut self, save_as: bool) {
+        let root_win = self
+            .root_window
+            .and_then(|id| self.windows.get_mut(&id))
+            .filter(|w| matches!(w.kind, WindowKind::FlowEditor));
+        let Some(win) = root_win else {
+            return;
+        };
+        if save_as {
+            win.handle_save_as(&mut self.root_flow);
+        } else {
+            win.handle_save(&mut self.root_flow);
+        }
+        let saved = win.history.is_empty();
+        if saved {
+            for w in self.windows.values_mut() {
+                if matches!(w.kind, WindowKind::FlowEditor) {
+                    w.history.clear();
+                }
+            }
+        }
+    }
+
     #[allow(clippy::needless_pass_by_value)]
     fn handle_file_message(&mut self, message: Message) {
         match message {
             Message::Save => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    match &win.kind {
-                        WindowKind::FunctionViewer(_) => {
-                            if let WindowKind::FunctionViewer(ref v) = win.kind {
-                                match file_ops::save_function_definition(v) {
-                                    Ok(()) => {
-                                        win.history.clear();
-                                        win.status = String::from("Function saved");
-                                    }
-                                    Err(e) => win.status = format!("Save failed: {e}"),
-                                }
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        match file_ops::save_function_definition(v) {
+                            Ok(()) => {
+                                win.history.clear();
+                                win.status = String::from("Function saved");
                             }
+                            Err(e) => win.status = format!("Save failed: {e}"),
                         }
-                        WindowKind::FlowEditor => win.handle_save(&mut self.root_flow),
+                        return;
                     }
                 }
+                self.save_root_flow(false);
             }
             Message::SaveAs => {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    match &win.kind {
-                        WindowKind::FunctionViewer(_) => {
-                            if let WindowKind::FunctionViewer(ref v) = win.kind {
-                                match file_ops::save_function_definition(v) {
-                                    Ok(()) => {
-                                        win.history.clear();
-                                        win.status = String::from("Function saved");
-                                    }
-                                    Err(e) => win.status = format!("Save failed: {e}"),
-                                }
+                    if let WindowKind::FunctionViewer(ref v) = win.kind {
+                        match file_ops::save_function_definition(v) {
+                            Ok(()) => {
+                                win.history.clear();
+                                win.status = String::from("Function saved");
                             }
+                            Err(e) => win.status = format!("Save failed: {e}"),
                         }
-                        WindowKind::FlowEditor => win.handle_save_as(&mut self.root_flow),
+                        return;
                     }
                 }
+                self.save_root_flow(true);
             }
             Message::Open => {
                 if let Some(root_id) = self.root_window {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -358,6 +358,42 @@ fn resolve_flow_def_mut<'a>(
     }
 }
 
+fn toolbar_btn(_theme: &Theme, status: button::Status) -> button::Style {
+    let is_hovered = matches!(status, button::Status::Hovered);
+    button::Style {
+        background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
+        text_color: Color::WHITE,
+        border: iced::Border {
+            color: if is_hovered {
+                Color::WHITE
+            } else {
+                Color::from_rgb(0.4, 0.4, 0.45)
+            },
+            width: 2.0,
+            radius: 8.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn toolbar_btn_active(_theme: &Theme, status: button::Status) -> button::Style {
+    let is_hovered = matches!(status, button::Status::Hovered);
+    button::Style {
+        background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
+        text_color: Color::WHITE,
+        border: iced::Border {
+            color: if is_hovered {
+                Color::WHITE
+            } else {
+                Color::from_rgb(0.4, 0.5, 0.7)
+            },
+            width: 2.0,
+            radius: 8.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
 impl FlowEdit {
     /// Create the application, parsing CLI args and optionally loading a flow file.
     fn new() -> (Self, Task<Message>) {
@@ -1121,47 +1157,13 @@ impl FlowEdit {
         window_id: window::Id,
     ) -> Element<'a, Message> {
         let edit_indicator = if win.history.is_empty() {
-            String::from("  |  saved")
+            "  |  saved"
         } else {
-            String::from("  |  unsaved edit(s)")
+            "  |  unsaved edit(s)"
         };
 
         let btn_pad = [6, 14];
         let btn_size = 13;
-        let toolbar_btn = |_theme: &Theme, status: button::Status| -> button::Style {
-            let is_hovered = matches!(status, button::Status::Hovered);
-            button::Style {
-                background: Some(iced::Background::Color(Color::from_rgb(0.25, 0.25, 0.30))),
-                text_color: Color::WHITE,
-                border: iced::Border {
-                    color: if is_hovered {
-                        Color::WHITE
-                    } else {
-                        Color::from_rgb(0.4, 0.4, 0.45)
-                    },
-                    width: 2.0,
-                    radius: 8.0.into(),
-                },
-                ..Default::default()
-            }
-        };
-        let toolbar_btn_active = |_theme: &Theme, status: button::Status| -> button::Style {
-            let is_hovered = matches!(status, button::Status::Hovered);
-            button::Style {
-                background: Some(iced::Background::Color(Color::from_rgb(0.3, 0.35, 0.5))),
-                text_color: Color::WHITE,
-                border: iced::Border {
-                    color: if is_hovered {
-                        Color::WHITE
-                    } else {
-                        Color::from_rgb(0.4, 0.5, 0.7)
-                    },
-                    width: 2.0,
-                    radius: 8.0.into(),
-                },
-                ..Default::default()
-            }
-        };
 
         let status_bar: Row<'_, Message> = if win.is_root {
             let mut compile_btn = button(Text::new("\u{1F528} Build").size(btn_size).center())
@@ -1171,27 +1173,21 @@ impl FlowEdit {
                 compile_btn = compile_btn.on_press(Message::Compile);
             }
 
-            let new_subflow_btn = button(Text::new("+ Sub-flow").size(btn_size).center())
-                .on_press(Message::NewSubFlow(window_id))
+            let open_btn = button(Text::new("\u{1F4C2} Open").size(btn_size).center())
+                .on_press(Message::Open)
                 .style(toolbar_btn)
                 .padding(btn_pad);
 
-            let new_func_btn = button(Text::new("+ Function").size(btn_size).center())
-                .on_press(Message::NewFunction(window_id))
+            let mut save_btn = button(Text::new("\u{1F4BE} Save").size(btn_size).center())
                 .style(toolbar_btn)
                 .padding(btn_pad);
+            if !win.history.is_empty() {
+                save_btn = save_btn.on_press(Message::Save);
+            }
 
-            let info_btn = button(Text::new("\u{2139} Info").size(btn_size).center())
-                .on_press(Message::FlowEdit(
-                    window_id,
-                    flow_def.route.clone(),
-                    FlowEditMessage::ToggleMetadata,
-                ))
-                .style(if win.show_metadata {
-                    toolbar_btn_active
-                } else {
-                    toolbar_btn
-                })
+            let save_as_btn = button(Text::new("Save As\u{2026}").size(btn_size).center())
+                .on_press(Message::SaveAs)
+                .style(toolbar_btn)
                 .padding(btn_pad);
 
             Row::new()
@@ -1202,7 +1198,23 @@ impl FlowEdit {
                         .width(Fill)
                         .clip(true),
                 )
-                .push(info_btn)
+                .push(open_btn)
+                .push(save_btn)
+                .push(save_as_btn)
+                .push(
+                    button(Text::new("\u{2139} Info").size(btn_size).center())
+                        .on_press(Message::FlowEdit(
+                            window_id,
+                            flow_def.route.clone(),
+                            FlowEditMessage::ToggleMetadata,
+                        ))
+                        .style(if win.show_metadata {
+                            toolbar_btn_active
+                        } else {
+                            toolbar_btn
+                        })
+                        .padding(btn_pad),
+                )
                 .push(
                     button(Text::new("\u{1F4C1} Libs").size(btn_size).center())
                         .on_press(Message::ToggleLibPaths)
@@ -1213,8 +1225,18 @@ impl FlowEdit {
                         })
                         .padding(btn_pad),
                 )
-                .push(new_subflow_btn)
-                .push(new_func_btn)
+                .push(
+                    button(Text::new("+ Sub-flow").size(btn_size).center())
+                        .on_press(Message::NewSubFlow(window_id))
+                        .style(toolbar_btn)
+                        .padding(btn_pad),
+                )
+                .push(
+                    button(Text::new("+ Function").size(btn_size).center())
+                        .on_press(Message::NewFunction(window_id))
+                        .style(toolbar_btn)
+                        .padding(btn_pad),
+                )
                 .push(compile_btn)
         } else {
             Row::new().spacing(8).padding([4, 8]).push(

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -1123,9 +1123,14 @@ impl WindowState {
 
     /// Prompt the user with a save dialog and save to the chosen path.
     pub(crate) fn perform_save_as(&mut self, flow_def: &mut FlowDefinition) {
-        let dialog = rfd::FileDialog::new()
+        let mut dialog = rfd::FileDialog::new()
             .add_filter("Flow", &["toml"])
             .set_file_name(format!("{}.toml", flow_def.name));
+        if let Some(dir) =
+            Self::file_path_of(flow_def).and_then(|p| p.parent().map(Path::to_path_buf))
+        {
+            dialog = dialog.set_directory(dir);
+        }
         if let Some(path) = dialog.save_file() {
             self.perform_save(flow_def, &path);
         }
@@ -1152,7 +1157,12 @@ impl WindowState {
         &mut self,
         flow_def: &mut FlowDefinition,
     ) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
-        let dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
+        let mut dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
+        if let Some(dir) =
+            Self::file_path_of(flow_def).and_then(|p| p.parent().map(Path::to_path_buf))
+        {
+            dialog = dialog.set_directory(dir);
+        }
         if let Some(path) = dialog.pick_file() {
             match file_ops::load_flow(&path) {
                 Ok(loaded_flow) => {

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -1103,10 +1103,13 @@ impl WindowState {
     }
     // --- File operations (from file_ops.rs) ---
 
-    pub(crate) fn perform_save(&mut self, flow_def: &mut FlowDefinition, path: &PathBuf) {
+    fn flow_directory(flow_def: &FlowDefinition) -> Option<PathBuf> {
+        Self::file_path_of(flow_def).and_then(|p| p.parent().map(Path::to_path_buf))
+    }
+
+    pub(crate) fn perform_save(&mut self, flow_def: &mut FlowDefinition, path: &PathBuf) -> bool {
         match file_ops::save_flow_toml(flow_def, path) {
             Ok(()) => {
-                self.history.clear();
                 Self::set_file_path_on(flow_def, path);
                 file_ops::save_editor_prefs(path, self.last_size, self.last_position);
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
@@ -1114,53 +1117,46 @@ impl WindowState {
                 } else {
                     self.status = String::from("Saved");
                 }
+                true
             }
             Err(e) => {
                 self.status = format!("Save failed: {e}");
+                false
             }
         }
     }
 
-    /// Prompt the user with a save dialog and save to the chosen path.
-    pub(crate) fn perform_save_as(&mut self, flow_def: &mut FlowDefinition) {
+    pub(crate) fn perform_save_as(&mut self, flow_def: &mut FlowDefinition) -> bool {
         let mut dialog = rfd::FileDialog::new()
             .add_filter("Flow", &["toml"])
             .set_file_name(format!("{}.toml", flow_def.name));
-        if let Some(dir) =
-            Self::file_path_of(flow_def).and_then(|p| p.parent().map(Path::to_path_buf))
-        {
+        if let Some(dir) = Self::flow_directory(flow_def) {
             dialog = dialog.set_directory(dir);
         }
         if let Some(path) = dialog.save_file() {
-            self.perform_save(flow_def, &path);
+            return self.perform_save(flow_def, &path);
         }
+        false
     }
 
-    /// Handle save message -- saves to existing path or prompts with save dialog.
-    pub(crate) fn handle_save(&mut self, flow_def: &mut FlowDefinition) {
+    pub(crate) fn handle_save(&mut self, flow_def: &mut FlowDefinition) -> bool {
         if let Some(path) = Self::file_path_of(flow_def) {
-            self.perform_save(flow_def, &path);
+            self.perform_save(flow_def, &path)
         } else {
-            self.perform_save_as(flow_def);
+            self.perform_save_as(flow_def)
         }
     }
 
-    /// Handle save-as message -- prompts with save dialog.
-    pub(crate) fn handle_save_as(&mut self, flow_def: &mut FlowDefinition) {
-        self.perform_save_as(flow_def);
+    pub(crate) fn handle_save_as(&mut self, flow_def: &mut FlowDefinition) -> bool {
+        self.perform_save_as(flow_def)
     }
 
-    /// Prompt the user with an open dialog and load the selected flow file.
-    /// Open a flow file and update the window state.
-    /// Returns the loaded flow definition and lib/context references if successful.
     pub(crate) fn perform_open(
         &mut self,
         flow_def: &mut FlowDefinition,
     ) -> Option<(BTreeSet<Url>, BTreeSet<Url>)> {
         let mut dialog = rfd::FileDialog::new().add_filter("Flow", &["toml"]);
-        if let Some(dir) =
-            Self::file_path_of(flow_def).and_then(|p| p.parent().map(Path::to_path_buf))
-        {
+        if let Some(dir) = Self::flow_directory(flow_def) {
             dialog = dialog.set_directory(dir);
         }
         if let Some(path) = dialog.pick_file() {


### PR DESCRIPTION
## Summary
- Add Open, Save, and Save As buttons to the root window toolbar
- Save button is disabled (greyed out) when there are no unsaved changes
- Extract toolbar button style closures into standalone functions to keep `view_toolbar` under the clippy line limit

## Test plan
- [x] `make clippy` passes
- [x] `make test` passes
- [ ] Open flowedit, verify Open/Save/Save As buttons appear in toolbar
- [ ] Verify Save is disabled on fresh load, enabled after making an edit
- [ ] Verify Open opens a file dialog and loads a new flow
- [ ] Verify Save As prompts for a new file path

Closes #2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Open" button added to the toolbar for file access
  * "Save As..." button added to the toolbar for saving with new names
  * Save button now only active/wired when unsaved changes exist
  * File dialogs now open with the current flow's directory preselected

* **Refactor**
  * Toolbar button styling and layout streamlined and reorganized
<!-- end of auto-generated comment: release notes by coderabbit.ai -->