### PR TITLE
flowedit: Inline editing of process names and I/O labels (#2620)

### DIFF
--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -100,6 +100,10 @@ pub(crate) enum CanvasMessage {
     HoverChanged(Option<crate::window_state::Tooltip>),
     /// Right-click on empty canvas — show context menu at screen position
     ContextMenu(f32, f32),
+    /// User clicked on a node's title text — start inline name editing
+    EditNodeName(usize),
+    /// User clicked on a flow I/O port label — start inline editing
+    EditIOName { is_input: bool, index: usize },
 }
 
 /// Tracks the drag-in-progress state: which node and the cursor offset from its origin.
@@ -204,7 +208,7 @@ struct ConnectingState {
 /// Corner radius for rounded rectangles
 pub(crate) const CORNER_RADIUS: f32 = 10.0;
 /// Title font size (minimum readable)
-const TITLE_FONT_SIZE: f32 = 16.0;
+pub(crate) const TITLE_FONT_SIZE: f32 = 16.0;
 /// Source label font size (minimum readable)
 pub(crate) const SOURCE_FONT_SIZE: f32 = 12.0;
 /// Port circle radius
@@ -802,6 +806,47 @@ impl FlowCanvas<'_> {
         None
     }
 
+    fn hit_test_flow_io_label(&self, world_pos: Point) -> Option<(bool, usize)> {
+        if !self.is_subflow {
+            return None;
+        }
+        let (box_x, _, box_w, _, center_y, spacing) =
+            flow_io_bounding_box(&self.nodes, &self.flow_def.inputs, &self.flow_def.outputs);
+        let font_size = 13.0;
+        let label_half_height = font_size / 2.0 + 4.0;
+
+        let input_start_y = center_y - (self.flow_def.inputs.len() as f32 - 1.0) * spacing / 2.0;
+        for (i, input) in self.flow_def.inputs.iter().enumerate() {
+            let port_y = input_start_y + i as f32 * spacing;
+            let label_right = box_x - 10.0;
+            let label_left = label_right - input.name().len() as f32 * font_size * 0.6;
+            if world_pos.x >= label_left
+                && world_pos.x <= label_right
+                && world_pos.y >= port_y - label_half_height
+                && world_pos.y <= port_y + label_half_height
+            {
+                return Some((true, i));
+            }
+        }
+
+        let right_x = box_x + box_w;
+        let output_start_y = center_y - (self.flow_def.outputs.len() as f32 - 1.0) * spacing / 2.0;
+        for (i, output) in self.flow_def.outputs.iter().enumerate() {
+            let port_y = output_start_y + i as f32 * spacing;
+            let label_left = right_x + 10.0;
+            let label_right = label_left + output.name().len() as f32 * font_size * 0.6;
+            if world_pos.x >= label_left
+                && world_pos.x <= label_right
+                && world_pos.y >= port_y - label_half_height
+                && world_pos.y <= port_y + label_half_height
+            {
+                return Some((false, i));
+            }
+        }
+
+        None
+    }
+
     /// Check type compatibility when one endpoint is a flow I/O port and the other is a node port.
     ///
     /// Looks up the flow IO's datatypes from `self.flow_def.inputs`/`outputs` and the
@@ -1107,6 +1152,22 @@ impl FlowCanvas<'_> {
 
         if let Some(idx) = self.hit_test_open_icon(world_pos) {
             return Some(canvas::Action::publish(CanvasMessage::OpenNode(idx)).and_capture());
+        }
+
+        if let Some((is_input, index)) = self.hit_test_flow_io_label(world_pos) {
+            return Some(
+                canvas::Action::publish(CanvasMessage::EditIOName { is_input, index })
+                    .and_capture(),
+            );
+        }
+
+        if let Some((idx, _)) = self
+            .nodes
+            .iter()
+            .enumerate()
+            .find(|(_, n)| n.is_in_title_zone(world_pos))
+        {
+            return Some(canvas::Action::publish(CanvasMessage::EditNodeName(idx)).and_capture());
         }
 
         if let Some(idx) = self.hit_test_node(world_pos) {
@@ -1685,7 +1746,7 @@ impl FlowCanvas<'_> {
             font_size,
             zoom,
             offset,
-            false,
+            true,
         );
         let output_positions = draw_flow_output_port_labels(
             frame,
@@ -1697,7 +1758,7 @@ impl FlowCanvas<'_> {
             font_size,
             zoom,
             offset,
-            false,
+            true,
         );
 
         self.draw_flow_io_connections(
@@ -1952,6 +2013,14 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
 
             if self.hit_test_open_icon(world_pos).is_some() {
                 return mouse::Interaction::Pointer;
+            }
+
+            if self.hit_test_flow_io_label(world_pos).is_some() {
+                return mouse::Interaction::Text;
+            }
+
+            if self.nodes.iter().any(|n| n.is_in_title_zone(world_pos)) {
+                return mouse::Interaction::Text;
             }
 
             if self.hit_test_node(world_pos).is_some() {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1226,6 +1226,7 @@ impl FlowEdit {
         let mut status_row = Row::new()
             .spacing(8)
             .padding([4, 8])
+            .align_y(iced::Alignment::Center)
             .push(
                 container(Text::new(format!("{}{}", win.status, edit_indicator)).size(14))
                     .width(Fill)

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1219,10 +1219,27 @@ impl FlowEdit {
             .view(&self.all_definitions)
             .map(move |msg| Message::Library(window_id, msg));
 
-        let left_panel = Column::new()
-            .push(hierarchy_panel)
-            .push(library_panel)
-            .height(Fill);
+        let mut left_panel = Column::new().push(hierarchy_panel).push(library_panel);
+
+        if self.show_lib_paths {
+            left_panel = left_panel.push(self.view_lib_paths_panel());
+        }
+
+        left_panel = left_panel.push(
+            container(
+                button(Text::new("LibPath").size(12).center())
+                    .on_press(Message::ToggleLibPaths)
+                    .style(if self.show_lib_paths {
+                        toolbar_btn_active
+                    } else {
+                        toolbar_btn
+                    })
+                    .padding([4, 8]),
+            )
+            .padding([4, 8]),
+        );
+
+        let left_panel = left_panel.height(Fill);
 
         let mut right_col: Column<'_, Message> =
             Column::new().push(container(canvas_with_controls).width(Fill).height(Fill));
@@ -1230,11 +1247,6 @@ impl FlowEdit {
         // Metadata editor panel (toggled by Info button)
         if win.show_metadata && matches!(win.kind, WindowKind::FlowEditor) {
             right_col = right_col.push(Self::view_metadata_panel(flow_def, window_id));
-        }
-
-        // Library paths panel (toggled by Libs button)
-        if self.show_lib_paths {
-            right_col = right_col.push(self.view_lib_paths_panel());
         }
 
         let top_row = Row::new().push(left_panel).push(right_col.width(Fill));
@@ -1308,16 +1320,6 @@ impl FlowEdit {
                             FlowEditMessage::ToggleMetadata,
                         ))
                         .style(if win.show_metadata {
-                            toolbar_btn_active
-                        } else {
-                            toolbar_btn
-                        })
-                        .padding(btn_pad),
-                )
-                .push(
-                    button(Text::new("\u{1F4C1} Libs").size(btn_size).center())
-                        .on_press(Message::ToggleLibPaths)
-                        .style(if self.show_lib_paths {
                             toolbar_btn_active
                         } else {
                             toolbar_btn

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -825,6 +825,18 @@ impl FlowEdit {
         let Some(win) = self.windows.get_mut(&win_id) else {
             return Task::none();
         };
+        let io_renamed = if matches!(canvas_msg, CanvasMessage::HoverChanged(_)) {
+            None
+        } else {
+            win.commit_io_name_edit(flow_def)
+        };
+        if let Some((is_input, old_name, new_name)) = io_renamed {
+            self.update_parent_io_rename(&route, is_input, &old_name, &new_name);
+        }
+        let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+        let Some(win) = self.windows.get_mut(&win_id) else {
+            return Task::none();
+        };
         let action = win.handle_canvas_message(flow_def, canvas_msg);
         let close_task = self.close_orphaned_windows();
         let action_task = match action {
@@ -886,6 +898,7 @@ impl FlowEdit {
         self.close_orphaned_windows()
     }
 
+    #[allow(clippy::too_many_lines)]
     fn handle_flow_edit(&mut self, win_id: window::Id, route: &Route, flow_msg: FlowEditMessage) {
         // Redirect IONameCommit through InputNameChanged/OutputNameChanged so
         // update_parent_io_rename runs for sub-flow parent connection propagation.
@@ -956,13 +969,45 @@ impl FlowEdit {
             _ => None,
         };
 
+        let node_rename = match &flow_msg {
+            FlowEditMessage::NodeNameCommit => self
+                .windows
+                .get(&win_id)
+                .and_then(|w| w.name_editor.as_ref())
+                .map(|e| (e.original.clone(), e.text.trim().to_string())),
+            _ => None,
+        };
+
         let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
         if let Some(win) = self.windows.get_mut(&win_id) {
             win.handle_flow_edit_message(flow_def, flow_msg);
         }
 
+        if let Some((old_alias, new_alias)) = node_rename {
+            if !new_alias.is_empty() && new_alias != old_alias {
+                let old_segment = format!("/{old_alias}");
+                let new_segment = format!("/{new_alias}");
+                for win in self.windows.values_mut() {
+                    let route_str = win.route.to_string();
+                    if route_str.contains(&old_segment) {
+                        let updated = route_str.replace(&old_segment, &new_segment);
+                        win.route = Route::from(updated.as_str());
+                    }
+                }
+            }
+        }
+
         if let Some((is_input, old_name, new_name)) = io_rename {
-            self.update_parent_io_rename(route, is_input, &old_name, &new_name);
+            let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
+            let ports = if is_input {
+                &flow_def.inputs
+            } else {
+                &flow_def.outputs
+            };
+            let renamed = ports.iter().any(|io| io.name() == &new_name);
+            if renamed {
+                self.update_parent_io_rename(route, is_input, &old_name, &new_name);
+            }
         }
         if let Some((is_input, deleted_name)) = io_delete {
             self.update_parent_io_delete(route, is_input, &deleted_name);

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -1219,27 +1219,23 @@ impl FlowEdit {
             .view(&self.all_definitions)
             .map(move |msg| Message::Library(window_id, msg));
 
-        let mut left_panel = Column::new().push(hierarchy_panel).push(library_panel);
-
-        if self.show_lib_paths {
-            left_panel = left_panel.push(self.view_lib_paths_panel());
-        }
-
-        left_panel = left_panel.push(
-            container(
-                button(Text::new("LibPath").size(12).center())
-                    .on_press(Message::ToggleLibPaths)
-                    .style(if self.show_lib_paths {
-                        toolbar_btn_active
-                    } else {
-                        toolbar_btn
-                    })
+        let left_panel = if self.show_lib_paths {
+            Column::new().push(self.view_lib_paths_panel()).height(Fill)
+        } else {
+            Column::new()
+                .push(hierarchy_panel)
+                .push(library_panel)
+                .push(
+                    container(
+                        button(Text::new("LibPath").size(12).center())
+                            .on_press(Message::ToggleLibPaths)
+                            .style(toolbar_btn)
+                            .padding([4, 8]),
+                    )
                     .padding([4, 8]),
-            )
-            .padding([4, 8]),
-        );
-
-        let left_panel = left_panel.height(Fill);
+                )
+                .height(Fill)
+        };
 
         let mut right_col: Column<'_, Message> =
             Column::new().push(container(canvas_with_controls).width(Fill).height(Fill));
@@ -1447,8 +1443,25 @@ impl FlowEdit {
 
     /// Build the library paths panel.
     fn view_lib_paths_panel(&self) -> Element<'_, Message> {
-        let mut paths_col = Column::new().spacing(4).padding(12);
-        paths_col = paths_col.push(Text::new("Library Search Paths").size(14));
+        let header = Row::new()
+            .spacing(6)
+            .align_y(iced::Alignment::Center)
+            .push(Text::new("Library Search Paths").size(14))
+            .push(iced::widget::Space::new().width(Fill))
+            .push(
+                button(Text::new("+ Add").size(11).center())
+                    .on_press(Message::AddLibraryPath)
+                    .style(toolbar_btn)
+                    .padding([3, 8]),
+            )
+            .push(
+                button(Text::new("\u{2715}").size(11).center())
+                    .on_press(Message::ToggleLibPaths)
+                    .style(toolbar_btn)
+                    .padding([3, 6]),
+            );
+
+        let mut paths_col = Column::new().spacing(4).padding(8).push(header);
 
         for (i, p) in self.lib_paths.iter().enumerate() {
             let row = Row::new()
@@ -1464,14 +1477,8 @@ impl FlowEdit {
                 );
             paths_col = paths_col.push(row);
         }
-        paths_col = paths_col.push(
-            button(Text::new("+ Add Path...").size(12).center())
-                .on_press(Message::AddLibraryPath)
-                .style(button::secondary)
-                .padding([4, 10]),
-        );
 
-        let lib_panel = container(paths_col)
+        container(paths_col)
             .style(|_theme: &Theme| container::Style {
                 background: Some(iced::Background::Color(Color::from_rgb(0.14, 0.14, 0.18))),
                 border: iced::Border {
@@ -1481,9 +1488,8 @@ impl FlowEdit {
                 },
                 ..Default::default()
             })
-            .width(Fill);
-
-        lib_panel.into()
+            .width(Fill)
+            .into()
     }
 
     fn view_function_definition_tab(

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -887,25 +887,23 @@ impl FlowEdit {
     }
 
     fn handle_flow_edit(&mut self, win_id: window::Id, route: &Route, flow_msg: FlowEditMessage) {
+        // Redirect IONameCommit through InputNameChanged/OutputNameChanged so
+        // update_parent_io_rename runs for sub-flow parent connection propagation.
         if matches!(flow_msg, FlowEditMessage::IONameCommit) {
-            if let Some(win) = self.windows.get(&win_id) {
-                if let Some(ref editor) = win.io_name_editor {
-                    let new_name = editor.text.trim().to_string();
-                    if !new_name.is_empty() && new_name != editor.original {
-                        let redirected = if editor.is_input {
-                            FlowEditMessage::InputNameChanged(editor.index, new_name)
-                        } else {
-                            FlowEditMessage::OutputNameChanged(editor.index, new_name)
-                        };
-                        if let Some(win) = self.windows.get_mut(&win_id) {
-                            win.io_name_editor = None;
-                        }
-                        return self.handle_flow_edit(win_id, route, redirected);
-                    }
+            let editor = self
+                .windows
+                .get_mut(&win_id)
+                .and_then(|w| w.io_name_editor.take());
+            if let Some(editor) = editor {
+                let new_name = editor.text.trim().to_string();
+                if !new_name.is_empty() && new_name != editor.original {
+                    let redirected = if editor.is_input {
+                        FlowEditMessage::InputNameChanged(editor.index, new_name)
+                    } else {
+                        FlowEditMessage::OutputNameChanged(editor.index, new_name)
+                    };
+                    return self.handle_flow_edit(win_id, route, redirected);
                 }
-            }
-            if let Some(win) = self.windows.get_mut(&win_id) {
-                win.io_name_editor = None;
             }
             return;
         }

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -86,6 +86,14 @@ pub(crate) enum FlowEditMessage {
     InputNameChanged(usize, String),
     /// Flow output port name changed
     OutputNameChanged(usize, String),
+    /// Update the text while editing a node name
+    NodeNameEditing(String),
+    /// Commit the node name edit
+    NodeNameCommit,
+    /// Update the text while editing an I/O port name
+    IONameEditing(String),
+    /// Commit the I/O port name edit
+    IONameCommit,
 }
 
 /// Messages for function definition viewing/editing, tagged by window
@@ -176,6 +184,8 @@ enum Message {
     CloseActiveWindow,
     /// Quit the entire application (Cmd+Q)
     QuitAll,
+    /// Escape key pressed — cancel active inline edit
+    EscapePressed,
     /// A window received focus
     WindowFocused(window::Id),
     /// Window was resized — track the new size
@@ -877,6 +887,28 @@ impl FlowEdit {
     }
 
     fn handle_flow_edit(&mut self, win_id: window::Id, route: &Route, flow_msg: FlowEditMessage) {
+        if matches!(flow_msg, FlowEditMessage::IONameCommit) {
+            if let Some(win) = self.windows.get(&win_id) {
+                if let Some(ref editor) = win.io_name_editor {
+                    let new_name = editor.text.trim().to_string();
+                    if !new_name.is_empty() && new_name != editor.original {
+                        let redirected = if editor.is_input {
+                            FlowEditMessage::InputNameChanged(editor.index, new_name)
+                        } else {
+                            FlowEditMessage::OutputNameChanged(editor.index, new_name)
+                        };
+                        if let Some(win) = self.windows.get_mut(&win_id) {
+                            win.io_name_editor = None;
+                        }
+                        return self.handle_flow_edit(win_id, route, redirected);
+                    }
+                }
+            }
+            if let Some(win) = self.windows.get_mut(&win_id) {
+                win.io_name_editor = None;
+            }
+            return;
+        }
         let affects_parent = matches!(
             flow_msg,
             FlowEditMessage::NameChanged(_)
@@ -1036,6 +1068,14 @@ impl FlowEdit {
             }
             Message::Undo => return self.handle_undo_redo(false),
             Message::Redo => return self.handle_undo_redo(true),
+            Message::EscapePressed => {
+                if let Some(win) = self.focused_window.and_then(|id| self.windows.get_mut(&id)) {
+                    win.name_editor = None;
+                    win.io_name_editor = None;
+                    win.initializer_editor = None;
+                    win.context_menu = None;
+                }
+            }
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
                 self.handle_file_message(message);
             }
@@ -1154,10 +1194,11 @@ impl FlowEdit {
             right_col = right_col.push(self.view_lib_paths_panel());
         }
 
-        right_col = right_col.push(self.view_toolbar(win, flow_def, window_id));
-
-        let layout = Row::new().push(left_panel).push(right_col.width(Fill));
-        layout.into()
+        let top_row = Row::new().push(left_panel).push(right_col.width(Fill));
+        Column::new()
+            .push(container(top_row).height(Fill))
+            .push(self.view_toolbar(win, flow_def, window_id))
+            .into()
     }
 
     /// Build the toolbar/status bar with action buttons and status text.
@@ -1728,6 +1769,10 @@ impl FlowEdit {
                 "q" => Some(Message::QuitAll),
                 _ => None,
             },
+            keyboard::Event::KeyPressed {
+                key: keyboard::Key::Named(keyboard::key::Named::Escape),
+                ..
+            } => Some(Message::EscapePressed),
             _ => None,
         });
 

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -931,6 +931,16 @@ impl FlowEdit {
                 | FlowEditMessage::OutputNameChanged(_, _)
         );
 
+        // Clear io_name_editor before deletion to avoid stale auto-commit
+        if matches!(
+            flow_msg,
+            FlowEditMessage::DeleteInput(_) | FlowEditMessage::DeleteOutput(_)
+        ) {
+            if let Some(win) = self.windows.get_mut(&win_id) {
+                win.io_name_editor = None;
+            }
+        }
+
         // Capture deleted I/O name before deletion for parent connection cleanup
         let io_delete = match &flow_msg {
             FlowEditMessage::DeleteInput(idx) => {
@@ -985,13 +995,20 @@ impl FlowEdit {
 
         if let Some((old_alias, new_alias)) = node_rename {
             if !new_alias.is_empty() && new_alias != old_alias {
-                let old_segment = format!("/{old_alias}");
-                let new_segment = format!("/{new_alias}");
-                for win in self.windows.values_mut() {
-                    let route_str = win.route.to_string();
-                    if route_str.contains(&old_segment) {
-                        let updated = route_str.replace(&old_segment, &new_segment);
-                        win.route = Route::from(updated.as_str());
+                let flow_def = resolve_flow_def_mut(&mut self.root_flow, route);
+                let renamed = flow_def.process_refs.iter().any(|p| p.alias == new_alias);
+                if renamed {
+                    let parent_route = route.to_string();
+                    let old_prefix = format!("{parent_route}/{old_alias}");
+                    let new_prefix = format!("{parent_route}/{new_alias}");
+                    for win in self.windows.values_mut() {
+                        let route_str = win.route.to_string();
+                        if route_str == old_prefix
+                            || route_str.starts_with(&format!("{old_prefix}/"))
+                        {
+                            let updated = route_str.replacen(&old_prefix, &new_prefix, 1);
+                            win.route = Route::from(updated.as_str());
+                        }
                     }
                 }
             }
@@ -1120,6 +1137,7 @@ impl FlowEdit {
                 }
             }
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
+                self.flush_pending_edits();
                 self.handle_file_message(message);
             }
             Message::FlowEdit(win_id, ref route, flow_msg) => {
@@ -2284,6 +2302,28 @@ impl FlowEdit {
 
         self.windows.insert(new_id, child);
         open_task.discard()
+    }
+
+    fn flush_pending_edits(&mut self) {
+        let win_ids: Vec<window::Id> = self.windows.keys().copied().collect();
+        let mut io_renames = Vec::new();
+        for win_id in win_ids {
+            let route = self
+                .windows
+                .get(&win_id)
+                .map(|w| w.route.clone())
+                .unwrap_or_default();
+            let flow_def = resolve_flow_def_mut(&mut self.root_flow, &route);
+            if let Some(win) = self.windows.get_mut(&win_id) {
+                win.commit_name_edit(flow_def);
+                if let Some(rename_info) = win.commit_io_name_edit(flow_def) {
+                    io_renames.push((route, rename_info));
+                }
+            }
+        }
+        for (route, (is_input, old_name, new_name)) in io_renames {
+            self.update_parent_io_rename(&route, is_input, &old_name, &new_name);
+        }
     }
 
     fn has_unsaved_flow_edits(&self) -> bool {

--- a/flowedit/src/node_layout.rs
+++ b/flowedit/src/node_layout.rs
@@ -17,6 +17,7 @@ use flowcore::model::name::HasName;
 use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 
+use crate::flow_canvas::TITLE_FONT_SIZE;
 use crate::utils::{base_port_name, derive_short_name, format_value, split_route};
 
 /// Default node width when no layout width is specified
@@ -231,6 +232,18 @@ impl<'a> NodeLayout<'a> {
             }
         }
         None
+    }
+
+    pub(crate) fn is_in_title_zone(&self, point: Point) -> bool {
+        let text_center_x = self.x() + self.width() / 2.0;
+        let text_top_y = self.y() + 6.0;
+        let text_height = TITLE_FONT_SIZE + 8.0;
+        let text_half_width = self.width() * 0.45;
+
+        point.x >= text_center_x - text_half_width
+            && point.x <= text_center_x + text_half_width
+            && point.y >= text_top_y
+            && point.y <= text_top_y + text_height
     }
 
     pub(crate) fn is_in_source_text_zone(&self, point: Point) -> bool {

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::indexing_slicing)]
+#![allow(clippy::indexing_slicing, clippy::unwrap_used)]
 
 use super::*;
 use flowcore::model::connection::Connection;
@@ -2205,4 +2205,352 @@ fn subflow_output_delete_removes_parent_connections() {
         !has_pixels_after,
         "parent connection from deleted output should be removed"
     );
+}
+
+// ---- Group: Inline node name editing ----
+
+#[test]
+fn edit_node_name_opens_editor() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let win = app.windows.get(&win_id).unwrap();
+    assert!(win.name_editor.is_some());
+    let editor = win.name_editor.as_ref().unwrap();
+    assert_eq!(editor.node_index, 0);
+    assert_eq!(editor.text, "add");
+    assert_eq!(editor.original, "add");
+}
+
+#[test]
+fn node_name_editing_updates_text() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("adder".into()),
+    ));
+    let editor = app
+        .windows
+        .get(&win_id)
+        .unwrap()
+        .name_editor
+        .as_ref()
+        .unwrap();
+    assert_eq!(editor.text, "adder");
+}
+
+#[test]
+fn node_name_commit_renames_alias() {
+    let (mut app, win_id) = test_app();
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "stdout"));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("adder".into()),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameCommit,
+    ));
+    assert_eq!(app.root_flow.process_refs[0].alias, "adder");
+    assert!(app.windows.get(&win_id).unwrap().name_editor.is_none());
+    assert_eq!(app.root_flow.connections[0].from().to_string(), "adder");
+}
+
+#[test]
+fn node_name_commit_noop_when_unchanged() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameCommit,
+    ));
+    assert_eq!(app.root_flow.process_refs[0].alias, "add");
+    assert!(app.windows.get(&win_id).unwrap().name_editor.is_none());
+}
+
+#[test]
+fn node_name_commit_rejects_duplicate() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("stdout".into()),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameCommit,
+    ));
+    assert_eq!(app.root_flow.process_refs[0].alias, "add");
+    assert!(app
+        .windows
+        .get(&win_id)
+        .unwrap()
+        .status
+        .contains("already in use"));
+}
+
+#[test]
+fn escape_cancels_name_editor() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("renamed".into()),
+    ));
+    let _ = app.update(Message::EscapePressed);
+    assert!(app.windows.get(&win_id).unwrap().name_editor.is_none());
+    assert_eq!(app.root_flow.process_refs[0].alias, "add");
+}
+
+#[test]
+fn clicking_elsewhere_commits_name_edit() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("adder".into()),
+    ));
+    let _ = app.update(Message::WindowCanvas(win_id, CanvasMessage::Selected(None)));
+    assert_eq!(app.root_flow.process_refs[0].alias, "adder");
+    assert!(app.windows.get(&win_id).unwrap().name_editor.is_none());
+}
+
+#[test]
+fn node_rename_updates_connection_to() {
+    let (mut app, win_id) = test_app();
+    app.root_flow
+        .connections
+        .push(Connection::new("add", "stdout"));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(1),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("output".into()),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameCommit,
+    ));
+    assert_eq!(app.root_flow.process_refs[1].alias, "output");
+    let to_routes: Vec<String> = app.root_flow.connections[0]
+        .to()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    assert!(to_routes.iter().any(|r| r.contains("output")));
+}
+
+// ---- Group: Inline I/O name editing ----
+
+#[test]
+fn edit_io_name_opens_editor() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditIOName {
+            is_input: true,
+            index: 0,
+        },
+    ));
+    let win = app.windows.get(&win_id).unwrap();
+    assert!(win.io_name_editor.is_some());
+    let editor = win.io_name_editor.as_ref().unwrap();
+    assert!(editor.is_input);
+    assert_eq!(editor.index, 0);
+}
+
+#[test]
+fn io_name_editing_updates_text() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditIOName {
+            is_input: true,
+            index: 0,
+        },
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::IONameEditing("data_in".into()),
+    ));
+    let editor = app
+        .windows
+        .get(&win_id)
+        .unwrap()
+        .io_name_editor
+        .as_ref()
+        .unwrap();
+    assert_eq!(editor.text, "data_in");
+}
+
+#[test]
+fn io_name_commit_renames_input() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddInput,
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditIOName {
+            is_input: true,
+            index: 0,
+        },
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::IONameEditing("data_in".into()),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::IONameCommit,
+    ));
+    assert_eq!(app.root_flow.inputs[0].name(), "data_in");
+    assert!(app.windows.get(&win_id).unwrap().io_name_editor.is_none());
+}
+
+#[test]
+fn escape_cancels_io_name_editor() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::AddOutput,
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditIOName {
+            is_input: false,
+            index: 0,
+        },
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::IONameEditing("renamed".into()),
+    ));
+    let _ = app.update(Message::EscapePressed);
+    assert!(app.windows.get(&win_id).unwrap().io_name_editor.is_none());
+    assert_eq!(app.root_flow.outputs[0].name(), "output0");
+}
+
+#[test]
+fn switching_edit_commits_previous() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(0),
+    ));
+    let _ = app.update(Message::FlowEdit(
+        win_id,
+        Route::default(),
+        FlowEditMessage::NodeNameEditing("adder".into()),
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::EditNodeName(1),
+    ));
+    assert_eq!(app.root_flow.process_refs[0].alias, "adder");
+    let win = app.windows.get(&win_id).unwrap();
+    assert_eq!(win.name_editor.as_ref().unwrap().node_index, 1);
+}
+
+// ---- Group: is_in_title_zone ----
+
+#[test]
+fn title_zone_hit_test() {
+    use crate::node_layout::NodeLayout;
+    use flowcore::model::process_reference::ProcessReference;
+    use iced::Point;
+    use std::collections::BTreeMap;
+
+    let pref = ProcessReference {
+        alias: "test".into(),
+        source: "lib://test".into(),
+        initializations: BTreeMap::new(),
+        x: Some(100.0),
+        y: Some(100.0),
+        width: Some(180.0),
+        height: Some(120.0),
+    };
+    let node = NodeLayout {
+        process_ref: &pref,
+        process: None,
+    };
+    assert!(node.is_in_title_zone(Point::new(190.0, 115.0)));
+    assert!(!node.is_in_title_zone(Point::new(190.0, 80.0)));
+    assert!(!node.is_in_title_zone(Point::new(190.0, 200.0)));
+    assert!(!node.is_in_title_zone(Point::new(50.0, 115.0)));
+}
+
+// ---- Group: has_unsaved_flow_edits ----
+
+#[test]
+fn has_unsaved_flow_edits_false_initially() {
+    let (app, _) = test_app();
+    assert!(!app.has_unsaved_flow_edits());
+}
+
+#[test]
+fn has_unsaved_flow_edits_true_after_edit() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::Moved(0, 200.0, 200.0),
+    ));
+    let _ = app.update(Message::WindowCanvas(
+        win_id,
+        CanvasMessage::MoveCompleted(0, 100.0, 100.0, 200.0, 200.0),
+    ));
+    assert!(app.has_unsaved_flow_edits());
 }

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -731,17 +731,15 @@ fn lib_paths_add_message() {
 
 #[test]
 fn lib_paths_remove_message() {
-    let saved = std::env::var("FLOW_LIB_PATH").ok();
+    // Add a path then remove it so update_lib_paths() restores FLOW_LIB_PATH
+    // to its original value. Tests run as threads in the same process, so
+    // env var mutations from set_var are visible to all concurrent tests.
     let (mut app, _) = test_app();
-    app.lib_paths.push("/tmp/test_lib".into());
-    let count_before = app.lib_paths.len();
-    let _ = app.update(Message::RemoveLibraryPath(count_before - 1));
-    assert_eq!(app.lib_paths.len(), count_before - 1);
-    if let Some(val) = saved {
-        std::env::set_var("FLOW_LIB_PATH", val);
-    } else {
-        std::env::remove_var("FLOW_LIB_PATH");
-    }
+    let initial_count = app.lib_paths.len();
+    app.lib_paths.push("/tmp/flowedit_test_lib_path".into());
+    assert_eq!(app.lib_paths.len(), initial_count + 1);
+    let _ = app.update(Message::RemoveLibraryPath(initial_count));
+    assert_eq!(app.lib_paths.len(), initial_count);
 }
 
 #[test]

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -731,11 +731,17 @@ fn lib_paths_add_message() {
 
 #[test]
 fn lib_paths_remove_message() {
+    let saved = std::env::var("FLOW_LIB_PATH").ok();
     let (mut app, _) = test_app();
     app.lib_paths.push("/tmp/test_lib".into());
     let count_before = app.lib_paths.len();
     let _ = app.update(Message::RemoveLibraryPath(count_before - 1));
     assert_eq!(app.lib_paths.len(), count_before - 1);
+    if let Some(val) = saved {
+        std::env::set_var("FLOW_LIB_PATH", val);
+    } else {
+        std::env::remove_var("FLOW_LIB_PATH");
+    }
 }
 
 #[test]
@@ -1469,6 +1475,22 @@ fn load_mandlebrot_app() -> (FlowEdit, window::Id, std::path::PathBuf) {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    if let Ok(home) = std::env::var("HOME") {
+        let default_lib = std::path::PathBuf::from(&home).join(".flow").join("lib");
+        if default_lib.exists() {
+            let current = std::env::var("FLOW_LIB_PATH").unwrap_or_default();
+            let default_str = default_lib.to_string_lossy();
+            if !current.contains(default_str.as_ref()) {
+                let new_val = if current.is_empty() {
+                    default_str.to_string()
+                } else {
+                    format!("{current},{default_str}")
+                };
+                std::env::set_var("FLOW_LIB_PATH", new_val);
+            }
+        }
+    }
 
     let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -695,6 +695,50 @@ fn click_libs_toggles_panel() {
 }
 
 #[test]
+fn lib_paths_panel_replaces_hierarchy() {
+    let (mut app, win_id) = test_app();
+    let _ = app.update(Message::ToggleLibPaths);
+    assert!(app.show_lib_paths);
+    let view = app.view(win_id);
+    let mut sim = simulator(view);
+    assert!(
+        sim.find("Library Search Paths").is_ok(),
+        "LibPath panel should be visible"
+    );
+    assert!(
+        sim.find("+ Add").is_ok(),
+        "Add button should be in LibPath header"
+    );
+}
+
+#[test]
+fn lib_paths_close_button_hides_panel() {
+    let (mut app, _win_id) = test_app();
+    let _ = app.update(Message::ToggleLibPaths);
+    assert!(app.show_lib_paths);
+    let _ = app.update(Message::ToggleLibPaths);
+    assert!(!app.show_lib_paths);
+}
+
+#[test]
+fn lib_paths_add_message() {
+    let (mut app, _) = test_app();
+    let initial_count = app.lib_paths.len();
+    let _ = app.update(Message::ToggleLibPaths);
+    assert!(app.show_lib_paths);
+    assert_eq!(app.lib_paths.len(), initial_count);
+}
+
+#[test]
+fn lib_paths_remove_message() {
+    let (mut app, _) = test_app();
+    app.lib_paths.push("/tmp/test_lib".into());
+    let count_before = app.lib_paths.len();
+    let _ = app.update(Message::RemoveLibraryPath(count_before - 1));
+    assert_eq!(app.lib_paths.len(), count_before - 1);
+}
+
+#[test]
 fn metadata_panel_shows_fields() {
     let (mut app, win_id) = test_app();
     click_and_update(&mut app, win_id, "\u{2139} Info");

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -688,9 +688,9 @@ fn click_info_toggles_metadata() {
 fn click_libs_toggles_panel() {
     let (mut app, win_id) = test_app();
     assert!(!app.show_lib_paths);
-    click_and_update(&mut app, win_id, "\u{1F4C1} Libs");
+    click_and_update(&mut app, win_id, "LibPath");
     assert!(app.show_lib_paths);
-    click_and_update(&mut app, win_id, "\u{1F4C1} Libs");
+    let _ = app.update(Message::ToggleLibPaths);
     assert!(!app.show_lib_paths);
 }
 

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1474,6 +1474,8 @@ fn load_mandlebrot_app() -> (FlowEdit, window::Id, std::path::PathBuf) {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
 
+    // Ensure ~/.flow/lib is on FLOW_LIB_PATH so lib:// URLs resolve.
+    // Only adds if not already present — idempotent across concurrent calls.
     if let Ok(home) = std::env::var("HOME") {
         let default_lib = std::path::PathBuf::from(&home).join(".flow").join("lib");
         if default_lib.exists() {

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -388,7 +388,6 @@ impl WindowState {
     ) -> CanvasAction {
         if !matches!(msg, CanvasMessage::HoverChanged(_)) {
             self.commit_name_edit(flow_def);
-            self.commit_io_name_edit(flow_def);
         }
         match msg {
             CanvasMessage::Selected(idx) => self.handle_selected(flow_def, idx),
@@ -1320,6 +1319,8 @@ impl WindowState {
                     self.tooltip = None;
                     self.context_menu = None;
                     self.initializer_editor = None;
+                    self.name_editor = None;
+                    self.io_name_editor = None;
                     self.show_metadata = false;
                     self.history = EditHistory::default();
                     self.auto_fit_pending = true;
@@ -1346,6 +1347,8 @@ impl WindowState {
         self.tooltip = None;
         self.context_menu = None;
         self.initializer_editor = None;
+        self.name_editor = None;
+        self.io_name_editor = None;
         self.show_metadata = false;
         self.history = EditHistory::default();
         self.auto_fit_pending = false;
@@ -1797,7 +1800,7 @@ impl WindowState {
 
     // --- Flow editing (from main.rs) ---
 
-    fn rename_flow_input(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) {
+    fn rename_flow_input(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) -> bool {
         let duplicate = flow_def
             .inputs
             .iter()
@@ -1805,7 +1808,7 @@ impl WindowState {
             .any(|(i, io)| i != idx && io.name() == name);
         if duplicate {
             self.status = format!("Input name \"{name}\" already in use");
-            return;
+            return false;
         }
         if let Some(io) = flow_def.inputs.get_mut(idx) {
             let old_name = io.name().clone();
@@ -1821,9 +1824,15 @@ impl WindowState {
         self.status = String::new();
         self.history.mark_modified();
         self.canvas_state.request_redraw();
+        true
     }
 
-    fn rename_flow_output(&mut self, flow_def: &mut FlowDefinition, idx: usize, name: &str) {
+    fn rename_flow_output(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+        idx: usize,
+        name: &str,
+    ) -> bool {
         let duplicate = flow_def
             .outputs
             .iter()
@@ -1831,7 +1840,7 @@ impl WindowState {
             .any(|(i, io)| i != idx && io.name() == name);
         if duplicate {
             self.status = format!("Output name \"{name}\" already in use");
-            return;
+            return false;
         }
         if let Some(io) = flow_def.outputs.get_mut(idx) {
             let old_name = io.name().clone();
@@ -1856,6 +1865,7 @@ impl WindowState {
         self.status = String::new();
         self.history.mark_modified();
         self.canvas_state.request_redraw();
+        true
     }
 
     /// Handle flow metadata and I/O editing messages.
@@ -1965,17 +1975,24 @@ impl WindowState {
         }
     }
 
-    fn commit_io_name_edit(&mut self, flow_def: &mut FlowDefinition) {
-        if let Some(editor) = self.io_name_editor.take() {
-            let new_name = editor.text.trim().to_string();
-            if !new_name.is_empty() && new_name != editor.original {
-                if editor.is_input {
-                    self.rename_flow_input(flow_def, editor.index, &new_name);
-                } else {
-                    self.rename_flow_output(flow_def, editor.index, &new_name);
-                }
+    pub(crate) fn commit_io_name_edit(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+    ) -> Option<(bool, String, String)> {
+        let editor = self.io_name_editor.take()?;
+        let new_name = editor.text.trim().to_string();
+        if !new_name.is_empty() && new_name != editor.original {
+            let old_name = editor.original.clone();
+            let success = if editor.is_input {
+                self.rename_flow_input(flow_def, editor.index, &new_name)
+            } else {
+                self.rename_flow_output(flow_def, editor.index, &new_name)
+            };
+            if success {
+                return Some((editor.is_input, old_name, new_name));
             }
         }
+        None
     }
 
     fn commit_name_edit(&mut self, flow_def: &mut FlowDefinition) {
@@ -2011,6 +2028,9 @@ impl WindowState {
         }
         if let Some(pref) = flow_def.process_refs.get_mut(idx) {
             pref.alias = new_alias.into();
+        }
+        if let Some(proc) = flow_def.subprocesses.remove(old_alias) {
+            flow_def.subprocesses.insert(new_alias.into(), proc);
         }
         for conn in &mut flow_def.connections {
             let (from_node, from_port) = split_route(conn.from().as_ref());

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -386,12 +386,7 @@ impl WindowState {
         flow_def: &mut FlowDefinition,
         msg: CanvasMessage,
     ) -> CanvasAction {
-        if !matches!(
-            msg,
-            CanvasMessage::EditNodeName(_)
-                | CanvasMessage::EditIOName { .. }
-                | CanvasMessage::HoverChanged(_)
-        ) {
+        if !matches!(msg, CanvasMessage::HoverChanged(_)) {
             self.commit_name_edit(flow_def);
             self.commit_io_name_edit(flow_def);
         }
@@ -1999,11 +1994,17 @@ impl WindowState {
         old_alias: &str,
         new_alias: &str,
     ) {
-        let duplicate = flow_def
-            .process_refs
-            .iter()
-            .enumerate()
-            .any(|(i, p)| i != idx && p.alias == new_alias);
+        let duplicate = flow_def.process_refs.iter().enumerate().any(|(i, p)| {
+            if i == idx {
+                return false;
+            }
+            let effective = if p.alias.is_empty() {
+                derive_short_name(&p.source)
+            } else {
+                p.alias.clone()
+            };
+            effective == new_alias
+        });
         if duplicate {
             self.status = format!("Name \"{new_alias}\" already in use");
             return;

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -1995,7 +1995,7 @@ impl WindowState {
         None
     }
 
-    fn commit_name_edit(&mut self, flow_def: &mut FlowDefinition) {
+    pub(crate) fn commit_name_edit(&mut self, flow_def: &mut FlowDefinition) {
         if let Some(editor) = self.name_editor.take() {
             let new_name = editor.text.trim().to_string();
             if !new_name.is_empty() && new_name != editor.original {

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -28,7 +28,7 @@ use flowcore::model::route::Route;
 
 use crate::file_ops;
 use crate::flow_canvas::{
-    flow_io_bounding_box, transform_point, CanvasAction, CanvasMessage, FlowCanvas,
+    flow_io_bounding_box, transform_point, CanvasAction, CanvasMessage, FlowCanvas, TITLE_FONT_SIZE,
 };
 use crate::hierarchy_panel::FlowHierarchy;
 use crate::history::{EditAction, EditHistory};
@@ -64,6 +64,21 @@ pub(crate) struct InitializerEditor {
     pub(crate) init_type: String,
     /// The value as a string (JSON)
     pub(crate) value_text: String,
+}
+
+/// State for inline node name editing on the canvas.
+pub(crate) struct NameEditor {
+    pub(crate) node_index: usize,
+    pub(crate) text: String,
+    pub(crate) original: String,
+}
+
+/// State for inline I/O port name editing on the canvas.
+pub(crate) struct IONameEditor {
+    pub(crate) is_input: bool,
+    pub(crate) index: usize,
+    pub(crate) text: String,
+    pub(crate) original: String,
 }
 
 /// State for a function definition viewer/editor window.
@@ -292,6 +307,10 @@ pub(crate) struct WindowState {
     pub(crate) tooltip: Option<Tooltip>,
     /// Active initializer editor dialog, if any
     pub(crate) initializer_editor: Option<InitializerEditor>,
+    /// Active inline node name editor, if any
+    pub(crate) name_editor: Option<NameEditor>,
+    /// Active inline I/O port name editor, if any
+    pub(crate) io_name_editor: Option<IONameEditor>,
     /// Whether this is the root (main) window
     pub(crate) is_root: bool,
     /// Context menu position (screen coords), if showing
@@ -320,6 +339,8 @@ impl Default for WindowState {
             auto_fit_enabled: false,
             tooltip: None,
             initializer_editor: None,
+            name_editor: None,
+            io_name_editor: None,
             is_root: false,
             context_menu: None,
             show_metadata: false,
@@ -365,6 +386,15 @@ impl WindowState {
         flow_def: &mut FlowDefinition,
         msg: CanvasMessage,
     ) -> CanvasAction {
+        if !matches!(
+            msg,
+            CanvasMessage::EditNodeName(_)
+                | CanvasMessage::EditIOName { .. }
+                | CanvasMessage::HoverChanged(_)
+        ) {
+            self.commit_name_edit(flow_def);
+            self.commit_io_name_edit(flow_def);
+        }
         match msg {
             CanvasMessage::Selected(idx) => self.handle_selected(flow_def, idx),
             CanvasMessage::Moved(idx, x, y) => {
@@ -466,6 +496,36 @@ impl WindowState {
             }
             CanvasMessage::OpenNode(idx) => {
                 return CanvasAction::OpenNode(idx);
+            }
+            CanvasMessage::EditIOName { is_input, index } => {
+                let ports = if is_input {
+                    &flow_def.inputs
+                } else {
+                    &flow_def.outputs
+                };
+                if let Some(port) = ports.get(index) {
+                    let name = port.name().clone();
+                    self.io_name_editor = Some(IONameEditor {
+                        is_input,
+                        index,
+                        text: name.clone(),
+                        original: name,
+                    });
+                }
+            }
+            CanvasMessage::EditNodeName(idx) => {
+                if let Some(pref) = flow_def.process_refs.get(idx) {
+                    let alias = if pref.alias.is_empty() {
+                        derive_short_name(&pref.source)
+                    } else {
+                        pref.alias.clone()
+                    };
+                    self.name_editor = Some(NameEditor {
+                        node_index: idx,
+                        text: alias.clone(),
+                        original: alias,
+                    });
+                }
             }
             CanvasMessage::ContextMenu(x, y) => {
                 self.context_menu = Some(crate::window_state::MenuPosition { x, y });
@@ -706,6 +766,7 @@ impl WindowState {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn view_canvas_area<'a>(
         &'a self,
         flow_def: &'a FlowDefinition,
@@ -801,6 +862,24 @@ impl WindowState {
             canvas_stack.push(Self::build_tooltip_overlay(tip));
         }
 
+        if let Some(ref editor) = self.name_editor {
+            canvas_stack.push(Self::build_name_editor_overlay(
+                editor,
+                flow_def,
+                &self.canvas_state,
+                window_id,
+            ));
+        }
+
+        if let Some(ref editor) = self.io_name_editor {
+            canvas_stack.push(Self::build_io_name_editor_overlay(
+                editor,
+                flow_def,
+                &self.canvas_state,
+                window_id,
+            ));
+        }
+
         if let Some(ref editor) = self.initializer_editor {
             canvas_stack.push(self.build_initializer_dialog(flow_def, window_id, editor));
         }
@@ -812,7 +891,62 @@ impl WindowState {
         stack(canvas_stack).into()
     }
 
-    fn build_flow_io_overlays<'a>(
+    fn build_name_editor_overlay<'a>(
+        editor: &'a NameEditor,
+        flow_def: &'a FlowDefinition,
+        canvas_state: &FlowCanvasState,
+        window_id: window::Id,
+    ) -> Element<'a, Message> {
+        let route = flow_def.route.clone();
+        let zoom = canvas_state.zoom;
+        let offset = canvas_state.scroll_offset;
+
+        if let Some(pref) = flow_def.process_refs.get(editor.node_index) {
+            let node_x = pref.x.unwrap_or(100.0);
+            let node_y = pref.y.unwrap_or(100.0);
+            let node_w = pref.width.unwrap_or(180.0);
+            let screen_pos = transform_point(
+                Point::new(node_x + node_w / 2.0, node_y + 8.0),
+                zoom,
+                offset,
+            );
+            let input_width = (node_w * zoom).max(100.0);
+
+            let route_edit = route.clone();
+            let name_input = text_input("name", &editor.text)
+                .on_input(move |s| {
+                    Message::FlowEdit(
+                        window_id,
+                        route_edit.clone(),
+                        FlowEditMessage::NodeNameEditing(s),
+                    )
+                })
+                .on_submit(Message::FlowEdit(
+                    window_id,
+                    route.clone(),
+                    FlowEditMessage::NodeNameCommit,
+                ))
+                .size(TITLE_FONT_SIZE * zoom)
+                .padding(2)
+                .width(input_width);
+
+            return container(name_input)
+                .width(Fill)
+                .height(Fill)
+                .padding(iced::Padding {
+                    top: (screen_pos.y - 4.0).max(0.0),
+                    left: (screen_pos.x - input_width / 2.0).max(0.0),
+                    right: 0.0,
+                    bottom: 0.0,
+                })
+                .into();
+        }
+
+        container(Text::new("")).into()
+    }
+
+    fn build_io_name_editor_overlay<'a>(
+        editor: &'a IONameEditor,
         flow_def: &'a FlowDefinition,
         canvas_state: &FlowCanvasState,
         window_id: window::Id,
@@ -823,136 +957,154 @@ impl WindowState {
         let zoom = canvas_state.zoom;
         let offset = canvas_state.scroll_offset;
         let route = flow_def.route.clone();
-        let right_x = box_x + box_w;
 
+        let ports = if editor.is_input {
+            &flow_def.inputs
+        } else {
+            &flow_def.outputs
+        };
+        let port_count = ports.len();
+        let start_y = center_y - (port_count as f32 - 1.0) * spacing / 2.0;
+        let port_y = start_y + editor.index as f32 * spacing;
+        let port_x = if editor.is_input {
+            box_x
+        } else {
+            box_x + box_w
+        };
+        let screen_pos = transform_point(Point::new(port_x, port_y), zoom, offset);
+
+        let route_edit = route.clone();
+        let name_input = text_input("name", &editor.text)
+            .on_input(move |s| {
+                Message::FlowEdit(
+                    window_id,
+                    route_edit.clone(),
+                    FlowEditMessage::IONameEditing(s),
+                )
+            })
+            .on_submit(Message::FlowEdit(
+                window_id,
+                route.clone(),
+                FlowEditMessage::IONameCommit,
+            ))
+            .size(PORT_FONT_SIZE)
+            .padding(2)
+            .width(80);
+
+        let route_del = route;
+        let del_msg = if editor.is_input {
+            FlowEditMessage::DeleteInput(editor.index)
+        } else {
+            FlowEditMessage::DeleteOutput(editor.index)
+        };
+        let del_btn = button(Text::new("\u{2715}").size(9))
+            .on_press(Message::FlowEdit(window_id, route_del, del_msg))
+            .style(button::text)
+            .padding([1, 3]);
+
+        let row = if editor.is_input {
+            Row::new()
+                .spacing(2)
+                .align_y(iced::Alignment::Center)
+                .push(del_btn)
+                .push(name_input)
+        } else {
+            Row::new()
+                .spacing(2)
+                .align_y(iced::Alignment::Center)
+                .push(name_input)
+                .push(del_btn)
+        };
+
+        let left = if editor.is_input {
+            (screen_pos.x - 100.0).max(0.0)
+        } else {
+            screen_pos.x + 8.0
+        };
+
+        container(row)
+            .width(Fill)
+            .height(Fill)
+            .padding(iced::Padding {
+                top: (screen_pos.y - 12.0).max(0.0),
+                left,
+                right: 0.0,
+                bottom: 0.0,
+            })
+            .into()
+    }
+
+    fn build_flow_io_overlays<'a>(
+        flow_def: &'a FlowDefinition,
+        canvas_state: &FlowCanvasState,
+        window_id: window::Id,
+    ) -> Element<'a, Message> {
         let mut layers: Vec<Element<'_, Message>> = Vec::new();
-
-        Self::build_io_layers(
-            &mut layers,
-            &flow_def.inputs,
-            box_x,
-            center_y,
-            spacing,
-            zoom,
-            offset,
-            &route,
-            window_id,
-            true,
-        );
-        Self::build_io_layers(
-            &mut layers,
-            &flow_def.outputs,
-            right_x,
-            center_y,
-            spacing,
-            zoom,
-            offset,
-            &route,
-            window_id,
-            false,
-        );
-
+        Self::build_io_add_buttons(&mut layers, flow_def, canvas_state, window_id);
         stack(layers).into()
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn build_io_layers<'a>(
+    fn build_io_add_buttons<'a>(
         layers: &mut Vec<Element<'a, Message>>,
-        ports: &'a [IO],
-        port_x: f32,
-        center_y: f32,
-        spacing: f32,
-        zoom: f32,
-        offset: Point,
-        route: &Route,
+        flow_def: &'a FlowDefinition,
+        canvas_state: &FlowCanvasState,
         window_id: window::Id,
-        is_input: bool,
     ) {
+        let nodes = NodeLayout::build_from_flow(flow_def);
+        let (box_x, _, box_w, _, center_y, spacing) =
+            flow_io_bounding_box(&nodes, &flow_def.inputs, &flow_def.outputs);
+        let zoom = canvas_state.zoom;
+        let offset = canvas_state.scroll_offset;
+        let route = flow_def.route.clone();
+        let right_x = box_x + box_w;
         let row_height = 24.0;
-        let (row_x_offset, add_x_offset) = if is_input {
-            (-100.0, -60.0)
-        } else {
-            (8.0, 8.0)
-        };
-        let start_y = center_y - (ports.len() as f32 - 1.0) * spacing / 2.0;
 
-        for (i, port) in ports.iter().enumerate() {
-            let world_y = start_y + i as f32 * spacing;
-            let screen_pos = transform_point(Point::new(port_x, world_y), zoom, offset);
-            let route_clone = route.clone();
-
-            let name_input = text_input("name", port.name())
-                .on_input(move |s| {
-                    let msg = if is_input {
-                        FlowEditMessage::InputNameChanged(i, s)
-                    } else {
-                        FlowEditMessage::OutputNameChanged(i, s)
-                    };
-                    Message::FlowEdit(window_id, route_clone.clone(), msg)
-                })
-                .size(PORT_FONT_SIZE)
-                .padding(2)
-                .width(80);
-
-            let route_del = route.clone();
-            let del_msg = if is_input {
-                FlowEditMessage::DeleteInput(i)
-            } else {
-                FlowEditMessage::DeleteOutput(i)
-            };
-            let del_btn = button(Text::new("\u{2715}").size(9))
-                .on_press(Message::FlowEdit(window_id, route_del, del_msg))
-                .style(button::text)
-                .padding([1, 3]);
-
-            let row = if is_input {
-                Row::new()
-                    .spacing(2)
-                    .align_y(iced::Alignment::Center)
-                    .push(del_btn)
-                    .push(name_input)
-            } else {
-                Row::new()
-                    .spacing(2)
-                    .align_y(iced::Alignment::Center)
-                    .push(name_input)
-                    .push(del_btn)
-            };
-
-            layers.push(
-                container(row)
-                    .width(Fill)
-                    .height(Fill)
-                    .padding(iced::Padding {
-                        top: (screen_pos.y - row_height / 2.0).max(0.0),
-                        left: (screen_pos.x + row_x_offset).max(0.0),
-                        right: 0.0,
-                        bottom: 0.0,
-                    })
-                    .into(),
-            );
-        }
-
-        let add_y = start_y + ports.len() as f32 * spacing;
-        let add_screen = transform_point(Point::new(port_x, add_y), zoom, offset);
-        let route_add = route.clone();
-        let (add_label, add_msg) = if is_input {
-            ("+ Input", FlowEditMessage::AddInput)
-        } else {
-            ("+ Output", FlowEditMessage::AddOutput)
-        };
+        let input_start_y = center_y - (flow_def.inputs.len() as f32 - 1.0) * spacing / 2.0;
+        let input_add_y = input_start_y + flow_def.inputs.len() as f32 * spacing;
+        let input_screen = transform_point(Point::new(box_x, input_add_y), zoom, offset);
+        let route_add_in = route.clone();
         layers.push(
             container(
-                button(Text::new(add_label).size(10))
-                    .on_press(Message::FlowEdit(window_id, route_add, add_msg))
-                    .style(button::text)
-                    .padding([2, 4]),
+                button(Text::new("+ Input").size(10).center())
+                    .on_press(Message::FlowEdit(
+                        window_id,
+                        route_add_in,
+                        FlowEditMessage::AddInput,
+                    ))
+                    .style(crate::toolbar_btn)
+                    .padding([4, 8]),
             )
             .width(Fill)
             .height(Fill)
             .padding(iced::Padding {
-                top: (add_screen.y - row_height / 2.0).max(0.0),
-                left: (add_screen.x + add_x_offset).max(0.0),
+                top: (input_screen.y - row_height / 2.0).max(0.0),
+                left: (input_screen.x - 70.0).max(0.0),
+                right: 0.0,
+                bottom: 0.0,
+            })
+            .into(),
+        );
+
+        let output_start_y = center_y - (flow_def.outputs.len() as f32 - 1.0) * spacing / 2.0;
+        let output_add_y = output_start_y + flow_def.outputs.len() as f32 * spacing;
+        let output_screen = transform_point(Point::new(right_x, output_add_y), zoom, offset);
+        let route_add_out = route;
+        layers.push(
+            container(
+                button(Text::new("+ Output").size(10).center())
+                    .on_press(Message::FlowEdit(
+                        window_id,
+                        route_add_out,
+                        FlowEditMessage::AddOutput,
+                    ))
+                    .style(crate::toolbar_btn)
+                    .padding([4, 8]),
+            )
+            .width(Fill)
+            .height(Fill)
+            .padding(iced::Padding {
+                top: (output_screen.y - row_height / 2.0).max(0.0),
+                left: (output_screen.x + 8.0).max(0.0),
                 right: 0.0,
                 bottom: 0.0,
             })
@@ -1712,6 +1864,7 @@ impl WindowState {
     }
 
     /// Handle flow metadata and I/O editing messages.
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn handle_flow_edit_message(
         &mut self,
         flow_def: &mut FlowDefinition,
@@ -1800,7 +1953,96 @@ impl WindowState {
             FlowEditMessage::OutputNameChanged(idx, name) => {
                 self.rename_flow_output(flow_def, idx, &name);
             }
+            FlowEditMessage::NodeNameEditing(text) => {
+                if let Some(ref mut editor) = self.name_editor {
+                    editor.text = text;
+                }
+            }
+            FlowEditMessage::NodeNameCommit => {
+                self.commit_name_edit(flow_def);
+            }
+            FlowEditMessage::IONameEditing(text) => {
+                if let Some(ref mut editor) = self.io_name_editor {
+                    editor.text = text;
+                }
+            }
+            FlowEditMessage::IONameCommit => {}
         }
+    }
+
+    fn commit_io_name_edit(&mut self, flow_def: &mut FlowDefinition) {
+        if let Some(editor) = self.io_name_editor.take() {
+            let new_name = editor.text.trim().to_string();
+            if !new_name.is_empty() && new_name != editor.original {
+                if editor.is_input {
+                    self.rename_flow_input(flow_def, editor.index, &new_name);
+                } else {
+                    self.rename_flow_output(flow_def, editor.index, &new_name);
+                }
+            }
+        }
+    }
+
+    fn commit_name_edit(&mut self, flow_def: &mut FlowDefinition) {
+        if let Some(editor) = self.name_editor.take() {
+            let new_name = editor.text.trim().to_string();
+            if !new_name.is_empty() && new_name != editor.original {
+                self.rename_process(flow_def, editor.node_index, &editor.original, &new_name);
+            }
+        }
+    }
+
+    fn rename_process(
+        &mut self,
+        flow_def: &mut FlowDefinition,
+        idx: usize,
+        old_alias: &str,
+        new_alias: &str,
+    ) {
+        let duplicate = flow_def
+            .process_refs
+            .iter()
+            .enumerate()
+            .any(|(i, p)| i != idx && p.alias == new_alias);
+        if duplicate {
+            self.status = format!("Name \"{new_alias}\" already in use");
+            return;
+        }
+        if let Some(pref) = flow_def.process_refs.get_mut(idx) {
+            pref.alias = new_alias.into();
+        }
+        for conn in &mut flow_def.connections {
+            let (from_node, from_port) = split_route(conn.from().as_ref());
+            if from_node == old_alias {
+                let new_from = if from_port.is_empty() {
+                    new_alias.to_string()
+                } else {
+                    format!("{new_alias}/{from_port}")
+                };
+                conn.set_from(Route::from(new_from.as_str()));
+            }
+            let new_to: Vec<Route> = conn
+                .to()
+                .iter()
+                .map(|r| {
+                    let (to_node, to_port) = split_route(r.as_ref());
+                    if to_node == old_alias {
+                        let new_r = if to_port.is_empty() {
+                            new_alias.to_string()
+                        } else {
+                            format!("{new_alias}/{to_port}")
+                        };
+                        Route::from(new_r.as_str())
+                    } else {
+                        r.clone()
+                    }
+                })
+                .collect();
+            conn.set_to(new_to);
+        }
+        self.status = String::new();
+        self.history.mark_modified();
+        self.canvas_state.request_redraw();
     }
 }
 


### PR DESCRIPTION
## Summary
- Click-to-edit for process node titles (aliases) directly on the canvas
- Click-to-edit for sub-flow I/O port labels on the canvas
- I-beam cursor on hover over editable text (titles and I/O labels)
- Escape cancels, Enter commits, click-elsewhere auto-commits
- Process rename updates all connection routes referencing the old alias
- Replace always-visible I/O text_inputs with canvas-drawn labels + on-demand editor overlays
- Style "+ Input" / "+ Output" buttons with toolbar button styling
- Move toolbar/status bar to full window width below all panels (hierarchy, library, canvas)

## Test plan
- [x] `make clippy` passes
- [x] `make test` passes (239 flowedit tests)
- [x] Click node title to edit — verify text_input appears, Enter commits, connections update
- [x] Hover over titles — verify I-beam cursor
- [x] Open sub-flow, click I/O label — verify inline editor with delete button
- [x] Verify "+ Input" / "+ Output" buttons have toolbar styling
- [ ] Verify toolbar spans full window width
- [x] Escape cancels edits without committing

Closes #2620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click node titles or I/O labels to inline-edit node and port names; commits on submit or clicking elsewhere, duplicate names rejected, renames propagate to existing connections.
  * Single-overlay editors for node/port names with delete for ports; add buttons for new inputs/outputs.

* **Style**
  * I/O port labels now visible; text cursor on hover for editable zones.
  * Toolbar relocated beneath main panels; status row centered; library paths panel redesigned.

* **Bug Fixes**
  * Escape cancels active edits.

* **Tests**
  * Expanded UI tests covering inline editing, rename propagation, cancel/commit behaviors, and library paths panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->