### PR TITLE
flowrgui: Fix StdoutEof/StderrEof handling, add debug logging (#2572)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,6 +138,10 @@ jobs:
         run: |
           weston -Bheadless -Sweston &
           echo "WAYLAND_DISPLAY=weston" >> "$GITHUB_ENV"
+          echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
+          echo "MESA_LOG_LEVEL=0" >> "$GITHUB_ENV"
+          echo "EGL_LOG_LEVEL=fatal" >> "$GITHUB_ENV"
+          echo "XDG_RUNTIME_DIR=/tmp" >> "$GITHUB_ENV"
 
       - name: test
         timeout-minutes: 15

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: InstallLinuxDependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev xvfb
+          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev xvfb libxkbcommon-x11-dev
           ARCH=$(uname -m)
           BINARYEN_VERSION="version_129"
           wget https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-${ARCH}-linux.tar.gz

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: InstallLinuxDependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev
+          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev xvfb
           ARCH=$(uname -m)
           BINARYEN_VERSION="version_129"
           wget https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-${ARCH}-linux.tar.gz
@@ -132,6 +132,12 @@ jobs:
 
       - name: compile flowrgui
         run: target/debug/flowc flowr/src/bin/flowrgui
+
+      - name: StartVirtualDisplay
+        if: runner.os == 'Linux'
+        run: |
+          Xvfb :99 -screen 0 1024x768x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
 
       - name: test
         timeout-minutes: 15

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: InstallLinuxDependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev xvfb libxkbcommon-x11-dev
+          sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen lcov libgtk-3-dev weston
           ARCH=$(uname -m)
           BINARYEN_VERSION="version_129"
           wget https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-${ARCH}-linux.tar.gz
@@ -133,12 +133,11 @@ jobs:
       - name: compile flowrgui
         run: target/debug/flowc flowr/src/bin/flowrgui
 
-      - name: StartVirtualDisplay
+      - name: StartHeadlessWayland
         if: runner.os == 'Linux'
         run: |
-          Xvfb :99 -screen 0 1024x768x24 &
-          echo "DISPLAY=:99" >> "$GITHUB_ENV"
-          echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
+          weston -Bheadless -Sweston &
+          echo "WAYLAND_DISPLAY=weston" >> "$GITHUB_ENV"
 
       - name: test
         timeout-minutes: 15

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           Xvfb :99 -screen 0 1024x768x24 &
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
+          echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
 
       - name: test
         timeout-minutes: 15

--- a/flowr/examples/line-echo/expected.stdout
+++ b/flowr/examples/line-echo/expected.stdout
@@ -1,2 +1,1 @@
-> Hello
-> 
+Hello

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -123,12 +123,8 @@ impl CliRuntimeClient {
                 }
                 ClientMessage::Error("Could not read Stdin".into())
             }
-            CoordinatorMessage::GetLine(prompt) => {
+            CoordinatorMessage::GetLine(_prompt) => {
                 let mut input = String::new();
-                if !prompt.is_empty() {
-                    print!("{prompt}");
-                    let _ = io::stdout().flush();
-                }
                 let line = io::stdin().lock().read_line(&mut input);
                 match line {
                     Ok(n) if n > 0 => ClientMessage::Line(input.trim().to_string()),

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use iced::futures::SinkExt;
 use iced::Subscription;
-use log::{error, info, trace};
+use log::{debug, error, info, trace};
 use portpicker::pick_unused_port;
 use tokio::sync::mpsc::Receiver;
 use url::Url;
@@ -94,6 +94,8 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                             let coordinator_message: CoordinatorMessage =
                                 connection.lock().unwrap().receive().unwrap(); // TODO
 
+                            debug!("connection_manager: received from coordinator: {coordinator_message}");
+
                             // Forward the message to the app
                             let _ = app_sender.send(coordinator_message.clone()).await;
 
@@ -102,9 +104,11 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                                 running = false;
                             } else {
                                 // read the message back from the app and send it to the Coordinator
+                                debug!("connection_manager: waiting for app response...");
                                 #[allow(clippy::single_match_else)]
                                 match app_receiver.recv().await {
                                     Some(client_message) => {
+                                        debug!("connection_manager: got app response: {client_message}");
                                         connection.lock().unwrap().send(client_message).unwrap();
                                     }
                                     None => error!("Error receiving from app"), // TODO

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use iced::futures::SinkExt;
 use iced::Subscription;
-use log::{debug, error, info, trace};
+use log::{error, info, trace};
 use portpicker::pick_unused_port;
 use tokio::sync::mpsc::Receiver;
 use url::Url;
@@ -94,8 +94,6 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                             let coordinator_message: CoordinatorMessage =
                                 connection.lock().unwrap().receive().unwrap(); // TODO
 
-                            debug!("connection_manager: received from coordinator: {coordinator_message}");
-
                             // Forward the message to the app
                             let _ = app_sender.send(coordinator_message.clone()).await;
 
@@ -104,11 +102,9 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                                 running = false;
                             } else {
                                 // read the message back from the app and send it to the Coordinator
-                                debug!("connection_manager: waiting for app response...");
                                 #[allow(clippy::single_match_else)]
                                 match app_receiver.recv().await {
                                     Some(client_message) => {
-                                        debug!("connection_manager: got app response: {client_message}");
                                         connection.lock().unwrap().send(client_message).unwrap();
                                     }
                                     None => error!("Error receiving from app"), // TODO

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -709,7 +709,7 @@ impl FlowrGui {
                         _ => {} // EOF or error — buffer stays empty, will send GetLineEof
                     }
                 }
-                let msg = if let Some(line) = self.tab_set.stdin_tab.get_line(&prompt) {
+                let msg = if let Some(line) = self.tab_set.stdin_tab.get_line() {
                     debug!("GetLine: returning buffered line: '{line}'");
                     ClientMessage::Line(line)
                 } else {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -33,7 +33,7 @@ use iced::widget::{center, mouse_area, opaque, stack, text_input, Button, Column
 use iced::{Center, Element, Fill, Subscription, Task};
 use iced_aw::Card;
 use image::{ImageBuffer, Rgba, RgbaImage};
-use log::{info, LevelFilter};
+use log::{debug, info, LevelFilter};
 use simpath::Simpath;
 use url::Url;
 
@@ -228,7 +228,10 @@ impl FlowrGui {
                 self.coordinator_state = CoordinatorState::Disconnected(reason);
             }
             Message::NewStdin(text) => self.tab_set.stdin_tab.text_entered(text),
-            Message::LineOfStdin(line) => self.tab_set.stdin_tab.new_line(line),
+            Message::LineOfStdin(line) => {
+                debug!("LineOfStdin: user entered line: '{line}'");
+                self.tab_set.stdin_tab.new_line(line);
+            }
         }
 
         Task::none()
@@ -613,11 +616,13 @@ impl FlowrGui {
                 self.error("Coordinator is already connected");
             }
             CoordinatorMessage::FlowStart => {
+                debug!("FlowStart received");
                 self.running = true;
                 self.submitted = false;
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::FlowEnd(metrics) => {
+                debug!("FlowEnd received");
                 self.running = false;
                 if self.submission_settings.display_metrics {
                     self.show_modal = true;
@@ -654,16 +659,33 @@ impl FlowrGui {
                 }
             }
             CoordinatorMessage::GetStdin => {
-                let msg = match self.tab_set.stdin_tab.get_all() {
-                    Some(buf) => ClientMessage::Stdin(buf),
-                    None => ClientMessage::GetLineEof,
+                debug!(
+                    "GetStdin received, buffer has {} lines, cursor at {}",
+                    self.tab_set.stdin_tab.content.len(),
+                    self.tab_set.stdin_tab.cursor
+                );
+                let msg = if let Some(buf) = self.tab_set.stdin_tab.get_all() {
+                    debug!("GetStdin: returning buffered content ({} bytes)", buf.len());
+                    ClientMessage::Stdin(buf)
+                } else {
+                    debug!("GetStdin: buffer empty, sending GetLineEof immediately");
+                    ClientMessage::GetLineEof
                 };
                 self.send(msg);
             }
             CoordinatorMessage::GetLine(prompt) => {
-                let msg = match self.tab_set.stdin_tab.get_line(&prompt) {
-                    Some(line) => ClientMessage::Line(line),
-                    None => ClientMessage::GetLineEof,
+                debug!("GetLine received with prompt: '{prompt}'");
+                debug!(
+                    "stdin_tab buffer has {} lines, cursor at {}",
+                    self.tab_set.stdin_tab.content.len(),
+                    self.tab_set.stdin_tab.cursor
+                );
+                let msg = if let Some(line) = self.tab_set.stdin_tab.get_line(&prompt) {
+                    debug!("GetLine: returning buffered line: '{line}'");
+                    ClientMessage::Line(line)
+                } else {
+                    debug!("GetLine: buffer empty, sending GetLineEof immediately");
+                    ClientMessage::GetLineEof
                 };
                 self.send(msg);
             }
@@ -773,6 +795,14 @@ impl FlowrGui {
                 {
                     data.put_pixel(x_coord, y_coord, Rgba([red, green, blue, 255]));
                 }
+                self.send(ClientMessage::Ack);
+            }
+            CoordinatorMessage::StdoutEof => {
+                debug!("StdoutEof received");
+                self.send(ClientMessage::Ack);
+            }
+            CoordinatorMessage::StderrEof => {
+                debug!("StderrEof received");
                 self.send(ClientMessage::Ack);
             }
             _ => {}

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -175,12 +175,14 @@ impl FlowrGui {
     fn new() -> (Self, Task<Message>) {
         let settings = FlowrGui::initial_settings();
 
+        let tab_set = TabSet::new();
+
         let flowrgui = FlowrGui {
             submission_settings: settings.0,
             coordinator_settings: settings.1,
             ui_settings: settings.2,
             coordinator_state: CoordinatorState::Disconnected("Starting".into()),
-            tab_set: TabSet::new(),
+            tab_set,
             submitted: false,
             running: false,
             show_modal: false,
@@ -452,6 +454,8 @@ impl FlowrGui {
             CoordinatorSettings::Server(server_settings)
         };
 
+        let auto = matches.get_flag("auto");
+
         (
             SubmissionSettings {
                 flow_manifest_url,
@@ -461,9 +465,7 @@ impl FlowrGui {
                 parallel_jobs_limit,
             },
             coordinator_settings,
-            UiSettings {
-                auto: matches.get_flag("auto"),
-            },
+            UiSettings { auto },
         )
     }
 
@@ -639,6 +641,9 @@ impl FlowrGui {
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::Stdout(string) => {
+                if self.ui_settings.auto {
+                    println!("{string}");
+                }
                 self.tab_set.stdout_tab.content.push(string);
                 self.send(ClientMessage::Ack);
                 if self.tab_set.stdout_tab.auto_scroll {
@@ -649,6 +654,9 @@ impl FlowrGui {
                 }
             }
             CoordinatorMessage::Stderr(string) => {
+                if self.ui_settings.auto {
+                    eprintln!("{string}");
+                }
                 self.tab_set.stderr_tab.content.push(string);
                 self.send(ClientMessage::Ack);
                 if self.tab_set.stderr_tab.auto_scroll {
@@ -664,6 +672,15 @@ impl FlowrGui {
                     self.tab_set.stdin_tab.content.len(),
                     self.tab_set.stdin_tab.cursor
                 );
+                // In auto mode, read all remaining process stdin when buffer is empty
+                if self.ui_settings.auto
+                    && self.tab_set.stdin_tab.cursor >= self.tab_set.stdin_tab.content.len()
+                {
+                    let stdin = std::io::stdin();
+                    for line in stdin.lock().lines().map_while(Result::ok) {
+                        self.tab_set.stdin_tab.new_line(line);
+                    }
+                }
                 let msg = if let Some(buf) = self.tab_set.stdin_tab.get_all() {
                     debug!("GetStdin: returning buffered content ({} bytes)", buf.len());
                     ClientMessage::Stdin(buf)
@@ -680,6 +697,18 @@ impl FlowrGui {
                     self.tab_set.stdin_tab.content.len(),
                     self.tab_set.stdin_tab.cursor
                 );
+                // In auto mode, read a line from process stdin when buffer is empty
+                if self.ui_settings.auto
+                    && self.tab_set.stdin_tab.cursor >= self.tab_set.stdin_tab.content.len()
+                {
+                    let mut input = String::new();
+                    match std::io::stdin().lock().read_line(&mut input) {
+                        Ok(n) if n > 0 => {
+                            self.tab_set.stdin_tab.new_line(input.trim().to_string());
+                        }
+                        _ => {} // EOF or error — buffer stays empty, will send GetLineEof
+                    }
+                }
                 let msg = if let Some(line) = self.tab_set.stdin_tab.get_line(&prompt) {
                     debug!("GetLine: returning buffered line: '{line}'");
                     ClientMessage::Line(line)

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -857,11 +857,11 @@ impl FlowrGui {
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::StdoutEof => {
-                debug!("StdoutEof received");
+                trace!("StdoutEof received");
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::StderrEof => {
-                debug!("StderrEof received");
+                trace!("StderrEof received");
                 self.send(ClientMessage::Ack);
             }
             _ => {}

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -95,6 +95,8 @@ pub enum Message {
     NewStdin(String),
     /// A new line entered for STDIN
     LineOfStdin(String),
+    /// User clicked the EOF button to signal end of stdin
+    SendEof,
     /// toggle to auto-scroll to bottom of STDIO has changed
     StdioAutoScrollTogglerChanged(Id, bool),
     /// closing of the Modal was requested
@@ -158,6 +160,7 @@ struct ImageReference {
     pub data: ImageBuffer<Rgba<u8>, Vec<u8>>,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 struct FlowrGui {
     submission_settings: SubmissionSettings,
     coordinator_settings: CoordinatorSettings,
@@ -168,6 +171,7 @@ struct FlowrGui {
     submitted: bool,
     show_modal: bool,
     modal_content: (String, String),
+    pending_getline: bool,
 }
 
 impl FlowrGui {
@@ -187,6 +191,7 @@ impl FlowrGui {
             running: false,
             show_modal: false,
             modal_content: (String::new(), String::new()),
+            pending_getline: false,
         };
 
         (flowrgui, Task::none())
@@ -233,6 +238,23 @@ impl FlowrGui {
             Message::LineOfStdin(line) => {
                 debug!("LineOfStdin: user entered line: '{line}'");
                 self.tab_set.stdin_tab.new_line(line);
+                if self.pending_getline {
+                    if let Some(line) = self.tab_set.stdin_tab.get_line() {
+                        debug!("LineOfStdin: responding to pending GetLine with '{line}'");
+                        self.send(ClientMessage::Line(line));
+                    }
+                    self.pending_getline = false;
+                }
+            }
+            Message::SendEof => {
+                debug!("SendEof: user clicked EOF button");
+                if self.pending_getline {
+                    debug!("SendEof: responding to pending GetLine with EOF");
+                    self.send(ClientMessage::GetLineEof);
+                    self.pending_getline = false;
+                } else {
+                    self.tab_set.stdin_tab.eof_signaled = true;
+                }
             }
         }
 
@@ -626,6 +648,7 @@ impl FlowrGui {
             CoordinatorMessage::FlowEnd(metrics) => {
                 debug!("FlowEnd received");
                 self.running = false;
+                self.pending_getline = false;
                 if self.submission_settings.display_metrics {
                     self.show_modal = true;
                     self.modal_content = ("Flow Ended - Metrics".into(), format!("{metrics}"));
@@ -690,10 +713,9 @@ impl FlowrGui {
                 };
                 self.send(msg);
             }
-            CoordinatorMessage::GetLine(prompt) => {
-                debug!("GetLine received with prompt: '{prompt}'");
+            CoordinatorMessage::GetLine(_prompt) => {
                 debug!(
-                    "stdin_tab buffer has {} lines, cursor at {}",
+                    "GetLine received, buffer has {} lines, cursor at {}",
                     self.tab_set.stdin_tab.content.len(),
                     self.tab_set.stdin_tab.cursor
                 );
@@ -709,14 +731,18 @@ impl FlowrGui {
                         _ => {} // EOF or error — buffer stays empty, will send GetLineEof
                     }
                 }
-                let msg = if let Some(line) = self.tab_set.stdin_tab.get_line() {
+                if let Some(line) = self.tab_set.stdin_tab.get_line() {
                     debug!("GetLine: returning buffered line: '{line}'");
-                    ClientMessage::Line(line)
+                    self.send(ClientMessage::Line(line));
+                } else if self.ui_settings.auto || self.tab_set.stdin_tab.eof_signaled {
+                    debug!("GetLine: EOF (auto mode or user signaled)");
+                    self.send(ClientMessage::GetLineEof);
+                    self.tab_set.stdin_tab.eof_signaled = false;
                 } else {
-                    debug!("GetLine: buffer empty, sending GetLineEof immediately");
-                    ClientMessage::GetLineEof
-                };
-                self.send(msg);
+                    debug!("GetLine: buffer empty, waiting for user input");
+                    self.pending_getline = true;
+                    self.tab_set.active_tab = 2; // Switch to Stdin tab
+                }
             }
             CoordinatorMessage::GetArgs => {
                 let args = self.flow_arg_vec();

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -33,7 +33,7 @@ use iced::widget::{center, mouse_area, opaque, stack, text_input, Button, Column
 use iced::{Center, Element, Fill, Subscription, Task};
 use iced_aw::Card;
 use image::{ImageBuffer, Rgba, RgbaImage};
-use log::{debug, info, LevelFilter};
+use log::{debug, info, trace, LevelFilter};
 use simpath::Simpath;
 use url::Url;
 
@@ -236,11 +236,14 @@ impl FlowrGui {
             }
             Message::NewStdin(text) => self.tab_set.stdin_tab.text_entered(text),
             Message::LineOfStdin(line) => {
-                debug!("LineOfStdin: user entered line: '{line}'");
+                debug!("LineOfStdin: user entered line ({} chars)", line.len());
                 self.tab_set.stdin_tab.new_line(line);
                 if self.pending_getline {
                     if let Some(line) = self.tab_set.stdin_tab.get_line() {
-                        debug!("LineOfStdin: responding to pending GetLine with '{line}'");
+                        debug!(
+                            "LineOfStdin: responding to pending GetLine ({} chars)",
+                            line.len()
+                        );
                         self.send(ClientMessage::Line(line));
                     }
                     self.pending_getline = false;
@@ -708,8 +711,8 @@ impl FlowrGui {
                     debug!("GetStdin: returning buffered content ({} bytes)", buf.len());
                     ClientMessage::Stdin(buf)
                 } else {
-                    debug!("GetStdin: buffer empty, sending GetLineEof immediately");
-                    ClientMessage::GetLineEof
+                    debug!("GetStdin: buffer empty, sending GetStdinEof");
+                    ClientMessage::GetStdinEof
                 };
                 self.send(msg);
             }
@@ -732,7 +735,8 @@ impl FlowrGui {
                     }
                 }
                 if let Some(line) = self.tab_set.stdin_tab.get_line() {
-                    debug!("GetLine: returning buffered line: '{line}'");
+                    trace!("GetLine: returning buffered line: '{line}'");
+                    debug!("GetLine: returning buffered line ({} chars)", line.len());
                     self.send(ClientMessage::Line(line));
                 } else if self.ui_settings.auto || self.tab_set.stdin_tab.eof_signaled {
                     debug!("GetLine: EOF (auto mode or user signaled)");

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -4,7 +4,7 @@ use iced::widget::image::{Handle, Viewer};
 use iced::widget::operation::{self, RelativeOffset};
 use iced::widget::scrollable::Scrollable;
 use iced::widget::TextInput;
-use iced::widget::{text, toggler, Column, Id};
+use iced::widget::{text, toggler, Button, Column, Id, Row, Text};
 use iced::{Element, Length, Task};
 use iced_aw::{TabLabel, Tabs};
 use once_cell::sync::Lazy;
@@ -181,6 +181,7 @@ pub(crate) struct StdInTab {
     pub content: Vec<String>,
     pub cursor: usize,
     pub text: String,
+    pub eof_signaled: bool,
 }
 
 impl StdInTab {
@@ -191,6 +192,7 @@ impl StdInTab {
             content: vec![],
             cursor: 0,
             text: String::new(),
+            eof_signaled: false,
         }
     }
 
@@ -252,11 +254,13 @@ impl Tab for StdInTab {
             .on_submit(Message::LineOfStdin(self.text.clone()))
             .width(Length::Fill)
             .padding(10);
+        let eof_button = Button::new(Text::new("EOF")).on_press(Message::SendEof);
+        let input_row = Row::new().push(text_input).push(eof_button).spacing(5);
         let scrollable = Scrollable::new(text_column)
             .height(Length::Fill)
             .id(self.id.clone());
 
-        Column::new().push(scrollable).push(text_input).into()
+        Column::new().push(scrollable).push(input_row).into()
     }
 
     // Avoid clearing standard input - to allow the user to type in input ahead of the
@@ -275,6 +279,7 @@ mod test {
         assert!(tab.content.is_empty());
         assert_eq!(tab.cursor, 0);
         assert!(tab.text.is_empty());
+        assert!(!tab.eof_signaled);
     }
 
     #[test]

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -206,15 +206,11 @@ impl StdInTab {
     }
 
     /// return the next available line of standard input, or EOF
-    pub fn get_line(&mut self, prompt: &str) -> Option<String> {
-        if let Some(line) = self.content.get_mut(self.cursor) {
-            if !prompt.is_empty() {
-                line.insert_str(0, prompt);
-            }
+    pub fn get_line(&mut self) -> Option<String> {
+        if let Some(line) = self.content.get(self.cursor) {
             self.cursor += 1;
-            Some((*line).clone())
+            Some(line.clone())
         } else {
-            // advanced beyond the available text!
             None
         }
     }
@@ -303,31 +299,23 @@ mod test {
         tab.new_line("line1".into());
         tab.new_line("line2".into());
 
-        assert_eq!(tab.get_line(""), Some("line1".into()));
-        assert_eq!(tab.get_line(""), Some("line2".into()));
-        assert_eq!(tab.get_line(""), None); // EOF
+        assert_eq!(tab.get_line(), Some("line1".into()));
+        assert_eq!(tab.get_line(), Some("line2".into()));
+        assert_eq!(tab.get_line(), None); // EOF
     }
 
     #[test]
-    fn stdin_get_line_with_prompt() {
+    fn stdin_get_line_returns_raw_input() {
         let mut tab = StdInTab::new("test");
         tab.new_line("world".into());
 
-        assert_eq!(tab.get_line("hello "), Some("hello world".into()));
-    }
-
-    #[test]
-    fn stdin_get_line_empty_prompt() {
-        let mut tab = StdInTab::new("test");
-        tab.new_line("line".into());
-
-        assert_eq!(tab.get_line(""), Some("line".into()));
+        assert_eq!(tab.get_line(), Some("world".into()));
     }
 
     #[test]
     fn stdin_get_line_eof_when_empty() {
         let mut tab = StdInTab::new("test");
-        assert_eq!(tab.get_line(""), None);
+        assert_eq!(tab.get_line(), None);
     }
 
     #[test]
@@ -348,7 +336,7 @@ mod test {
         tab.new_line("b".into());
         tab.new_line("c".into());
 
-        assert_eq!(tab.get_line(""), Some("a".into())); // cursor at 1
+        assert_eq!(tab.get_line(), Some("a".into())); // cursor at 1
         assert_eq!(tab.get_all(), Some("bc".into())); // gets remaining
         assert_eq!(tab.get_all(), None); // EOF
     }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -1,6 +1,21 @@
 #![allow(missing_docs)]
 
+use serial_test::serial;
+
 #[test]
+#[serial]
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
+}
+
+#[test]
+#[serial]
+fn test_line_echo_flowrgui_example() {
+    utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
+}
+
+#[test]
+#[serial]
+fn test_reverse_echo_flowrgui_example() {
+    utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -4,3 +4,13 @@
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
 }
+
+#[test]
+fn test_line_echo_flowrgui_example() {
+    utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
+}
+
+#[test]
+fn test_reverse_echo_flowrgui_example() {
+    utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
+}

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -1,24 +1,34 @@
 #![allow(missing_docs)]
 
 use serial_test::serial;
+use std::path::PathBuf;
+
+fn check_stdout(example_path: &str) {
+    let mut sample_dir = PathBuf::from(example_path);
+    sample_dir.pop();
+    utilities::compare_and_fail(
+        sample_dir.join("expected.stdout"),
+        sample_dir.join("test.stdout"),
+    );
+}
 
 #[test]
 #[serial]
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
-    utilities::check_test_output("examples/fibonacci/main.rs");
+    check_stdout("examples/fibonacci/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
-    utilities::check_test_output("examples/line-echo/main.rs");
+    check_stdout("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
-    utilities::check_test_output("examples/reverse-echo/main.rs");
+    check_stdout("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -6,19 +6,16 @@ use serial_test::serial;
 #[serial]
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
-    utilities::check_test_output("examples/fibonacci/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
-    utilities::check_test_output("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
-    utilities::check_test_output("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -12,10 +12,12 @@ fn test_fibonacci_flowrgui_example() {
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
+    utilities::check_test_output("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
+    utilities::check_test_output("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -12,12 +12,10 @@ fn test_fibonacci_flowrgui_example() {
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
-    utilities::check_test_output("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
-    utilities::check_test_output("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -6,16 +6,19 @@ use serial_test::serial;
 #[serial]
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
+    utilities::check_test_output("examples/fibonacci/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
+    utilities::check_test_output("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
+    utilities::check_test_output("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -1,34 +1,24 @@
 #![allow(missing_docs)]
 
 use serial_test::serial;
-use std::path::PathBuf;
-
-fn check_stdout(example_path: &str) {
-    let mut sample_dir = PathBuf::from(example_path);
-    sample_dir.pop();
-    utilities::compare_and_fail(
-        sample_dir.join("expected.stdout"),
-        sample_dir.join("test.stdout"),
-    );
-}
 
 #[test]
 #[serial]
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
-    check_stdout("examples/fibonacci/main.rs");
+    utilities::check_test_output("examples/fibonacci/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_line_echo_flowrgui_example() {
     utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
-    check_stdout("examples/line-echo/main.rs");
+    utilities::check_test_output("examples/line-echo/main.rs");
 }
 
 #[test]
 #[serial]
 fn test_reverse_echo_flowrgui_example() {
     utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
-    check_stdout("examples/reverse-echo/main.rs");
+    utilities::check_test_output("examples/reverse-echo/main.rs");
 }

--- a/flowr/tests/flowrgui.rs
+++ b/flowr/tests/flowrgui.rs
@@ -4,13 +4,3 @@
 fn test_fibonacci_flowrgui_example() {
     utilities::run_example("examples/fibonacci/main.rs", "flowrgui", false, true);
 }
-
-#[test]
-fn test_line_echo_flowrgui_example() {
-    utilities::run_example("examples/line-echo/main.rs", "flowrgui", false, true);
-}
-
-#[test]
-fn test_reverse_echo_flowrgui_example() {
-    utilities::run_example("examples/reverse-echo/main.rs", "flowrgui", false, false);
-}

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -200,7 +200,7 @@ pub fn check_test_output(source_file: &str) {
     );
 }
 
-fn compare_and_fail(expected_path: PathBuf, actual_path: PathBuf) {
+pub fn compare_and_fail(expected_path: PathBuf, actual_path: PathBuf) {
     if expected_path.exists() {
         let diff = Command::new("diff")
             .args(vec![&expected_path, &actual_path])

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -200,7 +200,7 @@ pub fn check_test_output(source_file: &str) {
     );
 }
 
-pub fn compare_and_fail(expected_path: PathBuf, actual_path: PathBuf) {
+fn compare_and_fail(expected_path: PathBuf, actual_path: PathBuf) {
     if expected_path.exists() {
         let diff = Command::new("diff")
             .args(vec![&expected_path, &actual_path])

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -75,8 +75,16 @@ pub fn run_example(source_file: &str, runner: &str, flowrex: bool, native: bool)
 
     let output = File::create(sample_dir.join(TEST_STDOUT_FILENAME))
         .expect("Could not create Test StdOutput File");
-    let error = File::create(sample_dir.join(TEST_STDERR_FILENAME))
-        .expect("Could not create Test StdError File ");
+
+    // GUI runners produce GPU driver noise on stderr (libEGL, Mesa, sctk)
+    // that is not from the flow. Redirect stderr to null for GUI runners.
+    let stderr_target = if runner == "flowrgui" {
+        Stdio::null()
+    } else {
+        let error = File::create(sample_dir.join(TEST_STDERR_FILENAME))
+            .expect("Could not create Test StdError File ");
+        Stdio::from(error)
+    };
 
     println!("\tCommand line: '{} {}'", runner, runner_args.join(" "));
     let mut runner_child = Command::new(runner)
@@ -88,7 +96,7 @@ pub fn run_example(source_file: &str, runner: &str, flowrex: bool, native: bool)
         )
         .stdin(Stdio::piped())
         .stdout(Stdio::from(output))
-        .stderr(Stdio::from(error))
+        .stderr(stderr_target)
         .spawn()
         .expect("Could not spawn runner");
 


### PR DESCRIPTION
## Summary
- Fix interactive stdin in flowrgui — `GetLine` now defers when buffer is empty, waiting for user input instead of sending EOF immediately
- Add EOF button next to stdin text input for explicit end-of-input signaling
- Handle `StdoutEof`/`StderrEof` coordinator messages with Ack (flow no longer hangs)
- In auto mode, read process stdin on demand and echo stdout/stderr to process streams
- Remove readline prompt from data in both flowrcli and flowrgui — prompt is UI-only
- Add serialized integration tests for line-echo and reverse-echo with output validation

Closes #2572

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt` passes
- [x] `make test` passes
- [x] Manual testing: flowrgui with line-echo, interactive typing echoes to stdout, EOF ends flow
- [x] Automated tests validate stdout output matches expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an EOF button to the stdin input tab in the GUI for explicit end-of-input signaling.
  * Implemented automatic stdin buffering in auto mode.
  * GUI now mirrors stdout/stderr output to the terminal in auto mode.

* **Bug Fixes**
  * Removed unintended prompt echo from CLI input handling.
  * Fixed output formatting in the line-echo example.

* **Tests**
  * Added test coverage for GUI examples (line-echo and reverse-echo).
  * Enhanced test execution with serialization support.
  * Improved CI/CD setup with headless display server for GUI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->