### PR TITLE
flowedit: Add Run button to launch flowrgui

### DIFF
--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -1006,7 +1006,7 @@ impl FlowEdit {
                 self.handle_file_message(message);
             }
             Message::Run => {
-                self.handle_file_message(message);
+                self.launch_flowrgui();
             }
             Message::FlowEdit(win_id, ref route, flow_msg) => {
                 self.handle_flow_edit(win_id, route, flow_msg);
@@ -2341,33 +2341,39 @@ impl FlowEdit {
                     }
                 }
             }
-            Message::Run => {
-                let target = self.focused_window.or(self.root_window);
-                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
-                    if let Some(manifest) = win.history.compiled_manifest() {
-                        let flowrgui = std::env::current_exe()
-                            .ok()
-                            .and_then(|p| p.parent().map(|d| d.join("flowrgui")))
-                            .unwrap_or_else(|| PathBuf::from("flowrgui"));
-                        match Command::new(&flowrgui).arg("--auto").arg(manifest).spawn() {
-                            Ok(child) => {
-                                win.status = "Running flow in flowrgui".into();
-                                self.running_process = Some(child);
-                            }
-                            Err(e) => {
-                                win.status = format!("Failed to launch flowrgui: {e}");
-                            }
-                        }
-                    } else {
-                        win.status = "Build the flow first".into();
-                    }
-                }
-            }
             _ => {}
         }
     }
 
-    fn check_running_process(&mut self) {
+    fn launch_flowrgui(&mut self) {
+        let manifest = self
+            .root_window
+            .and_then(|id| self.windows.get(&id))
+            .and_then(|win| win.history.compiled_manifest())
+            .map(Path::to_path_buf);
+        let target = self.focused_window.or(self.root_window);
+        if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+            if let Some(manifest) = manifest {
+                let flowrgui = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.parent().map(|d| d.join("flowrgui")))
+                    .unwrap_or_else(|| PathBuf::from("flowrgui"));
+                match Command::new(&flowrgui).arg("--auto").arg(&manifest).spawn() {
+                    Ok(child) => {
+                        win.status = "Running flow in flowrgui".into();
+                        self.running_process = Some(child);
+                    }
+                    Err(e) => {
+                        win.status = format!("Failed to launch flowrgui: {e}");
+                    }
+                }
+            } else {
+                win.status = "Build the flow first".into();
+            }
+        }
+    }
+
+    pub(crate) fn check_running_process(&mut self) {
         if let Some(ref mut child) = self.running_process {
             match child.try_wait() {
                 Ok(Some(status)) => {

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
 use std::sync::Arc;
 
 use iced::keyboard;
@@ -132,6 +133,8 @@ pub(crate) enum Message {
     New,
     /// Compile the current flow
     Compile,
+    /// Run the compiled flow in flowrgui
+    Run,
     /// Initializer type changed in the editor dialog, tagged with the originating window ID
     InitializerTypeChanged(window::Id, String),
     /// Initializer value changed in the editor dialog, tagged with the originating window ID
@@ -183,6 +186,7 @@ pub(crate) struct FlowEdit {
     pub(crate) lib_paths: Vec<String>,
     pub(crate) library_cache: HashMap<Url, LibraryManifest>,
     pub(crate) all_definitions: HashMap<Url, Process>,
+    pub(crate) running_process: Option<Child>,
 }
 
 impl Default for FlowEdit {
@@ -197,6 +201,7 @@ impl Default for FlowEdit {
             lib_paths: Vec::new(),
             library_cache: HashMap::new(),
             all_definitions: HashMap::new(),
+            running_process: None,
         }
     }
 }
@@ -334,6 +339,7 @@ impl FlowEdit {
             lib_paths,
             library_cache,
             all_definitions,
+            running_process: None,
         };
 
         (app, open_task.discard())
@@ -969,6 +975,7 @@ impl FlowEdit {
 
     /// Handle messages from canvas interactions.
     pub(crate) fn update(&mut self, message: Message) -> Task<Message> {
+        self.check_running_process();
         match message {
             Message::WindowCanvas(win_id, canvas_msg) => {
                 return self.handle_canvas_update(win_id, canvas_msg);
@@ -996,6 +1003,9 @@ impl FlowEdit {
             }
             Message::Save | Message::SaveAs | Message::Open | Message::New | Message::Compile => {
                 self.flush_pending_edits();
+                self.handle_file_message(message);
+            }
+            Message::Run => {
                 self.handle_file_message(message);
             }
             Message::FlowEdit(win_id, ref route, flow_msg) => {
@@ -1221,6 +1231,18 @@ impl FlowEdit {
                         .padding(btn_pad),
                 )
                 .push(compile_btn);
+
+            let is_running = self.running_process.is_some();
+            let mut run_btn =
+                button(Text::new("\u{25B6} Run").size(btn_size).center()).padding(btn_pad);
+            if win.history.compiled_manifest().is_some() && !is_running {
+                run_btn = run_btn.on_press(Message::Run).style(toolbar_btn);
+            } else if is_running {
+                run_btn = run_btn.style(toolbar_btn_active);
+            } else {
+                run_btn = run_btn.style(toolbar_btn);
+            }
+            status_row = status_row.push(run_btn);
         }
 
         container(status_row).width(Fill).padding(5).into()
@@ -1720,6 +1742,7 @@ impl FlowEdit {
                 "o" => Some(Message::Open),
                 "n" => Some(Message::New),
                 "b" => Some(Message::Compile),
+                "r" => Some(Message::Run),
                 "w" => Some(Message::CloseActiveWindow),
                 "q" => Some(Message::QuitAll),
                 _ => None,
@@ -2318,7 +2341,58 @@ impl FlowEdit {
                     }
                 }
             }
+            Message::Run => {
+                let target = self.focused_window.or(self.root_window);
+                if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
+                    if let Some(manifest) = win.history.compiled_manifest() {
+                        match Command::new("flowrgui").arg("--auto").arg(manifest).spawn() {
+                            Ok(child) => {
+                                win.status = "Running flow in flowrgui".into();
+                                self.running_process = Some(child);
+                            }
+                            Err(e) => {
+                                win.status = format!("Failed to launch flowrgui: {e}");
+                            }
+                        }
+                    } else {
+                        win.status = "Build the flow first".into();
+                    }
+                }
+            }
             _ => {}
+        }
+    }
+
+    fn check_running_process(&mut self) {
+        if let Some(ref mut child) = self.running_process {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    let msg = if status.success() {
+                        "flowrgui exited successfully".into()
+                    } else {
+                        format!("flowrgui exited with {status}")
+                    };
+                    self.running_process = None;
+                    if let Some(win) = self
+                        .focused_window
+                        .or(self.root_window)
+                        .and_then(|id| self.windows.get_mut(&id))
+                    {
+                        win.status = msg;
+                    }
+                }
+                Ok(None) => {} // still running
+                Err(e) => {
+                    self.running_process = None;
+                    if let Some(win) = self
+                        .focused_window
+                        .or(self.root_window)
+                        .and_then(|id| self.windows.get_mut(&id))
+                    {
+                        win.status = format!("Error checking flowrgui: {e}");
+                    }
+                }
+            }
         }
     }
 

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -2345,7 +2345,11 @@ impl FlowEdit {
                 let target = self.focused_window.or(self.root_window);
                 if let Some(win) = target.and_then(|id| self.windows.get_mut(&id)) {
                     if let Some(manifest) = win.history.compiled_manifest() {
-                        match Command::new("flowrgui").arg("--auto").arg(manifest).spawn() {
+                        let flowrgui = std::env::current_exe()
+                            .ok()
+                            .and_then(|p| p.parent().map(|d| d.join("flowrgui")))
+                            .unwrap_or_else(|| PathBuf::from("flowrgui"));
+                        match Command::new(&flowrgui).arg("--auto").arg(manifest).spawn() {
                             Ok(child) => {
                                 win.status = "Running flow in flowrgui".into();
                                 self.running_process = Some(child);

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -3003,3 +3003,43 @@ fn view_lib_paths_panel_toggle() {
     );
     assert!(sim.find("+ Add").is_ok(), "Add button in panel");
 }
+
+#[test]
+fn run_without_manifest_shows_build_first() {
+    let (mut app, win_id) = test_app();
+    assert!(app.running_process.is_none());
+    let _ = app.update(Message::Run);
+    let win = app.windows.get(&win_id).unwrap();
+    assert_eq!(win.status, "Build the flow first");
+}
+
+#[test]
+fn run_button_disabled_without_manifest() {
+    let (app, win_id) = test_app();
+    let view = app.view(win_id);
+    let mut sim = simulator(view);
+    let run_btn = sim.find("\u{25B6} Run");
+    assert!(run_btn.is_ok(), "Run button should be visible");
+}
+
+#[test]
+fn run_button_enabled_with_manifest() {
+    let (mut app, win_id) = test_app();
+    app.windows
+        .get_mut(&win_id)
+        .unwrap()
+        .history
+        .set_compiled_manifest(PathBuf::from("/tmp/test-manifest.json"));
+    let _ = app.update(Message::Run);
+    let win = app.windows.get(&win_id).unwrap();
+    // Should attempt to launch, not show "Build the flow first"
+    assert_ne!(win.status, "Build the flow first");
+}
+
+#[test]
+fn check_running_process_clears_on_none() {
+    let (mut app, _win_id) = test_app();
+    assert!(app.running_process.is_none());
+    app.check_running_process();
+    assert!(app.running_process.is_none());
+}


### PR DESCRIPTION
## Summary
- Add a Run button (▶ Run) beside Build in flowedit's toolbar
- Launches `flowrgui --auto <manifest>` to run the compiled flow
- Button enabled after successful Build, disabled while running
- Tracks child process via `try_wait()` polling, updates status on exit
- Cmd+R keyboard shortcut

Closes #2634

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt` passes
- [x] `make test` passes
- [ ] Manual: open flowedit with a flow, Build, then Run — flowrgui launches
- [ ] Manual: Run button disabled before Build and while running
- [ ] Manual: Status bar shows running/exit state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Run" button to the toolbar for executing compiled flows
  * Keyboard shortcut Cmd+R available for quick access to run functionality
  * Button automatically disables when no compiled flow is available or when a flow is currently executing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->