### PR TITLE
Replace archived actions-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,24 +35,19 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.95.0
-          override: true
-          components: clippy
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.95.0
+          components: clippy
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get -y install libzmq3-dev libgtk-3-dev
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
       - name: run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic --deny warnings
+        run: cargo clippy --tests --no-deps --all-features --all-targets -- --warn clippy::pedantic --deny warnings
 
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -72,12 +67,10 @@ jobs:
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> "$GITHUB_ENV"
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.95.0
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
@@ -121,9 +114,7 @@ jobs:
           echo LLVM_PROFILE_FILE="flow-%p-%m.profraw" >> "$GITHUB_ENV"
 
       - name: build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
 
       - name: compile flowstdlib to WASM
         run: target/debug/flowc -d -g -O flowstdlib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,17 +74,16 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0
+          targets: wasm32-unknown-unknown
       - name: InstallLinuxDependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen
       - name: InstallMacDependencies
         if: matrix.os == 'macos-latest'
         run: brew install zmq binaryen
-      - name: AddWasmTarget
-        run: rustup target add wasm32-unknown-unknown
       - name: InstallWasmTools
         run: cargo install wasm-gc wasm-snip
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
Replaces the archived and unmaintained `actions-rs/toolchain@v1` and `actions-rs/cargo@v1` GitHub Actions with:
- [`dtolnay/rust-toolchain@master`](https://github.com/dtolnay/rust-toolchain) for toolchain installation
- Direct `cargo` commands instead of `actions-rs/cargo`

Addresses the CodeRabbit review comment on PR #2650.

## Test plan
- [ ] CI passes with the new actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)