### PR TITLE
Update macOS CI runner from macos-14 to macos-26

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-14, ubuntu-24.04, ubuntu-24.04-arm ]
+        os: [ macos-26, ubuntu-24.04, ubuntu-24.04-arm ]
         rust: [ 1.95.0 ]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-latest
         - target: x86_64-apple-darwin
-          os: macos-latest
+          os: macos-26
     runs-on: ${{ matrix.os }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get -y install libzmq3-dev binaryen
       - name: InstallMacDependencies
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: brew install zmq binaryen
       - name: InstallWasmTools
         run: cargo install wasm-gc wasm-snip


### PR DESCRIPTION
## Summary
Updates the macOS CI runner from `macos-14` (Sonoma) to `macos-26` (Tahoe), matching pigg's CI configuration.

Changes:
- `build_and_test.yml`: `macos-14` → `macos-26` in the build matrix
- `release.yml`: `macos-latest` → `macos-26` for release builds, fix condition to use `runner.os == 'macOS'`

Closes #2560

## Test plan
- [ ] CI passes on macos-26 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure with newer macOS runners for improved build and release processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->