### PR TITLE
Add Stop button to flowrgui

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
@@ -38,6 +39,19 @@ pub enum CoordinatorState {
 
 /// Global storage for coordinator settings, initialized once and read by the subscription
 static COORDINATOR_SETTINGS: OnceLock<CoordinatorSettings> = OnceLock::new();
+
+/// Global flag for requesting flow stop from the GUI
+static STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Request the currently running flow to stop
+pub fn request_stop() {
+    STOP_REQUESTED.store(true, Ordering::Relaxed);
+}
+
+/// Check and clear the stop request flag
+pub fn take_stop_request() -> bool {
+    STOP_REQUESTED.swap(false, Ordering::Relaxed)
+}
 
 // Creates an asynchronous worker that sends messages back and forth between the App and
 // the Coordinator

--- a/flowr/src/bin/flowrgui/gui/client_message.rs
+++ b/flowr/src/bin/flowrgui/gui/client_message.rs
@@ -30,8 +30,6 @@ pub enum ClientMessage {
     GetStdinEof,
     /// EOF was detected on input reading Stdin using Readline
     GetLineEof,
-    /// Request to stop the currently running flow
-    StopFlow,
     /// Invalid - used when deserialization goes wrong
     Invalid,
     /// Contents read from a file
@@ -58,7 +56,6 @@ impl fmt::Display for ClientMessage {
                 ClientMessage::ClientExiting(_) => "ClientExiting",
                 ClientMessage::ClientSubmission(_) => "ClientSubmission",
                 ClientMessage::EnterDebugger => "EnterDebugger",
-                ClientMessage::StopFlow => "StopFlow",
                 ClientMessage::Invalid => "Invalid",
                 ClientMessage::FileContents(_, _) => "FileContents",
             }

--- a/flowr/src/bin/flowrgui/gui/client_message.rs
+++ b/flowr/src/bin/flowrgui/gui/client_message.rs
@@ -30,6 +30,8 @@ pub enum ClientMessage {
     GetStdinEof,
     /// EOF was detected on input reading Stdin using Readline
     GetLineEof,
+    /// Request to stop the currently running flow
+    StopFlow,
     /// Invalid - used when deserialization goes wrong
     Invalid,
     /// Contents read from a file
@@ -56,6 +58,7 @@ impl fmt::Display for ClientMessage {
                 ClientMessage::ClientExiting(_) => "ClientExiting",
                 ClientMessage::ClientSubmission(_) => "ClientSubmission",
                 ClientMessage::EnterDebugger => "EnterDebugger",
+                ClientMessage::StopFlow => "StopFlow",
                 ClientMessage::Invalid => "Invalid",
                 ClientMessage::FileContents(_, _) => "FileContents",
             }

--- a/flowr/src/bin/flowrgui/gui/submission_handler.rs
+++ b/flowr/src/bin/flowrgui/gui/submission_handler.rs
@@ -60,6 +60,21 @@ impl SubmissionHandler for CLISubmissionHandler {
         }
     }
 
+    fn should_stop(&mut self) -> Result<bool> {
+        let msg = self
+            .coordinator_connection
+            .lock()
+            .map_err(|_| "Could not lock coordinator connection")?
+            .receive(DONT_WAIT);
+        match msg {
+            Ok(ClientMessage::StopFlow) => {
+                debug!("Got StopFlow message");
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     fn flow_execution_ended(&mut self, state: &RunState, metrics: Metrics) -> Result<()> {
         self.coordinator_connection
             .lock()

--- a/flowr/src/bin/flowrgui/gui/submission_handler.rs
+++ b/flowr/src/bin/flowrgui/gui/submission_handler.rs
@@ -8,6 +8,7 @@ use flowrlib::run_state::RunState;
 use flowrlib::submission_handler::SubmissionHandler;
 use log::{debug, error, info, trace};
 
+use crate::connection_manager;
 use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_connection::{DONT_WAIT, WAIT};
 use crate::gui::coordinator_message::CoordinatorMessage;
@@ -61,17 +62,11 @@ impl SubmissionHandler for CLISubmissionHandler {
     }
 
     fn should_stop(&mut self) -> Result<bool> {
-        let msg = self
-            .coordinator_connection
-            .lock()
-            .map_err(|_| "Could not lock coordinator connection")?
-            .receive(DONT_WAIT);
-        match msg {
-            Ok(ClientMessage::StopFlow) => {
-                debug!("Got StopFlow message");
-                Ok(true)
-            }
-            _ => Ok(false),
+        if connection_manager::take_stop_request() {
+            debug!("Stop requested by user");
+            Ok(true)
+        } else {
+            Ok(false)
         }
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -242,15 +242,7 @@ impl FlowrGui {
                 self.modal_content = ("Error".into(), msg);
             }
             Message::StopFlow => {
-                if let CoordinatorState::Connected(sender) = &self.coordinator_state {
-                    let sender = sender.clone();
-                    return Task::perform(
-                        async move {
-                            let _ = sender.send(ClientMessage::StopFlow).await;
-                        },
-                        |()| Message::Submitted, // reuse Submitted to reset UI state
-                    );
-                }
+                connection_manager::request_stop();
             }
             Message::FlowArgsChanged(value) => self.submission_settings.flow_args = value,
             Message::MaxJobsChanged(value) => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -714,6 +714,7 @@ impl FlowrGui {
                 debug!("FlowEnd received");
                 self.running = false;
                 self.pending_getline = false;
+                self.tab_set.stdin_tab.waiting_for_input = false;
                 if self.submission_settings.display_metrics {
                     self.show_modal = true;
                     self.modal_content = ("Flow Ended - Metrics".into(), format!("{metrics}"));

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -105,6 +105,8 @@ pub enum Message {
     SendEof,
     /// toggle to auto-scroll to bottom of STDIO has changed
     StdioAutoScrollTogglerChanged(Id, bool),
+    /// Request to stop the currently running flow
+    StopFlow,
     /// Clear the content of an output tab
     ClearTab(String),
     /// closing of the Modal was requested
@@ -238,6 +240,17 @@ impl FlowrGui {
             Message::SubmitError(msg) => {
                 self.show_modal = true;
                 self.modal_content = ("Error".into(), msg);
+            }
+            Message::StopFlow => {
+                if let CoordinatorState::Connected(sender) = &self.coordinator_state {
+                    let sender = sender.clone();
+                    return Task::perform(
+                        async move {
+                            let _ = sender.send(ClientMessage::StopFlow).await;
+                        },
+                        |()| Message::Submitted, // reuse Submitted to reset UI state
+                    );
+                }
             }
             Message::FlowArgsChanged(value) => self.submission_settings.flow_args = value,
             Message::MaxJobsChanged(value) => {
@@ -406,10 +419,15 @@ impl FlowrGui {
             && !self.running
             && !self.submitted;
 
-        let mut play = Button::new("Play");
-        if can_run {
-            play = play.on_press(Message::SubmitFlow);
-        }
+        let play = if self.running {
+            Button::new("Stop").on_press(Message::StopFlow)
+        } else {
+            let mut btn = Button::new("Play");
+            if can_run {
+                btn = btn.on_press(Message::SubmitFlow);
+            }
+            btn
+        };
 
         let mut debug_play = Button::new("Debug");
         if can_run {

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -122,6 +122,12 @@ impl<'a> Coordinator<'a> {
 
             'jobs: loop {
                 trace!("{state}");
+
+                #[cfg(feature = "submission")]
+                if self.submission_handler.should_stop()? {
+                    break 'flow_execution;
+                }
+
                 #[cfg(feature = "debugger")]
                 if state.submission.debug_enabled
                     && self.submission_handler.should_enter_debugger()?

--- a/flowr/src/lib/submission_handler.rs
+++ b/flowr/src/lib/submission_handler.rs
@@ -46,6 +46,16 @@ pub trait SubmissionHandler {
     ///
     fn wait_for_submission(&mut self) -> Result<Option<Submission>>;
 
+    /// The [Coordinator][crate::coordinator::Coordinator] periodically checks if the client
+    /// has requested that execution be stopped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check fails
+    fn should_stop(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+
     /// The [Coordinator][crate::coordinator::Coordinator] is about to exit
     ///
     /// # Errors


### PR DESCRIPTION
## Summary
Adds a Stop button to flowrgui that allows stopping a running flow.

- **Play button becomes Stop** while a flow is running
- Uses a new `should_stop()` method on the `SubmissionHandler` trait — the coordinator polls it each job loop iteration (non-blocking)
- `ClientMessage::StopFlow` is sent through the existing coordinator channel when Stop is pressed
- No debug logic involved — works independently of the debugger
- Debug button is unchanged (future async debug client tracked in #2657)

Closes #2630

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt` passes
- [ ] CI passes
- [ ] Visual: Run reverse-echo, Play shows as Stop while running, clicking Stop terminates the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to stop a running flow via a new "Stop" action in the UI; stopping resets the interface to ready.
  * Execution now periodically checks for a stop request so runs can be halted promptly.
  * UI input state is cleared when flows end or are stopped to avoid lingering "waiting for input" indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->