### PR TITLE
Use fully qualified names in flowmacro generated code

### DIFF
--- a/flowmacro/src/lib.rs
+++ b/flowmacro/src/lib.rs
@@ -187,9 +187,9 @@ fn generate_code(
                                       input_data_length as usize)
             };
 
-            let inputs: Vec<Value> = serde_json::from_slice(&input_data).unwrap();
+            let inputs: Vec<serde_json::Value> = serde_json::from_slice(&input_data).unwrap();
             let object = #struct_name {};
-            let result = object.run(&inputs);
+            let result = flowcore::Implementation::run(&object, &inputs);
 
             let return_data = serde_json::to_vec(&result).unwrap();
 
@@ -208,9 +208,8 @@ fn generate_code(
             #docs_comment
             #[derive(Debug)]
             pub struct #struct_name;
-            use flowcore::Implementation;
-            impl Implementation for #struct_name {
-                fn run(&self, inputs: &[Value]) -> flowcore::errors::Result<(Option<Value>, flowcore::RunAgain)> {
+            impl flowcore::Implementation for #struct_name {
+                fn run(&self, inputs: &[serde_json::Value]) -> flowcore::errors::Result<(Option<serde_json::Value>, flowcore::RunAgain)> {
     //                #input_conversion
                     #input_number_check
 


### PR DESCRIPTION
## Summary
- Replace bare `Value` with `serde_json::Value` in the code generated by the `flow_function` proc macro
- Replace `use flowcore::Implementation; impl Implementation` with `impl flowcore::Implementation`  
- Use fully qualified trait method call `flowcore::Implementation::run()` in wasm boilerplate

Closes #1830

## Test plan
- [x] Clean build passes (including flowstdlib wasm compilation)
- [x] `make test` passes
- [x] `make clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type consistency in generated code for the flow function macro to ensure explicit use of serialization value types across both standard and WebAssembly implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->