### PR TITLE
Add Save buttons to flowrgui output tabs

### DIFF
--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -70,6 +70,7 @@ wasmtime = { version = "45.0.0", default-features = false, features = ["runtime"
 iced = { version = "0.14.0", default-features = false, features = ["canvas", "tokio", "debug", "wgpu", "tiny-skia", "image", "wayland", "x11"] }
 iced_aw = { version = "0.14.1", default-features = false, features = ["tabs", "card"] }
 once_cell = "1.21.4"
+rfd = "0.17"
 tokio = { version = "1", features = ["sync"] }
 
 # Optional dependencies

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -111,6 +111,10 @@ pub enum Message {
     StopFlow,
     /// Clear the content of an output tab
     ClearTab(String),
+    /// Save the text content of a tab to a file
+    SaveTabContent(String),
+    /// Save an image to a file by its name key
+    SaveImage(String),
     /// closing of the Modal was requested
     CloseModal,
 }
@@ -266,7 +270,9 @@ impl FlowrGui {
             Message::UrlChanged(value) => self.submission_settings.flow_manifest_url = value,
             Message::TabSelected(_)
             | Message::StdioAutoScrollTogglerChanged(_, _)
-            | Message::ClearTab(_) => {
+            | Message::ClearTab(_)
+            | Message::SaveTabContent(_)
+            | Message::SaveImage(_) => {
                 return self.tab_set.update(message);
             }
             Message::CoordinatorSent(coord_msg) => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -115,6 +115,8 @@ pub enum Message {
     SaveTabContent(String),
     /// Save an image to a file by its name key
     SaveImage(String),
+    /// An error occurred while saving content to a file
+    SaveError(String),
     /// closing of the Modal was requested
     CloseModal,
 }
@@ -243,7 +245,7 @@ impl FlowrGui {
                 self.tab_set.clear();
                 self.submitted = true;
             }
-            Message::SubmitError(msg) => {
+            Message::SubmitError(msg) | Message::SaveError(msg) => {
                 self.show_modal = true;
                 self.modal_content = ("Error".into(), msg);
             }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1085,4 +1085,32 @@ mod test {
         let found = ui.find("OK");
         assert!(found.is_ok(), "OK button should be present in error modal");
     }
+
+    #[test]
+    fn save_error_shows_modal() {
+        let mut gui = test_gui();
+        assert!(!gui.show_modal);
+        drop(gui.update(Message::SaveError("write failed".into())));
+        assert!(gui.show_modal);
+        assert_eq!(gui.modal_content.0, "Error");
+        assert_eq!(gui.modal_content.1, "write failed");
+    }
+
+    #[test]
+    fn submitted_sets_flow_name_from_url() {
+        let mut gui = test_gui();
+        gui.submission_settings.flow_manifest_url =
+            "flowr/examples/mandlebrot/manifest.json".into();
+        drop(gui.update(Message::Submitted));
+        assert_eq!(gui.tab_set.flow_name, "mandlebrot");
+        assert!(gui.submitted);
+    }
+
+    #[test]
+    fn submitted_sets_empty_flow_name_when_no_parent() {
+        let mut gui = test_gui();
+        gui.submission_settings.flow_manifest_url = "manifest.json".into();
+        drop(gui.update(Message::Submitted));
+        assert!(gui.tab_set.flow_name.is_empty());
+    }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -243,6 +243,13 @@ impl FlowrGui {
             }
             Message::Submitted => {
                 self.tab_set.clear();
+                self.tab_set.flow_name =
+                    std::path::Path::new(&self.submission_settings.flow_manifest_url)
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("")
+                        .to_string();
                 self.submitted = true;
             }
             Message::SubmitError(msg) | Message::SaveError(msg) => {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -21,6 +21,7 @@ pub(crate) struct TabSet {
     pub stdin_tab: StdInTab,
     pub images_tab: ImageTab,
     pub fileio_tab: StdOutTab,
+    pub flow_name: String,
 }
 
 impl TabSet {
@@ -50,6 +51,7 @@ impl TabSet {
                 auto_scroll: true,
                 unread_count: 0,
             },
+            flow_name: String::new(),
         }
     }
 
@@ -99,9 +101,14 @@ impl TabSet {
                 };
 
                 if let Some(lines) = content {
+                    let prefix = if self.flow_name.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{}_", self.flow_name)
+                    };
                     let dialog = rfd::FileDialog::new()
                         .add_filter("Text", &["txt"])
-                        .set_file_name(format!("{name}.txt"));
+                        .set_file_name(format!("{prefix}{name}.txt"));
                     if let Some(path) = dialog.save_file() {
                         if let Err(e) = fs::write(&path, lines.join("\n")) {
                             let msg = format!("Failed to save {name}: {e}");
@@ -113,14 +120,19 @@ impl TabSet {
             }
             Message::SaveImage(ref name) => {
                 if let Some(image_ref) = self.images_tab.images.get(name) {
-                    let has_png_ext = std::path::Path::new(name)
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("png"));
-                    let file_name = if has_png_ext {
-                        name.clone()
+                    let image_number = self
+                        .images_tab
+                        .images
+                        .keys()
+                        .position(|k| k == name)
+                        .unwrap_or(0)
+                        + 1;
+                    let prefix = if self.flow_name.is_empty() {
+                        String::new()
                     } else {
-                        format!("{name}.png")
+                        format!("{}_", self.flow_name)
                     };
+                    let file_name = format!("{prefix}image_{image_number}.png");
                     let dialog = rfd::FileDialog::new()
                         .add_filter("PNG", &["png"])
                         .set_file_name(file_name);

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -104,7 +104,9 @@ impl TabSet {
                         .set_file_name(format!("{name}.txt"));
                     if let Some(path) = dialog.save_file() {
                         if let Err(e) = fs::write(&path, lines.join("\n")) {
-                            error!("Failed to save {name}: {e}");
+                            let msg = format!("Failed to save {name}: {e}");
+                            error!("{msg}");
+                            return Task::done(Message::SaveError(msg));
                         }
                     }
                 }
@@ -123,8 +125,13 @@ impl TabSet {
                         .add_filter("PNG", &["png"])
                         .set_file_name(file_name);
                     if let Some(path) = dialog.save_file() {
-                        if let Err(e) = image_ref.data.save(&path) {
-                            error!("Failed to save image {name}: {e}");
+                        if let Err(e) = image_ref
+                            .data
+                            .save_with_format(&path, image::ImageFormat::Png)
+                        {
+                            let msg = format!("Failed to save image {name}: {e}");
+                            error!("{msg}");
+                            return Task::done(Message::SaveError(msg));
                         }
                     }
                 }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs;
 
 use iced::widget::image::{Handle, Viewer};
 use iced::widget::operation::{self, RelativeOffset};
@@ -7,6 +8,7 @@ use iced::widget::TextInput;
 use iced::widget::{text, toggler, Button, Column, Id, Row, Text};
 use iced::{Element, Length, Task};
 use iced_aw::{TabLabel, Tabs};
+use log::error;
 use once_cell::sync::Lazy;
 
 use crate::{ImageReference, Message};
@@ -83,6 +85,50 @@ impl TabSet {
                     return operation::snap_to(id, RelativeOffset::END);
                 }
             }
+            Message::SaveTabContent(ref name) => {
+                let content = if name == &self.stdout_tab.name {
+                    Some(&self.stdout_tab.content)
+                } else if name == &self.stderr_tab.name {
+                    Some(&self.stderr_tab.content)
+                } else if name == &self.stdin_tab.name {
+                    Some(&self.stdin_tab.content)
+                } else if name == &self.fileio_tab.name {
+                    Some(&self.fileio_tab.content)
+                } else {
+                    None
+                };
+
+                if let Some(lines) = content {
+                    let dialog = rfd::FileDialog::new()
+                        .add_filter("Text", &["txt"])
+                        .set_file_name(format!("{name}.txt"));
+                    if let Some(path) = dialog.save_file() {
+                        if let Err(e) = fs::write(&path, lines.join("\n")) {
+                            error!("Failed to save {name}: {e}");
+                        }
+                    }
+                }
+            }
+            Message::SaveImage(ref name) => {
+                if let Some(image_ref) = self.images_tab.images.get(name) {
+                    let has_png_ext = std::path::Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("png"));
+                    let file_name = if has_png_ext {
+                        name.clone()
+                    } else {
+                        format!("{name}.png")
+                    };
+                    let dialog = rfd::FileDialog::new()
+                        .add_filter("PNG", &["png"])
+                        .set_file_name(file_name);
+                    if let Some(path) = dialog.save_file() {
+                        if let Err(e) = image_ref.data.save(&path) {
+                            error!("Failed to save image {name}: {e}");
+                        }
+                    }
+                }
+            }
             _ => {}
         }
 
@@ -153,10 +199,16 @@ impl Tab for StdOutTab {
             .on_toggle(|v| Message::StdioAutoScrollTogglerChanged(self.id.clone(), v))
             .width(Length::Shrink);
 
+        let save_button =
+            Button::new(Text::new("Save")).on_press(Message::SaveTabContent(self.name.clone()));
         let clear_button =
             Button::new(Text::new("Clear")).on_press(Message::ClearTab(self.name.clone()));
 
-        let toolbar = Row::new().push(toggler).push(clear_button).spacing(10);
+        let toolbar = Row::new()
+            .push(toggler)
+            .push(save_button)
+            .push(clear_button)
+            .spacing(10);
 
         Column::new().push(toolbar).push(scrollable).into()
     }
@@ -195,14 +247,21 @@ impl Tab for ImageTab {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        let mut col = Column::new();
+        let mut col = Column::new().spacing(10);
 
-        for image_ref in self.images.values() {
-            col = col.push(Viewer::new(Handle::from_rgba(
+        for (name, image_ref) in &self.images {
+            let viewer = Viewer::new(Handle::from_rgba(
                 image_ref.width,
                 image_ref.height,
                 image_ref.data.as_raw().clone(),
-            )));
+            ));
+            let save_button =
+                Button::new(Text::new("Save")).on_press(Message::SaveImage(name.clone()));
+            let header = Row::new()
+                .push(Text::new(name.as_str()))
+                .push(save_button)
+                .spacing(10);
+            col = col.push(header).push(viewer);
         }
 
         col.into()
@@ -292,6 +351,10 @@ impl Tab for StdInTab {
                 .width(Length::Fill)
                 .padding(1);
 
+        let save_button =
+            Button::new(Text::new("Save")).on_press(Message::SaveTabContent(self.name.clone()));
+        let toolbar = Row::new().push(save_button).spacing(10);
+
         let text_input = TextInput::new("Enter new line of Standard input", &self.text)
             .on_input(Message::NewStdin)
             .on_paste(Message::NewStdin)
@@ -304,7 +367,11 @@ impl Tab for StdInTab {
             .height(Length::Fill)
             .id(self.id.clone());
 
-        Column::new().push(scrollable).push(input_row).into()
+        Column::new()
+            .push(toolbar)
+            .push(scrollable)
+            .push(input_row)
+            .into()
     }
 
     // Avoid clearing standard input - to allow the user to type in input ahead of the

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -584,4 +584,78 @@ mod test {
         assert_eq!(tabs.stdout_tab.unread_count, 0);
         assert_eq!(tabs.stderr_tab.unread_count, 3);
     }
+
+    #[test]
+    fn tabset_flow_name_default_empty() {
+        let tabs = TabSet::new();
+        assert!(tabs.flow_name.is_empty());
+    }
+
+    #[test]
+    fn tabset_clear_resets_all_tabs() {
+        let mut tabs = TabSet::new();
+        tabs.stdout_tab.content.push("hello".into());
+        tabs.stderr_tab.content.push("error".into());
+        tabs.fileio_tab.content.push("file".into());
+        tabs.flow_name = "myflow".into();
+        tabs.clear();
+        assert!(tabs.stdout_tab.content.is_empty());
+        assert!(tabs.stderr_tab.content.is_empty());
+        assert!(tabs.fileio_tab.content.is_empty());
+    }
+
+    #[test]
+    fn clear_tab_stdout() {
+        let mut tabs = TabSet::new();
+        tabs.stdout_tab.content.push("line1".into());
+        tabs.stdout_tab.content.push("line2".into());
+        drop(tabs.update(Message::ClearTab("Stdout".into())));
+        assert!(tabs.stdout_tab.content.is_empty());
+    }
+
+    #[test]
+    fn clear_tab_stderr() {
+        let mut tabs = TabSet::new();
+        tabs.stderr_tab.content.push("err".into());
+        drop(tabs.update(Message::ClearTab("Stderr".into())));
+        assert!(tabs.stderr_tab.content.is_empty());
+    }
+
+    #[test]
+    fn clear_tab_unknown_is_noop() {
+        let mut tabs = TabSet::new();
+        tabs.stdout_tab.content.push("keep".into());
+        drop(tabs.update(Message::ClearTab("Unknown".into())));
+        assert_eq!(tabs.stdout_tab.content, vec!["keep"]);
+    }
+
+    #[test]
+    fn save_image_unknown_name_is_noop() {
+        let mut tabs = TabSet::new();
+        drop(tabs.update(Message::SaveImage("nonexistent".into())));
+    }
+
+    #[test]
+    fn save_tab_content_unknown_name_is_noop() {
+        let mut tabs = TabSet::new();
+        tabs.stdout_tab.content.push("data".into());
+        drop(tabs.update(Message::SaveTabContent("Unknown".into())));
+        assert_eq!(tabs.stdout_tab.content, vec!["data"]);
+    }
+
+    #[test]
+    fn image_tab_clear_removes_images() {
+        let mut tab = ImageTab::new("Images");
+        tab.images.insert(
+            "test".into(),
+            ImageReference {
+                width: 1,
+                height: 1,
+                data: image::RgbaImage::new(1, 1),
+            },
+        );
+        tab.new_activity = true;
+        Tab::clear(&mut tab);
+        assert!(tab.images.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- Add Save button to stdout, stderr, stdin, and fileio tabs to save text content to disk via native file dialog
- Add per-image Save button in the Images tab to save individual images as PNG
- Uses `rfd` crate for file dialogs, consistent with `flowedit`

Closes #1902

## Test plan
- [x] Clean build passes (including flowstdlib wasm compilation)
- [x] `make clippy` clean
- [x] `cargo fmt` clean
- [x] `make test` passes
- [ ] Manual: run flowrgui, execute a flow producing stdout/images, verify Save buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save content across tabs: export StdOut/StdIn text to .txt and save individual images to .png
  * Save buttons added to tab toolbars and per-image headers
  * File dialogs with sensible default filenames that include the current flow name

* **Bug Fixes / UX**
  * Save failures surface a clear error modal so users know when saving fails

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->