### PR TITLE
Add flow hierarchy to manifest and recursive idle detection

### DIFF
--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -8,12 +8,13 @@ use log::info;
 use url::Url;
 
 use flowcore::model::flow_definition::FlowDefinition;
-use flowcore::model::flow_manifest::{FlowManifest, DEFAULT_MANIFEST_FILENAME};
+use flowcore::model::flow_manifest::{FlowInfo, FlowManifest, DEFAULT_MANIFEST_FILENAME};
 use flowcore::model::function_definition::FunctionDefinition;
 use flowcore::model::input::Input;
 use flowcore::model::metadata::MetaData;
 #[cfg(feature = "debugger")]
 use flowcore::model::name::HasName;
+use flowcore::model::process::Process;
 #[cfg(feature = "debugger")]
 use flowcore::model::route::HasRoute;
 use flowcore::model::runtime_function::RuntimeFunction;
@@ -51,12 +52,30 @@ pub fn create_manifest(
         );
     }
 
+    emit_flow_hierarchy(flow, &mut manifest);
+
     manifest.set_lib_references(&tables.libs);
     manifest.set_context_references(&tables.context_functions);
     #[cfg(feature = "debugger")]
     manifest.set_source_urls(source_urls);
 
     Ok(manifest)
+}
+
+fn emit_flow_hierarchy(flow: &FlowDefinition, manifest: &mut FlowManifest) {
+    let mut sub_flow_ids = Vec::new();
+
+    for subprocess in flow.subprocesses.values() {
+        if let Process::FlowProcess(ref sub_flow) = subprocess {
+            sub_flow_ids.push(sub_flow.id);
+            emit_flow_hierarchy(sub_flow, manifest);
+        }
+    }
+
+    manifest.add_flow_info(FlowInfo {
+        flow_id: flow.id,
+        sub_flow_ids,
+    });
 }
 
 /// Generate a manifest for the flow in JSON that can be used to execute it

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -31,6 +31,15 @@ pub struct Cargo {
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+/// Describes a flow's direct children: which sub-flow IDs it contains
+pub struct FlowInfo {
+    /// The unique flow ID
+    pub flow_id: usize,
+    /// IDs of direct child sub-flows
+    pub sub_flow_ids: Vec<usize>,
+}
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 /// A `flows` `Manifest` describes it and describes all the `Functions` it uses as well as
 /// a list of references to libraries.
 pub struct FlowManifest {
@@ -42,6 +51,9 @@ pub struct FlowManifest {
     context_references: BTreeSet<Url>,
     /// A list of `RuntimeFunctions` in this flow
     functions: Vec<RuntimeFunction>,
+    /// Flow hierarchy: which sub-flows each flow contains
+    #[serde(default)]
+    flows: Vec<FlowInfo>,
     #[cfg(feature = "debugger")]
     /// A list of the source files used to build this `flow`
     source_urls: BTreeMap<String, Url>,
@@ -69,6 +81,7 @@ impl FlowManifest {
             lib_references: BTreeSet::<Url>::new(),
             context_references: BTreeSet::<Url>::new(),
             functions: Vec::<RuntimeFunction>::new(),
+            flows: Vec::<FlowInfo>::new(),
             #[cfg(feature = "debugger")]
             source_urls: BTreeMap::<String, Url>::new(),
         }
@@ -77,6 +90,17 @@ impl FlowManifest {
     /// Add a run-time Function to the manifest for use in serialization
     pub fn add_function(&mut self, function: RuntimeFunction) {
         self.functions.push(function);
+    }
+
+    /// Add flow hierarchy info to the manifest
+    pub fn add_flow_info(&mut self, flow_info: FlowInfo) {
+        self.flows.push(flow_info);
+    }
+
+    /// Get the flow hierarchy
+    #[must_use]
+    pub fn flows(&self) -> &[FlowInfo] {
+        &self.flows
     }
 
     /// Get the list of functions in this manifest

--- a/flowr/src/bin/flowrcli/cli/cli_submission_handler.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_submission_handler.rs
@@ -101,7 +101,7 @@ impl SubmissionHandler for CLISubmissionHandler {
                         Ok(ClientMessage::ClientSubmission(submission)) => {
                             info!("Coordinator received a submission for execution");
                             trace!("\n{submission}");
-                            return Ok(Some(submission));
+                            return Ok(Some(*submission));
                         }
                         Ok(ClientMessage::ClientExiting(_)) => return Ok(None),
                         Ok(r) => error!("Coordinator did not expect response from client: '{r:?}'"),

--- a/flowr/src/bin/flowrcli/cli/coordinator_message.rs
+++ b/flowr/src/bin/flowrcli/cli/coordinator_message.rs
@@ -85,7 +85,7 @@ pub enum ClientMessage {
     /// ** These messages are used to implement the `SubmissionProtocol` between the Coordinator
     /// and the client
     /// A submission from the client for execution
-    ClientSubmission(Submission),
+    ClientSubmission(Box<Submission>),
     /// Client requests that server enters the ddebugger at the next opportunity
     EnterDebugger,
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -407,7 +407,7 @@ fn client(
     }
 
     info!("Client sending submission to coordinator");
-    client_connection.send(ClientMessage::ClientSubmission(submission))?;
+    client_connection.send(ClientMessage::ClientSubmission(Box::new(submission)))?;
 
     trace!("Entering client event loop");
     client.event_loop(client_connection)

--- a/flowr/src/bin/flowrgui/gui/client_message.rs
+++ b/flowr/src/bin/flowrgui/gui/client_message.rs
@@ -10,7 +10,7 @@ pub enum ClientMessage {
     /// ** These messages are used to implement the `SubmissionProtocol` between the Coordinator
     /// and the client
     /// A submission from the client for execution
-    ClientSubmission(Submission),
+    ClientSubmission(Box<Submission>),
     /// Client requests that server enters the ddebugger at the next opportunity
     EnterDebugger,
 

--- a/flowr/src/bin/flowrgui/gui/submission_handler.rs
+++ b/flowr/src/bin/flowrgui/gui/submission_handler.rs
@@ -94,7 +94,7 @@ impl SubmissionHandler for CLISubmissionHandler {
                         Ok(ClientMessage::ClientSubmission(submission)) => {
                             info!("Coordinator received a submission for execution");
                             trace!("\n{submission}");
-                            return Ok(Some(submission));
+                            return Ok(Some(*submission));
                         }
                         Ok(ClientMessage::ClientExiting(_)) => return Ok(None),
                         // Unexpected message — log and continue waiting for a valid submission

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -389,7 +389,7 @@ impl FlowrGui {
 
         info!("Sending submission to Coordinator");
         sender
-            .send(ClientMessage::ClientSubmission(submission))
+            .send(ClientMessage::ClientSubmission(Box::new(submission)))
             .await
             .map_err(|e| format!("Could not submit flow to coordinator: {e}"))
     }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -600,6 +600,22 @@ impl RunState {
         self.submission.manifest.functions().len()
     }
 
+    /// Check if a flow and all its sub-flows are idle (no busy functions, recursively)
+    fn is_flow_idle(&self, flow_id: usize) -> bool {
+        if self.busy_flows.contains_key(&flow_id) {
+            return false;
+        }
+        for flow_info in self.submission.manifest.flows() {
+            if flow_info.flow_id == flow_id {
+                return flow_info
+                    .sub_flow_ids
+                    .iter()
+                    .all(|&sub_id| self.is_flow_idle(sub_id));
+            }
+        }
+        true
+    }
+
     // Check if a flow has gone idle and run flow initializers if so
     #[allow(unused_variables, unused_assignments, unused_mut)]
     fn unblock_flows(
@@ -612,8 +628,8 @@ impl RunState {
 
         self.remove_from_busy(job.function_id);
 
-        // if the flow is now idle, run flow initializers
-        if self.busy_flows.get(&job.flow_id).is_none() {
+        // if the flow and all its sub-flows are idle, run flow initializers
+        if self.is_flow_idle(job.flow_id) {
             debug!(
                 "Job #{}:\tFlow #{} is now idle",
                 job.payload.job_id, job.flow_id


### PR DESCRIPTION
## Summary
- Add `FlowInfo` struct to `FlowManifest` with `flow_id` and `sub_flow_ids`
- Compiler emits flow hierarchy by recursing through `FlowDefinition.subprocesses`
- Add `is_flow_idle()` to `RunState` that recursively checks sub-flows
- Use recursive idle check in `unblock_flows()` — a parent flow is only idle when all its sub-flows are also idle
- Box `ClientSubmission` to fix clippy `large_enum_variant` warning

This is infrastructure for sub-flow run-to-completion semantics (#2649, #2671). No behavioral changes to existing tests.

## Test plan
- [x] `make clippy` clean
- [x] `cargo fmt` clean
- [x] `make test` passes (all examples including ignored ones)
- [x] All flowstdlib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced flow manifests now include detailed flow hierarchy information with sub-flow relationships.

* **Bug Fixes**
  * Fixed flow unblocking logic to correctly evaluate idle states across the entire flow and sub-flow hierarchy, ensuring flows properly resume when all child flows are ready.

* **Refactor**
  * Optimized submission message handling in CLI and GUI clients for improved memory efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->