### PR TITLE
Bump serde_yml to 0.0.13, fix lifetime bound (#2682)

### DIFF
--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -37,7 +37,7 @@ url = { version = "2.2", features = ["serde"] }
 log = {version = "0.4.30"}
 serde = { version = "~1.0.228"}
 toml = { version = "1.1.2" }
-serde_yml = "0.0.12"
+serde_yml = "0.0.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 curl = {version = "~0.4" }

--- a/flowcore/src/deserializers/yaml_deserializer.rs
+++ b/flowcore/src/deserializers/yaml_deserializer.rs
@@ -11,14 +11,14 @@ use super::deserializer::Deserializer;
 #[derive(Default)]
 pub struct YamlDeserializer<T>
 where
-    T: DeserializeOwned,
+    T: DeserializeOwned + 'static,
 {
     t: PhantomData<T>,
 }
 
 impl<T> YamlDeserializer<T>
 where
-    T: DeserializeOwned,
+    T: DeserializeOwned + 'static,
 {
     /// Create a new `YamlDeserializer`
     pub fn new() -> Self {
@@ -28,7 +28,7 @@ where
 
 impl<'a, T> Deserializer<'a, T> for YamlDeserializer<T>
 where
-    T: DeserializeOwned,
+    T: DeserializeOwned + 'static,
 {
     fn deserialize(&self, contents: &'a str, url: Option<&Url>) -> Result<T> {
         serde_yml::from_str(contents).chain_err(|| {


### PR DESCRIPTION
## Summary
- Fixes the CI failure in dependabot PR #2682
- `serde_yml` 0.0.13 is a deprecation shim that resolves RUSTSEC-2025-0068 (segfault via C-FFI libyaml)
- The new version requires `T: 'static` on `from_str`, so add that bound to `YamlDeserializer`

## Test plan
- [x] `make test` passes
- [x] `make clippy` clean

Supersedes #2682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)