### PR TITLE
Use flow-provided filename for image save in flowrgui (#1946)

### DIFF
--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -120,22 +120,9 @@ impl TabSet {
             }
             Message::SaveImage(ref name) => {
                 if let Some(image_ref) = self.images_tab.images.get(name) {
-                    let image_number = self
-                        .images_tab
-                        .images
-                        .keys()
-                        .position(|k| k == name)
-                        .unwrap_or(0)
-                        + 1;
-                    let prefix = if self.flow_name.is_empty() {
-                        String::new()
-                    } else {
-                        format!("{}_", self.flow_name)
-                    };
-                    let file_name = format!("{prefix}image_{image_number}.png");
                     let dialog = rfd::FileDialog::new()
                         .add_filter("PNG", &["png"])
-                        .set_file_name(file_name);
+                        .set_file_name(name);
                     if let Some(path) = dialog.save_file() {
                         if let Err(e) = image_ref
                             .data


### PR DESCRIPTION
## Summary
- flowrgui's Save Image dialog was auto-generating filenames like `flow_image_1.png`, ignoring the name the flow provides
- Now uses the flow-provided name directly (e.g. `test.file`), consistent with flowrcli
- Removes 14 lines of unnecessary naming logic

## Test plan
- [x] `make test` passes
- [x] `make clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined image export functionality by simplifying the save dialog naming logic. Images now save using their original filename instead of generating auto-incremented names (image_1.png, image_2.png, etc.). PNG format exports remain supported, providing more intuitive file management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewdavidmackenzie/flow/pull/2684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->