### PR TITLE
Add message count to flowrgui status bar (#2700)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
@@ -51,6 +51,19 @@ pub fn request_stop() {
 /// Check and clear the stop request flag
 pub fn take_stop_request() -> bool {
     STOP_REQUESTED.swap(false, Ordering::Relaxed)
+}
+
+/// Global counter for jobs created, updated by the coordinator thread
+static JOB_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Set the current job count (called from coordinator thread)
+pub fn set_job_count(count: usize) {
+    JOB_COUNT.store(count, Ordering::Relaxed);
+}
+
+/// Get the current job count (called from GUI thread)
+pub fn get_job_count() -> usize {
+    JOB_COUNT.load(Ordering::Relaxed)
 }
 
 // Creates an asynchronous worker that sends messages back and forth between the App and

--- a/flowr/src/bin/flowrgui/gui/submission_handler.rs
+++ b/flowr/src/bin/flowrgui/gui/submission_handler.rs
@@ -70,6 +70,10 @@ impl SubmissionHandler for CLISubmissionHandler {
         }
     }
 
+    fn jobs_created(&mut self, count: usize) {
+        connection_manager::set_job_count(count);
+    }
+
     fn flow_execution_ended(&mut self, state: &RunState, metrics: Metrics) -> Result<()> {
         self.coordinator_connection
             .lock()

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -192,6 +192,7 @@ struct FlowrGui {
     show_modal: bool,
     modal_content: (String, String),
     pending_getline: bool,
+    message_count: usize,
 }
 
 impl FlowrGui {
@@ -212,6 +213,7 @@ impl FlowrGui {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
+            message_count: 0,
         };
 
         (flowrgui, Task::none())
@@ -466,7 +468,11 @@ impl FlowrGui {
             }
         };
 
-        Row::new().push(Text::new(format!("Coordinator: {status}")))
+        let mut row = Row::new().push(Text::new(format!("Coordinator: {status}")));
+        if self.running {
+            row = row.push(Text::new(format!("    Messages: {}", self.message_count)));
+        }
+        row
     }
 
     // Create initial Settings structs for Submission and Coordinator from the CLI options
@@ -709,6 +715,9 @@ impl FlowrGui {
 
     #[allow(clippy::too_many_lines)]
     fn process_coordinator_message(&mut self, message: CoordinatorMessage) -> Task<Message> {
+        if self.running {
+            self.message_count += 1;
+        }
         match message {
             CoordinatorMessage::Connected(_) => {
                 self.error("Coordinator is already connected");
@@ -716,11 +725,13 @@ impl FlowrGui {
             CoordinatorMessage::FlowStart => {
                 self.running = true;
                 self.submitted = false;
+                self.message_count = 0;
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::FlowEnd(metrics) => {
                 self.submitted = false;
                 self.pending_getline = false;
+                self.message_count = 0;
                 self.tab_set.stdin_tab.waiting_for_input = false;
                 if self.submission_settings.display_metrics {
                     self.show_modal = true;
@@ -1038,6 +1049,7 @@ mod test {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
+            message_count: 0,
         }
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -192,7 +192,6 @@ struct FlowrGui {
     show_modal: bool,
     modal_content: (String, String),
     pending_getline: bool,
-    message_count: usize,
 }
 
 impl FlowrGui {
@@ -213,7 +212,6 @@ impl FlowrGui {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
-            message_count: 0,
         };
 
         (flowrgui, Task::none())
@@ -470,7 +468,10 @@ impl FlowrGui {
 
         let mut row = Row::new().push(Text::new(format!("Coordinator: {status}")));
         if self.running {
-            row = row.push(Text::new(format!("    Messages: {}", self.message_count)));
+            row = row.push(Text::new(format!(
+                "    Jobs: {}",
+                connection_manager::get_job_count()
+            )));
         }
         row
     }
@@ -715,9 +716,6 @@ impl FlowrGui {
 
     #[allow(clippy::too_many_lines)]
     fn process_coordinator_message(&mut self, message: CoordinatorMessage) -> Task<Message> {
-        if self.running {
-            self.message_count += 1;
-        }
         match message {
             CoordinatorMessage::Connected(_) => {
                 self.error("Coordinator is already connected");
@@ -725,13 +723,13 @@ impl FlowrGui {
             CoordinatorMessage::FlowStart => {
                 self.running = true;
                 self.submitted = false;
-                self.message_count = 0;
+                connection_manager::set_job_count(0);
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::FlowEnd(metrics) => {
                 self.submitted = false;
                 self.pending_getline = false;
-                self.message_count = 0;
+                connection_manager::set_job_count(0);
                 self.tab_set.stdin_tab.waiting_for_input = false;
                 if self.submission_settings.display_metrics {
                     self.show_modal = true;
@@ -1049,7 +1047,6 @@ mod test {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
-            message_count: 0,
         }
     }
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -154,6 +154,10 @@ impl<'a> Coordinator<'a> {
                     &mut metrics,
                 )?;
 
+                #[cfg(feature = "submission")]
+                self.submission_handler
+                    .jobs_created(state.get_number_of_jobs_created());
+
                 if restart {
                     break 'jobs;
                 }

--- a/flowr/src/lib/submission_handler.rs
+++ b/flowr/src/lib/submission_handler.rs
@@ -56,6 +56,10 @@ pub trait SubmissionHandler {
         Ok(false)
     }
 
+    /// Called by the [Coordinator][crate::coordinator::Coordinator] after jobs are retired,
+    /// with the total number of jobs created so far. Default implementation is a no-op.
+    fn jobs_created(&mut self, _count: usize) {}
+
     /// The [Coordinator][crate::coordinator::Coordinator] is about to exit
     ///
     /// # Errors


### PR DESCRIPTION
## Summary
- Adds a live "Messages: N" counter to the flowrgui status bar
- Counter increments on each coordinator message during flow execution
- Resets to 0 on FlowStart and FlowEnd
- Only visible while the flow is running
- Helps the user know the flow is actively processing

Fixes #2700

## Test plan
- [x] `make clippy` clean
- [x] Existing tests pass
- [ ] CI passes
- [ ] Visual verification: counter increments during flow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Coordinator status row now displays real-time job count tracking during flow execution. The job counter automatically updates as jobs are created and processed, and resets appropriately when flows start and end. This provides operators with immediate visibility into job creation metrics throughout the flow lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->