### PR TITLE
Fix flowrgui never returning to Ready after flow completion (#2705)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -727,6 +727,7 @@ impl FlowrGui {
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::FlowEnd(metrics) => {
+                self.running = false;
                 self.submitted = false;
                 self.pending_getline = false;
                 connection_manager::set_job_count(0);


### PR DESCRIPTION
## Summary
- FlowEnd handler was missing `self.running = false`
- GUI stayed in "Running" state forever after a flow completed
- One-line fix: set `self.running = false` in the FlowEnd handler

Fixes #2705
Fixes #2702

## Test plan
- [x] `make clippy` clean
- [x] Verified mandelbrot returns to "Connected(Ready)" after completion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)