### PR TITLE
Quote digraph names in dot output (#1594)

### DIFF
--- a/flowc/src/lib/dumper/flow_to_dot.rs
+++ b/flowc/src/lib/dumper/flow_to_dot.rs
@@ -412,7 +412,7 @@ fn digraph_start(flow: &FlowDefinition) -> String {
     // Create a directed graph named after the flow
     let _ = writeln!(
         wrapper,
-        "digraph {} {{",
+        "digraph \"{}\" {{",
         str::replace(&flow.alias.clone(), "-", "_")
     );
     let _ = writeln!(wrapper, "\tlabel=\"{}\";", flow.alias);

--- a/flowc/src/lib/dumper/functions_to_dot.rs
+++ b/flowc/src/lib/dumper/functions_to_dot.rs
@@ -77,7 +77,7 @@ pub fn dump_functions(
     info!("\tGenerating functions.dot, Use \"dotty\" to view it");
     dot_file.write_all(
         format!(
-            "digraph {} {{\nnodesep=1.0\n",
+            "digraph \"{}\" {{\nnodesep=1.0\n",
             str::replace(&flow.alias.clone(), "-", "_")
         )
         .as_bytes(),


### PR DESCRIPTION
## Summary
- Quote digraph names in both flow and functions dot files
- Prevents invalid dot syntax when flow names contain spaces or special characters

Fixes #1594

## Test plan
- [x] `make clippy` clean
- [x] Verified dot files render correctly with `dot -Tsvg`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow name quoting in graph visualization output to ensure proper compatibility with special characters and downstream tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->