### PR TITLE
Fix missing diagram references in example docs (#1521)

### DIFF
--- a/flowr/examples/debug-help-string/DESCRIPTION.md
+++ b/flowr/examples/debug-help-string/DESCRIPTION.md
@@ -3,4 +3,8 @@ debug-help-string
 
 Description
 ===
-Test of printing debug help string from the debugger
+Test of printing debug help string from the debugger.
+
+Root Diagram
+===
+<a href="root.dot.svg" target="_blank"><img src="root.dot.svg"></a>

--- a/flowr/examples/debug-print-args/DESCRIPTION.md
+++ b/flowr/examples/debug-print-args/DESCRIPTION.md
@@ -4,5 +4,8 @@ debug-print-args
 Description
 ===
 Check that we can execute a flow in the debugger and that it works.
+The flow is the same as print-args.
 
-The flow features used is not important for this test and the flow is the same as ../print-args.
+Root Diagram
+===
+<a href="root.dot.svg" target="_blank"><img src="root.dot.svg"></a>

--- a/flowr/examples/game-of-life/DESCRIPTION.md
+++ b/flowr/examples/game-of-life/DESCRIPTION.md
@@ -15,6 +15,12 @@ Root Diagram
 
 Click image to navigate flow hierarchy.
 
+Functions Diagram
+===
+<a href="functions.dot.svg" target="_blank"><img src="functions.dot.svg"></a>
+
+Click image to view functions graph.
+
 Features Used
 ===
 * Root Flow

--- a/flowr/examples/gcd/DESCRIPTION.md
+++ b/flowr/examples/gcd/DESCRIPTION.md
@@ -16,6 +16,12 @@ Root Diagram
 
 Click image to navigate flow hierarchy.
 
+Functions Diagram
+===
+<a href="functions.dot.svg" target="_blank"><img src="functions.dot.svg"></a>
+
+Click image to view functions graph.
+
 Features Used
 ===
 * Library Functions used

--- a/flowr/examples/hamming/DESCRIPTION.md
+++ b/flowr/examples/hamming/DESCRIPTION.md
@@ -34,6 +34,12 @@ Root Diagram
 
 Click image to navigate flow hierarchy.
 
+Functions Diagram
+===
+<a href="functions.dot.svg" target="_blank"><img src="functions.dot.svg"></a>
+
+Click image to view functions graph.
+
 Features Used
 ===
 * Provided function (hamming_step - compiled to WASM)

--- a/flowr/examples/image-analysis/DESCRIPTION.md
+++ b/flowr/examples/image-analysis/DESCRIPTION.md
@@ -36,6 +36,12 @@ Root Diagram
 
 Click image to navigate flow hierarchy.
 
+Functions Diagram
+===
+<a href="functions.dot.svg" target="_blank"><img src="functions.dot.svg"></a>
+
+Click image to view functions graph.
+
 Features Used
 ===
 * Provided functions (histogram, contrast_stretch — compiled to WASM)


### PR DESCRIPTION
## Summary
- Add functions diagram references to game-of-life, gcd, hamming, image-analysis
- Add root diagram references to debug-help-string, debug-print-args
- All examples now consistently reference their generated SVG diagrams

Fixes #1521

## Test plan
- [x] `make book` builds clean with no broken links
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)