### PR TITLE
Remove get_function() from job retire path (#1627)

### DIFF
--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -903,6 +903,8 @@ mod test {
     fn test_job() -> Job {
         Job {
             process_id: 0,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -898,6 +898,8 @@ mod test {
     fn execute_job() {
         let job1 = Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {
@@ -911,6 +913,8 @@ mod test {
 
         let job2 = Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {
@@ -924,6 +928,8 @@ mod test {
 
         let job3 = Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {

--- a/flowr/src/lib/job.rs
+++ b/flowr/src/lib/job.rs
@@ -27,6 +27,9 @@ pub struct Job {
     pub process_id: usize,
     /// The `parent_id` of the flow containing the function executing the job
     pub parent_id: usize,
+    /// The function name (for logging without looking up the function)
+    #[cfg(feature = "debugger")]
+    pub function_name: String,
     /// the payload required to execute the job
     pub payload: Payload,
     /// The result of the execution with the `job_id`, the optional output Value and if the function
@@ -73,6 +76,8 @@ mod test {
     fn display_job_test() {
         let job = super::Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {
@@ -90,6 +95,8 @@ mod test {
     fn get_entire_output_value() {
         let job = super::Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {
@@ -119,6 +126,8 @@ mod test {
         let value = json!(map);
         let job = super::Job {
             process_id: 1,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             parent_id: 0,
             connections: vec![],
             payload: Payload {

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -284,6 +284,7 @@ impl RunState {
     }
 
     /// Get a reference to the function with `id`
+    #[cfg(any(feature = "debugger", test))]
     #[must_use]
     pub fn get_function(&self, id: usize) -> Option<&RuntimeFunction> {
         self.submission.manifest.functions().get(&id)

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -355,9 +355,7 @@ impl RunState {
                     "Job #{}: Function #{} '{}' {:?} -> {:?}",
                     job.payload.job_id,
                     job.process_id,
-                    self.get_function(job.process_id)
-                        .ok_or("No such function")?
-                        .name(),
+                    job.function_name,
                     job.payload.input_set,
                     output_value
                 );
@@ -581,6 +579,8 @@ impl RunState {
                 let job = Job {
                     process_id,
                     parent_id,
+                    #[cfg(feature = "debugger")]
+                    function_name: function.name().to_string(),
                     connections: function.get_output_connections().clone(),
                     payload: Payload {
                         job_id,
@@ -941,6 +941,8 @@ mod test {
         Job {
             process_id: source_process_id,
             parent_id: 0,
+            #[cfg(feature = "debugger")]
+            function_name: String::new(),
             connections: vec![out_conn],
             payload: Payload {
                 job_id: 1,
@@ -1249,6 +1251,8 @@ mod test {
         fn test_job() -> Job {
             Job {
                 process_id: 0,
+                #[cfg(feature = "debugger")]
+                function_name: String::new(),
                 parent_id: 0,
                 connections: vec![],
                 payload: Payload {


### PR DESCRIPTION
## Summary
- Add `function_name: String` to `Job` struct (behind `#[cfg(feature = "debugger")]`)
- Set it at job creation time from `function.name()`
- Use `job.function_name` in the retire debug log instead of calling `get_function()`
- Eliminates a function lookup on the hot path (every job retirement)

Fixes #1627

## Test plan
- [x] `make clippy` clean
- [x] All tests compile with debugger feature
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)