### PR TITLE
Narrow initializer values through subroutes at sub-flow boundaries (#1997)

### DIFF
--- a/flowc/src/lib/compiler/gatherer.rs
+++ b/flowc/src/lib/compiler/gatherer.rs
@@ -13,8 +13,34 @@ use flowcore::model::process::Process::FunctionProcess;
 use flowcore::model::route::HasRoute;
 use flowcore::model::route::Route;
 
+use flowcore::model::input::InputInitializer;
+use serde_json::Value;
+
 use crate::compiler::compile::CompilerTables;
 use crate::errors::Result;
+
+fn apply_subroute_to_initializer(
+    initializer: &Option<InputInitializer>,
+    subroute: &Route,
+) -> Option<InputInitializer> {
+    if subroute.is_empty() {
+        return initializer.clone();
+    }
+
+    initializer.as_ref().map(|init| {
+        let value = init.get_value();
+        let narrowed = apply_subroute_to_value(value, subroute);
+        match init {
+            InputInitializer::Always(_) => InputInitializer::Always(narrowed),
+            InputInitializer::Once(_) => InputInitializer::Once(narrowed),
+        }
+    })
+}
+
+fn apply_subroute_to_value(value: &Value, subroute: &Route) -> Value {
+    let route_str = subroute.to_string();
+    value.pointer(&route_str).cloned().unwrap_or_else(|| value.clone())
+}
 
 /// Recursively go through the flow hierarchy, harvesting out functions and connections within
 /// each flow into the `CompilerTables` that will be used in later compilers.
@@ -161,6 +187,14 @@ pub fn collapse_connections(tables: &mut CompilerTables) -> Result<()> {
             // connection starts at a flow's input via a FlowInputInitializer - propagate to destination function
             IOType::FlowInput | IOType::FlowOutput => {
                 if connection.from_io().get_initializer().is_some() {
+                    let from_str = connection.from().to_string();
+                    let io_route = connection.from_io().route().to_string();
+                    let source_subroute = Route::from(
+                        from_str.strip_prefix(&io_route).unwrap_or(""),
+                    );
+                    debug!("Initializer propagation: from='{}', io_route='{}', subroute='{}'",
+                        from_str, io_route, source_subroute);
+
                     // find the destination functions (the connection could split to multiple destinations)
                     let destinations = if connection.to_io().io_type() == &IOType::FunctionInput {
                         vec![(
@@ -194,9 +228,11 @@ pub fn collapse_connections(tables: &mut CompilerTables) -> Result<()> {
                                 "Could not find a function #{destination_function_id}"
                             ))?;
 
-                        let flow_initializer = connection.from_io().get_initializer().clone();
-
-                        // TODO check types
+                        let flow_initializer =
+                            apply_subroute_to_initializer(
+                                connection.from_io().get_initializer(),
+                                &source_subroute,
+                            );
 
                         destination_function
                             .set_flow_initializer(*destination_input_index, flow_initializer)?;

--- a/flowc/src/lib/compiler/gatherer.rs
+++ b/flowc/src/lib/compiler/gatherer.rs
@@ -13,34 +13,8 @@ use flowcore::model::process::Process::FunctionProcess;
 use flowcore::model::route::HasRoute;
 use flowcore::model::route::Route;
 
-use flowcore::model::input::InputInitializer;
-use serde_json::Value;
-
 use crate::compiler::compile::CompilerTables;
 use crate::errors::Result;
-
-fn apply_subroute_to_initializer(
-    initializer: &Option<InputInitializer>,
-    subroute: &Route,
-) -> Option<InputInitializer> {
-    if subroute.is_empty() {
-        return initializer.clone();
-    }
-
-    initializer.as_ref().map(|init| {
-        let value = init.get_value();
-        let narrowed = apply_subroute_to_value(value, subroute);
-        match init {
-            InputInitializer::Always(_) => InputInitializer::Always(narrowed),
-            InputInitializer::Once(_) => InputInitializer::Once(narrowed),
-        }
-    })
-}
-
-fn apply_subroute_to_value(value: &Value, subroute: &Route) -> Value {
-    let route_str = subroute.to_string();
-    value.pointer(&route_str).cloned().unwrap_or_else(|| value.clone())
-}
 
 /// Recursively go through the flow hierarchy, harvesting out functions and connections within
 /// each flow into the `CompilerTables` that will be used in later compilers.
@@ -187,14 +161,6 @@ pub fn collapse_connections(tables: &mut CompilerTables) -> Result<()> {
             // connection starts at a flow's input via a FlowInputInitializer - propagate to destination function
             IOType::FlowInput | IOType::FlowOutput => {
                 if connection.from_io().get_initializer().is_some() {
-                    let from_str = connection.from().to_string();
-                    let io_route = connection.from_io().route().to_string();
-                    let source_subroute = Route::from(
-                        from_str.strip_prefix(&io_route).unwrap_or(""),
-                    );
-                    debug!("Initializer propagation: from='{}', io_route='{}', subroute='{}'",
-                        from_str, io_route, source_subroute);
-
                     // find the destination functions (the connection could split to multiple destinations)
                     let destinations = if connection.to_io().io_type() == &IOType::FunctionInput {
                         vec![(
@@ -220,7 +186,6 @@ pub fn collapse_connections(tables: &mut CompilerTables) -> Result<()> {
                                 destination_io.route()
                             ))?;
 
-                        // get a mutable reference to the destination function and set the initializer on it
                         let destination_function = tables
                             .functions
                             .get_mut(destination_function_id)
@@ -228,11 +193,7 @@ pub fn collapse_connections(tables: &mut CompilerTables) -> Result<()> {
                                 "Could not find a function #{destination_function_id}"
                             ))?;
 
-                        let flow_initializer =
-                            apply_subroute_to_initializer(
-                                connection.from_io().get_initializer(),
-                                &source_subroute,
-                            );
+                        let flow_initializer = connection.from_io().get_initializer().clone();
 
                         destination_function
                             .set_flow_initializer(*destination_input_index, flow_initializer)?;

--- a/flowc/tests/test-flows/subflow-type-boundary/extract_first.toml
+++ b/flowc/tests/test-flows/subflow-type-boundary/extract_first.toml
@@ -1,0 +1,16 @@
+flow = "extract_first"
+
+# Sub-flow that takes array/number and extracts the first element via subroute
+
+[[input]]
+name = "pair"
+type = "array/number"
+
+[[output]]
+name = "first"
+type = "number"
+
+# Select element 0 from the pair using subroute
+[[connection]]
+from = "input/pair/0"
+to = "output/first"

--- a/flowc/tests/test-flows/subflow-type-boundary/manifest.json
+++ b/flowc/tests/test-flows/subflow-type-boundary/manifest.json
@@ -20,27 +20,24 @@
         {
           "generic": true,
           "flow_initializer": {
-            "once": [
-              10,
-              20
-            ]
+            "once": 10
           }
         }
       ]
     }
   },
   "flows": {
+    "1": {
+      "process_id": 1,
+      "parent_id": 0,
+      "sub_flow_ids": []
+    },
     "0": {
       "process_id": 0,
       "parent_id": null,
       "sub_flow_ids": [
         1
       ]
-    },
-    "1": {
-      "process_id": 1,
-      "parent_id": 0,
-      "sub_flow_ids": []
     }
   },
   "source_urls": {}

--- a/flowc/tests/test-flows/subflow-type-boundary/manifest.json
+++ b/flowc/tests/test-flows/subflow-type-boundary/manifest.json
@@ -1,0 +1,47 @@
+{
+  "metadata": {
+    "name": "",
+    "version": "",
+    "description": "",
+    "authors": []
+  },
+  "lib_references": [],
+  "context_references": [
+    "context://stdio/stdout"
+  ],
+  "functions": {
+    "2": {
+      "name": "stdout",
+      "route": "/subflow-type-boundary/stdout",
+      "process_id": 2,
+      "parent_id": 0,
+      "implementation_location": "context://stdio/stdout",
+      "inputs": [
+        {
+          "generic": true,
+          "flow_initializer": {
+            "once": [
+              10,
+              20
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "flows": {
+    "0": {
+      "process_id": 0,
+      "parent_id": null,
+      "sub_flow_ids": [
+        1
+      ]
+    },
+    "1": {
+      "process_id": 1,
+      "parent_id": 0,
+      "sub_flow_ids": []
+    }
+  },
+  "source_urls": {}
+}

--- a/flowc/tests/test-flows/subflow-type-boundary/root.toml
+++ b/flowc/tests/test-flows/subflow-type-boundary/root.toml
@@ -1,0 +1,17 @@
+flow = "subflow-type-boundary"
+
+# Test: args/get produces array/string, we take string/1 as an array/number pair,
+# feed it to extract_first sub-flow which should extract element 0.
+
+# Use an initializer directly on the sub-flow input
+[[process]]
+source = "extract_first"
+input.pair = { once = [10, 20] }
+
+[[process]]
+source = "context://stdio/stdout"
+
+# We expect "10" (element 0 of [10,20]), not "[10,20]" (the whole array)
+[[connection]]
+from = "extract_first/first"
+to = "stdout"

--- a/flowcore/src/model/flow_definition.rs
+++ b/flowcore/src/model/flow_definition.rs
@@ -397,12 +397,13 @@ impl FlowDefinition {
         debug!("Looking for connection {direction:?} '{route}'");
         match (&direction, route.parse_subroute()?) {
             (&FROM, RouteType::FlowInput(input_name, sub_route)) => {
-                // make sure the sub-route of the input is added to the source of the connection
                 let mut from = self
                     .inputs
                     .find_by_subroute(&Route::from(input_name.clone()))?;
-                // accumulate any subroute within the input
                 from.route_mut().extend(&sub_route);
+                if !sub_route.is_empty() {
+                    from.narrow_initializer(&sub_route);
+                }
                 Ok(from)
             }
 

--- a/flowcore/src/model/io.rs
+++ b/flowcore/src/model/io.rs
@@ -67,6 +67,17 @@ pub struct IO {
     io_type: IOType,
 }
 
+fn narrow_init_option(init: Option<InputInitializer>, pointer: &str) -> Option<InputInitializer> {
+    init.map(|i| {
+        let narrowed = i.get_value().pointer(pointer).cloned();
+        match (&i, narrowed) {
+            (InputInitializer::Always(_), Some(v)) => InputInitializer::Always(v),
+            (InputInitializer::Once(_), Some(v)) => InputInitializer::Once(v),
+            _ => i,
+        }
+    })
+}
+
 impl IO {
     /// Create a new [IO] with a specific datatype and at a specific `Route`
     pub fn new<R: Into<Route>>(datatypes: Vec<DataType>, route: R) -> Self {
@@ -155,6 +166,19 @@ impl IO {
     #[must_use]
     pub fn get_flow_initializer(&self) -> &Option<InputInitializer> {
         &self.flow_initializer
+    }
+
+    /// Narrow the initializer value using a JSON pointer subroute.
+    /// For example, subroute `0` on initializer `[10, 20]` narrows to `10`.
+    pub fn narrow_initializer(&mut self, subroute: &Route) {
+        let route_str = subroute.to_string();
+        let pointer = if route_str.starts_with('/') {
+            route_str
+        } else {
+            format!("/{route_str}")
+        };
+        self.initializer = narrow_init_option(self.initializer.take(), &pointer);
+        self.flow_initializer = narrow_init_option(self.flow_initializer.take(), &pointer);
     }
 
     /// Set the input initializer of this IO


### PR DESCRIPTION
## Summary
When a connection inside a sub-flow uses a subroute on a flow input (e.g., `from = "input/pair/0"`), the initializer value is now narrowed by the subroute using JSON pointer selection.

**Before:** sub-flow input initialized with `[10, 20]`, internal connection selects `/0` → output was `[10, 20]` (whole array, subroute ignored)

**After:** output is `10` (element 0, correctly narrowed)

### Implementation
- Added `narrow_initializer()` to `IO` (`flowcore/src/model/io.rs`)
- Called from `get_io_by_route()` in `flow_definition.rs` when resolving a `FlowInput` with a subroute
- Cleaned up dead code in `gatherer.rs` (removed `apply_subroute_to_initializer` helper)
- Test flow: `subflow-type-boundary` with `extract_first` sub-flow

Fixes #1997

## Test plan
- [x] `make clippy` clean
- [x] `make test` all pass (including mandelbrot which uses subroutes on sub-flow inputs)
- [x] New test flow verifies subroute narrowing: outputs `10` from `[10, 20]`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)