### PR TITLE
Style revamp: Catppuccin theme with system dark/light detection (#1959)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -75,6 +75,9 @@ mod tabs;
 /// to get access to everything `error_chain` creates.
 mod errors;
 
+/// custom widget styling
+mod theme;
+
 /// [Message] enum captures all the types of messages that are sent to and processed by the
 /// `flowrgui` Iced Application
 #[derive(Debug, Clone)]
@@ -127,11 +130,31 @@ enum CoordinatorState {
     Connected(tokio::sync::mpsc::Sender<ClientMessage>),
 }
 
+/// Detect if the system prefers dark mode.
+fn dark_mode_enabled() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // Check macOS dark mode via `defaults read`
+        std::process::Command::new("defaults")
+            .args(["read", "-g", "AppleInterfaceStyle"])
+            .output()
+            .map_or(true, |o| {
+                String::from_utf8_lossy(&o.stdout).contains("Dark")
+            })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Default to dark on Linux/other
+        true
+    }
+}
+
 /// Main for flowrgui binary - call `run()` and print any error that results or exit silently if OK
 fn main() -> iced::Result {
     iced::application(FlowrGui::new, FlowrGui::update, FlowrGui::view)
         .subscription(FlowrGui::subscription)
         .title(FlowrGui::title)
+        .theme(FlowrGui::theme)
         .antialiasing(true)
         .run()
 }
@@ -220,6 +243,15 @@ impl FlowrGui {
     #[allow(clippy::unused_self)]
     fn title(&self) -> String {
         String::from("flowrgui")
+    }
+
+    #[allow(clippy::unused_self)]
+    fn theme(&self) -> iced::Theme {
+        if dark_mode_enabled() {
+            iced::Theme::CatppuccinMocha
+        } else {
+            iced::Theme::CatppuccinLatte
+        }
     }
 
     fn update(&mut self, message: Message) -> Task<Message> {
@@ -325,11 +357,11 @@ impl FlowrGui {
 
     fn view(&self) -> Element<'_, Message> {
         let main_content = Column::new()
-            .spacing(10)
+            .spacing(12)
             .push(self.command_row())
             .push(self.tab_set.view())
             .push(self.status_row())
-            .padding(10);
+            .padding(16);
 
         if self.show_modal {
             let modal_card = Card::new(
@@ -429,23 +461,31 @@ impl FlowrGui {
             && !self.submitted;
 
         let play = if self.running {
-            Button::new("Stop").on_press(Message::StopFlow)
+            Button::new(Text::new("\u{23F9} Stop"))
+                .on_press(Message::StopFlow)
+                .style(theme::styled_button)
+                .padding([6, 16])
         } else {
-            let mut btn = Button::new("Play");
+            let mut btn = Button::new(Text::new("\u{25B6} Play"))
+                .style(theme::styled_button)
+                .padding([6, 16]);
             if can_run {
                 btn = btn.on_press(Message::SubmitFlow);
             }
             btn
         };
 
-        let mut debug_play = Button::new("Debug");
+        let mut debug_play = Button::new(Text::new("\u{1F41B} Debug"))
+            .style(theme::styled_button)
+            .padding([6, 16]);
         if can_run {
             debug_play = debug_play.on_press(Message::DebugSubmitFlow);
         }
 
         Row::new()
             .spacing(10)
-            .align_y(iced::alignment::Vertical::Bottom)
+            .padding(5)
+            .align_y(iced::alignment::Vertical::Center)
             .push(url)
             .push(args)
             .push(max_jobs)
@@ -454,24 +494,25 @@ impl FlowrGui {
     }
 
     fn status_row(&self) -> Row<'_, Message> {
-        let status = match &self.coordinator_state {
-            CoordinatorState::Disconnected(reason) => format!("Disconnected({reason})"),
-            CoordinatorState::Connected(_) => {
-                let msg = match (self.submitted, self.running) {
-                    (false, false) => "Ready",
-                    (_, true) => "Running",
-                    (true, false) => "Submitted",
-                };
-                format!("Connected({msg})")
+        let (indicator, status) = match &self.coordinator_state {
+            CoordinatorState::Disconnected(reason) => {
+                ("\u{1F534}", format!("Disconnected({reason})"))
             }
+            CoordinatorState::Connected(_) => match (self.submitted, self.running) {
+                (false, false) => ("\u{1F7E2}", "Ready".to_string()),
+                (_, true) => ("\u{1F535}", "Running".to_string()),
+                (true, false) => ("\u{1F7E1}", "Submitted".to_string()),
+            },
         };
 
-        let mut row = Row::new().push(Text::new(format!("Coordinator: {status}")));
+        let mut row = Row::new()
+            .spacing(8)
+            .align_y(iced::alignment::Vertical::Center)
+            .push(Text::new(indicator))
+            .push(Text::new(status).size(13));
         if self.running {
-            row = row.push(Text::new(format!(
-                "    Jobs: {}",
-                connection_manager::get_job_count()
-            )));
+            row = row
+                .push(Text::new(format!("Jobs: {}", connection_manager::get_job_count())).size(13));
         }
         row
     }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -205,16 +205,22 @@ impl Tab for StdOutTab {
             .on_toggle(|v| Message::StdioAutoScrollTogglerChanged(self.id.clone(), v))
             .width(Length::Shrink);
 
-        let save_button =
-            Button::new(Text::new("Save")).on_press(Message::SaveTabContent(self.name.clone()));
-        let clear_button =
-            Button::new(Text::new("Clear")).on_press(Message::ClearTab(self.name.clone()));
+        let save_button = Button::new(Text::new("Save"))
+            .on_press(Message::SaveTabContent(self.name.clone()))
+            .style(crate::theme::styled_button)
+            .padding([4, 12]);
+        let clear_button = Button::new(Text::new("Clear"))
+            .on_press(Message::ClearTab(self.name.clone()))
+            .style(crate::theme::styled_button)
+            .padding([4, 12]);
 
         let toolbar = Row::new()
             .push(toggler)
             .push(save_button)
             .push(clear_button)
-            .spacing(10);
+            .spacing(10)
+            .padding(4)
+            .align_y(iced::alignment::Vertical::Center);
 
         Column::new().push(toolbar).push(scrollable).into()
     }
@@ -304,8 +310,10 @@ impl Tab for ImageTab {
                     u16::try_from(display_height.min(300)).unwrap_or(300),
                 )));
             let label = format!("{name} ({}x{})", image_ref.width, image_ref.height);
-            let save_button =
-                Button::new(Text::new("Save")).on_press(Message::SaveImage(name.clone()));
+            let save_button = Button::new(Text::new("Save"))
+                .on_press(Message::SaveImage(name.clone()))
+                .style(crate::theme::styled_button)
+                .padding([4, 12]);
             let header = Row::new()
                 .push(Text::new(label))
                 .push(save_button)
@@ -403,9 +411,11 @@ impl Tab for StdInTab {
                 .width(Length::Fill)
                 .padding(1);
 
-        let save_button =
-            Button::new(Text::new("Save")).on_press(Message::SaveTabContent(self.name.clone()));
-        let toolbar = Row::new().push(save_button).spacing(10);
+        let save_button = Button::new(Text::new("Save"))
+            .on_press(Message::SaveTabContent(self.name.clone()))
+            .style(crate::theme::styled_button)
+            .padding([4, 12]);
+        let toolbar = Row::new().push(save_button).spacing(10).padding(4);
 
         let text_input = TextInput::new("Enter new line of Standard input", &self.text)
             .on_input(Message::NewStdin)
@@ -413,7 +423,10 @@ impl Tab for StdInTab {
             .on_submit(Message::LineOfStdin(self.text.clone()))
             .width(Length::Fill)
             .padding(10);
-        let eof_button = Button::new(Text::new("EOF")).on_press(Message::SendEof);
+        let eof_button = Button::new(Text::new("EOF"))
+            .on_press(Message::SendEof)
+            .style(crate::theme::styled_button)
+            .padding([4, 12]);
         let input_row = Row::new().push(text_input).push(eof_button).spacing(5);
         let scrollable = Scrollable::new(text_column)
             .height(Length::Fill)

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -1,0 +1,94 @@
+//! Custom styling for flowrgui widgets.
+
+use iced::widget::button;
+use iced::{Background, Border, Color, Shadow, Theme, Vector};
+
+/// Accent color used for active/hover states
+const ACCENT: Color = Color {
+    r: 0.424,
+    g: 0.361,
+    b: 0.906,
+    a: 1.0,
+};
+
+/// Border radius for buttons and tabs
+const RADIUS: f32 = 8.0;
+
+/// Border width for hover highlight
+const BORDER_WIDTH: f32 = 2.0;
+
+/// Custom button style with rounded corners and hover border highlight.
+pub fn styled_button(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.palette();
+    let base = button::Style {
+        border: Border {
+            radius: RADIUS.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: Shadow {
+            color: Color::BLACK,
+            offset: Vector::new(0.0, 1.0),
+            blur_radius: 3.0,
+        },
+        snap: true,
+        ..button::Style::default()
+    };
+
+    match status {
+        button::Status::Active => button::Style {
+            background: Some(Background::Color(Color {
+                r: 0.25,
+                g: 0.25,
+                b: 0.35,
+                a: 1.0,
+            })),
+            text_color: palette.text,
+            ..base
+        },
+        button::Status::Hovered => button::Style {
+            background: Some(Background::Color(ACCENT)),
+            text_color: Color::WHITE,
+            border: Border {
+                radius: RADIUS.into(),
+                width: BORDER_WIDTH,
+                color: lighten(ACCENT, 0.3),
+            },
+            ..base
+        },
+        button::Status::Pressed => button::Style {
+            background: Some(Background::Color(darken(ACCENT, 0.2))),
+            text_color: Color::WHITE,
+            ..base
+        },
+        button::Status::Disabled => button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.3,
+                ..palette.primary
+            })),
+            text_color: Color {
+                a: 0.5,
+                ..palette.text
+            },
+            ..base
+        },
+    }
+}
+
+fn lighten(c: Color, amount: f32) -> Color {
+    Color {
+        r: (c.r + amount).min(1.0),
+        g: (c.g + amount).min(1.0),
+        b: (c.b + amount).min(1.0),
+        a: c.a,
+    }
+}
+
+fn darken(c: Color, amount: f32) -> Color {
+    Color {
+        r: (c.r - amount).max(0.0),
+        g: (c.g - amount).max(0.0),
+        b: (c.b - amount).max(0.0),
+        a: c.a,
+    }
+}


### PR DESCRIPTION
## Summary
- System theme detection: Catppuccin Mocha (dark) or Catppuccin Latte (light) based on OS setting
- Custom button styling: rounded corners (8px), accent hover border, shadow, consistent across all buttons
- Icon buttons: ▶ Play, ⏹ Stop, 🐛 Debug
- Color-coded status: 🟢 Ready, 🔵 Running, 🟡 Submitted, 🔴 Disconnected
- Better padding, spacing, and vertical alignment throughout
- New `theme.rs` module for centralized widget styling

Fixes #1959

## Test plan
- [x] `make clippy` clean
- [x] Visual verification on macOS (dark mode)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic dark mode detection adapts the GUI theme based on system preferences for a personalized experience

* **Style**
  * Redesigned button styling with improved visual appearance and icon labels across the application
  * Adjusted spacing and padding throughout the interface for better visual hierarchy and usability
  * Enhanced status indicators using emoji labels for clearer, more intuitive user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->