### PR TITLE
Add input name validation and flow_output! macro (#717)

### DIFF
--- a/book/describing/provided_functions.md
+++ b/book/describing/provided_functions.md
@@ -41,13 +41,82 @@ Example: [escapes.rs](../../flowr/examples/mandlebrot/escapes/escapes.rs)
 
 This may optionally include tests, that will be compiled and run natively.
 
+### Writing function implementations
+
+Function implementations use the `#[flow_function]` macro from `flowmacro`. The macro
+generates boilerplate code for input extraction, type checking, and WASM interop.
+
+#### Typed input parameters
+
+Instead of manually extracting inputs from a `&[Value]` slice, declare typed parameters
+that match the input names in the function's TOML definition:
+
+```rust
+use serde_json::{json, Value};
+use flowcore::errors::Result;
+use flowcore::{RunAgain, RUN_AGAIN};
+use flowmacro::flow_function;
+
+#[flow_function]
+fn inner_add(i1: &Value, i2: &Value) -> Result<(Option<Value>, RunAgain)> {
+    // i1 and i2 are extracted and type-checked by the macro
+    // No manual inputs.first().ok_or(...)? needed
+    Ok((Some(json!(1)), RUN_AGAIN))
+}
+```
+
+Supported parameter types:
+
+| Rust type | Flow type | What the macro generates |
+|-----------|-----------|------------------------|
+| `&Value` | generic | `inputs.get(i).ok_or(...)` |
+| `Value` | generic | `inputs.get(i).ok_or(...)?.clone()` |
+| `&Number` | number | `inputs.get(i).ok_or(...)?.as_number().ok_or(...)` |
+| `f64` | number | `inputs.get(i).ok_or(...)?.as_f64().ok_or(...)` |
+| `i64` | number | `inputs.get(i).ok_or(...)?.as_i64().ok_or(...)` |
+| `bool` | boolean | `inputs.get(i).ok_or(...)?.as_bool().ok_or(...)` |
+| `&str` | string | `inputs.get(i).ok_or(...)?.as_str().ok_or(...)` |
+
+The parameter names must match the input names in the TOML definition (hyphens
+are normalized to underscores). The macro validates this at compile time.
+
+#### Named outputs with `flow_output!`
+
+For functions with multiple named outputs, use the `flow_output!` macro instead
+of manually building a `serde_json::Map`:
+
+```rust
+use flowcore::flow_output;
+use serde_json::json;
+
+// Instead of:
+//   let mut map = serde_json::Map::new();
+//   map.insert("result".into(), json!(33));
+//   map.insert("remainder".into(), json!(1));
+//   Ok((Some(Value::Object(map)), RUN_AGAIN))
+
+// Use:
+flow_output!(
+    "result" => json!(33),
+    "remainder" => json!(1)
+)
+```
+
+The macro builds the output map and returns `Ok((Some(map), RUN_AGAIN))`.
+
+For functions with a single unnamed output, return the value directly:
+
+```rust
+Ok((Some(json!(result)), RUN_AGAIN))
+```
+
 #### Build file
-In the case of the `rust` type (the only type implemented!), a `Cargo.toml` file that is used to compile 
-the function's implementation to WASM as a stand-along project. 
+In the case of the `rust` type (the only type implemented!), a `Cargo.toml` file that is used to compile
+the function's implementation to WASM as a stand-alone project.
 
 ### How are provided function implementations loaded and ran
-If the flow running app (using the `flowrlib`library`) is statically linked, how can it load and then run the
+If the flow running app (using the `flowrlib` library) is statically linked, how can it load and then run the
 provided implementation?
 
 This is done by compiling the provided implementation to WebAssembly, using the provided build file. The .wasm
-byte code file is generated when the flow is compiled and then loaded when the flow is loaded by `flowrlib`
+byte code file is generated when the flow is compiled and then loaded when the flow is loaded by `flowrlib`.

--- a/flowcore/src/lib.rs
+++ b/flowcore/src/lib.rs
@@ -5,6 +5,30 @@ use serde_json::Value;
 
 use crate::errors::Result;
 
+/// Build a named output map and return `Ok((Some(map), RUN_AGAIN))`.
+///
+/// Eliminates boilerplate for functions with multiple named outputs.
+///
+/// # Examples
+/// ```
+/// use flowcore::flow_output;
+/// use serde_json::json;
+///
+/// let result: flowcore::errors::Result<(Option<serde_json::Value>, bool)> =
+///     flow_output!("result" => json!(42), "remainder" => json!(0));
+/// let (output, again) = result.unwrap();
+/// assert!(again);
+/// assert_eq!(output.unwrap().pointer("/result").unwrap(), &json!(42));
+/// ```
+#[macro_export]
+macro_rules! flow_output {
+    ($($key:expr => $val:expr),+ $(,)?) => {{
+        let mut map = serde_json::Map::new();
+        $(map.insert($key.into(), $val);)+
+        Ok((Some(serde_json::Value::Object(map)), $crate::RUN_AGAIN))
+    }};
+}
+
 /// serializers to read definition files from various text formats based on file extension
 pub mod deserializers;
 

--- a/flowmacro/src/lib.rs
+++ b/flowmacro/src/lib.rs
@@ -14,6 +14,7 @@ use quote::{format_ident, quote, ToTokens};
 use syn::{parse_macro_input, FnArg, ItemFn, Pat, ReturnType, Type};
 
 use flowcore::model::function_definition::FunctionDefinition;
+use flowcore::model::name::HasName;
 
 /// The `flow_function` macro definition
 ///
@@ -99,6 +100,23 @@ fn analyze_inputs(definition: &FunctionDefinition, implementation_ast: &ItemFn) 
                 Pat::Ident(pat_ident) => &pat_ident.ident,
                 _ => panic!("flow_function: unsupported parameter pattern"),
             };
+
+            // Validate parameter name matches TOML input name (skip if TOML name is empty/default)
+            let toml_name = definition
+                .inputs
+                .get(i)
+                .expect("input index out of bounds")
+                .name();
+            if !toml_name.is_empty() {
+                let param_str = param_name.to_string();
+                let toml_normalized = toml_name.replace('-', "_");
+                assert_eq!(
+                    param_str, toml_normalized,
+                    "flow_function: parameter '{param_str}' at position {i} does not match \
+                     TOML input name '{toml_name}' in function '{}'",
+                    definition.name
+                );
+            }
 
             let extraction = generate_extraction(i, param_name, &pat_type.ty);
             extractions.push(extraction);

--- a/flowstdlib/src/math/divide/divide.rs
+++ b/flowstdlib/src/math/divide/divide.rs
@@ -1,28 +1,25 @@
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
-use flowcore::{RunAgain, RUN_AGAIN};
+use flowcore::flow_output;
+use flowcore::RunAgain;
 use flowmacro::flow_function;
 
 #[flow_function]
 fn inner_divide(dividend: &Value, divisor: &Value) -> Result<(Option<Value>, RunAgain)> {
     if dividend.is_null() || divisor.is_null() {
-        let mut null_map = serde_json::Map::new();
-        null_map.insert("result".into(), Value::Null);
-        null_map.insert("remainder".into(), Value::Null);
-        return Ok((Some(Value::Object(null_map)), RUN_AGAIN));
+        return flow_output!("result" => Value::Null, "remainder" => Value::Null);
     }
-
-    let mut output_map = serde_json::Map::new();
 
     let dividend = dividend
         .as_f64()
         .ok_or("Could not get dividend as number")?;
     let divisor = divisor.as_f64().ok_or("Could not get divisor as number")?;
-    output_map.insert("result".into(), json!(dividend / divisor));
-    output_map.insert("remainder".into(), json!(dividend % divisor));
 
-    Ok((Some(Value::Object(output_map)), RUN_AGAIN))
+    flow_output!(
+        "result" => json!(dividend / divisor),
+        "remainder" => json!(dividend % divisor)
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **Input name validation**: macro checks parameter names match TOML input names at compile time (hyphens normalized to underscores, unnamed inputs skipped)
- **flow_output! macro**: builds named output maps with `Ok((Some(map), RUN_AGAIN))` in one call, eliminating Map::new() + insert boilerplate
- Converted divide as demonstration of flow_output!
- Split TOML/Cargo.toml generation to #2722

### Before (divide):
```rust
let mut output_map = serde_json::Map::new();
output_map.insert("result".into(), json!(dividend / divisor));
output_map.insert("remainder".into(), json!(dividend % divisor));
Ok((Some(Value::Object(output_map)), RUN_AGAIN))
```

### After:
```rust
flow_output!(
    "result" => json!(dividend / divisor),
    "remainder" => json!(dividend % divisor)
)
```

Partial fix for #717

## Test plan
- [x] `make clippy` clean
- [x] Divide tests pass with flow_output!
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new macro for streamlined output construction in flow functions.

* **Improvements**
  * Enhanced compile-time validation to ensure implementation parameter names match their declared input names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->