### PR TITLE
Generate function TOML from Rust source (#717)

### DIFF
--- a/book/describing/provided_functions.md
+++ b/book/describing/provided_functions.md
@@ -24,16 +24,43 @@ The `flowr` crate has several examples that provide functions as part of the flo
 In order to provide a function as part of a flow the developer must provide:
 
 #### Function definition file
-Definition of the function in a TOML file.   
-Example [escapes.toml](../../flowr/examples/mandlebrot/escapes/escapes.toml)  
-The same as any other function definition it must define:
-   * `function` - field to show this is a function definition file and provide the function's name 
-   * `source` - the name of the implementation file (relative path to this file)
-   * `type` - to define what type of implementation is provided (`"rust"` is the only supported value at this time)
-   * `input`- the function's inputs - as described in [IOs](ios.md)
-   * `output`- the function's outputs - as described in [IOs](ios.md)
-   * `docs` - Documentation markdown file (relative path)  
-Example [escapes.md](../../flowr/examples/mandlebrot/escapes/escapes.md)
+The function definition can be provided in two ways:
+
+**Option 1: Hand-written TOML** (traditional)
+
+Write a TOML file alongside the implementation.
+Example [escapes.toml](../../flowr/examples/mandlebrot/escapes/escapes.toml)
+
+The definition must include:
+   * `function` - the function's name
+   * `source` - the implementation file (relative path)
+   * `type` - implementation type (`"rust"`)
+   * `input` - the function's inputs (see [IOs](ios.md))
+   * `output` - the function's outputs (see [IOs](ios.md))
+   * `docs` - documentation markdown file (optional)
+
+**Option 2: Auto-generated from Rust source** (recommended for new functions)
+
+If no `.toml` file exists alongside the `.rs` file, the `#[flow_function]`
+macro generates it automatically at compile time. The generated TOML derives:
+- Function name from the implementation function (stripping `inner_` prefix)
+- Input names and types from the typed parameters
+- Source filename from the `.rs` file
+- Description from doc comments on the function
+
+This means you only need to write the `.rs` implementation — the definition
+is generated for you. Example:
+
+```rust
+/// Double a number
+#[flow_function]
+fn inner_double(value: f64) -> Result<(Option<Value>, RunAgain)> {
+    flow_output!(json!(value * 2.0))
+}
+```
+
+This generates a `double.toml` with input `value` of type `number` and
+description "Double a number".
 
 #### Implementation
 Code that implements the function of the type specified by `type` in the file specified by `source`.  

--- a/flowc/tests/test-flows/generated-toml/double/Cargo.toml
+++ b/flowc/tests/test-flows/generated-toml/double/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "double"
+version = "0.142.0"
+edition = "2021"
+
+[lib]
+name = "double"
+crate-type = ["cdylib"]
+path = "double.rs"
+
+[dependencies]
+flowcore = { path = "../../../../../flowcore", version = "0.142.0" }
+flowmacro = { path = "../../../../../flowmacro", version = "0.142.0" }
+serde_json = "1.0"
+
+[workspace]

--- a/flowc/tests/test-flows/generated-toml/double/double.rs
+++ b/flowc/tests/test-flows/generated-toml/double/double.rs
@@ -1,0 +1,12 @@
+/// Double a number
+use serde_json::{json, Value};
+
+use flowcore::errors::Result;
+use flowcore::flow_output;
+use flowcore::RunAgain;
+use flowmacro::flow_function;
+
+#[flow_function]
+fn inner_double(value: f64) -> Result<(Option<Value>, RunAgain)> {
+    flow_output!(json!(value * 2.0))
+}

--- a/flowc/tests/test-flows/generated-toml/double/double.rs
+++ b/flowc/tests/test-flows/generated-toml/double/double.rs
@@ -1,4 +1,3 @@
-/// Double a number
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
@@ -6,6 +5,7 @@ use flowcore::flow_output;
 use flowcore::RunAgain;
 use flowmacro::flow_function;
 
+/// Double a number
 #[flow_function]
 fn inner_double(value: f64) -> Result<(Option<Value>, RunAgain)> {
     flow_output!(json!(value * 2.0))

--- a/flowc/tests/test-flows/generated-toml/double/double.toml
+++ b/flowc/tests/test-flows/generated-toml/double/double.toml
@@ -1,10 +1,7 @@
 function = "double"
-impure = false
 source = "double.rs"
-docs = ""
-description = ""
+description = "Double a number"
 type = "rust"
-output = []
 
 [[input]]
 name = "value"

--- a/flowc/tests/test-flows/generated-toml/double/double.toml
+++ b/flowc/tests/test-flows/generated-toml/double/double.toml
@@ -1,0 +1,13 @@
+function = "double"
+impure = false
+source = "double.rs"
+docs = ""
+description = ""
+type = "rust"
+output = []
+
+[[input]]
+name = "value"
+
+[[input.type]]
+string = "number"

--- a/flowcore/src/model/function_definition.rs
+++ b/flowcore/src/model/function_definition.rs
@@ -18,6 +18,11 @@ use crate::model::route::SetIORoutes;
 use crate::model::route::SetRoute;
 use crate::model::validation::Validate;
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
 /// `FunctionDefinition` defines a Function (compile time) that implements some processing in the flow hierarchy
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -26,15 +31,15 @@ pub struct FunctionDefinition {
     #[serde(rename = "function")]
     pub name: Name,
     /// Is this an impure function that interacts with the environment
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub impure: bool,
     /// Name of the source file for the function implementation
     pub source: String,
     /// Name of any docs file associated with this Function
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub docs: String,
     /// Optional description of what this function does
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
     /// Type of build used to compile Function's implementation to WASM from source
     #[serde(default, rename = "type")]
@@ -43,7 +48,7 @@ pub struct FunctionDefinition {
     #[serde(default, rename = "input")]
     pub inputs: IOSet,
     /// The set of outputs this function generates when executed
-    #[serde(default, rename = "output")]
+    #[serde(default, rename = "output", skip_serializing_if = "Vec::is_empty")]
     pub outputs: IOSet,
     /// As a function can be used multiple times in a single flow, the repeated instances must
     /// be referred to using an alias to disambiguate which instance is being referred to

--- a/flowmacro/src/lib.rs
+++ b/flowmacro/src/lib.rs
@@ -23,12 +23,23 @@ use flowcore::model::name::HasName;
 /// Will panic if the file path of the source file where the macro was used cannot be determined.
 #[proc_macro_attribute]
 pub fn flow_function(_attr: TokenStream, implementation: TokenStream) -> TokenStream {
-    let mut definition_file_path = Span::call_site()
+    let source_file = Span::call_site()
         .local_file()
         .expect("the 'flow' macro could not get the file path where macro was invoked");
+
+    let mut definition_file_path = source_file.clone();
     definition_file_path.set_extension("toml");
 
-    let function_definition = load_function_definition(&definition_file_path);
+    let function_definition = if definition_file_path.exists() {
+        load_function_definition(&definition_file_path)
+    } else {
+        let impl_clone: proc_macro2::TokenStream = implementation.clone().into();
+        let ast =
+            syn::parse2::<ItemFn>(impl_clone).expect("flow_function: could not parse function");
+        let def = generate_function_definition(&ast, &source_file);
+        write_function_definition(&def, &definition_file_path);
+        def
+    };
 
     generate_code(implementation, &function_definition)
 }
@@ -47,6 +58,121 @@ fn load_function_definition(path: &Path) -> FunctionDefinition {
             path.display()
         )
     })
+}
+
+/// Generate a `FunctionDefinition` from the function's signature and doc comments.
+fn generate_function_definition(ast: &ItemFn, source_file: &Path) -> FunctionDefinition {
+    let fn_name = ast.sig.ident.to_string();
+    let name = fn_name
+        .strip_prefix("inner_")
+        .unwrap_or(&fn_name)
+        .to_string();
+
+    let source = source_file
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Extract description from doc comments
+    let description = ast
+        .attrs
+        .iter()
+        .filter_map(|attr| {
+            if attr.path().is_ident("doc") {
+                attr.meta.require_name_value().ok().and_then(|nv| {
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(s),
+                        ..
+                    }) = &nv.value
+                    {
+                        Some(s.value().trim().to_string())
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // Check for docs .md file
+    let mut docs_path = source_file.to_path_buf();
+    docs_path.set_extension("md");
+    let docs = if docs_path.exists() {
+        docs_path
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    // Build inputs from typed parameters
+    let inputs = build_inputs_from_signature(ast);
+
+    // Default: single unnamed output (most common case)
+    let outputs = flowcore::model::io::IOSet::default();
+
+    let mut def = FunctionDefinition::default();
+    def.name = name;
+    def.source = source;
+    def.docs = docs;
+    def.description = description;
+    def.build_type = "rust".to_string();
+    def.inputs = inputs;
+    def.outputs = outputs;
+    def
+}
+
+/// Build an `IOSet` from the function's typed parameters.
+fn build_inputs_from_signature(ast: &ItemFn) -> flowcore::model::io::IOSet {
+    use flowcore::model::datatype::DataType;
+    use flowcore::model::io::IO;
+
+    let mut ios = Vec::new();
+
+    for fn_arg in &ast.sig.inputs {
+        if let FnArg::Typed(pat_type) = fn_arg {
+            let param_name = match pat_type.pat.as_ref() {
+                Pat::Ident(pat_ident) => pat_ident.ident.to_string(),
+                _ => String::new(),
+            };
+
+            let type_str = pat_type.ty.to_token_stream().to_string();
+            let flow_type = rust_type_to_flow_type(&type_str);
+
+            let mut io = IO::new(vec![DataType::from(flow_type.as_str())], "");
+            io.set_name(param_name);
+            ios.push(io);
+        }
+    }
+
+    flowcore::model::io::IOSet::from(ios)
+}
+
+/// Map a Rust parameter type string to a flow type string.
+fn rust_type_to_flow_type(type_str: &str) -> String {
+    match type_str {
+        "& Number" | "& serde_json :: Number" | "f64" | "i64" => "number".to_string(),
+        "bool" => "boolean".to_string(),
+        "& str" => "string".to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Write a generated `FunctionDefinition` to a TOML file.
+fn write_function_definition(def: &FunctionDefinition, path: &Path) {
+    let toml_str = toml::to_string_pretty(def).unwrap_or_else(|e| {
+        panic!("flow_function: could not serialize generated definition to TOML: {e}")
+    });
+    fs::write(path, toml_str).unwrap_or_else(|e| {
+        panic!(
+            "flow_function: could not write generated definition to '{}': {e}",
+            path.display()
+        )
+    });
 }
 
 /// Determines how to call the implementation function based on its signature.


### PR DESCRIPTION
## Summary
The `#[flow_function]` macro now auto-generates the function definition TOML when no `.toml` file exists alongside the `.rs` source.

### How it works
- If `function.toml` exists → read it (current behavior, backward compatible)
- If no TOML → generate it from the Rust function signature:
  - Function name from `inner_X` → `X`
  - Input names and types from typed parameters
  - Description from doc comments
  - Source filename from the `.rs` file

### Test
`double` function in `flowc/tests/test-flows/generated-toml/` — compiles with NO hand-written TOML. The macro generates `double.toml` automatically.

### Book
Updated Provided Functions page with "Option 2: Auto-generated" documentation.

Fixes #717

## Test plan
- [x] `make clippy` clean
- [x] `make book` builds clean
- [x] Test function compiles and generates TOML
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated function definition documentation to describe hand-written and auto-generated approaches.

* **New Features**
  * Macro now auto-generates TOML function definitions from Rust source code, extracting function metadata from signatures and doc comments.

* **Tests**
  * Added test flow demonstrating auto-generated TOML functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->