### PR TITLE
Add editable source code view in function viewer (#1255)

### DIFF
--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -437,9 +437,25 @@ pub(crate) fn save_function_definition(viewer: &FunctionViewer) -> Result<(), St
     std::fs::write(&toml_path, &toml)
         .map_err(|e| format!("Could not write {}: {e}", toml_path.display()))?;
 
-    generate_skeleton_rs(dir, func)?;
+    save_source_file(dir, func, viewer)?;
     generate_cargo_manifest(dir, func)?;
 
+    Ok(())
+}
+
+fn save_source_file(
+    dir: &Path,
+    func: &flowcore::model::function_definition::FunctionDefinition,
+    viewer: &FunctionViewer,
+) -> Result<(), String> {
+    let editor_text = viewer.rs_editor_content.text();
+    if editor_text == viewer.rs_content {
+        generate_skeleton_rs(dir, func)?;
+    } else {
+        let rs_path = dir.join(&func.source);
+        std::fs::write(&rs_path, editor_text)
+            .map_err(|e| format!("Could not write {}: {e}", rs_path.display()))?;
+    }
     Ok(())
 }
 
@@ -917,9 +933,11 @@ mod test {
             func_def.set_source_url(&url);
         }
 
+        let rs_content = String::new();
         let viewer = FunctionViewer {
             func_def,
-            rs_content: String::new(),
+            rs_editor_content: iced::widget::text_editor::Content::with_text(&rs_content),
+            rs_content,
             docs_content: None,
             active_tab: 0,
             parent_window: None,
@@ -971,9 +989,11 @@ mod test {
             func_def.set_source_url(&url);
         }
 
+        let rs_content = String::new();
         let viewer = FunctionViewer {
             func_def,
-            rs_content: String::new(),
+            rs_editor_content: iced::widget::text_editor::Content::with_text(&rs_content),
+            rs_content,
             docs_content: None,
             active_tab: 0,
             parent_window: None,

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -4,7 +4,7 @@ use std::process::{Child, Command};
 use std::sync::Arc;
 
 use iced::keyboard;
-use iced::widget::{button, container, text_input, Column, Row, Text};
+use iced::widget::{button, container, text_editor, text_input, Column, Row, Text};
 use iced::window;
 use iced::{Color, Element, Fill, Subscription, Task, Theme};
 use log::{info, warn};
@@ -96,6 +96,8 @@ pub(crate) enum FunctionEditMessage {
     OutputNameChanged(usize, String),
     /// Output port type changed
     OutputTypeChanged(usize, String),
+    /// Source code edited in the text editor
+    SourceEdited(text_editor::Action),
     /// Save function definition to disk
     Save,
 }
@@ -1625,7 +1627,11 @@ impl FlowEdit {
         output_col
     }
 
-    fn view_function_source_tab(window_id: window::Id, rs_content: &str) -> Element<'_, Message> {
+    fn view_function_source_tab(
+        window_id: window::Id,
+        content: &text_editor::Content,
+        read_only: bool,
+    ) -> Element<'_, Message> {
         let back_btn = button(Text::new("\u{2190} Definition").size(13).center())
             .on_press(Message::FunctionEdit(
                 window_id,
@@ -1633,20 +1639,18 @@ impl FlowEdit {
             ))
             .style(button::secondary)
             .padding([6, 14]);
+        let mut editor = text_editor(content)
+            .font(iced::Font::MONOSPACE)
+            .size(14)
+            .height(Fill);
+        if !read_only {
+            editor = editor.on_action(move |action| {
+                Message::FunctionEdit(window_id, FunctionEditMessage::SourceEdited(action))
+            });
+        }
         Column::new()
             .push(container(back_btn).padding([8, 12]))
-            .push(
-                container(
-                    iced::widget::scrollable(
-                        Text::new(rs_content).size(14).font(iced::Font::MONOSPACE),
-                    )
-                    .width(Fill)
-                    .height(Fill),
-                )
-                .width(Fill)
-                .height(Fill)
-                .padding(12),
-            )
+            .push(container(editor).width(Fill).height(Fill).padding(12))
             .into()
     }
 
@@ -1685,7 +1689,11 @@ impl FlowEdit {
     ) -> Element<'a, Message> {
         let content: Element<'_, Message> = match viewer.active_tab {
             0 => Self::view_function_definition_tab(window_id, viewer),
-            1 => Self::view_function_source_tab(window_id, &viewer.rs_content),
+            1 => Self::view_function_source_tab(
+                window_id,
+                &viewer.rs_editor_content,
+                viewer.read_only,
+            ),
             _ => Self::view_function_docs_tab(window_id, viewer.docs_content.as_deref()),
         };
 
@@ -1989,9 +1997,11 @@ impl FlowEdit {
         if let Ok(url) = Url::from_file_path(toml_path) {
             func_def.set_source_url(&url);
         }
+        let rs_editor_content = text_editor::Content::with_text(&rs_content);
         let viewer = FunctionViewer {
             func_def: func_def.clone(),
             rs_content,
+            rs_editor_content,
             docs_content,
             active_tab: 0,
             parent_window: Some(parent_win_id),
@@ -2467,6 +2477,7 @@ impl FlowEdit {
                     viewer.func_def.source = rel;
                     viewer.rs_content = std::fs::read_to_string(&selected)
                         .unwrap_or_else(|_| String::from("// Could not read file"));
+                    viewer.rs_editor_content = text_editor::Content::with_text(&viewer.rs_content);
                 }
                 win.history.mark_modified();
             }
@@ -2649,9 +2660,12 @@ impl FlowEdit {
         if let Ok(url) = Url::from_file_path(path) {
             func_def.set_source_url(&url);
         }
+        let rs_content = String::from("// Save to generate skeleton source");
+        let rs_editor_content = text_editor::Content::with_text(&rs_content);
         FunctionViewer {
             func_def,
-            rs_content: String::from("// Save to generate skeleton source"),
+            rs_content,
+            rs_editor_content,
             docs_content: None,
             active_tab: 0,
             parent_window: Some(parent_id),
@@ -2762,6 +2776,16 @@ impl FlowEdit {
             }
             FunctionEditMessage::OutputTypeChanged(idx, dtype) => {
                 self.handle_func_io_type_changed(win_id, idx, dtype, false);
+            }
+            FunctionEditMessage::SourceEdited(action) => {
+                if let Some(win) = self.windows.get_mut(&win_id) {
+                    if let WindowKind::FunctionViewer(ref mut viewer) = win.kind {
+                        if !viewer.read_only {
+                            viewer.rs_editor_content.perform(action);
+                            win.history.mark_modified();
+                        }
+                    }
+                }
             }
             FunctionEditMessage::Save => self.handle_func_save(win_id),
         }

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -2087,9 +2087,11 @@ fn function_edit_name_change() {
     let mut func_def = flowcore::model::function_definition::FunctionDefinition::default();
     func_def.name = "orig".into();
     func_def.source = "orig.rs".into();
+    let rs_content = String::new();
     let viewer = crate::window_state::FunctionViewer {
         func_def,
-        rs_content: String::new(),
+        rs_editor_content: iced::widget::text_editor::Content::with_text(&rs_content),
+        rs_content,
         docs_content: None,
         active_tab: 0,
         parent_window: Some(win_id),
@@ -2119,9 +2121,11 @@ fn function_edit_tab_switch() {
     let (mut app, win_id) = test_app();
     let func_win_id = window::Id::unique();
     let func_def = flowcore::model::function_definition::FunctionDefinition::default();
+    let rs_content = String::new();
     let viewer = crate::window_state::FunctionViewer {
         func_def,
-        rs_content: String::new(),
+        rs_editor_content: iced::widget::text_editor::Content::with_text(&rs_content),
+        rs_content,
         docs_content: None,
         active_tab: 0,
         parent_window: Some(win_id),

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -86,6 +86,7 @@ pub(crate) struct FunctionViewer {
     /// The canonical function definition (owns name, description, source, inputs, outputs, `source_url`)
     pub(crate) func_def: FunctionDefinition,
     pub(crate) rs_content: String,
+    pub(crate) rs_editor_content: iced::widget::text_editor::Content,
     pub(crate) docs_content: Option<String>,
     pub(crate) active_tab: usize,
     /// Parent window that opened this viewer (for propagating edits back to canvas)


### PR DESCRIPTION
## Summary
- Replace read-only `Text` widget with iced's built-in `text_editor` for function source code in the function viewer
- Source edits are saved to disk alongside the TOML definition when Save is pressed
- Library/context functions remain read-only (no `on_action` callback)
- Existing `.rs` files are only overwritten when editor content differs from what was loaded

## Test plan
- [x] `make clippy` clean
- [x] `cargo fmt` clean
- [x] All 303 flowedit tests pass
- [ ] `make test` full suite
- [ ] Manual: open flowedit with provided function, verify source tab is editable
- [ ] Manual: edit source, save, verify `.rs` file updated on disk
- [ ] Manual: open library function, verify source tab is read-only

Closes part of #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced an interactive, editable text editor for Rust source code in the source editing interface, replacing the previous read-only view and enabling direct code modifications.

* **Improvements**
  * Optimized source file handling and persistence logic for more intelligent and reliable file management during save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->