### PR TITLE
Enable editing library function definitions (#1255)

### DIFF
--- a/book/editing/flowedit.md
+++ b/book/editing/flowedit.md
@@ -273,6 +273,17 @@ alias (e.g., `add_2`, `add_3`).
 Each function also has a pencil icon (✎) that opens the function definition
 in a viewer window, showing its TOML definition, Rust source, and documentation.
 
+### Managing Library Functions
+
+Library functions (not context functions) have additional management controls:
+
+- **Move** (⇄) — moves the function to a different category directory within the
+  library. A folder picker dialog lets you select the destination category.
+- **Delete** (✕) — removes the function from the library by deleting its directory
+  and updating the library manifest.
+
+Both operations update the library's `manifest.json` and refresh the panel immediately.
+
 ## Flow Hierarchy
 
 Above the Process Library, a collapsible tree view shows the structure of the

--- a/book/editing/flowedit.md
+++ b/book/editing/flowedit.md
@@ -281,7 +281,7 @@ as children, recursively.
 
 - **Orange** nodes are flows — click to expand/collapse, pencil icon to open
 - **Purple** nodes are provided implementations — click to open in editor
-- **Blue** nodes are library/context functions (display only)
+- **Blue** nodes are library/context functions — click pencil icon to view or edit
 
 ## Creating New Processes
 
@@ -337,11 +337,27 @@ editor showing:
   or click "..." to browse for a different source file
 - **Docs tab** — if a `.md` documentation file exists alongside the function
 
+The **Source** tab shows the function's Rust implementation in a full text editor.
+For provided functions and library functions, the source code is editable — changes
+are saved to disk alongside the TOML definition. For context functions (which are
+runtime-provided stubs), the source tab is read-only.
+
 The **💾 Save** button writes the function definition to disk:
 - Updates the `.toml` definition file with the current name, inputs, and outputs
+- Saves any source code edits to the `.rs` implementation file
 - Generates a skeleton `.rs` source file if one doesn't exist (with the
   `#[flow_function]` boilerplate and correct input bindings)
 - Generates a `function.toml` Cargo manifest if one doesn't exist
+
+### Editing Library Functions
+
+Library functions (from `flowstdlib` or other installed libraries) can be edited
+in the same way as provided functions. When editing a library function, an orange
+warning is shown in the status bar: "Editing installed library function". Changes
+are saved directly to the installed library directory (e.g., `~/.flow/lib/flowstdlib/...`).
+
+Context functions (`context://`) remain read-only since they are runtime-provided
+and have no editable source on disk.
 
 ## Compiling
 

--- a/flowcore/src/model/lib_manifest.rs
+++ b/flowcore/src/model/lib_manifest.rs
@@ -513,4 +513,45 @@ mod test {
 
         assert!(library1 == library2);
     }
+
+    #[test]
+    fn remove_existing_locator() {
+        let mut manifest = LibraryManifest::new(
+            Url::parse("lib://test").expect("valid url"),
+            test_meta_data(),
+        );
+        manifest
+            .add_locator(
+                "bin/my.wasm",
+                "bin",
+                #[cfg(feature = "debugger")]
+                "/users/me/myproject/bin/my.rs",
+            )
+            .expect("Could not add to manifest");
+        assert_eq!(manifest.locators.len(), 1);
+
+        let locator_url = Url::parse("lib://test/bin").expect("valid url");
+        manifest.remove_locator(&locator_url);
+        assert_eq!(manifest.locators.len(), 0);
+    }
+
+    #[test]
+    fn remove_nonexistent_locator_is_noop() {
+        let mut manifest = LibraryManifest::new(
+            Url::parse("lib://test").expect("valid url"),
+            test_meta_data(),
+        );
+        manifest
+            .add_locator(
+                "bin/my.wasm",
+                "bin",
+                #[cfg(feature = "debugger")]
+                "/users/me/myproject/bin/my.rs",
+            )
+            .expect("Could not add to manifest");
+
+        let nonexistent = Url::parse("lib://test/nonexistent").expect("valid url");
+        manifest.remove_locator(&nonexistent);
+        assert_eq!(manifest.locators.len(), 1);
+    }
 }

--- a/flowcore/src/model/lib_manifest.rs
+++ b/flowcore/src/model/lib_manifest.rs
@@ -157,7 +157,10 @@ impl LibraryManifest {
         Ok(())
     }
 
-    /// Remove a locator from the manifest by its library URL
+    /// Remove a locator from the manifest by its library URL.
+    ///
+    /// If the locator is a `RelativePath`, the corresponding entry in `source_urls` is also removed.
+    /// If the locator does not exist, this method does nothing.
     pub fn remove_locator(&mut self, locator_url: &Url) {
         if let Some(ImplementationLocator::RelativePath(rel_path)) =
             self.locators.remove(locator_url)

--- a/flowcore/src/model/lib_manifest.rs
+++ b/flowcore/src/model/lib_manifest.rs
@@ -157,6 +157,15 @@ impl LibraryManifest {
         Ok(())
     }
 
+    /// Remove a locator from the manifest by its library URL
+    pub fn remove_locator(&mut self, locator_url: &Url) {
+        if let Some(ImplementationLocator::RelativePath(rel_path)) =
+            self.locators.remove(locator_url)
+        {
+            self.source_urls.remove(&rel_path);
+        }
+    }
+
     /// Given an output directory, return a `PathBuf` to the json format manifest that should be
     /// generated inside it
     #[must_use]

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -577,6 +577,34 @@ pub(crate) fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
     })
 }
 
+/// Move a directory, falling back to recursive copy + remove if `rename` fails
+/// (e.g. across filesystem boundaries).
+pub(crate) fn move_directory(src: &Path, dest: &Path) -> Result<(), String> {
+    if std::fs::rename(src, dest).is_ok() {
+        return Ok(());
+    }
+    copy_dir_recursive(src, dest)?;
+    std::fs::remove_dir_all(src).map_err(|e| format!("Could not remove source after copy: {e}"))
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| format!("Could not create {}: {e}", dest.display()))?;
+    let entries =
+        std::fs::read_dir(src).map_err(|e| format!("Could not read {}: {e}", src.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Could not read entry: {e}"))?;
+        let dest_path = dest.join(entry.file_name());
+        if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            copy_dir_recursive(&entry.path(), &dest_path)?;
+        } else {
+            std::fs::copy(entry.path(), &dest_path)
+                .map_err(|e| format!("Could not copy {}: {e}", entry.path().display()))?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[allow(clippy::indexing_slicing)]

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -580,8 +580,17 @@ pub(crate) fn load_editor_prefs(flow_path: &Path) -> Option<EditorPrefs> {
 /// Move a directory, falling back to recursive copy + remove if `rename` fails
 /// (e.g. across filesystem boundaries).
 pub(crate) fn move_directory(src: &Path, dest: &Path) -> Result<(), String> {
-    if std::fs::rename(src, dest).is_ok() {
-        return Ok(());
+    match std::fs::rename(src, dest) {
+        Ok(()) => return Ok(()),
+        // EXDEV (18) — cross-device link, fall back to copy+remove
+        Err(e) if e.raw_os_error() == Some(18) => {}
+        Err(e) => {
+            return Err(format!(
+                "Could not move {} to {}: {e}",
+                src.display(),
+                dest.display()
+            ));
+        }
     }
     copy_dir_recursive(src, dest)?;
     std::fs::remove_dir_all(src).map_err(|e| format!("Could not remove source after copy: {e}"))

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -943,6 +943,7 @@ mod test {
             parent_window: None,
             node_source: String::new(),
             read_only: false,
+            is_library: false,
         };
 
         save_function_definition(&viewer).expect("save failed");
@@ -999,6 +1000,7 @@ mod test {
             parent_window: None,
             node_source: String::new(),
             read_only: false,
+            is_library: false,
         };
 
         save_function_definition(&viewer).expect("save failed");

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -600,6 +600,121 @@ impl FlowEdit {
         }
     }
 
+    fn handle_library_delete(&mut self, source: &str) {
+        use flowcore::provider::Provider;
+
+        let Ok(source_url) = Url::parse(source) else {
+            return;
+        };
+        let provider = file_ops::build_meta_provider();
+        let Ok((resolved_url, _)) = provider.resolve_url(&source_url, "default", &["toml"]) else {
+            return;
+        };
+        let Ok(func_path) = resolved_url.to_file_path() else {
+            return;
+        };
+        let Some(func_dir) = func_path.parent() else {
+            return;
+        };
+
+        if let Err(e) = std::fs::remove_dir_all(func_dir) {
+            warn!("Could not delete {}: {e}", func_dir.display());
+            return;
+        }
+
+        let lib_name = source_url.host_str().unwrap_or_default();
+        if let Some(manifest) = self.library_cache.get_mut(
+            &Url::parse(&format!("lib://{lib_name}")).unwrap_or_else(|_| source_url.clone()),
+        ) {
+            manifest.remove_locator(&source_url);
+            let manifest_path = func_dir
+                .ancestors()
+                .find(|p| p.join("manifest.json").exists())
+                .map(|p| p.join("manifest.json"));
+            if let Some(path) = manifest_path {
+                let _ = manifest.write_json(&path);
+            }
+        }
+
+        self.rebuild_library_tree();
+    }
+
+    fn handle_library_move(&mut self, source: &str) {
+        use flowcore::provider::Provider;
+
+        let Ok(source_url) = Url::parse(source) else {
+            return;
+        };
+        let provider = file_ops::build_meta_provider();
+        let Ok((resolved_url, _)) = provider.resolve_url(&source_url, "default", &["toml"]) else {
+            return;
+        };
+        let Ok(func_path) = resolved_url.to_file_path() else {
+            return;
+        };
+        let Some(func_dir) = func_path.parent() else {
+            return;
+        };
+        let func_dir_name = func_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let dialog = rfd::FileDialog::new()
+            .set_title("Select destination category directory")
+            .set_directory(func_dir.parent().unwrap_or(func_dir));
+        let Some(dest_category) = dialog.pick_folder() else {
+            return;
+        };
+
+        let dest_dir = dest_category.join(&func_dir_name);
+        if dest_dir == func_dir {
+            return;
+        }
+
+        if let Err(e) = std::fs::rename(func_dir, &dest_dir) {
+            warn!("Could not move {}: {e}", func_dir.display());
+            return;
+        }
+
+        let lib_name = source_url.host_str().unwrap_or_default();
+        let lib_url =
+            Url::parse(&format!("lib://{lib_name}")).unwrap_or_else(|_| source_url.clone());
+        if let Some(manifest) = self.library_cache.get_mut(&lib_url) {
+            manifest.remove_locator(&source_url);
+            let manifest_path = dest_dir
+                .ancestors()
+                .find(|p| p.join("manifest.json").exists())
+                .map(|p| p.join("manifest.json"));
+
+            // Compute new lib reference path from the destination relative to lib root
+            if let Some(ref mp) = manifest_path {
+                if let Some(lib_root) = mp.parent() {
+                    if let Ok(rel) = dest_dir.strip_prefix(lib_root) {
+                        let new_ref = rel.to_string_lossy().replace('\\', "/");
+                        let wasm_name = format!("{func_dir_name}.wasm");
+                        let wasm_rel = format!("{new_ref}/{wasm_name}");
+                        let _ = manifest.add_locator(&wasm_rel, &new_ref, "");
+                    }
+                }
+            }
+            if let Some(path) = manifest_path {
+                let _ = manifest.write_json(&path);
+            }
+        }
+
+        self.rebuild_library_tree();
+    }
+
+    fn rebuild_library_tree(&mut self) {
+        let lib_refs = self.root_flow.lib_references.clone();
+        let (lc, ad) = library_mgmt::load_library_catalogs(&lib_refs);
+        self.library_cache = lc;
+        self.all_definitions = ad;
+        self.library_tree = LibraryTree::from_cache(&self.library_cache, &self.all_definitions);
+    }
+
     fn handle_library_message(
         &mut self,
         win_id: window::Id,
@@ -619,6 +734,12 @@ impl FlowEdit {
             }
             LibraryAction::View(source, _name) => {
                 return self.open_library_function(&source);
+            }
+            LibraryAction::Delete(source) => {
+                self.handle_library_delete(&source);
+            }
+            LibraryAction::Move(source) => {
+                self.handle_library_move(&source);
             }
             LibraryAction::AddLibrary => {
                 self.handle_add_library(win_id);

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -632,7 +632,9 @@ impl FlowEdit {
                 .find(|p| p.join("manifest.json").exists())
                 .map(|p| p.join("manifest.json"));
             if let Some(path) = manifest_path {
-                let _ = manifest.write_json(&path);
+                if let Err(e) = manifest.write_json(&path) {
+                    warn!("Could not write manifest {}: {e}", path.display());
+                }
             }
         }
 
@@ -673,7 +675,7 @@ impl FlowEdit {
             return;
         }
 
-        if let Err(e) = std::fs::rename(func_dir, &dest_dir) {
+        if let Err(e) = file_ops::move_directory(func_dir, &dest_dir) {
             warn!("Could not move {}: {e}", func_dir.display());
             return;
         }
@@ -688,7 +690,6 @@ impl FlowEdit {
                 .find(|p| p.join("manifest.json").exists())
                 .map(|p| p.join("manifest.json"));
 
-            // Compute new lib reference path from the destination relative to lib root
             if let Some(ref mp) = manifest_path {
                 if let Some(lib_root) = mp.parent() {
                     if let Ok(rel) = dest_dir.strip_prefix(lib_root) {
@@ -700,7 +701,9 @@ impl FlowEdit {
                 }
             }
             if let Some(path) = manifest_path {
-                let _ = manifest.write_json(&path);
+                if let Err(e) = manifest.write_json(&path) {
+                    warn!("Could not write manifest {}: {e}", path.display());
+                }
             }
         }
 

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -1584,7 +1584,7 @@ impl FlowEdit {
         );
         if editable {
             source_row = source_row.push(
-                button(Text::new("...").size(12).center())
+                button(Text::new("Browse...").size(12).center())
                     .on_press(Message::FunctionEdit(
                         window_id,
                         FunctionEditMessage::BrowseSource,

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -601,8 +601,6 @@ impl FlowEdit {
     }
 
     fn handle_library_delete(&mut self, source: &str) {
-        use flowcore::provider::Provider;
-
         let Ok(source_url) = Url::parse(source) else {
             return;
         };
@@ -642,8 +640,6 @@ impl FlowEdit {
     }
 
     fn handle_library_move(&mut self, source: &str) {
-        use flowcore::provider::Provider;
-
         let Ok(source_url) = Url::parse(source) else {
             return;
         };
@@ -684,21 +680,24 @@ impl FlowEdit {
         let lib_url =
             Url::parse(&format!("lib://{lib_name}")).unwrap_or_else(|_| source_url.clone());
         if let Some(manifest) = self.library_cache.get_mut(&lib_url) {
-            manifest.remove_locator(&source_url);
             let manifest_path = dest_dir
                 .ancestors()
                 .find(|p| p.join("manifest.json").exists())
                 .map(|p| p.join("manifest.json"));
 
-            if let Some(ref mp) = manifest_path {
-                if let Some(lib_root) = mp.parent() {
-                    if let Ok(rel) = dest_dir.strip_prefix(lib_root) {
-                        let new_ref = rel.to_string_lossy().replace('\\', "/");
-                        let wasm_name = format!("{func_dir_name}.wasm");
-                        let wasm_rel = format!("{new_ref}/{wasm_name}");
-                        let _ = manifest.add_locator(&wasm_rel, &new_ref, "");
-                    }
-                }
+            let added = manifest_path
+                .as_ref()
+                .and_then(|mp| mp.parent())
+                .and_then(|lib_root| dest_dir.strip_prefix(lib_root).ok())
+                .is_some_and(|rel| {
+                    let new_ref = rel.to_string_lossy().replace('\\', "/");
+                    let wasm_name = format!("{func_dir_name}.wasm");
+                    let wasm_rel = format!("{new_ref}/{wasm_name}");
+                    manifest.add_locator(&wasm_rel, &new_ref, "").is_ok()
+                });
+
+            if added {
+                manifest.remove_locator(&source_url);
             }
             if let Some(path) = manifest_path {
                 if let Err(e) = manifest.write_json(&path) {

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -1726,9 +1726,15 @@ impl FlowEdit {
             iced::widget::tooltip::Position::Top,
         );
 
-        let status_bar = Row::new()
-            .spacing(8)
-            .push(Text::new(status).size(14))
+        let mut status_bar = Row::new().spacing(8).push(Text::new(status).size(14));
+        if viewer.is_library {
+            status_bar = status_bar.push(
+                Text::new("Editing installed library function")
+                    .size(12)
+                    .color(Color::from_rgb(0.8, 0.5, 0.0)),
+            );
+        }
+        let status_bar = status_bar
             .push(iced::widget::Space::new().width(Fill))
             .push(save_with_tooltip);
 
@@ -1992,7 +1998,8 @@ impl FlowEdit {
 
         let (new_id, open_task) = window::open(self.child_window_settings(700.0, 500.0));
 
-        let read_only = node_source.starts_with("lib://") || node_source.starts_with("context://");
+        let read_only = node_source.starts_with("context://");
+        let is_library = node_source.starts_with("lib://");
         let mut func_def = func.clone();
         if let Ok(url) = Url::from_file_path(toml_path) {
             func_def.set_source_url(&url);
@@ -2007,6 +2014,7 @@ impl FlowEdit {
             parent_window: Some(parent_win_id),
             node_source: node_source.to_string(),
             read_only,
+            is_library,
         };
 
         let mut func_flow_def = FlowDefinition {
@@ -2671,6 +2679,7 @@ impl FlowEdit {
             parent_window: Some(parent_id),
             node_source: node_source.into(),
             read_only: false,
+            is_library: false,
         }
     }
 

--- a/flowedit/src/library_panel.rs
+++ b/flowedit/src/library_panel.rs
@@ -29,6 +29,10 @@ pub(crate) enum LibraryMessage {
     AddFunction(String, String),
     /// View a library function/flow definition.
     ViewFunction(String, String),
+    /// Delete a function from the library: `source_url`.
+    DeleteFunction(String),
+    /// Move a function to a different category: `source_url`.
+    MoveFunction(String),
     /// Add a library manually via file dialog.
     AddLibrary,
     /// Toggle the library search paths editor panel.
@@ -41,6 +45,8 @@ pub(crate) enum LibraryAction {
     None,
     Add(String, String),
     View(String, String),
+    Delete(String),
+    Move(String),
     AddLibrary,
     ToggleLibPaths,
 }
@@ -146,6 +152,8 @@ impl LibraryTree {
             LibraryMessage::ViewFunction(source, name) => {
                 LibraryAction::View(source.clone(), name.clone())
             }
+            LibraryMessage::DeleteFunction(source) => LibraryAction::Delete(source.clone()),
+            LibraryMessage::MoveFunction(source) => LibraryAction::Move(source.clone()),
             LibraryMessage::AddLibrary => LibraryAction::AddLibrary,
             LibraryMessage::ToggleLibPaths => LibraryAction::ToggleLibPaths,
         }
@@ -266,11 +274,26 @@ fn view_function_entry<'a>(
         .style(button::text)
         .padding([2, 4]);
 
-    let row = Row::new()
+    let is_library = func_url.scheme() == "lib";
+
+    let mut row = Row::new()
         .spacing(2)
         .align_y(iced::Alignment::Center)
         .push(view_btn)
         .push(func_btn);
+
+    if is_library {
+        let src = func_url.to_string();
+        let delete_btn = button(text("\u{2715}").size(9))
+            .on_press(LibraryMessage::DeleteFunction(src.clone()))
+            .style(button::text)
+            .padding([1, 3]);
+        let move_btn = button(text("\u{21C4}").size(9))
+            .on_press(LibraryMessage::MoveFunction(src))
+            .style(button::text)
+            .padding([1, 3]);
+        row = row.push(move_btn).push(delete_btn);
+    }
 
     let entry_widget: Element<'_, LibraryMessage> = if description.is_empty() {
         row.into()

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -2097,6 +2097,7 @@ fn function_edit_name_change() {
         parent_window: Some(win_id),
         node_source: "orig".into(),
         read_only: false,
+        is_library: false,
     };
     let child = WindowState {
         route: Route::from("/test/orig"),
@@ -2131,6 +2132,7 @@ fn function_edit_tab_switch() {
         parent_window: Some(win_id),
         node_source: String::new(),
         read_only: false,
+        is_library: false,
     };
     let child = WindowState {
         kind: WindowKind::FunctionViewer(Box::new(viewer)),

--- a/flowedit/src/window_state.rs
+++ b/flowedit/src/window_state.rs
@@ -93,8 +93,10 @@ pub(crate) struct FunctionViewer {
     pub(crate) parent_window: Option<window::Id>,
     /// Source string of the node this viewer is editing (to find the `NodeLayout`)
     pub(crate) node_source: String,
-    /// Whether this viewer is read-only (library/context functions cannot be edited)
+    /// Whether this viewer is read-only (context functions cannot be edited)
     pub(crate) read_only: bool,
+    /// Whether this function comes from an installed library
+    pub(crate) is_library: bool,
 }
 
 impl FunctionViewer {


### PR DESCRIPTION
## Summary
- Remove `lib://` from the `read_only` check so library function definitions can be edited (name, ports, description, source code)
- Context functions (`context://`) remain read-only
- Show an orange warning text "Editing installed library function" in the status bar when editing a library function
- Add `is_library` flag to `FunctionViewer` to track library origin

## Test plan
- [x] `make clippy` clean
- [x] `cargo fmt` clean
- [x] All 303 flowedit tests pass
- [ ] Manual: open library function viewer — editable with warning
- [ ] Manual: context functions remain read-only

Partial fix for #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete and move installed library functions directly from the UI (new controls on library entries).
  * More robust move handling for library functions to improve reliability.

* **Behavior Changes**
  * Status bar shows when viewing an installed library function.
  * Source tab: installed library functions are editable and saved back to the installed library; context functions remain read-only.
  * Save generates missing scaffolding/manifests when creating function source.

* **Documentation**
  * Updated editor docs describing library function management and Source tab behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->