### PR TITLE
Bump version to 0.96.0 — Ease of Authoring milestone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flowc"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "clap",
  "colored",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "flowcore"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "curl",
  "error-chain",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "flowedit"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "flowgraph"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "flowcore",
  "log",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "flowmacro"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "flowcore",
  "proc-macro2",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "flowr"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1440,11 +1440,11 @@ dependencies = [
 
 [[package]]
 name = "flowr-utilities"
-version = "0.95.0"
+version = "0.96.0"
 
 [[package]]
 name = "flowstdlib"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "error-chain",
  "flowcore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["flowc", "flowstdlib", "flowr", "flowcore", "flowmacro", "flo
 resolver = "2"
 
 [workspace.package]
-version = "0.95.0"
+version = "0.96.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 license = "MIT"
 license-file = "LICENSE"

--- a/flowc/Cargo.toml
+++ b/flowc/Cargo.toml
@@ -29,8 +29,8 @@ default = ["debugger"]
 debugger = ["flowcore/debugger"] # feature to add output for the debugger
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "0.95.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
-flowgraph = {path = "../flowgraph", version = "0.95.0"}
+flowcore = {path = "../flowcore", version = "0.96.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
+flowgraph = {path = "../flowgraph", version = "0.96.0"}
 clap = "~4"
 env_logger = "0.11.10"
 log = "0.4.30"
@@ -46,7 +46,7 @@ colored = "3"
 toml = { version = "1.1.2" }
 
 [dev-dependencies]
-flowcore = {path = "../flowcore", version = "0.95.0", features = ["context"]}
+flowcore = {path = "../flowcore", version = "0.96.0", features = ["context"]}
 tempfile = "3"
 simpath = { version = "~2.5", features = ["urls"]}
 serial_test = "3.5.0"

--- a/flowc/tests/test-flows/generated-toml/double/Cargo.toml
+++ b/flowc/tests/test-flows/generated-toml/double/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "double"
-version = "0.95.0"
+version = "0.96.0"
 edition = "2021"
 
 [lib]
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 path = "double.rs"
 
 [dependencies]
-flowcore = { path = "../../../../../flowcore", version = "0.95.0" }
-flowmacro = { path = "../../../../../flowmacro", version = "0.95.0" }
+flowcore = { path = "../../../../../flowcore", version = "0.96.0" }
+flowmacro = { path = "../../../../../flowmacro", version = "0.96.0" }
 serde_json = "1.0"
 
 [workspace]

--- a/flowedit/Cargo.toml
+++ b/flowedit/Cargo.toml
@@ -18,8 +18,8 @@ name = "flowedit"
 path = "src/main.rs"
 
 [dependencies]
-flowcore = { path = "../flowcore", version = "0.95.0", features = ["meta_provider", "context", "file_provider"] }
-flowrclib = { package = "flowc", path = "../flowc", version = "0.95.0" }
+flowcore = { path = "../flowcore", version = "0.96.0", features = ["meta_provider", "context", "file_provider"] }
+flowrclib = { package = "flowc", path = "../flowc", version = "0.96.0" }
 clap = "~4"
 iced = { version = "0.14.0", default-features = false, features = ["canvas", "tokio", "wgpu", "tiny-skia", "wayland", "x11"] }
 simpath = { version = "~2.5", features = ["urls"] }

--- a/flowgraph/Cargo.toml
+++ b/flowgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowgraph"
-version = "0.95.0"
+version = "0.96.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 edition = "2021"
 description = "Graph layout and SVG rendering for flow programs"
@@ -9,7 +9,7 @@ description = "Graph layout and SVG rendering for flow programs"
 workspace = true
 
 [dependencies]
-flowcore = { path = "../flowcore", version = "0.95.0" }
+flowcore = { path = "../flowcore", version = "0.96.0" }
 svg = "0.18"
 log = "0.4"
 url = "2.2"

--- a/flowmacro/Cargo.toml
+++ b/flowmacro/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "~2.0", features =["full"] } #Full is required for ItemFn in macro parsing
 quote = "~1.0"
-flowcore = {path = "../flowcore", version = "0.95.0" }
+flowcore = {path = "../flowcore", version = "0.96.0" }
 toml = "1.1.2"
 proc-macro2 = "1.0"
 

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -44,9 +44,9 @@ submission = []
 context = ["flowcore/context"]
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "0.95.0", features = ["context", "file_provider", "http_provider",
+flowcore = {path = "../flowcore", version = "0.96.0", features = ["context", "file_provider", "http_provider",
         "context", "meta_provider"] }
-flowstdlib = {path = "../flowstdlib", version = "0.95.0", optional = true }
+flowstdlib = {path = "../flowstdlib", version = "0.96.0", optional = true }
 clap = "~4"
 log = "0.4.30"
 env_logger = "0.11.10"
@@ -82,4 +82,4 @@ portpicker = "0.1.1"
 iced_test = "0.14.0"
 # These two are needed for examples
 flowr-utilities = { path = "utilities" }
-flowstdlib = {path = "../flowstdlib", version = "0.95.0" }
+flowstdlib = {path = "../flowstdlib", version = "0.96.0" }

--- a/flowr/utilities/Cargo.toml
+++ b/flowr/utilities/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flowr-utilities"
 description = "A set of utilities for tests and examples"
-version = "0.95.0"
+version = "0.96.0"
 readme = "README.md"
 license = "MIT"
 documentation = "https://github.com/andrewdavidmackenzie/flow/README.md"

--- a/flowstdlib/Cargo.toml
+++ b/flowstdlib/Cargo.toml
@@ -2,7 +2,7 @@
 # Don't inherit from workspace as this is parsed by flowc for MetaData and it is not workspace inheritance aware
 name = "flowstdlib"
 description = "The standard library of functions and flows for 'flow' programs"
-version = "0.95.0"
+version = "0.96.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 # Inherit the other keys that are not parsed by flowc itself
 license.workspace = true
@@ -23,8 +23,8 @@ name = "flowstdlib"
 path = "src/lib.rs"
 
 [dependencies]
-flowmacro = {path = "../flowmacro", version = "0.95.0" }
-flowcore = {path = "../flowcore", version = "0.95.0" }
+flowmacro = {path = "../flowmacro", version = "0.96.0" }
+flowcore = {path = "../flowcore", version = "0.96.0" }
 simpath = { version = "2", features = ["urls"]}
 url = { version = "2.2", features = ["serde"] }
 serde_json = "1.0"
@@ -33,8 +33,8 @@ error-chain = "0.12.2"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3.5.0"
-flowcore = {path = "../flowcore", version = "0.95.0" }
-flowmacro = {path = "../flowmacro", version = "0.95.0" }
+flowcore = {path = "../flowcore", version = "0.96.0" }
+flowmacro = {path = "../flowmacro", version = "0.96.0" }
 serde_json = { version = "1.0", default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- Correct version from 0.95.0 (conflicted with existing 2023 tag) to 0.96.0
- Continues versioning path towards 1.0.0

After merge: tag `v0.96.0` and publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)