### PR TITLE
Show debug port in flowrgui status bar (#770 Phase 2)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -57,6 +57,16 @@ pub fn take_stop_request() -> bool {
     STOP_REQUESTED.swap(false, Ordering::Relaxed)
 }
 
+/// Global debug port, set when the debug server starts
+#[cfg(feature = "debugger")]
+static DEBUG_PORT: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0);
+
+/// Get the debug port (0 means not set)
+#[cfg(feature = "debugger")]
+pub fn get_debug_port() -> u16 {
+    DEBUG_PORT.load(Ordering::Relaxed)
+}
+
 /// Global counter for jobs created, updated by the coordinator thread
 static JOB_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -259,7 +269,10 @@ fn start_server(coordinator_settings: ServerSettings) -> Result<()> {
     let _mdns_debug = enable_service_discovery(DEBUG_SERVICE_NAME, debug_port)?;
 
     #[cfg(feature = "debugger")]
-    info!("Debug server listening on port {debug_port}. Connect with: flowdb --address localhost:{debug_port}");
+    {
+        DEBUG_PORT.store(debug_port, Ordering::Relaxed);
+        info!("Debug server listening on port {debug_port}. Connect with: flowdb --address localhost:{debug_port}");
+    }
 
     info!("Starting coordinator in background thread");
     thread::spawn(move || {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -510,6 +510,19 @@ impl FlowrGui {
             row = row
                 .push(Text::new(format!("Jobs: {}", connection_manager::get_job_count())).size(13));
         }
+
+        #[cfg(feature = "debugger")]
+        if self.submission_settings.debug_this_flow {
+            let debug_port = connection_manager::get_debug_port();
+            if debug_port > 0 {
+                row = row.push(
+                    Text::new(format!("flowdb --address localhost:{debug_port}"))
+                        .size(13)
+                        .color(iced::Color::from_rgb(0.4, 0.6, 1.0)),
+                );
+            }
+        }
+
         row
     }
 


### PR DESCRIPTION
## Summary

When the user clicks "Debug" in flowrgui, the status bar now shows the flowdb connection command (e.g. `flowdb --address localhost:12345`) in blue text, so they can easily connect from another terminal.

This enables the two-terminal debug workflow: run a flow in debug mode from flowrgui, attach flowdb from a separate terminal.

## Changes

- Add `DEBUG_PORT` global in `connection_manager.rs` (set when debug server starts)
- Add `get_debug_port()` accessor
- Show debug connection info in `status_row()` when `debug_this_flow` is set

## Test plan

- [x] `cargo build` passes
- [x] `make clippy` passes
- [ ] `make test` passes
- [ ] Manual: start flowrgui, click Debug on a flow, verify port shown in status bar, connect flowdb

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented debug port tracking to support the debugger feature functionality.
  * UI status row now displays debugger connection instructions when debugging is enabled for the active flow and a valid debug port is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->