### PR TITLE
Add GUI debug client to flowrgui (#770 Phase 3)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -377,13 +377,14 @@ fn coordinator(
 
 /// Global sender for debug commands from GUI to the debug client subscription
 #[cfg(feature = "debugger")]
-static DEBUG_CMD_SENDER: OnceLock<Mutex<tokio::sync::mpsc::Sender<DebugCommand>>> = OnceLock::new();
+static DEBUG_CMD_SENDER: std::sync::RwLock<Option<tokio::sync::mpsc::Sender<DebugCommand>>> =
+    std::sync::RwLock::new(None);
 
 /// Send a debug command from the GUI to the debug client subscription
 #[cfg(feature = "debugger")]
 pub fn send_debug_command(cmd: DebugCommand) {
-    if let Some(sender) = DEBUG_CMD_SENDER.get() {
-        if let Ok(sender) = sender.lock() {
+    if let Ok(guard) = DEBUG_CMD_SENDER.read() {
+        if let Some(ref sender) = *guard {
             let _ = sender.blocking_send(cmd);
         }
     }
@@ -517,7 +518,9 @@ fn debug_client_stream(port: u16) -> impl iced::futures::Stream<Item = Message> 
         100,
         move |mut sender: iced::futures::channel::mpsc::Sender<Message>| async move {
             let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<DebugCommand>(10);
-            DEBUG_CMD_SENDER.get_or_init(|| Mutex::new(cmd_tx));
+            if let Ok(mut guard) = DEBUG_CMD_SENDER.write() {
+                *guard = Some(cmd_tx);
+            }
 
             let mut blocking_sender = sender.clone();
             let result = tokio::task::spawn_blocking(move || -> std::result::Result<(), String> {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -22,7 +22,7 @@ use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_message::CoordinatorMessage;
 #[cfg(feature = "submission")]
 use crate::gui::submission_handler::CLISubmissionHandler;
-use crate::{context, CoordinatorSettings, ServerSettings};
+use crate::{context, CoordinatorSettings, Message, ServerSettings};
 use flowrlib::connections::ClientConnection;
 use flowrlib::connections::CoordinatorConnection;
 #[cfg(feature = "debugger")]
@@ -32,6 +32,11 @@ use flowrlib::discovery::enable_service_discovery;
 use flowrlib::services::COORDINATOR_SERVICE_NAME;
 #[cfg(feature = "debugger")]
 use flowrlib::services::DEBUG_SERVICE_NAME;
+
+#[cfg(feature = "debugger")]
+use flowcore::model::debug_command::DebugCommand;
+#[cfg(feature = "debugger")]
+use flowrlib::debug_server_message::DebugServerMessage;
 
 /// States in which the Connection to the Coordinator can find itself
 pub enum CoordinatorState {
@@ -368,6 +373,225 @@ fn coordinator(
         coordinator.submission_loop(loop_forever)?;
     }
     Ok(())
+}
+
+/// Global sender for debug commands from GUI to the debug client subscription
+#[cfg(feature = "debugger")]
+static DEBUG_CMD_SENDER: OnceLock<Mutex<tokio::sync::mpsc::Sender<DebugCommand>>> = OnceLock::new();
+
+/// Send a debug command from the GUI to the debug client subscription
+#[cfg(feature = "debugger")]
+pub fn send_debug_command(cmd: DebugCommand) {
+    if let Some(sender) = DEBUG_CMD_SENDER.get() {
+        if let Ok(sender) = sender.lock() {
+            let _ = sender.blocking_send(cmd);
+        }
+    }
+}
+
+/// Rewrite server messages that contain CLI-oriented text for the GUI context
+#[cfg(feature = "debugger")]
+fn rewrite_for_gui(msg: &str) -> String {
+    msg.replace(
+        "Use the 'b' command to set a breakpoint. Use 'h' for help.",
+        "Use the 'Set BP' button to set a breakpoint.",
+    )
+    .replace(
+        "Use 'i n' or 'inspect n' to inspect the function number 'n'",
+        "Enter a function number in the spec field and click 'Inspect'",
+    )
+    .replace(
+        "State variables that can be modified are:",
+        "Modifiable state variables:",
+    )
+}
+
+/// Format a `DebugServerMessage` into a human-readable string for the debug tab
+#[cfg(feature = "debugger")]
+fn format_debug_event(message: &DebugServerMessage) -> String {
+    match message {
+        DebugServerMessage::JobCompleted(job) => {
+            let mut s = format!(
+                "Job #{} completed by Function #{}",
+                job.payload.job_id, job.process_id
+            );
+            if let Ok((Some(output), _)) = &job.result {
+                use std::fmt::Write;
+                let _ = write!(s, "\n\tOutput value: '{output}'");
+            }
+            s
+        }
+        DebugServerMessage::PriorToSendingJob(job) => {
+            format!(
+                "About to send Job #{} to Function #{}\n\tInputs: {:?}",
+                job.payload.job_id, job.process_id, job.payload.input_set
+            )
+        }
+        DebugServerMessage::BlockBreakpoint(block) => format!("Block breakpoint: {block:?}"),
+        DebugServerMessage::DataBreakpoint(
+            source_name,
+            source_id,
+            output_route,
+            value,
+            dest_id,
+            dest_name,
+            io_name,
+            input_number,
+        ) => {
+            format!(
+                "Data breakpoint: Function #{source_id} '{source_name}{output_route}' \
+                --{value}-> Function #{dest_id}:{input_number} '{dest_name}'/'{io_name}'"
+            )
+        }
+        DebugServerMessage::Panic(message, jobs_created) => {
+            format!("Function panicked after {jobs_created} jobs created: {message}")
+        }
+        DebugServerMessage::JobError(job) => format!("Error executing Job: '{job}'"),
+        DebugServerMessage::Deadlock(message) => format!("Deadlock detected: {message}"),
+        DebugServerMessage::EnteringDebugger => {
+            "Entering debugger. Use the controls above to debug.".into()
+        }
+        DebugServerMessage::ExitingDebugger => "Debugger is exiting".into(),
+        DebugServerMessage::ExecutionStarted => "Running flow".into(),
+        DebugServerMessage::ExecutionEnded => "Flow has completed".into(),
+        DebugServerMessage::Functions(functions) => {
+            use std::fmt::Write;
+            let mut s = String::from("Functions List\n");
+            for f in functions {
+                let _ = writeln!(s, "\t#{} '{}' @ '{}'", f.id(), f.name(), f.route());
+            }
+            s
+        }
+        DebugServerMessage::SendingValue(source_id, value, dest_id, input_number) => {
+            format!("Function #{source_id} sending '{value}' to {dest_id}:{input_number}")
+        }
+        DebugServerMessage::Error(msg) => msg.clone(),
+        DebugServerMessage::Message(msg) => rewrite_for_gui(msg),
+        DebugServerMessage::Resetting => "Resetting state".into(),
+        DebugServerMessage::FunctionStates((function, states)) => {
+            format!("{function}\n\tState: {states:?}")
+        }
+        DebugServerMessage::OverallState(run_state) => format!("{run_state}"),
+        DebugServerMessage::InputState(input) => format!("{input}"),
+        DebugServerMessage::OutputState(connections) => {
+            if connections.is_empty() {
+                "No output connections from that sub-route".into()
+            } else {
+                connections
+                    .iter()
+                    .map(|c| format!("{c}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        DebugServerMessage::BlockState(blocks) => {
+            if blocks.is_empty() {
+                "No blocks matching the specification were found".into()
+            } else {
+                blocks
+                    .iter()
+                    .map(|b| format!("{b}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        DebugServerMessage::FlowUnblockBreakpoint(flow_id) => {
+            format!("Flow #{flow_id} was busy and has now gone idle, unblocking senders")
+        }
+        DebugServerMessage::WaitingForCommand(job_id) => {
+            format!("Waiting for command (Job #{job_id})")
+        }
+        DebugServerMessage::Invalid => "Invalid message from debug server".into(),
+    }
+}
+
+/// Create a subscription that runs a debug client, connecting to the debug server via ZMQ
+#[cfg(feature = "debugger")]
+pub fn debug_client_subscribe(port: u16) -> Subscription<Message> {
+    Subscription::run_with(port, |port| debug_client_stream(*port))
+}
+
+#[cfg(feature = "debugger")]
+fn debug_client_stream(port: u16) -> impl iced::futures::Stream<Item = Message> {
+    iced::stream::channel(
+        100,
+        move |mut sender: iced::futures::channel::mpsc::Sender<Message>| async move {
+            let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<DebugCommand>(10);
+            DEBUG_CMD_SENDER.get_or_init(|| Mutex::new(cmd_tx));
+
+            let mut blocking_sender = sender.clone();
+            let result = tokio::task::spawn_blocking(move || -> std::result::Result<(), String> {
+                let address = format!("localhost:{port}");
+                let connection = ClientConnection::new(&address)
+                    .map_err(|e| format!("Could not connect to debug server: {e}"))?;
+                if let Err(e) = connection.set_receive_timeout(5_000) {
+                    error!("Could not set receive timeout: {e}");
+                }
+
+                connection
+                    .send(DebugCommand::DebugClientStarting)
+                    .map_err(|e| format!("Could not send starting command: {e}"))?;
+
+                let _ = blocking_sender.try_send(Message::DebugConnected);
+
+                loop {
+                    let message: DebugServerMessage = match connection.receive() {
+                        Ok(msg) => msg,
+                        Err(e) => {
+                            let _ = blocking_sender
+                                .try_send(Message::DebugDisconnected(format!("{e}")));
+                            break;
+                        }
+                    };
+
+                    let is_exiting = matches!(message, DebugServerMessage::ExitingDebugger);
+                    let is_waiting = matches!(message, DebugServerMessage::WaitingForCommand(_));
+
+                    if !is_waiting {
+                        let _ = blocking_sender
+                            .try_send(Message::DebugEvent(format_debug_event(&message)));
+                    }
+
+                    if is_exiting {
+                        let _ = connection.send(DebugCommand::Ack);
+                        let _ = blocking_sender
+                            .try_send(Message::DebugDisconnected("Debugger exited".into()));
+                        break;
+                    }
+
+                    if is_waiting {
+                        let _ = blocking_sender.try_send(Message::DebugWaiting);
+                        if let Some(cmd) = cmd_rx.blocking_recv() {
+                            if let Err(e) = connection.send(cmd) {
+                                let _ = blocking_sender.try_send(Message::DebugDisconnected(
+                                    format!("Send error: {e}"),
+                                ));
+                                break;
+                            }
+                        } else {
+                            let _ = blocking_sender.try_send(Message::DebugDisconnected(
+                                "Command channel closed".into(),
+                            ));
+                            break;
+                        }
+                    } else if let Err(e) = connection.send(DebugCommand::Ack) {
+                        let _ = blocking_sender
+                            .try_send(Message::DebugDisconnected(format!("Send error: {e}")));
+                        break;
+                    }
+                }
+
+                Ok(())
+            })
+            .await;
+
+            if let Ok(Err(e)) = result {
+                let _ = sender.try_send(Message::DebugDisconnected(e));
+            }
+
+            std::future::pending::<()>().await;
+        },
+    )
 }
 
 // Return addresses and ports to be used for each of the three queues

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -45,6 +45,8 @@ use flowcore::model::submission::Submission;
 use flowcore::provider::Provider;
 use flowcore::url_helper::url_from_string;
 use flowrlib::connections::CoordinatorConnection;
+#[cfg(feature = "debugger")]
+use flowrlib::debug_client::DebugClient;
 use flowrlib::info as flowrlib_info;
 
 use crate::gui::client_message::ClientMessage;
@@ -117,6 +119,54 @@ pub enum Message {
     SaveError(String),
     /// closing of the Modal was requested
     CloseModal,
+    /// A formatted debug event from the debug server
+    #[cfg(feature = "debugger")]
+    DebugEvent(String),
+    /// The debugger is waiting for a command (enables debug buttons)
+    #[cfg(feature = "debugger")]
+    DebugWaiting,
+    /// Debug client connected to the debug server
+    #[cfg(feature = "debugger")]
+    DebugConnected,
+    /// Debug client disconnected from the debug server
+    #[cfg(feature = "debugger")]
+    DebugDisconnected(String),
+    /// User clicked Continue in the debug controls
+    #[cfg(feature = "debugger")]
+    DebugContinue,
+    /// User clicked Step in the debug controls
+    #[cfg(feature = "debugger")]
+    DebugStep,
+    /// User clicked Run/Reset in the debug controls
+    #[cfg(feature = "debugger")]
+    DebugReset,
+    /// User clicked Exit Debugger in the debug controls
+    #[cfg(feature = "debugger")]
+    DebugExit,
+    /// The step count text input changed
+    #[cfg(feature = "debugger")]
+    DebugStepCountChanged(String),
+    /// The breakpoint/inspect spec text input changed
+    #[cfg(feature = "debugger")]
+    DebugSpecChanged(String),
+    /// User clicked Set Breakpoint
+    #[cfg(feature = "debugger")]
+    DebugSetBreakpoint,
+    /// User clicked Delete All Breakpoints
+    #[cfg(feature = "debugger")]
+    DebugDeleteBreakpoints,
+    /// User clicked List Breakpoints
+    #[cfg(feature = "debugger")]
+    DebugListBreakpoints,
+    /// User clicked Inspect State
+    #[cfg(feature = "debugger")]
+    DebugInspect,
+    /// User clicked Functions list
+    #[cfg(feature = "debugger")]
+    DebugFunctions,
+    /// User clicked Validate
+    #[cfg(feature = "debugger")]
+    DebugValidate,
 }
 
 #[allow(clippy::ignored_unit_patterns)]
@@ -210,6 +260,14 @@ struct FlowrGui {
     show_modal: bool,
     modal_content: (String, String),
     pending_getline: bool,
+    #[cfg(feature = "debugger")]
+    debug_waiting: bool,
+    #[cfg(feature = "debugger")]
+    debug_spec_text: String,
+    #[cfg(feature = "debugger")]
+    debug_step_count: String,
+    #[cfg(feature = "debugger")]
+    debug_client_active: bool,
 }
 
 impl FlowrGui {
@@ -230,6 +288,14 @@ impl FlowrGui {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
+            #[cfg(feature = "debugger")]
+            debug_waiting: false,
+            #[cfg(feature = "debugger")]
+            debug_spec_text: String::new(),
+            #[cfg(feature = "debugger")]
+            debug_step_count: String::new(),
+            #[cfg(feature = "debugger")]
+            debug_client_active: false,
         };
 
         (flowrgui, Task::none())
@@ -249,6 +315,7 @@ impl FlowrGui {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::CoordinatorSent(CoordinatorMessage::Connected(sender)) => {
@@ -285,6 +352,13 @@ impl FlowrGui {
             }
             Message::StopFlow => {
                 connection_manager::request_stop();
+                #[cfg(feature = "debugger")]
+                if self.debug_client_active {
+                    self.debug_waiting = false;
+                    connection_manager::send_debug_command(
+                        flowcore::model::debug_command::DebugCommand::ExitDebugger,
+                    );
+                }
             }
             Message::FlowArgsChanged(value) => self.submission_settings.flow_args = value,
             Message::MaxJobsChanged(value) => {
@@ -295,6 +369,12 @@ impl FlowrGui {
                 if let CoordinatorState::Connected(sender) = &self.coordinator_state {
                     let mut settings = self.submission_settings.clone();
                     settings.debug_this_flow = true;
+                    self.submission_settings.debug_this_flow = true;
+                    #[cfg(feature = "debugger")]
+                    {
+                        self.debug_client_active = true;
+                        self.debug_waiting = false;
+                    }
                     return Task::perform(Self::submit(sender.clone(), settings), |result| {
                         match result {
                             Ok(()) => Message::Submitted,
@@ -315,6 +395,25 @@ impl FlowrGui {
                 return self.process_coordinator_message(coord_msg);
             }
             Message::CloseModal => self.show_modal = false,
+            #[cfg(feature = "debugger")]
+            msg @ (Message::DebugEvent(_)
+            | Message::DebugWaiting
+            | Message::DebugConnected
+            | Message::DebugDisconnected(_)
+            | Message::DebugContinue
+            | Message::DebugStep
+            | Message::DebugReset
+            | Message::DebugExit
+            | Message::DebugStepCountChanged(_)
+            | Message::DebugSpecChanged(_)
+            | Message::DebugSetBreakpoint
+            | Message::DebugDeleteBreakpoints
+            | Message::DebugListBreakpoints
+            | Message::DebugInspect
+            | Message::DebugFunctions
+            | Message::DebugValidate) => {
+                return self.process_debug_message(msg);
+            }
             Message::CoordinatorDisconnected(reason) => {
                 self.coordinator_state = CoordinatorState::Disconnected(reason);
             }
@@ -351,9 +450,14 @@ impl FlowrGui {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let main_content = Column::new()
-            .spacing(12)
-            .push(self.command_row())
+        let mut main_content = Column::new().spacing(12).push(self.command_row());
+
+        #[cfg(feature = "debugger")]
+        if self.submission_settings.debug_this_flow && self.debug_client_active {
+            main_content = main_content.push(self.debug_row());
+        }
+
+        let main_content = main_content
             .push(self.tab_set.view())
             .push(self.status_row())
             .padding(16);
@@ -383,8 +487,21 @@ impl FlowrGui {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        connection_manager::subscribe(self.coordinator_settings.clone())
-            .map(Message::CoordinatorSent)
+        let coordinator_sub = connection_manager::subscribe(self.coordinator_settings.clone())
+            .map(Message::CoordinatorSent);
+
+        #[cfg(feature = "debugger")]
+        if self.debug_client_active {
+            let debug_port = connection_manager::get_debug_port();
+            if debug_port > 0 {
+                return Subscription::batch([
+                    coordinator_sub,
+                    connection_manager::debug_client_subscribe(debug_port),
+                ]);
+            }
+        }
+
+        coordinator_sub
     }
 }
 
@@ -487,6 +604,108 @@ impl FlowrGui {
             .push(max_jobs)
             .push(play)
             .push(debug_play)
+    }
+
+    #[cfg(feature = "debugger")]
+    fn debug_row(&self) -> Row<'_, Message> {
+        let can_cmd = self.debug_waiting;
+
+        let mut continue_btn = Button::new(Text::new("\u{25B6} Continue"))
+            .style(theme::styled_button)
+            .padding([4, 10]);
+        if can_cmd {
+            continue_btn = continue_btn.on_press(Message::DebugContinue);
+        }
+
+        let mut step_btn = Button::new(Text::new("\u{23ED} Step"))
+            .style(theme::styled_button)
+            .padding([4, 10]);
+        if can_cmd {
+            step_btn = step_btn.on_press(Message::DebugStep);
+        }
+
+        let step_count = text_input("n", &self.debug_step_count)
+            .on_input(Message::DebugStepCountChanged)
+            .width(40);
+
+        let mut reset_btn = Button::new(Text::new("\u{21BB} Reset"))
+            .style(theme::styled_button)
+            .padding([4, 10]);
+        if can_cmd {
+            reset_btn = reset_btn.on_press(Message::DebugReset);
+        }
+
+        let mut exit_btn = Button::new(Text::new("\u{23F9} Exit"))
+            .style(theme::styled_button)
+            .padding([4, 10]);
+        if can_cmd {
+            exit_btn = exit_btn.on_press(Message::DebugExit);
+        }
+
+        let spec_input = text_input("breakpoint spec", &self.debug_spec_text)
+            .on_input(Message::DebugSpecChanged)
+            .width(120);
+
+        let mut bp_btn = Button::new(Text::new("Set BP"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            bp_btn = bp_btn.on_press(Message::DebugSetBreakpoint);
+        }
+
+        let mut del_btn = Button::new(Text::new("Del All"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            del_btn = del_btn.on_press(Message::DebugDeleteBreakpoints);
+        }
+
+        let mut list_btn = Button::new(Text::new("List BPs"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            list_btn = list_btn.on_press(Message::DebugListBreakpoints);
+        }
+
+        let mut inspect_btn = Button::new(Text::new("Inspect"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            inspect_btn = inspect_btn.on_press(Message::DebugInspect);
+        }
+
+        let mut funcs_btn = Button::new(Text::new("Functions"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            funcs_btn = funcs_btn.on_press(Message::DebugFunctions);
+        }
+
+        let mut validate_btn = Button::new(Text::new("Validate"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            validate_btn = validate_btn.on_press(Message::DebugValidate);
+        }
+
+        Row::new()
+            .spacing(6)
+            .padding(5)
+            .align_y(iced::alignment::Vertical::Center)
+            .push(continue_btn)
+            .push(step_btn)
+            .push(step_count)
+            .push(reset_btn)
+            .push(exit_btn)
+            .push(Text::new("|").size(13))
+            .push(spec_input)
+            .push(bp_btn)
+            .push(del_btn)
+            .push(list_btn)
+            .push(Text::new("|").size(13))
+            .push(inspect_btn)
+            .push(funcs_btn)
+            .push(validate_btn)
     }
 
     fn status_row(&self) -> Row<'_, Message> {
@@ -771,6 +990,142 @@ impl FlowrGui {
         if let CoordinatorState::Connected(ref sender) = self.coordinator_state {
             let _ = sender.try_send(msg);
         }
+    }
+
+    #[cfg(feature = "debugger")]
+    fn debug_separator(&mut self, label: &str) {
+        self.tab_set
+            .debug_tab
+            .content
+            .push(format!("\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} {label} \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"));
+    }
+
+    #[cfg(feature = "debugger")]
+    #[allow(clippy::too_many_lines)]
+    fn process_debug_message(&mut self, message: Message) -> Task<Message> {
+        use flowcore::model::debug_command::{BreakpointSpec, DebugCommand};
+
+        match message {
+            Message::DebugEvent(event) => {
+                self.tab_set.debug_tab.content.push(event);
+                if self.tab_set.active_tab != 5 {
+                    self.tab_set.debug_tab.unread_count += 1;
+                }
+                if self.tab_set.debug_tab.auto_scroll {
+                    return operation::snap_to(
+                        self.tab_set.debug_tab.id.clone(),
+                        RelativeOffset::END,
+                    );
+                }
+            }
+            Message::DebugWaiting => self.debug_waiting = true,
+            Message::DebugConnected => {
+                self.tab_set
+                    .debug_tab
+                    .content
+                    .push("Connected to debug server".into());
+                self.tab_set.active_tab = 5;
+            }
+            Message::DebugDisconnected(reason) => {
+                self.debug_waiting = false;
+                self.debug_client_active = false;
+                self.tab_set
+                    .debug_tab
+                    .content
+                    .push(format!("Disconnected: {reason}"));
+            }
+            Message::DebugContinue => {
+                self.debug_waiting = false;
+                self.debug_separator("Continue");
+                connection_manager::send_debug_command(DebugCommand::Continue);
+            }
+            Message::DebugStep => {
+                self.debug_waiting = false;
+                let params = if self.debug_step_count.is_empty() {
+                    None
+                } else {
+                    Some(vec![self.debug_step_count.clone()])
+                };
+                let count = DebugClient::parse_optional_int(params);
+                if let Some(n) = count {
+                    self.debug_separator(&format!("Step ({n})"));
+                } else {
+                    self.debug_separator("Step");
+                }
+                connection_manager::send_debug_command(DebugCommand::Step(count));
+            }
+            Message::DebugReset => {
+                self.debug_waiting = false;
+                self.debug_separator("Run / Reset");
+                connection_manager::send_debug_command(DebugCommand::RunReset);
+            }
+            Message::DebugExit => {
+                self.debug_waiting = false;
+                self.debug_separator("Exit Debugger");
+                connection_manager::send_debug_command(DebugCommand::ExitDebugger);
+            }
+            Message::DebugStepCountChanged(value) => self.debug_step_count = value,
+            Message::DebugSpecChanged(value) => self.debug_spec_text = value,
+            Message::DebugSetBreakpoint => {
+                self.debug_waiting = false;
+                let params = if self.debug_spec_text.is_empty() {
+                    None
+                } else {
+                    Some(vec![self.debug_spec_text.clone()])
+                };
+                let spec_label = if self.debug_spec_text.is_empty() {
+                    "no spec".to_string()
+                } else {
+                    self.debug_spec_text.clone()
+                };
+                self.debug_separator(&format!("Set Breakpoint ({spec_label})"));
+                let spec = DebugClient::parse_breakpoint_spec(params);
+                connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
+            }
+            Message::DebugDeleteBreakpoints => {
+                self.debug_waiting = false;
+                self.debug_separator("Delete All Breakpoints");
+                connection_manager::send_debug_command(DebugCommand::Delete(Some(
+                    BreakpointSpec::All,
+                )));
+            }
+            Message::DebugListBreakpoints => {
+                self.debug_waiting = false;
+                self.debug_separator("List Breakpoints");
+                connection_manager::send_debug_command(DebugCommand::List);
+            }
+            Message::DebugInspect => {
+                self.debug_waiting = false;
+                let params = if self.debug_spec_text.is_empty() {
+                    None
+                } else {
+                    Some(vec![self.debug_spec_text.clone()])
+                };
+                if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
+                    let label = if self.debug_spec_text.is_empty() {
+                        "Inspect (overall flow state)".to_string()
+                    } else {
+                        format!("Inspect ({})", self.debug_spec_text)
+                    };
+                    self.debug_separator(&label);
+                    connection_manager::send_debug_command(cmd);
+                } else {
+                    self.debug_waiting = true;
+                }
+            }
+            Message::DebugFunctions => {
+                self.debug_waiting = false;
+                self.debug_separator("Functions");
+                connection_manager::send_debug_command(DebugCommand::FunctionList);
+            }
+            Message::DebugValidate => {
+                self.debug_waiting = false;
+                self.debug_separator("Validate");
+                connection_manager::send_debug_command(DebugCommand::Validate);
+            }
+            _ => {}
+        }
+        Task::none()
     }
 
     #[allow(clippy::too_many_lines)]
@@ -1107,6 +1462,14 @@ mod test {
             show_modal: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
+            #[cfg(feature = "debugger")]
+            debug_waiting: false,
+            #[cfg(feature = "debugger")]
+            debug_spec_text: String::new(),
+            #[cfg(feature = "debugger")]
+            debug_step_count: String::new(),
+            #[cfg(feature = "debugger")]
+            debug_client_active: false,
         }
     }
 

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -21,6 +21,8 @@ pub(crate) struct TabSet {
     pub stdin_tab: StdInTab,
     pub images_tab: ImageTab,
     pub fileio_tab: StdOutTab,
+    #[cfg(feature = "debugger")]
+    pub debug_tab: StdOutTab,
     pub flow_name: String,
 }
 
@@ -51,6 +53,14 @@ impl TabSet {
                 auto_scroll: true,
                 unread_count: 0,
             },
+            #[cfg(feature = "debugger")]
+            debug_tab: StdOutTab {
+                name: "Debug".to_owned(),
+                id: Lazy::new(Id::unique).clone(),
+                content: vec![],
+                auto_scroll: true,
+                unread_count: 0,
+            },
             flow_name: String::new(),
         }
     }
@@ -64,6 +74,8 @@ impl TabSet {
                     1 if self.stderr_tab.auto_scroll => self.stderr_tab.unread_count = 0,
                     3 => self.images_tab.new_activity = false,
                     4 if self.fileio_tab.auto_scroll => self.fileio_tab.unread_count = 0,
+                    #[cfg(feature = "debugger")]
+                    5 if self.debug_tab.auto_scroll => self.debug_tab.unread_count = 0,
                     _ => {}
                 }
             }
@@ -74,6 +86,10 @@ impl TabSet {
                     self.stderr_tab.clear();
                 } else if name == &self.fileio_tab.name {
                     self.fileio_tab.clear();
+                }
+                #[cfg(feature = "debugger")]
+                if name == &self.debug_tab.name {
+                    self.debug_tab.clear();
                 }
             }
             Message::StdioAutoScrollTogglerChanged(id, value) => {
@@ -88,7 +104,7 @@ impl TabSet {
                 }
             }
             Message::SaveTabContent(ref name) => {
-                let content = if name == &self.stdout_tab.name {
+                let mut content = if name == &self.stdout_tab.name {
                     Some(&self.stdout_tab.content)
                 } else if name == &self.stderr_tab.name {
                     Some(&self.stderr_tab.content)
@@ -99,6 +115,10 @@ impl TabSet {
                 } else {
                     None
                 };
+                #[cfg(feature = "debugger")]
+                if name == &self.debug_tab.name {
+                    content = Some(&self.debug_tab.content);
+                }
 
                 if let Some(lines) = content {
                     let prefix = if self.flow_name.is_empty() {
@@ -142,14 +162,15 @@ impl TabSet {
     }
 
     pub(crate) fn view(&self) -> Element<'_, Message> {
-        Tabs::new(Message::TabSelected)
+        let tabs = Tabs::new(Message::TabSelected)
             .push(0, self.stdout_tab.tab_label(), self.stdout_tab.view())
             .push(1, self.stderr_tab.tab_label(), self.stderr_tab.view())
             .push(2, self.stdin_tab.tab_label(), self.stdin_tab.view())
             .push(3, self.images_tab.tab_label(), self.images_tab.view())
-            .push(4, self.fileio_tab.tab_label(), self.fileio_tab.view())
-            .set_active_tab(&self.active_tab)
-            .into()
+            .push(4, self.fileio_tab.tab_label(), self.fileio_tab.view());
+        #[cfg(feature = "debugger")]
+        let tabs = tabs.push(5, self.debug_tab.tab_label(), self.debug_tab.view());
+        tabs.set_active_tab(&self.active_tab).into()
     }
 
     pub(crate) fn clear(&mut self) {
@@ -158,6 +179,8 @@ impl TabSet {
         self.stdin_tab.clear();
         self.images_tab.clear();
         self.fileio_tab.clear();
+        #[cfg(feature = "debugger")]
+        self.debug_tab.clear();
     }
 }
 
@@ -191,10 +214,15 @@ impl Tab for StdOutTab {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let text_column =
-            Column::with_children(self.content.iter().cloned().map(text).map(Element::from))
-                .width(Length::Fill)
-                .padding(1);
+        let text_column = Column::with_children(
+            self.content
+                .iter()
+                .cloned()
+                .map(|s| text(s).shaping(iced::widget::text::Shaping::Advanced))
+                .map(Element::from),
+        )
+        .width(Length::Fill)
+        .padding(1);
 
         let scrollable = Scrollable::new(text_column)
             .height(Length::Fill)

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -125,7 +125,9 @@ impl DebugClient {
         Ok((input, command, None))
     }
 
-    pub(crate) fn parse_optional_int(params: Option<Vec<String>>) -> Option<usize> {
+    /// Parse an optional integer from the first element of a parameter list
+    #[must_use]
+    pub fn parse_optional_int(params: Option<Vec<String>>) -> Option<usize> {
         if let Some(param) = params {
             if !param.is_empty() {
                 if let Ok(integer) = param.first()?.parse::<usize>() {
@@ -137,7 +139,9 @@ impl DebugClient {
         None
     }
 
-    pub(crate) fn parse_breakpoint_spec(specs: Option<Vec<String>>) -> Option<BreakpointSpec> {
+    /// Parse a breakpoint specification from a parameter list
+    #[must_use]
+    pub fn parse_breakpoint_spec(specs: Option<Vec<String>>) -> Option<BreakpointSpec> {
         if let Some(spec) = specs {
             if !spec.is_empty() {
                 if spec.first()? == "*" {
@@ -179,7 +183,9 @@ impl DebugClient {
         None
     }
 
-    pub(crate) fn parse_inspect_spec(spec: Option<Vec<String>>) -> Option<DebugCommand> {
+    /// Parse an inspect specification into a [`DebugCommand`]
+    #[must_use]
+    pub fn parse_inspect_spec(spec: Option<Vec<String>>) -> Option<DebugCommand> {
         match Self::parse_breakpoint_spec(spec) {
             None => Some(Inspect),
             Some(BreakpointSpec::Numeric(function_id)) => Some(InspectFunction(function_id)),

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -27,6 +27,7 @@ pub struct DebugGuiHandler {
 
 impl DebugGuiHandler {
     /// Create a new GUI debug handler with the given channels
+    #[must_use]
     pub fn new(
         event_sender: mpsc::Sender<DebugServerMessage>,
         command_receiver: mpsc::Receiver<DebugCommand>,

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -76,6 +76,11 @@ pub mod debug_zmq_handler;
 pub mod debug_client;
 
 #[cfg(feature = "debugger")]
+/// Channel-based [`DebuggerHandler`][debugger_handler::DebuggerHandler] implementation
+/// for routing debug events to the GUI
+pub mod debug_gui_handler;
+
+#[cfg(feature = "debugger")]
 mod debugger;
 
 /// `wasmtime` module contains a number of implementations of the wasm execution


### PR DESCRIPTION
## Summary

- flowrgui acts as a debug **client** connecting to the existing debug server via ZMQ (same protocol as `flowrdb`)
- New debug control row (Continue, Step, Reset, Exit, breakpoints, inspect, functions, validate) appears when debugging
- New Debug output tab showing formatted events with command separators
- Stop button exits the debugger when a debug session is active
- CLI-oriented messages rewritten for GUI context
- Unicode text rendered correctly with advanced shaping

Closes #1707

## Test plan

- [x] `make clippy` passes
- [x] `make test` passes
- [ ] Manual: run `flowrgui <flow> -n`, click Debug, verify controls and event log work
- [ ] Manual: verify Stop exits debugger after flow completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated debugger functionality into flowrgui with interactive debug controls
  * Added dedicated Debug tab for managing debug sessions and viewing real-time debug output
  * Enabled flows to run in debug mode with breakpoint management, step execution, and function inspection capabilities
  * Implemented debug event display and command relay system for real-time debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->