### PR TITLE
Add job completion breakpoint type with 3+ syntax (#346)

### DIFF
--- a/flowcore/src/model/debug_command.rs
+++ b/flowcore/src/model/debug_command.rs
@@ -15,6 +15,8 @@ pub enum BreakpointSpec {
     Input((usize, usize)),
     /// A description of a "block" (when one function is blocked from running by another) was specified
     Block((Option<usize>, Option<usize>)),
+    /// A breakpoint on job completion for a specific function
+    Completed(usize),
 }
 
 /// A Command sent by the `debug_client` to the debugger

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -31,6 +31,7 @@ const FLOWDB_HISTORY_FILENAME: &str = ".flowrdb_history";
 const HELP_STRING: &str = "Debugger commands:
 'b' | 'breakpoint' {spec}     - Set a breakpoint using spec:
                                  - on a function by function_id (integer)
+                                 - on job completion by function_id+ (e.g. '3+')
                                  - on an output by source_id/output_route ('source_id/' for default output)
                                  - on an input by destination_id:input_number
                                  - on block creation by blocked_process_id->blocking_process_id
@@ -146,6 +147,12 @@ impl DebugClient {
             if !spec.is_empty() {
                 if spec.first()? == "*" {
                     return Some(BreakpointSpec::All);
+                }
+
+                if let Some(stripped) = spec.first()?.strip_suffix('+') {
+                    if let Ok(process_id) = stripped.parse::<usize>() {
+                        return Some(BreakpointSpec::Completed(process_id));
+                    }
                 }
 
                 if let Ok(integer) = spec.first()?.parse::<usize>() {
@@ -518,6 +525,19 @@ mod test {
         assert_eq!(
             DebugClient::parse_breakpoint_spec(specs("1->2")),
             Some(BreakpointSpec::Block((Some(1), Some(2))))
+        );
+    }
+
+    #[test]
+    fn parse_breakpoint_spec_completed() {
+        use crate::debug_command::BreakpointSpec;
+        assert_eq!(
+            DebugClient::parse_breakpoint_spec(specs("3+")),
+            Some(BreakpointSpec::Completed(3))
+        );
+        assert_eq!(
+            DebugClient::parse_breakpoint_spec(specs("0+")),
+            Some(BreakpointSpec::Completed(0))
         );
     }
 

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -32,6 +32,7 @@ pub struct Debugger<'a> {
     output_breakpoints: HashSet<(usize, String)>,
     break_at_job: usize,
     function_breakpoints: HashSet<usize>,
+    completed_breakpoints: HashSet<usize>,
     flow_unblock_breakpoints: HashSet<usize>,
 }
 
@@ -80,6 +81,7 @@ impl<'a> Debugger<'a> {
             output_breakpoints: HashSet::<(usize, String)>::new(),
             break_at_job: usize::MAX,
             function_breakpoints: HashSet::<usize>::new(),
+            completed_breakpoints: HashSet::<usize>::new(),
             flow_unblock_breakpoints: HashSet::<usize>::new(),
         }
     }
@@ -218,6 +220,18 @@ impl<'a> Debugger<'a> {
             }
         } else {
             self.debug_server.job_completed(job);
+            if self.completed_breakpoints.contains(&job.process_id) {
+                if let Some(function) = state.get_function(job.process_id) {
+                    self.debug_server.job_breakpoint(
+                        job,
+                        function,
+                        state.get_function_states(job.process_id),
+                    );
+                    if let Ok(result) = self.wait_for_command(state) {
+                        return result;
+                    }
+                }
+            }
         }
         (false, false)
     }
@@ -477,6 +491,24 @@ impl<'a> Debugger<'a> {
                     "Data breakpoint set on Function #{source_id} sending data via output: '{source_output_route}'"
                 ))
             }
+            Some(BreakpointSpec::Completed(process_id)) => {
+                if state.get_function(process_id).is_none() {
+                    bail!(
+                        "There is no Function with id '{process_id}' to set a completion breakpoint on"
+                    );
+                }
+
+                self.completed_breakpoints.insert(process_id);
+                let function = state
+                    .get_function(process_id)
+                    .ok_or("Could not get function")?;
+                Ok(format!(
+                    "Completion breakpoint set on Function #{} ({}) @ '{}'",
+                    process_id,
+                    function.name(),
+                    function.route()
+                ))
+            }
         }
     }
 
@@ -494,6 +526,7 @@ impl<'a> Debugger<'a> {
                 self.output_breakpoints.clear();
                 self.input_breakpoints.clear();
                 self.function_breakpoints.clear();
+                self.completed_breakpoints.clear();
                 Ok("Deleted all breakpoints\n".into())
             }
             Some(BreakpointSpec::Numeric(process_number)) => {
@@ -548,6 +581,21 @@ impl<'a> Debugger<'a> {
                     .remove(&(source_id, source_output_route));
                 Ok("Output breakpoint removed\n".into())
             }
+            Some(BreakpointSpec::Completed(process_id)) => {
+                if state.get_function(process_id).is_none() {
+                    bail!(
+                        "There is no Function with id '{process_id}' to delete a completion breakpoint from"
+                    );
+                }
+
+                if self.completed_breakpoints.remove(&process_id) {
+                    Ok(format!(
+                        "Completion breakpoint on Function #{process_id} was deleted"
+                    ))
+                } else {
+                    bail!("No completion breakpoint on Function #{process_id} exists\n")
+                }
+            }
         }
     }
 
@@ -588,6 +636,14 @@ impl<'a> Debugger<'a> {
             response.push_str("Block Breakpoints: \n");
             for (blocked_id, blocking_id) in &self.block_breakpoints {
                 let _ = writeln!(response, "\tBlock #{blocked_id}->#{blocking_id}");
+            }
+        }
+
+        if !self.completed_breakpoints.is_empty() {
+            breakpoints = true;
+            response.push_str("Completion Breakpoints: \n");
+            for process_id in &self.completed_breakpoints {
+                let _ = writeln!(response, "\tFunction #{process_id}+");
             }
         }
 


### PR DESCRIPTION
## Summary
- New `BreakpointSpec::Completed(usize)` variant for breaking after a function completes a job
- Use `b 3+` to set, `d 3+` to delete, shown as `Function #3+` in list
- Checks `completed_breakpoints` in `job_done()` and enters debugger with job result and function state

Closes #346

## Test plan
- [x] `make clippy` passes
- [x] New unit test for `parse_breakpoint_spec("3+")`
- [x] Existing debugger tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)