### PR TITLE
Add 'p' (processes) command for hierarchical function tree (#2737)

### DIFF
--- a/flowcore/src/model/debug_command.rs
+++ b/flowcore/src/model/debug_command.rs
@@ -60,6 +60,8 @@ pub enum DebugCommand {
     Step(Option<usize>),
     /// `validate` the current state
     Validate,
+    /// List all flows and functions in a hierarchical tree
+    ProcessList,
 }
 
 impl fmt::Display for DebugCommand {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -164,6 +164,9 @@ pub enum Message {
     /// User clicked Functions list
     #[cfg(feature = "debugger")]
     DebugFunctions,
+    /// User clicked Processes tree
+    #[cfg(feature = "debugger")]
+    DebugProcesses,
     /// User clicked Validate
     #[cfg(feature = "debugger")]
     DebugValidate,
@@ -411,6 +414,7 @@ impl FlowrGui {
             | Message::DebugListBreakpoints
             | Message::DebugInspect
             | Message::DebugFunctions
+            | Message::DebugProcesses
             | Message::DebugValidate) => {
                 return self.process_debug_message(msg);
             }
@@ -681,6 +685,13 @@ impl FlowrGui {
             funcs_btn = funcs_btn.on_press(Message::DebugFunctions);
         }
 
+        let mut procs_btn = Button::new(Text::new("Processes"))
+            .style(theme::styled_button)
+            .padding([4, 8]);
+        if can_cmd {
+            procs_btn = procs_btn.on_press(Message::DebugProcesses);
+        }
+
         let mut validate_btn = Button::new(Text::new("Validate"))
             .style(theme::styled_button)
             .padding([4, 8]);
@@ -705,6 +716,7 @@ impl FlowrGui {
             .push(Text::new("|").size(13))
             .push(inspect_btn)
             .push(funcs_btn)
+            .push(procs_btn)
             .push(validate_btn)
     }
 
@@ -1117,6 +1129,11 @@ impl FlowrGui {
                 self.debug_waiting = false;
                 self.debug_separator("Functions");
                 connection_manager::send_debug_command(DebugCommand::FunctionList);
+            }
+            Message::DebugProcesses => {
+                self.debug_waiting = false;
+                self.debug_separator("Processes");
+                connection_manager::send_debug_command(DebugCommand::ProcessList);
             }
             Message::DebugValidate => {
                 self.debug_waiting = false;

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -43,6 +43,7 @@ const HELP_STRING: &str = "Debugger commands:
 'i' | 'inspect' [n]           - Inspect the overall state, or the function number 'n'
 'l' | 'list'                  - List all breakpoints
 'm' | 'modify' [name]=[value] - Modify a debugger or runtime variable named 'name' to value 'value'
+'p' | 'processes'             - Show flows and functions in a hierarchical tree
 'q' | 'quit'                  - Stop flow execution and exit debugger
 'r' | 'reset' or 'run'        - Reset the state and re-run the flow
 's' | 'step' [n]              - Step over the next 'n' jobs (default = 1) then break
@@ -255,6 +256,7 @@ impl DebugClient {
             }
             "i" | "inspect" => Self::parse_inspect_spec(params),
             "l" | "list" => Some(List),
+            "p" | "processes" => Some(DebugCommand::ProcessList),
             "m" | "modify" => Some(Modify(params)),
             "r" | "run" | "reset" => Some(RunReset),
             "s" | "step" => Some(Step(Self::parse_optional_int(params))),

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -666,17 +666,19 @@ impl<'a> Debugger<'a> {
         let functions = state.get_functions();
         let mut by_parent: HashMap<usize, Vec<&RuntimeFunction>> = HashMap::new();
         for func in functions.values() {
-            by_parent
-                .entry(func.get_parent_id())
-                .or_default()
-                .push(func);
+            let parent = func.get_parent_id();
+            if parent == func.id() {
+                by_parent.entry(usize::MAX).or_default().push(func);
+            } else {
+                by_parent.entry(parent).or_default().push(func);
+            }
         }
         for children in by_parent.values_mut() {
             children.sort_by_key(|f| f.id());
         }
 
         let mut response = String::from("Process Tree\n");
-        Self::print_tree(&by_parent, functions, 0, 0, &mut response);
+        Self::print_tree(&by_parent, functions, usize::MAX, 0, &mut response);
         response
     }
 
@@ -1461,5 +1463,71 @@ mod test {
         assert!(debugger
             .delete_breakpoint(&state, Some(BreakpointSpec::Output((0, String::new()))))
             .is_ok());
+    }
+
+    #[test]
+    fn test_add_completed_breakpoint() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+        let result = debugger.add_breakpoint(&state, Some(BreakpointSpec::Completed(0)));
+        assert!(result.is_ok());
+        assert!(debugger.completed_breakpoints.contains(&0));
+    }
+
+    #[test]
+    fn test_add_completed_breakpoint_invalid_function() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+        let result = debugger.add_breakpoint(&state, Some(BreakpointSpec::Completed(99)));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_completed_breakpoint() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+        debugger
+            .add_breakpoint(&state, Some(BreakpointSpec::Completed(0)))
+            .expect("Couldn't add breakpoint");
+        assert!(debugger
+            .delete_breakpoint(&state, Some(BreakpointSpec::Completed(0)))
+            .is_ok());
+        assert!(!debugger.completed_breakpoints.contains(&0));
+    }
+
+    #[test]
+    fn test_list_completed_breakpoints() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+        debugger
+            .add_breakpoint(&state, Some(BreakpointSpec::Completed(0)))
+            .expect("Couldn't add breakpoint");
+        let list = debugger.list_breakpoints();
+        assert!(list.contains("Completion Breakpoints"));
+        assert!(list.contains("Function #0+"));
+    }
+
+    #[test]
+    fn test_process_tree() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let tree = Debugger::process_tree(&state);
+        assert!(tree.contains("Process Tree"));
+        assert!(tree.contains("#0"));
+    }
+
+    #[test]
+    fn test_job_done_with_completed_breakpoint() {
+        let mut state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let job = test_job();
+        let mut debugger = Debugger::new(&mut server);
+        debugger.completed_breakpoints.insert(0);
+        let _ = debugger.job_done(&mut state, &job);
+        assert!(server.job_completed);
+        assert_eq!(server.job_breakpoint, job.payload.job_id);
     }
 }

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -291,6 +291,10 @@ impl<'a> Debugger<'a> {
                     functions.sort_by_key(RuntimeFunction::id);
                     self.debug_server.function_list(&functions);
                 }
+                Ok(DebugCommand::ProcessList) => {
+                    let message = Self::process_tree(state);
+                    self.debug_server.message(message);
+                }
                 Ok(Inspect) => self.debug_server.run_state(state),
                 Ok(InspectFunction(function_id)) => {
                     if state.get_function(function_id).is_some() {
@@ -656,10 +660,64 @@ impl<'a> Debugger<'a> {
         response
     }
 
-    /*
-       Run checks on the current flow execution state to check if it is valid
-       Currently deadlock check is the only check that exists.
-    */
+    fn process_tree(state: &RunState) -> String {
+        use std::collections::HashMap;
+
+        let functions = state.get_functions();
+        let mut by_parent: HashMap<usize, Vec<&RuntimeFunction>> = HashMap::new();
+        for func in functions.values() {
+            by_parent
+                .entry(func.get_parent_id())
+                .or_default()
+                .push(func);
+        }
+        for children in by_parent.values_mut() {
+            children.sort_by_key(|f| f.id());
+        }
+
+        let mut response = String::from("Process Tree\n");
+        Self::print_tree(&by_parent, functions, 0, 0, &mut response);
+        response
+    }
+
+    fn print_tree(
+        by_parent: &std::collections::HashMap<usize, Vec<&RuntimeFunction>>,
+        all_functions: &std::collections::HashMap<usize, RuntimeFunction>,
+        parent_id: usize,
+        depth: usize,
+        response: &mut String,
+    ) {
+        let indent = "  ".repeat(depth);
+        if let Some(parent) = all_functions.get(&parent_id) {
+            let _ = writeln!(
+                response,
+                "{indent}#{} '{}' @ '{}'",
+                parent.id(),
+                parent.name(),
+                parent.route()
+            );
+        } else if depth == 0 {
+            let _ = writeln!(response, "{indent}/ (root flow)");
+        }
+
+        if let Some(children) = by_parent.get(&parent_id) {
+            for child in children {
+                if by_parent.contains_key(&child.id()) {
+                    Self::print_tree(by_parent, all_functions, child.id(), depth + 1, response);
+                } else {
+                    let child_indent = "  ".repeat(depth + 1);
+                    let _ = writeln!(
+                        response,
+                        "{child_indent}#{} '{}' @ '{}'",
+                        child.id(),
+                        child.name(),
+                        child.route()
+                    );
+                }
+            }
+        }
+    }
+
     fn validate(_state: &RunState) -> String {
         let mut response = String::new();
 


### PR DESCRIPTION
## Summary
- New `DebugCommand::ProcessList` variant and 'p'/'processes' debugger command
- Displays all flows and functions in an indented tree grouped by parent flow
- Processes button added to flowrgui debug controls

Closes #2737
Closes #1272

## Test plan
- [x] `make clippy` passes
- [x] Existing tests pass
- [ ] Manual: run `flowrdb`, type `p` to see process tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)