### PR TITLE
Add state-filtered inspect commands (#908)

### DIFF
--- a/book/debugging/debugger.md
+++ b/book/debugging/debugger.md
@@ -102,3 +102,8 @@ The `inspect` command accepts the following spec formats to examine specific par
 | `i 5:0` | Show state of input #0 on function #5 |
 | `i 3/result` | Show output connections from function #3's `/result` route |
 | `i 1->2` | Show blocks between functions #1 and #2 |
+| `i ready` | Show functions currently in Ready state |
+| `i waiting` | Show functions in Waiting state |
+| `i running` | Show functions in Running state with job IDs |
+| `i completed` | Show functions that have completed |
+| `i blocked` | Show functions blocked on output, and what blocks them |

--- a/flowcore/src/model/debug_command.rs
+++ b/flowcore/src/model/debug_command.rs
@@ -48,6 +48,8 @@ pub enum DebugCommand {
     InspectOutput(usize, String),
     /// Inspect a Block (optional source `function_id`, optional `destination_function_id`)
     InspectBlock(Option<usize>, Option<usize>),
+    /// Inspect functions filtered by state (ready, waiting, running, completed, blocked)
+    InspectState(String),
     /// Invalid - used when deserialization goes wrong
     Invalid,
     /// `list` existing breakpoints

--- a/flowr/examples/debug-print-args/main.rs
+++ b/flowr/examples/debug-print-args/main.rs
@@ -296,4 +296,34 @@ mod test {
         );
         assert!(stdout.contains("Debugger is exiting"), "No exit:\n{stdout}");
     }
+
+    #[test]
+    #[serial]
+    fn test_debug_inspect_ready() {
+        let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
+        session.send("i ready");
+        session.send("e");
+        let stdout = session.finish();
+
+        assert!(
+            stdout.contains("Functions in 'ready' state:"),
+            "No ready state header:\n{stdout}"
+        );
+        assert!(stdout.contains("Debugger is exiting"), "No exit:\n{stdout}");
+    }
+
+    #[test]
+    #[serial]
+    fn test_debug_inspect_waiting() {
+        let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
+        session.send("i waiting");
+        session.send("e");
+        let stdout = session.finish();
+
+        assert!(
+            stdout.contains("Functions in 'waiting' state:"),
+            "No waiting state header:\n{stdout}"
+        );
+        assert!(stdout.contains("Debugger is exiting"), "No exit:\n{stdout}");
+    }
 }

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -40,7 +40,13 @@ const HELP_STRING: &str = "Debugger commands:
 'e' | 'exit'                  - Stop flow execution and exit debugger
 'f' | 'functions'             - Show the list of functions
 'h' | 'help' | '?'            - Display this help message
-'i' | 'inspect' [n]           - Inspect the overall state, or the function number 'n'
+'i' | 'inspect' [spec]        - Inspect overall state, a function, input, output, or block
+                                 - 'i' with no args shows overall state
+                                 - 'i <id>' inspects function by ID
+                                 - 'i <id>:<input>' inspects an input
+                                 - 'i <id>/<route>' inspects output connections
+                                 - 'i <id>-><id>' inspects blocks between functions
+                                 - 'i ready|waiting|running|completed|blocked' filters by state
 'l' | 'list'                  - List all breakpoints
 'm' | 'modify' [name]=[value] - Modify a debugger or runtime variable named 'name' to value 'value'
 'p' | 'processes'             - Show flows and functions in a hierarchical tree
@@ -191,9 +197,19 @@ impl DebugClient {
         None
     }
 
+    const STATE_KEYWORDS: &[&str] = &["ready", "waiting", "running", "completed", "blocked"];
+
     /// Parse an inspect specification into a [`DebugCommand`]
     #[must_use]
     pub fn parse_inspect_spec(spec: Option<Vec<String>>) -> Option<DebugCommand> {
+        if let Some(ref params) = spec {
+            if let Some(keyword) = params.first() {
+                if Self::STATE_KEYWORDS.contains(&keyword.as_str()) {
+                    return Some(DebugCommand::InspectState(keyword.clone()));
+                }
+            }
+        }
+
         match Self::parse_breakpoint_spec(spec) {
             None => Some(Inspect),
             Some(BreakpointSpec::Numeric(function_id)) => Some(InspectFunction(function_id)),
@@ -560,6 +576,24 @@ mod test {
         assert_eq!(
             DebugClient::parse_inspect_spec(None),
             Some(DebugCommand::Inspect)
+        );
+    }
+
+    #[test]
+    fn parse_inspect_spec_state_ready() {
+        use crate::debug_command::DebugCommand;
+        assert_eq!(
+            DebugClient::parse_inspect_spec(specs("ready")),
+            Some(DebugCommand::InspectState("ready".into()))
+        );
+    }
+
+    #[test]
+    fn parse_inspect_spec_state_blocked() {
+        use crate::debug_command::DebugCommand;
+        assert_eq!(
+            DebugClient::parse_inspect_spec(specs("blocked")),
+            Some(DebugCommand::InspectState("blocked".into()))
         );
     }
 

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -20,7 +20,7 @@ use crate::debug_command::DebugCommand::{
 };
 use crate::debugger_handler::DebuggerHandler;
 use crate::job::Job;
-use crate::run_state::RunState;
+use crate::run_state::{RunState, State};
 
 /// Debugger struct contains all the info necessary to conduct a debugging session, storing
 /// set breakpoints, connections to the debug client etc
@@ -296,6 +296,10 @@ impl<'a> Debugger<'a> {
                     self.debug_server.message(message);
                 }
                 Ok(Inspect) => self.debug_server.run_state(state),
+                Ok(DebugCommand::InspectState(ref state_name)) => {
+                    let message = Self::inspect_by_state(state, state_name);
+                    self.debug_server.message(message);
+                }
                 Ok(InspectFunction(function_id)) => {
                     if state.get_function(function_id).is_some() {
                         self.debug_server.function_states(
@@ -655,6 +659,82 @@ impl<'a> Debugger<'a> {
             response.push_str(
                 "No Breakpoints set. Use the 'b' command to set a breakpoint. Use 'h' for help.\n",
             );
+        }
+
+        response
+    }
+
+    fn inspect_by_state(state: &RunState, state_name: &str) -> String {
+        let target_state = match state_name {
+            "ready" => Some(State::Ready),
+            "waiting" => Some(State::Waiting),
+            "running" => Some(State::Running),
+            "completed" => Some(State::Completed),
+            "blocked" => None,
+            _ => {
+                return format!(
+                "Unknown state '{state_name}'. Use: ready, waiting, running, completed, blocked"
+            )
+            }
+        };
+
+        let mut response = String::new();
+        let functions = state.get_functions();
+        let mut sorted: Vec<_> = functions.values().collect();
+        sorted.sort_by_key(|f| f.id());
+        let mut count = 0;
+
+        if state_name == "blocked" {
+            let _ = writeln!(response, "Blocked functions:");
+            for func in &sorted {
+                let states = state.get_function_states(func.id());
+                if states.contains(&State::Waiting) {
+                    if let Ok(blockers) = state.get_input_blockers(func.id()) {
+                        if !blockers.is_empty() {
+                            count += 1;
+                            let _ = writeln!(
+                                response,
+                                "  #{} '{}' @ '{}' — blocked by: {:?}",
+                                func.id(),
+                                func.name(),
+                                func.route(),
+                                blockers
+                            );
+                        }
+                    }
+                }
+            }
+        } else if let Some(ref target) = target_state {
+            let _ = writeln!(response, "Functions in '{state_name}' state:");
+            for func in &sorted {
+                let states = state.get_function_states(func.id());
+                if states.contains(target) {
+                    count += 1;
+                    let _ = write!(
+                        response,
+                        "  #{} '{}' @ '{}'",
+                        func.id(),
+                        func.name(),
+                        func.route()
+                    );
+                    if state_name == "running" {
+                        let running_jobs: Vec<_> = state
+                            .get_running()
+                            .iter()
+                            .filter(|(_, job)| job.process_id == func.id())
+                            .map(|(job_id, _)| format!("Job #{job_id}"))
+                            .collect();
+                        if !running_jobs.is_empty() {
+                            let _ = write!(response, " ({})", running_jobs.join(", "));
+                        }
+                    }
+                    let _ = writeln!(response);
+                }
+            }
+        }
+
+        if count == 0 {
+            let _ = writeln!(response, "  (none)");
         }
 
         response
@@ -1529,5 +1609,33 @@ mod test {
         let _ = debugger.job_done(&mut state, &job);
         assert!(server.job_completed);
         assert_eq!(server.job_breakpoint, job.payload.job_id);
+    }
+
+    #[test]
+    fn test_inspect_by_state_ready() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let result = Debugger::inspect_by_state(&state, "ready");
+        assert!(result.contains("Functions in 'ready' state:"));
+    }
+
+    #[test]
+    fn test_inspect_by_state_waiting() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let result = Debugger::inspect_by_state(&state, "waiting");
+        assert!(result.contains("Functions in 'waiting' state:"));
+    }
+
+    #[test]
+    fn test_inspect_by_state_unknown() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let result = Debugger::inspect_by_state(&state, "bogus");
+        assert!(result.contains("Unknown state"));
+    }
+
+    #[test]
+    fn test_inspect_by_state_blocked() {
+        let state = RunState::new(test_submission(vec![test_function(0)]));
+        let result = Debugger::inspect_by_state(&state, "blocked");
+        assert!(result.contains("Blocked functions:"));
     }
 }


### PR DESCRIPTION
## Summary
- New `i ready/waiting/running/completed/blocked` inspect commands
- Filters functions by runtime state for quick debugging
- `i running` also shows job IDs, `i blocked` shows blocking functions

## Test plan
- [x] `make clippy` passes
- [x] 6 new unit tests (4 state filter + 2 parse)
- [x] 2 new integration tests (i ready, i waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspect command now supports filtering functions by runtime state: `ready`, `waiting`, `running`, `completed`, and `blocked`. Running state queries include job IDs, and blocked queries show what's blocking them.

* **Documentation**
  * Updated inspect command documentation with new state filter options.

* **Tests**
  * Added integration and unit tests for state-based function inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->