### PR TITLE
Add clickable Function references in debug output (#2759)

### DIFF
--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -64,15 +64,28 @@ pub struct FlowManifest {
 
 impl Display for FlowManifest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.flows.is_empty() {
+            writeln!(f, "Flows:")?;
+            for (id, flow) in &self.flows {
+                let parent = flow
+                    .parent_id
+                    .map_or("root".to_string(), |p| format!("Flow #{p}"));
+                writeln!(f, "  Flow #{id} (parent: {parent})")?;
+                if !flow.sub_flow_ids.is_empty() {
+                    writeln!(f, "    Sub-flows: {:?}", flow.sub_flow_ids)?;
+                }
+            }
+        }
+        writeln!(f, "Functions:")?;
         for function in self.functions.values() {
             writeln!(
                 f,
-                "               Function #{} Implementation: {}",
+                "  Function #{} Implementation: {}",
                 function.id(),
                 function.get_implementation_url()
             )?;
         }
-        write!(f, "")
+        Ok(())
     }
 }
 

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -105,7 +105,7 @@ impl TryFrom<&IO> for Input {
 impl fmt::Display for Input {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.name.is_empty() {
-            write!(f, "({}) ", self.name)?;
+            write!(f, "'{}' ", self.name)?;
         }
         if !self.received.is_empty() {
             write!(f, "{:?}", self.received)?;

--- a/flowcore/src/model/output_connection.rs
+++ b/flowcore/src/model/output_connection.rs
@@ -96,7 +96,7 @@ impl fmt::Display for OutputConnection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Output '{}' -> Function #{}({}):{}",
+            "Output '{}' -> Function #{} (Flow #{}):{}",
             self.source,
             self.destination_id,
             self.destination_parent_id,

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -61,7 +61,11 @@ fn default_url() -> Url {
 #[cfg(feature = "debugger")]
 impl fmt::Display for RuntimeFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Function #{}({})", self.process_id, self.parent_id)?;
+        write!(
+            f,
+            "Function #{} (Flow #{})",
+            self.process_id, self.parent_id
+        )?;
 
         if !self.name.is_empty() {
             write!(f, " '{}'", self.name)?;

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -512,9 +512,10 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
         DebugServerMessage::FunctionStates((function, states)) => {
+            let func_id = function.id();
             let mut lines: Vec<DebugEventLine> = format!("{function}")
                 .lines()
-                .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
+                .map(|l| DebugEventLine::with_context(l.trim_start().to_string(), None, func_id))
                 .collect();
             lines.push(DebugEventLine::new(format!("State: {states:?}"), None));
             lines

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -433,13 +433,19 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             }
             lines
         }
-        DebugServerMessage::PriorToSendingJob(job) => line(
-            format!(
-                "About to send Job #{} to Function #{} '{}'\n\tInputs: {:?}",
-                job.payload.job_id, job.process_id, job.function_name, job.payload.input_set
+        DebugServerMessage::PriorToSendingJob(job) => vec![
+            DebugEventLine::new(
+                format!(
+                    "About to send Job #{} to Function #{} '{}'",
+                    job.payload.job_id, job.process_id, job.function_name
+                ),
+                Some(debug_colors::DATA_FLOW),
             ),
-            Some(debug_colors::DATA_FLOW),
-        ),
+            DebugEventLine::new(
+                format!("Inputs: {:?}", job.payload.input_set),
+                Some(debug_colors::DATA_FLOW),
+            ),
+        ],
         DebugServerMessage::BlockBreakpoint(block) => line(
             format!("Block breakpoint: {block:?}"),
             Some(debug_colors::BREAKPOINT),
@@ -506,10 +512,21 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
         DebugServerMessage::FunctionStates((function, states)) => {
-            line(format!("{function}\n\tState: {states:?}"), None)
+            let mut lines: Vec<DebugEventLine> = format!("{function}")
+                .lines()
+                .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
+                .collect();
+            lines.push(DebugEventLine::new(format!("State: {states:?}"), None));
+            lines
         }
-        DebugServerMessage::OverallState(run_state) => line(format!("{run_state}"), None),
-        DebugServerMessage::InputState(input) => line(format!("{input}"), None),
+        DebugServerMessage::OverallState(run_state) => format!("{run_state}")
+            .lines()
+            .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
+            .collect(),
+        DebugServerMessage::InputState(input) => format!("{input}")
+            .lines()
+            .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
+            .collect(),
         DebugServerMessage::OutputState(connections) => {
             if connections.is_empty() {
                 line("No output connections from that sub-route".into(), None)

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -524,10 +524,20 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             .lines()
             .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
             .collect(),
-        DebugServerMessage::InputState(input) => format!("{input}")
-            .lines()
-            .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
-            .collect(),
+        DebugServerMessage::InputState(input) => {
+            let display = format!("{input}");
+            if display.trim().is_empty() {
+                vec![DebugEventLine::new(
+                    format!("Input '{}' — no values queued", input.name()),
+                    None,
+                )]
+            } else {
+                display
+                    .lines()
+                    .map(|l| DebugEventLine::new(l.trim_start().to_string(), None))
+                    .collect()
+            }
+        }
         DebugServerMessage::OutputState(connections) => {
             if connections.is_empty() {
                 line("No output connections from that sub-route".into(), None)

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -420,8 +420,8 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::JobCompleted(job) => {
             let mut lines = vec![DebugEventLine::new(
                 format!(
-                    "Job #{} completed by Function #{} '{}'",
-                    job.payload.job_id, job.process_id, job.function_name
+                    "Job #{} completed by Function #{} (Flow #{}) '{}'",
+                    job.payload.job_id, job.process_id, job.parent_id, job.function_name
                 ),
                 Some(debug_colors::COMPLETION),
             )];
@@ -436,8 +436,8 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::PriorToSendingJob(job) => vec![
             DebugEventLine::new(
                 format!(
-                    "About to send Job #{} to Function #{} '{}'",
-                    job.payload.job_id, job.process_id, job.function_name
+                    "About to send Job #{} to Function #{} (Flow #{}) '{}'",
+                    job.payload.job_id, job.process_id, job.parent_id, job.function_name
                 ),
                 Some(debug_colors::DATA_FLOW),
             ),
@@ -472,8 +472,8 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         ),
         DebugServerMessage::JobError(job) => line(
             format!(
-                "Error executing Job #{} on Function #{} '{}': '{job}'",
-                job.payload.job_id, job.process_id, job.function_name
+                "Error executing Job #{} on Function #{} (Flow #{}) '{}': '{job}'",
+                job.payload.job_id, job.process_id, job.parent_id, job.function_name
             ),
             Some(debug_colors::ERROR),
         ),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -122,6 +122,7 @@ impl DebugEventLine {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn extract_links(text: &str) -> Vec<DebugLink> {
         let mut links = Vec::new();
         let mut search_from = 0;
@@ -209,7 +210,7 @@ impl DebugEventLine {
             search_from = output_text_end;
         }
 
-        // Match state keywords
+        // Match state keywords in square brackets like [Ready]
         for keyword in &[
             "[Ready]",
             "[Waiting]",
@@ -224,6 +225,40 @@ impl DebugEventLine {
                     end: pos + keyword.len(),
                     spec: state_name.to_lowercase(),
                 });
+            }
+        }
+
+        // Match RunState field labels as links to state inspections
+        for (label, spec) in &[
+            ("Jobs Running:", "running"),
+            ("Functions Ready:", "ready"),
+            ("Functions Completed:", "completed"),
+        ] {
+            if let Some(pos) = text.find(label) {
+                links.push(DebugLink {
+                    start: pos,
+                    end: pos + label.len(),
+                    spec: (*spec).to_string(),
+                });
+            }
+        }
+
+        // Match Busy Count entries like "1: 1, 0: 1" — the keys are function IDs
+        if let Some(after_colon) = text.strip_prefix("Busy Count:") {
+            for part in after_colon.split(',') {
+                let part = part.trim().trim_start_matches(['{', ' ']);
+                if let Some(colon_pos) = part.find(':') {
+                    let key = part[..colon_pos].trim();
+                    if let Ok(_id) = key.parse::<usize>() {
+                        if let Some(abs_pos) = text.find(&format!("{key}:")) {
+                            links.push(DebugLink {
+                                start: abs_pos,
+                                end: abs_pos + key.len(),
+                                spec: key.to_string(),
+                            });
+                        }
+                    }
+                }
             }
         }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -203,6 +203,26 @@ impl DebugEventLine {
             })
         });
 
+        // Match Job #N patterns — link to the function that ran the job
+        search_from = 0;
+        while let Some(pos) = text[search_from..].find("Job #") {
+            let abs_pos = search_from + pos;
+            let after_hash = abs_pos + "Job #".len();
+            let digit_end = text[after_hash..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map_or(text.len(), |i| after_hash + i);
+            if digit_end > after_hash {
+                if let Some(func_id) = context_func_id {
+                    links.push(DebugLink {
+                        start: abs_pos,
+                        end: digit_end,
+                        spec: func_id.to_string(),
+                    });
+                }
+            }
+            search_from = digit_end;
+        }
+
         // Match Input:N patterns
         search_from = 0;
         while let Some(pos) = text[search_from..].find("Input:") {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1747,6 +1747,8 @@ impl FlowrGui {
                 if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
                     self.debug_separator(&label);
                     connection_manager::send_debug_command(cmd);
+                } else {
+                    self.debug_waiting = true;
                 }
             }
             Message::ShowBpPopup => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1329,6 +1329,7 @@ impl FlowrGui {
                 (false, false) => ("\u{1F7E2}", "Ready".to_string()),
                 (_, true) => ("\u{1F535}", "Running".to_string()),
                 (true, false) => {
+                    #[cfg(feature = "debugger")]
                     if self.debug_client_active {
                         ("\u{1F7E3}", "Debugging".to_string())
                     } else if self.submission_settings.debug_this_flow {
@@ -1337,6 +1338,10 @@ impl FlowrGui {
                             "Waiting for debugger to connect...".to_string(),
                         )
                     } else {
+                        ("\u{1F7E1}", "Submitted".to_string())
+                    }
+                    #[cfg(not(feature = "debugger"))]
+                    {
                         ("\u{1F7E1}", "Submitted".to_string())
                     }
                 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -104,7 +104,17 @@ pub struct DebugEventLine {
 #[cfg(feature = "debugger")]
 impl DebugEventLine {
     fn new(text: String, color: Option<iced::Color>) -> Self {
-        let links = Self::extract_links(&text);
+        let links = Self::extract_links(&text, None);
+        Self {
+            text,
+            color,
+            separator: false,
+            links,
+        }
+    }
+
+    fn with_context(text: String, color: Option<iced::Color>, context_func_id: usize) -> Self {
+        let links = Self::extract_links(&text, Some(context_func_id));
         Self {
             text,
             color,
@@ -123,7 +133,7 @@ impl DebugEventLine {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn extract_links(text: &str) -> Vec<DebugLink> {
+    fn extract_links(text: &str, override_func_id: Option<usize>) -> Vec<DebugLink> {
         let mut links = Vec::new();
         let mut search_from = 0;
 
@@ -163,13 +173,14 @@ impl DebugEventLine {
             search_from = digit_end;
         }
 
-        // Extract function ID from first "Function #N" if present, for context
-        let context_func_id = text.find("Function #").and_then(|pos| {
-            let after = pos + "Function #".len();
-            let end = text[after..]
-                .find(|c: char| !c.is_ascii_digit())
-                .map_or(text.len(), |i| after + i);
-            text[after..end].parse::<usize>().ok()
+        let context_func_id = override_func_id.or_else(|| {
+            text.find("Function #").and_then(|pos| {
+                let after = pos + "Function #".len();
+                let end = text[after..]
+                    .find(|c: char| !c.is_ascii_digit())
+                    .map_or(text.len(), |i| after + i);
+                text[after..end].parse::<usize>().ok()
+            })
         });
 
         // Match Input:N patterns
@@ -1721,11 +1732,20 @@ impl FlowrGui {
             Message::DebugBreakpointListReceived(specs) => {
                 self.active_breakpoints = specs.into_iter().collect();
             }
-            Message::DebugInspectLink(spec) if self.debug_waiting => {
+            Message::DebugInspectLink(ref spec) if self.debug_waiting => {
                 self.debug_waiting = false;
-                let params = Some(vec![spec]);
+                let label = if spec.parse::<usize>().is_ok() {
+                    format!("Inspect #{spec}")
+                } else if spec.contains(':') {
+                    format!("Inspect Input ({spec})")
+                } else if spec.contains('/') {
+                    format!("Inspect Output ({spec})")
+                } else {
+                    format!("Inspect {spec}")
+                };
+                let params = Some(vec![spec.clone()]);
                 if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
-                    self.debug_separator("Inspect");
+                    self.debug_separator(&label);
                     connection_manager::send_debug_command(cmd);
                 }
             }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -143,6 +143,25 @@ impl DebugEventLine {
             search_from = digit_end;
         }
 
+        // Match Flow #N patterns
+        search_from = 0;
+        while let Some(pos) = text[search_from..].find("Flow #") {
+            let abs_pos = search_from + pos;
+            let after_hash = abs_pos + "Flow #".len();
+            let digit_end = text[after_hash..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map_or(text.len(), |i| after_hash + i);
+            if digit_end > after_hash {
+                let id_str = &text[after_hash..digit_end];
+                links.push(DebugLink {
+                    start: abs_pos,
+                    end: digit_end,
+                    spec: id_str.to_string(),
+                });
+            }
+            search_from = digit_end;
+        }
+
         // Extract function ID from first "Function #N" if present, for context
         let context_func_id = text.find("Function #").and_then(|pos| {
             let after = pos + "Function #".len();

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1004,12 +1004,35 @@ impl FlowrGui {
 
     #[cfg(feature = "debugger")]
     fn tip<'a>(content: impl Into<Element<'a, Message>>, hint: &str) -> Element<'a, Message> {
+        let tip_content = iced::widget::Container::new(Text::new(hint.to_string()).size(13))
+            .padding([4, 8])
+            .style(|theme: &iced::Theme| {
+                let palette = theme.palette();
+                iced::widget::container::Style {
+                    background: Some(iced::Background::Color(iced::Color {
+                        r: 0.15,
+                        g: 0.15,
+                        b: 0.2,
+                        a: 0.95,
+                    })),
+                    border: iced::Border {
+                        color: iced::Color {
+                            a: 0.3,
+                            ..palette.text
+                        },
+                        width: 1.0,
+                        radius: 6.0.into(),
+                    },
+                    text_color: Some(palette.text),
+                    ..Default::default()
+                }
+            });
         iced::widget::tooltip(
             content,
-            Text::new(hint.to_string()).size(12),
+            tip_content,
             iced::widget::tooltip::Position::Bottom,
         )
-        .gap(2)
+        .gap(4)
         .into()
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -154,6 +154,26 @@ impl DebugEventLine {
             search_from = digit_end;
         }
 
+        // Match standalone #N patterns (process tree lines like "#1 'add' @ ...")
+        if text.trim_start().starts_with('#') && !text.contains("Function #") {
+            let trimmed = text.trim_start();
+            let hash_pos = text.len() - trimmed.len();
+            let after_hash = hash_pos + 1;
+            if after_hash < text.len() {
+                let digit_end = text[after_hash..]
+                    .find(|c: char| !c.is_ascii_digit())
+                    .map_or(text.len(), |i| after_hash + i);
+                if digit_end > after_hash {
+                    let id_str = &text[after_hash..digit_end];
+                    links.push(DebugLink {
+                        start: hash_pos,
+                        end: digit_end,
+                        spec: id_str.to_string(),
+                    });
+                }
+            }
+        }
+
         // Match Flow #N patterns
         search_from = 0;
         while let Some(pos) = text[search_from..].find("Flow #") {
@@ -221,7 +241,7 @@ impl DebugEventLine {
             search_from = output_text_end;
         }
 
-        // Match state keywords in square brackets like [Ready]
+        // Match ALL occurrences of state keywords in square brackets
         for keyword in &[
             "[Ready]",
             "[Waiting]",
@@ -229,13 +249,33 @@ impl DebugEventLine {
             "[Completed]",
             "[Blocked]",
         ] {
-            if let Some(pos) = text.find(keyword) {
+            let mut kw_from = 0;
+            while let Some(pos) = text[kw_from..].find(keyword) {
+                let abs_pos = kw_from + pos;
                 let state_name = &keyword[1..keyword.len() - 1];
                 links.push(DebugLink {
-                    start: pos,
-                    end: pos + keyword.len(),
+                    start: abs_pos,
+                    end: abs_pos + keyword.len(),
                     spec: state_name.to_lowercase(),
                 });
+                kw_from = abs_pos + keyword.len();
+            }
+        }
+
+        // Match route paths like '/my-first-flow/add'
+        search_from = 0;
+        while let Some(pos) = text[search_from..].find("'/") {
+            let abs_pos = search_from + pos + 1;
+            if let Some(end_quote) = text[abs_pos..].find('\'') {
+                let route = &text[abs_pos..abs_pos + end_quote];
+                links.push(DebugLink {
+                    start: abs_pos,
+                    end: abs_pos + end_quote,
+                    spec: route.to_string(),
+                });
+                search_from = abs_pos + end_quote;
+            } else {
+                break;
             }
         }
 
@@ -963,6 +1003,18 @@ impl FlowrGui {
     }
 
     #[cfg(feature = "debugger")]
+    fn tip<'a>(content: impl Into<Element<'a, Message>>, hint: &str) -> Element<'a, Message> {
+        iced::widget::tooltip(
+            content,
+            Text::new(hint.to_string()).size(12),
+            iced::widget::tooltip::Position::Bottom,
+        )
+        .gap(2)
+        .into()
+    }
+
+    #[cfg(feature = "debugger")]
+    #[allow(clippy::too_many_lines)]
     fn debug_row(&self) -> Row<'_, Message> {
         let can_cmd = self.debug_waiting;
 
@@ -1056,21 +1108,33 @@ impl FlowrGui {
             .spacing(6)
             .padding(5)
             .align_y(iced::alignment::Vertical::Center)
-            .push(continue_btn)
-            .push(step_btn)
-            .push(step_count)
-            .push(reset_btn)
-            .push(exit_btn)
+            .push(Self::tip(
+                continue_btn,
+                "Continue execution until next breakpoint",
+            ))
+            .push(Self::tip(step_btn, "Execute the next job(s) then pause"))
+            .push(Self::tip(step_count, "Number of jobs to step"))
+            .push(Self::tip(
+                reset_btn,
+                "Reset flow state and re-run from start",
+            ))
+            .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
             .push(Text::new("|").size(13))
-            .push(spec_input)
-            .push(bp_btn)
-            .push(del_btn)
-            .push(list_btn)
+            .push(Self::tip(
+                spec_input,
+                "Enter breakpoint spec (e.g. 3, 3+, 1:0, 1/sum)",
+            ))
+            .push(Self::tip(bp_btn, "Open breakpoint picker"))
+            .push(Self::tip(del_btn, "Delete all breakpoints"))
+            .push(Self::tip(list_btn, "List active breakpoints"))
             .push(Text::new("|").size(13))
-            .push(inspect_btn)
-            .push(funcs_btn)
-            .push(procs_btn)
-            .push(validate_btn)
+            .push(Self::tip(
+                inspect_btn,
+                "Inspect state (use spec field for specific target)",
+            ))
+            .push(Self::tip(funcs_btn, "List all functions"))
+            .push(Self::tip(procs_btn, "Show flow/function hierarchy"))
+            .push(Self::tip(validate_btn, "Validate flow state for deadlocks"))
     }
 
     #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -75,7 +75,19 @@ mod errors;
 /// custom widget styling
 mod theme;
 
-/// A line of debug output with optional color
+/// A clickable link in debug output
+#[cfg(feature = "debugger")]
+#[derive(Debug, Clone)]
+pub struct DebugLink {
+    /// Byte range in the text
+    pub start: usize,
+    /// End of byte range
+    pub end: usize,
+    /// Inspect spec to trigger on click
+    pub spec: String,
+}
+
+/// A line of debug output with optional color and clickable links
 #[cfg(feature = "debugger")]
 #[derive(Debug, Clone)]
 pub struct DebugEventLine {
@@ -85,15 +97,19 @@ pub struct DebugEventLine {
     pub color: Option<iced::Color>,
     /// Whether this line is a separator (rendered as Rule + label + Rule)
     pub separator: bool,
+    /// Clickable links in this line
+    pub links: Vec<DebugLink>,
 }
 
 #[cfg(feature = "debugger")]
 impl DebugEventLine {
     fn new(text: String, color: Option<iced::Color>) -> Self {
+        let links = Self::extract_links(&text);
         Self {
             text,
             color,
             separator: false,
+            links,
         }
     }
 
@@ -102,7 +118,32 @@ impl DebugEventLine {
             text: label,
             color: Some(color),
             separator: true,
+            links: Vec::new(),
         }
+    }
+
+    fn extract_links(text: &str) -> Vec<DebugLink> {
+        let mut links = Vec::new();
+        let mut search_from = 0;
+
+        while let Some(pos) = text[search_from..].find("Function #") {
+            let abs_pos = search_from + pos;
+            let after_hash = abs_pos + "Function #".len();
+            let digit_end = text[after_hash..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map_or(text.len(), |i| after_hash + i);
+            if digit_end > after_hash {
+                let id_str = &text[after_hash..digit_end];
+                links.push(DebugLink {
+                    start: abs_pos,
+                    end: digit_end,
+                    spec: id_str.to_string(),
+                });
+            }
+            search_from = digit_end;
+        }
+
+        links
     }
 }
 
@@ -219,6 +260,9 @@ pub enum Message {
     /// Cycle before/after breakpoint on a function in Route tab
     #[cfg(feature = "debugger")]
     BpCycleFunction(usize),
+    /// A clickable link in the debug output was clicked (spec to inspect)
+    #[cfg(feature = "debugger")]
+    DebugInspectLink(String),
     /// Function list received from debug server
     #[cfg(feature = "debugger")]
     DebugFunctionListReceived(Vec<CachedFunction>),
@@ -568,7 +612,8 @@ impl FlowrGui {
             | Message::BpPopupConfirm
             | Message::BpCycleFunction(_)
             | Message::DebugFunctionListReceived(_)
-            | Message::DebugBreakpointListReceived(_)) => {
+            | Message::DebugBreakpointListReceived(_)
+            | Message::DebugInspectLink(_)) => {
                 return self.process_debug_message(msg);
             }
             Message::CoordinatorDisconnected(reason) => {
@@ -1559,6 +1604,14 @@ impl FlowrGui {
             }
             Message::DebugBreakpointListReceived(specs) => {
                 self.active_breakpoints = specs.into_iter().collect();
+            }
+            Message::DebugInspectLink(spec) if self.debug_waiting => {
+                self.debug_waiting = false;
+                let params = Some(vec![spec]);
+                if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
+                    self.debug_separator("Inspect");
+                    connection_manager::send_debug_command(cmd);
+                }
             }
             Message::ShowBpPopup => {
                 self.show_bp_popup = true;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -143,6 +143,54 @@ impl DebugEventLine {
             search_from = digit_end;
         }
 
+        // Extract function ID from first "Function #N" if present, for context
+        let context_func_id = text.find("Function #").and_then(|pos| {
+            let after = pos + "Function #".len();
+            let end = text[after..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map_or(text.len(), |i| after + i);
+            text[after..end].parse::<usize>().ok()
+        });
+
+        // Match Input:N patterns
+        search_from = 0;
+        while let Some(pos) = text[search_from..].find("Input:") {
+            let abs_pos = search_from + pos;
+            let after = abs_pos + "Input:".len();
+            let digit_end = text[after..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map_or(text.len(), |i| after + i);
+            if digit_end > after {
+                if let Some(func_id) = context_func_id {
+                    let input_num = &text[after..digit_end];
+                    links.push(DebugLink {
+                        start: abs_pos,
+                        end: digit_end,
+                        spec: format!("{func_id}:{input_num}"),
+                    });
+                }
+            }
+            search_from = digit_end;
+        }
+
+        // Match Output routes like "Output '...'" or "Output:"
+        search_from = 0;
+        while let Some(pos) = text[search_from..].find("Output ") {
+            let abs_pos = search_from + pos;
+            let output_text_end = text[abs_pos..]
+                .find("->")
+                .map_or(abs_pos + "Output ".len(), |i| abs_pos + i);
+            if let Some(func_id) = context_func_id {
+                links.push(DebugLink {
+                    start: abs_pos,
+                    end: output_text_end.min(abs_pos + 20),
+                    spec: format!("{func_id}/"),
+                });
+            }
+            search_from = output_text_end;
+        }
+
+        // Match state keywords
         for keyword in &[
             "[Ready]",
             "[Waiting]",
@@ -161,6 +209,8 @@ impl DebugEventLine {
         }
 
         links.sort_by_key(|l| l.start);
+        // Remove overlapping links
+        links.dedup_by(|b, a| b.start < a.end);
         links
     }
 }
@@ -1498,12 +1548,6 @@ impl FlowrGui {
             }
             Message::DebugWaiting => {
                 self.debug_waiting = true;
-                if self.show_bp_popup && !self.cached_functions.is_empty() {
-                    self.debug_waiting = false;
-                    connection_manager::send_debug_command(
-                        flowcore::model::debug_command::DebugCommand::List,
-                    );
-                }
             }
             Message::DebugConnected => {
                 self.tab_set

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1265,7 +1265,9 @@ impl FlowrGui {
                 (false, false) => ("\u{1F7E2}", "Ready".to_string()),
                 (_, true) => ("\u{1F535}", "Running".to_string()),
                 (true, false) => {
-                    if self.submission_settings.debug_this_flow {
+                    if self.debug_client_active {
+                        ("\u{1F7E3}", "Debugging".to_string())
+                    } else if self.submission_settings.debug_this_flow {
                         (
                             "\u{1F7E0}",
                             "Waiting for debugger to connect...".to_string(),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1832,6 +1832,8 @@ impl FlowrGui {
                     format!("Inspect #{spec}")
                 } else if spec.contains(':') {
                     format!("Inspect Input ({spec})")
+                } else if spec.starts_with('/') {
+                    format!("Inspect Route ({spec})")
                 } else if spec.contains('/') {
                     format!("Inspect Output ({spec})")
                 } else {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -143,6 +143,24 @@ impl DebugEventLine {
             search_from = digit_end;
         }
 
+        for keyword in &[
+            "[Ready]",
+            "[Waiting]",
+            "[Running]",
+            "[Completed]",
+            "[Blocked]",
+        ] {
+            if let Some(pos) = text.find(keyword) {
+                let state_name = &keyword[1..keyword.len() - 1];
+                links.push(DebugLink {
+                    start: pos,
+                    end: pos + keyword.len(),
+                    spec: state_name.to_lowercase(),
+                });
+            }
+        }
+
+        links.sort_by_key(|l| l.start);
         links
     }
 }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -525,6 +525,7 @@ impl DebugTab {
             text,
             color: None,
             separator: false,
+            links: Vec::new(),
         });
     }
 }
@@ -560,12 +561,43 @@ impl Tab for DebugTab {
                         .push(rule_right)
                         .padding([6, 0]),
                 )
-            } else {
+            } else if line.links.is_empty() {
                 let mut t = text(line.text.clone()).shaping(iced::widget::text::Shaping::Advanced);
                 if let Some(color) = line.color {
                     t = t.color(color);
                 }
                 Element::from(t)
+            } else {
+                let base_color = line.color;
+                let link_color = iced::Color::from_rgb(0.3, 0.6, 1.0);
+                let mut spans: Vec<iced::widget::text::Span<'_, String>> = Vec::new();
+                let mut pos = 0;
+                for link in &line.links {
+                    if link.start > pos {
+                        let mut s = iced::widget::span(line.text[pos..link.start].to_string());
+                        if let Some(c) = base_color {
+                            s = s.color(c);
+                        }
+                        spans.push(s);
+                    }
+                    spans.push(
+                        iced::widget::span(line.text[link.start..link.end].to_string())
+                            .color(link_color)
+                            .underline(true)
+                            .link(link.spec.clone()),
+                    );
+                    pos = link.end;
+                }
+                if pos < line.text.len() {
+                    let mut s = iced::widget::span(line.text[pos..].to_string());
+                    if let Some(c) = base_color {
+                        s = s.color(c);
+                    }
+                    spans.push(s);
+                }
+                Element::from(
+                    iced::widget::rich_text(spans).on_link_click(Message::DebugInspectLink),
+                )
             }
         }))
         .width(Length::Fill)

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -313,9 +313,12 @@ impl<'a> Debugger<'a> {
                                 .clone(),
                             state.get_function_states(function_id),
                         );
+                    } else if state.submission.manifest.flows().contains_key(&function_id) {
+                        let message = Self::inspect_flow(state, function_id);
+                        self.debug_server.message(message);
                     } else {
                         self.debug_server
-                            .debugger_error(format!("No function with id = {function_id}"));
+                            .debugger_error(format!("No function or flow with id = {function_id}"));
                     }
                 }
                 Ok(InspectInput(function_id, input_number)) => {
@@ -670,6 +673,44 @@ impl<'a> Debugger<'a> {
             .values()
             .find(|f| f.route() == route)
             .map(RuntimeFunction::id)
+    }
+
+    fn inspect_flow(state: &RunState, flow_id: usize) -> String {
+        let mut response = String::new();
+        let _ = writeln!(response, "Flow #{flow_id}");
+        if let Some(flow_info) = state.submission.manifest.flows().get(&flow_id) {
+            if let Some(parent) = flow_info.parent_id {
+                let _ = writeln!(response, "Parent: Flow #{parent}");
+            } else {
+                let _ = writeln!(response, "Parent: root");
+            }
+            if !flow_info.sub_flow_ids.is_empty() {
+                let _ = writeln!(response, "Sub-flows: {:?}", flow_info.sub_flow_ids);
+            }
+        }
+        let _ = writeln!(response, "Children:");
+        let mut children: Vec<_> = state
+            .get_functions()
+            .values()
+            .filter(|f| f.get_parent_id() == flow_id && f.id() != flow_id)
+            .collect();
+        children.sort_by_key(|f| f.id());
+        if children.is_empty() {
+            let _ = writeln!(response, "  (none)");
+        } else {
+            for child in children {
+                let states = state.get_function_states(child.id());
+                let _ = writeln!(
+                    response,
+                    "  Function #{} '{}' @ '{}' [{:?}]",
+                    child.id(),
+                    child.name(),
+                    child.route(),
+                    states
+                );
+            }
+        }
+        response
     }
 
     fn inspect_by_route(state: &RunState, route: &str) -> String {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -702,7 +702,7 @@ impl<'a> Debugger<'a> {
                 let states = state.get_function_states(child.id());
                 let _ = writeln!(
                     response,
-                    "  Function #{} '{}' @ '{}' [{:?}]",
+                    "  Function #{} '{}' @ '{}' {:?}",
                     child.id(),
                     child.name(),
                     child.route(),
@@ -747,7 +747,7 @@ impl<'a> Debugger<'a> {
                     let states = state.get_function_states(child.id());
                     let _ = writeln!(
                         response,
-                        "  #{} '{}' @ '{}' [{:?}]",
+                        "  #{} '{}' @ '{}' {:?}",
                         child.id(),
                         child.name(),
                         child.route(),
@@ -896,7 +896,7 @@ impl<'a> Debugger<'a> {
             let states = state.get_function_states(parent.id());
             let _ = writeln!(
                 response,
-                "{indent}#{} '{}' @ '{}' [{:?}]",
+                "{indent}#{} '{}' @ '{}' {:?}",
                 parent.id(),
                 parent.name(),
                 parent.route(),
@@ -925,7 +925,7 @@ impl<'a> Debugger<'a> {
                     let states = state.get_function_states(child.id());
                     let _ = writeln!(
                         response,
-                        "{child_indent}#{} '{}' @ '{}' [{:?}]",
+                        "{child_indent}#{} '{}' @ '{}' {:?}",
                         child.id(),
                         child.name(),
                         child.route(),


### PR DESCRIPTION
## Summary
- Function references like `Function #3` in debug output are now clickable
- Clicking triggers an inspect command for that function
- Uses iced `rich_text` with `Span::link()` and `on_link_click()`
- Links displayed in blue with underline
- No new dependencies — simple string matching for link extraction

## Test plan
- [x] `make clippy` passes
- [ ] `make test`
- [ ] Manual: debug fibonacci, click Function #1 in output, verify inspect triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug output now shows clickable, styled links for functions, flows, inputs/outputs and state entries so you can inspect items directly from the log.
  * Clicking a link sends an inspect command when the debugger is waiting; parsing failures leave the debugger state unchanged.

* **Improvements**
  * Multi-line debug messages render as separate, clearer entries.
  * Flow and function inspection output formatting improved for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->