### PR TITLE
Add coordinator discovery with picker UI (#2762)

### DIFF
--- a/flowcore/src/discovery.rs
+++ b/flowcore/src/discovery.rs
@@ -94,3 +94,52 @@ pub fn discover_service(name: &str) -> Result<String> {
         }
     }
 }
+
+/// Discover all instances of a service by name using mDNS-SD.
+///
+/// Scans for the given timeout and returns all matching services found as
+/// `(address, port)` pairs.
+///
+/// # Errors
+/// - Cannot create `ServiceDaemon`
+/// - Cannot get receiver for discovery messages
+pub fn discover_services(name: &str, timeout: Duration) -> Result<Vec<(String, u16)>> {
+    let mdns = ServiceDaemon::new().map_err(|e| format!("Could not create mDNS daemon: {e}"))?;
+
+    let receiver = mdns
+        .browse(FLOW_SERVICE_TYPE)
+        .map_err(|e| format!("Could not browse for mDNS services: {e}"))?;
+
+    let full_name_suffix = format!(".{FLOW_SERVICE_TYPE}");
+    let start = Instant::now();
+    let mut results = Vec::new();
+
+    loop {
+        if start.elapsed() > timeout {
+            break;
+        }
+
+        if let Ok(ServiceEvent::ServiceResolved(info)) =
+            receiver.recv_timeout(Duration::from_millis(500))
+        {
+            let instance = info
+                .get_fullname()
+                .strip_suffix(&full_name_suffix)
+                .unwrap_or(info.get_fullname());
+
+            if instance == name {
+                let port = info.get_port();
+                if let Some(addr) = info.get_addresses_v4().into_iter().next() {
+                    let address = format!("{addr}:{port}");
+                    if !results.iter().any(|(a, _): &(String, u16)| *a == address) {
+                        info!("Discovered mDNS service '{name}' at {address}");
+                        results.push((address, port));
+                    }
+                }
+            }
+        }
+    }
+
+    mdns.shutdown().ok();
+    Ok(results)
+}

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -121,7 +121,7 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
         move |mut app_sender: iced::futures::channel::mpsc::Sender<CoordinatorMessage>| async move {
             let mut state = match settings {
                 CoordinatorSettings::Server(sett) => CoordinatorState::Init(sett.clone()),
-                CoordinatorSettings::ClientOnly(_) => CoordinatorState::Discovery,
+                CoordinatorSettings::ClientOnly => CoordinatorState::Discovery,
             };
 
             let mut running = false;

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -49,6 +49,25 @@ pub enum CoordinatorState {
 /// Global storage for coordinator settings, initialized once and read by the subscription
 static COORDINATOR_SETTINGS: OnceLock<CoordinatorSettings> = OnceLock::new();
 
+/// Global storage for a user-selected coordinator address (from the picker)
+static DISCOVERED_ADDRESS: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
+
+/// Set a discovered coordinator address for the subscription to pick up
+pub fn set_discovered_address(address: String) {
+    if let Ok(mut guard) = DISCOVERED_ADDRESS.write() {
+        *guard = Some(address);
+    }
+}
+
+/// Take the discovered address (consumes it)
+fn take_discovered_address() -> Option<String> {
+    if let Ok(mut guard) = DISCOVERED_ADDRESS.write() {
+        guard.take()
+    } else {
+        None
+    }
+}
+
 /// Global flag for requesting flow stop from the GUI
 static STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
 
@@ -121,15 +140,19 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                     },
 
                     CoordinatorState::Discovery => {
-                        match discover_service(COORDINATOR_SERVICE_NAME) {
-                            Ok(address) => state = CoordinatorState::Discovered(address),
-                            Err(e) => {
-                                let _ = app_sender
-                                    .send(CoordinatorMessage::Disconnected(format!(
-                                        "Could not discover coordinator: {e}"
-                                    )))
-                                    .await;
-                                break;
+                        if let Some(address) = take_discovered_address() {
+                            state = CoordinatorState::Discovered(address);
+                        } else {
+                            match discover_service(COORDINATOR_SERVICE_NAME) {
+                                Ok(address) => state = CoordinatorState::Discovered(address),
+                                Err(e) => {
+                                    let _ = app_sender
+                                        .send(CoordinatorMessage::Disconnected(format!(
+                                            "Could not discover coordinator: {e}"
+                                        )))
+                                        .await;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -59,6 +59,11 @@ pub fn set_discovered_address(address: String) {
     }
 }
 
+/// Check if a discovered address has been set
+pub fn has_discovered_address() -> bool {
+    DISCOVERED_ADDRESS.read().is_ok_and(|guard| guard.is_some())
+}
+
 /// Take the discovered address (consumes it)
 fn take_discovered_address() -> Option<String> {
     if let Ok(mut guard) = DISCOVERED_ADDRESS.write() {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -124,6 +124,7 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
     iced::stream::channel(
         100,
         move |mut app_sender: iced::futures::channel::mpsc::Sender<CoordinatorMessage>| async move {
+            let is_client_only = matches!(settings, CoordinatorSettings::ClientOnly);
             let mut state = match settings {
                 CoordinatorSettings::Server(sett) => CoordinatorState::Init(sett.clone()),
                 CoordinatorSettings::ClientOnly => CoordinatorState::Discovery,
@@ -147,6 +148,8 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                     CoordinatorState::Discovery => {
                         if let Some(address) = take_discovered_address() {
                             state = CoordinatorState::Discovered(address);
+                        } else if is_client_only {
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         } else {
                             match discover_service(COORDINATOR_SERVICE_NAME) {
                                 Ok(address) => state = CoordinatorState::Discovered(address),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -713,6 +713,7 @@ struct FlowrGui {
     show_coordinator_picker: bool,
     discovered_services: Vec<(String, String)>,
     discovering: bool,
+    selected_debug_address: Option<String>,
 }
 
 impl FlowrGui {
@@ -760,6 +761,7 @@ impl FlowrGui {
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,
+            selected_debug_address: None,
         };
 
         (flowrgui, Task::none())
@@ -919,6 +921,7 @@ impl FlowrGui {
                 } else if service_type == "Debug Server" {
                     #[cfg(feature = "debugger")]
                     {
+                        self.selected_debug_address = Some(address);
                         self.debug_client_active = true;
                         self.submission_settings.debug_this_flow = true;
                     }
@@ -1083,16 +1086,20 @@ impl FlowrGui {
 
         #[cfg(feature = "debugger")]
         if self.debug_client_active {
-            let address = match &self.submission_settings.debug_mode {
-                DebugMode::GuiLocal => {
-                    let port = connection_manager::get_debug_port();
-                    if port > 0 {
-                        Some(format!("localhost:{port}"))
-                    } else {
-                        None
+            let address = if let Some(ref addr) = self.selected_debug_address {
+                Some(addr.clone())
+            } else {
+                match &self.submission_settings.debug_mode {
+                    DebugMode::GuiLocal => {
+                        let port = connection_manager::get_debug_port();
+                        if port > 0 {
+                            Some(format!("localhost:{port}"))
+                        } else {
+                            None
+                        }
                     }
+                    _ => None,
                 }
-                _ => None,
             };
             if let Some(addr) = address {
                 return Subscription::batch([
@@ -2726,6 +2733,7 @@ mod test {
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,
+            selected_debug_address: None,
         }
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -794,6 +794,11 @@ impl FlowrGui {
                 }
             }
             Message::SubmitFlow => {
+                if matches!(self.coordinator_state, CoordinatorState::Disconnected(_))
+                    && matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly)
+                {
+                    return Task::done(Message::DiscoverCoordinators);
+                }
                 if let CoordinatorState::Connected(sender) = &self.coordinator_state {
                     return Task::perform(
                         Self::submit(sender.clone(), self.submission_settings.clone()),
@@ -835,6 +840,12 @@ impl FlowrGui {
                 self.submission_settings.max_jobs_text = value;
             }
             Message::DebugSubmitFlow => {
+                if matches!(self.coordinator_state, CoordinatorState::Disconnected(_))
+                    && matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly)
+                {
+                    self.submission_settings.debug_this_flow = true;
+                    return Task::done(Message::DiscoverCoordinators);
+                }
                 if let CoordinatorState::Connected(sender) = &self.coordinator_state {
                     let mut settings = self.submission_settings.clone();
                     settings.debug_this_flow = true;
@@ -1151,7 +1162,9 @@ impl FlowrGui {
             .on_input(Message::MaxJobsChanged)
             .width(80);
 
-        let can_run = matches!(self.coordinator_state, CoordinatorState::Connected(_))
+        let is_client_mode = matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly);
+        let can_run = (matches!(self.coordinator_state, CoordinatorState::Connected(_))
+            || is_client_mode)
             && !self.running
             && !self.submitted;
 
@@ -1815,8 +1828,16 @@ impl FlowrGui {
         } else if let Some(val) = matches.get_one::<String>("debugger") {
             if val.is_empty() {
                 DebugMode::GuiLocal
-            } else {
+            } else if val.contains(':')
+                && val.split(':').count() == 2
+                && val
+                    .split(':')
+                    .next_back()
+                    .is_some_and(|p| p.parse::<u16>().is_ok())
+            {
                 DebugMode::GuiRemote(val.clone())
+            } else {
+                DebugMode::GuiLocal
             }
         } else {
             DebugMode::Off

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -844,7 +844,6 @@ impl FlowrGui {
                 if matches!(self.coordinator_state, CoordinatorState::Disconnected(_))
                     && matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly)
                 {
-                    self.submission_settings.debug_this_flow = true;
                     return Task::done(Message::DiscoverCoordinators);
                 }
                 if let CoordinatorState::Connected(sender) = &self.coordinator_state {
@@ -875,14 +874,20 @@ impl FlowrGui {
                         tokio::task::spawn_blocking(move || {
                             let mut results = Vec::new();
                             let timeout = std::time::Duration::from_secs(5);
-                            if let Ok(coords) = flowcore::discovery::discover_services(
+                            match flowcore::discovery::discover_services(
                                 flowrlib::services::COORDINATOR_SERVICE_NAME,
                                 timeout,
                             ) {
-                                for (addr, _port) in coords {
-                                    results.push(("Coordinator".to_string(), addr));
+                                Ok(coords) => {
+                                    for (addr, _port) in coords {
+                                        results.push(("Coordinator".to_string(), addr));
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("Coordinator discovery failed: {e}");
                                 }
                             }
+                            #[cfg(feature = "debugger")]
                             if discover_debug {
                                 if let Ok(debugs) = flowcore::discovery::discover_services(
                                     flowrlib::services::DEBUG_SERVICE_NAME,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -904,16 +904,24 @@ impl FlowrGui {
                 self.discovering = false;
             }
             Message::ServiceSelected(service_type, address) => {
-                self.show_coordinator_picker = false;
                 info!("User selected {service_type} at {address}");
                 if service_type == "Coordinator" {
                     connection_manager::set_discovered_address(address);
+                    if !self.submission_settings.debug_this_flow
+                        || self
+                            .discovered_services
+                            .iter()
+                            .all(|(t, _)| t != "Debug Server")
+                    {
+                        self.show_coordinator_picker = false;
+                    }
                 } else if service_type == "Debug Server" {
                     #[cfg(feature = "debugger")]
                     {
                         self.debug_client_active = true;
                         self.submission_settings.debug_this_flow = true;
                     }
+                    self.show_coordinator_picker = false;
                 }
             }
             Message::CloseCoordinatorPicker => {
@@ -1197,12 +1205,6 @@ impl FlowrGui {
             .push(max_jobs)
             .push(play)
             .push(debug_play)
-            .push(
-                Button::new(Text::new("\u{1F50D} Connect"))
-                    .style(theme::styled_button)
-                    .padding([6, 16])
-                    .on_press(Message::DiscoverCoordinators),
-            )
     }
 
     fn coordinator_picker_card(&self) -> Card<'_, Message> {
@@ -1224,8 +1226,22 @@ impl FlowrGui {
                     .color(iced::Color::from_rgb(0.8, 0.4, 0.4)),
             );
         } else {
+            if self.submission_settings.debug_this_flow {
+                items = items.push(
+                    Text::new("Select a coordinator, then a debug server")
+                        .size(12)
+                        .color(iced::Color::from_rgb(0.6, 0.6, 0.6)),
+                );
+            }
             for (service_type, address) in &self.discovered_services {
-                let btn = Button::new(Text::new(format!("{service_type}: {address}")).size(14))
+                let is_coord_selected =
+                    service_type == "Coordinator" && connection_manager::has_discovered_address();
+                let label = if is_coord_selected {
+                    format!("\u{2714} {service_type}: {address}")
+                } else {
+                    format!("{service_type}: {address}")
+                };
+                let btn = Button::new(Text::new(label).size(14))
                     .width(Length::Fill)
                     .padding([6, 10])
                     .style(theme::list_button)

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -472,10 +472,10 @@ pub enum Message {
     DebugBreakpointListReceived(Vec<String>),
     /// Discover coordinators on the network
     DiscoverCoordinators,
-    /// Coordinators discovered
-    CoordinatorsDiscovered(Vec<(String, u16)>),
-    /// User selected a coordinator from the picker
-    CoordinatorSelected(String),
+    /// Services discovered (label, address)
+    ServicesDiscovered(Vec<(String, String)>),
+    /// User selected a service from the picker
+    ServiceSelected(String, String),
     /// Close the coordinator picker
     CloseCoordinatorPicker,
     /// Show the inspect helper popup
@@ -560,7 +560,7 @@ pub enum CoordinatorSettings {
     /// Start a server coordinator using the settings supplied
     Server(ServerSettings),
     /// Don't start a coordinator server, just discover existing one on this port
-    ClientOnly(u16),
+    ClientOnly,
 }
 
 #[cfg(feature = "debugger")]
@@ -712,7 +712,7 @@ struct FlowrGui {
     #[cfg(feature = "debugger")]
     inspect_tab: InspectTab,
     show_coordinator_picker: bool,
-    discovered_coordinators: Vec<(String, u16)>,
+    discovered_services: Vec<(String, String)>,
     discovering: bool,
 }
 
@@ -759,7 +759,7 @@ impl FlowrGui {
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
             show_coordinator_picker: false,
-            discovered_coordinators: Vec::new(),
+            discovered_services: Vec::new(),
             discovering: false,
         };
 
@@ -856,30 +856,55 @@ impl FlowrGui {
             Message::DiscoverCoordinators => {
                 self.show_coordinator_picker = true;
                 self.discovering = true;
-                self.discovered_coordinators.clear();
+                self.discovered_services.clear();
+                let discover_debug = self.submission_settings.debug_this_flow;
                 return Task::perform(
-                    async {
-                        tokio::task::spawn_blocking(|| {
-                            flowcore::discovery::discover_services(
+                    async move {
+                        tokio::task::spawn_blocking(move || {
+                            let mut results = Vec::new();
+                            let timeout = std::time::Duration::from_secs(5);
+                            if let Ok(coords) = flowcore::discovery::discover_services(
                                 flowrlib::services::COORDINATOR_SERVICE_NAME,
-                                std::time::Duration::from_secs(5),
-                            )
-                            .unwrap_or_default()
+                                timeout,
+                            ) {
+                                for (addr, _port) in coords {
+                                    results.push(("Coordinator".to_string(), addr));
+                                }
+                            }
+                            if discover_debug {
+                                if let Ok(debugs) = flowcore::discovery::discover_services(
+                                    flowrlib::services::DEBUG_SERVICE_NAME,
+                                    timeout,
+                                ) {
+                                    for (addr, _port) in debugs {
+                                        results.push(("Debug Server".to_string(), addr));
+                                    }
+                                }
+                            }
+                            results
                         })
                         .await
                         .unwrap_or_default()
                     },
-                    Message::CoordinatorsDiscovered,
+                    Message::ServicesDiscovered,
                 );
             }
-            Message::CoordinatorsDiscovered(coordinators) => {
-                self.discovered_coordinators = coordinators;
+            Message::ServicesDiscovered(services) => {
+                self.discovered_services = services;
                 self.discovering = false;
             }
-            Message::CoordinatorSelected(address) => {
+            Message::ServiceSelected(service_type, address) => {
                 self.show_coordinator_picker = false;
-                info!("User selected coordinator at {address}");
-                connection_manager::set_discovered_address(address);
+                info!("User selected {service_type} at {address}");
+                if service_type == "Coordinator" {
+                    connection_manager::set_discovered_address(address);
+                } else if service_type == "Debug Server" {
+                    #[cfg(feature = "debugger")]
+                    {
+                        self.debug_client_active = true;
+                        self.submission_settings.debug_this_flow = true;
+                    }
+                }
             }
             Message::CloseCoordinatorPicker => {
                 self.show_coordinator_picker = false;
@@ -1177,23 +1202,26 @@ impl FlowrGui {
 
         if self.discovering {
             items = items.push(
-                Text::new("Discovering coordinators...")
+                Text::new("Discovering services...")
                     .size(14)
                     .color(iced::Color::from_rgb(0.6, 0.6, 0.6)),
             );
-        } else if self.discovered_coordinators.is_empty() {
+        } else if self.discovered_services.is_empty() {
             items = items.push(
-                Text::new("No coordinators found on the network")
+                Text::new("No services found on the network")
                     .size(14)
                     .color(iced::Color::from_rgb(0.8, 0.4, 0.4)),
             );
         } else {
-            for (address, port) in &self.discovered_coordinators {
-                let btn = Button::new(Text::new(format!("{address} (port {port})")).size(14))
+            for (service_type, address) in &self.discovered_services {
+                let btn = Button::new(Text::new(format!("{service_type}: {address}")).size(14))
                     .width(Length::Fill)
                     .padding([6, 10])
                     .style(theme::list_button)
-                    .on_press(Message::CoordinatorSelected(address.clone()));
+                    .on_press(Message::ServiceSelected(
+                        service_type.clone(),
+                        address.clone(),
+                    ));
                 items = items.push(btn);
             }
         }
@@ -1798,8 +1826,8 @@ impl FlowrGui {
         #[cfg(not(feature = "debugger"))]
         let debug_this_flow = false;
 
-        let coordinator_settings = if let Some(port) = matches.get_one::<u16>("client") {
-            CoordinatorSettings::ClientOnly(*port)
+        let coordinator_settings = if matches.get_flag("client") {
+            CoordinatorSettings::ClientOnly
         } else {
             let lib_dirs = if matches.contains_id("lib_dir") {
                 if let Some(dirs) = matches.get_many::<String>("lib_dir") {
@@ -1886,9 +1914,8 @@ impl FlowrGui {
             Arg::new("client")
                 .short('c')
                 .long("client")
-                .number_of_values(1)
-                .value_parser(clap::value_parser!(u16))
-                .help("Launch only a client (no coordinator) to connect to a remote coordinator"),
+                .action(clap::ArgAction::SetTrue)
+                .help("Client only — discover and connect to a remote coordinator"),
         );
 
         let app = app.arg(
@@ -2635,7 +2662,7 @@ mod test {
                 #[cfg(feature = "debugger")]
                 debug_mode: DebugMode::Off,
             },
-            coordinator_settings: CoordinatorSettings::ClientOnly(0),
+            coordinator_settings: CoordinatorSettings::ClientOnly,
             ui_settings: UiSettings {
                 auto_start: false,
                 auto_exit: false,
@@ -2672,7 +2699,7 @@ mod test {
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
             show_coordinator_picker: false,
-            discovered_coordinators: Vec::new(),
+            discovered_services: Vec::new(),
             discovering: false,
         }
     }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -878,9 +878,8 @@ impl FlowrGui {
             }
             Message::CoordinatorSelected(address) => {
                 self.show_coordinator_picker = false;
-                self.coordinator_state =
-                    CoordinatorState::Disconnected(format!("Connecting to {address}..."));
                 info!("User selected coordinator at {address}");
+                connection_manager::set_discovered_address(address);
             }
             Message::CloseCoordinatorPicker => {
                 self.show_coordinator_picker = false;
@@ -1206,7 +1205,13 @@ impl FlowrGui {
         let body = Column::new().spacing(8).push(list);
 
         Card::new(Text::new("Discover Coordinators"), body)
-            .on_close(Message::CloseCoordinatorPicker)
+            .foot(
+                Button::new(Text::new("Close").align_x(Center))
+                    .width(Fill)
+                    .on_press(Message::CloseCoordinatorPicker)
+                    .style(theme::styled_button)
+                    .padding([4, 8]),
+            )
             .max_width(450.0)
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1880,7 +1880,9 @@ impl FlowrGui {
         let auto = matches.get_flag("auto");
         let mut auto_start = auto || matches.get_flag("auto-start");
         #[cfg(feature = "debugger")]
-        if debug_mode != DebugMode::Off {
+        if debug_mode != DebugMode::Off
+            && !matches!(coordinator_settings, CoordinatorSettings::ClientOnly)
+        {
             auto_start = true;
         }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -914,6 +914,7 @@ impl FlowrGui {
                             .all(|(t, _)| t != "Debug Server")
                     {
                         self.show_coordinator_picker = false;
+                        self.ui_settings.auto_start = true;
                     }
                 } else if service_type == "Debug Server" {
                     #[cfg(feature = "debugger")]
@@ -922,6 +923,7 @@ impl FlowrGui {
                         self.submission_settings.debug_this_flow = true;
                     }
                     self.show_coordinator_picker = false;
+                    self.ui_settings.auto_start = true;
                 }
             }
             Message::CloseCoordinatorPicker => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -470,6 +470,14 @@ pub enum Message {
     /// Breakpoint list received from debug server
     #[cfg(feature = "debugger")]
     DebugBreakpointListReceived(Vec<String>),
+    /// Discover coordinators on the network
+    DiscoverCoordinators,
+    /// Coordinators discovered
+    CoordinatorsDiscovered(Vec<(String, u16)>),
+    /// User selected a coordinator from the picker
+    CoordinatorSelected(String),
+    /// Close the coordinator picker
+    CloseCoordinatorPicker,
     /// Show the inspect helper popup
     #[cfg(feature = "debugger")]
     ShowInspectPopup,
@@ -703,6 +711,9 @@ struct FlowrGui {
     suppress_next_output: bool,
     #[cfg(feature = "debugger")]
     inspect_tab: InspectTab,
+    show_coordinator_picker: bool,
+    discovered_coordinators: Vec<(String, u16)>,
+    discovering: bool,
 }
 
 impl FlowrGui {
@@ -747,6 +758,9 @@ impl FlowrGui {
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
+            show_coordinator_picker: false,
+            discovered_coordinators: Vec::new(),
+            discovering: false,
         };
 
         (flowrgui, Task::none())
@@ -839,6 +853,38 @@ impl FlowrGui {
                 }
             }
             Message::UrlChanged(value) => self.submission_settings.flow_manifest_url = value,
+            Message::DiscoverCoordinators => {
+                self.show_coordinator_picker = true;
+                self.discovering = true;
+                self.discovered_coordinators.clear();
+                return Task::perform(
+                    async {
+                        tokio::task::spawn_blocking(|| {
+                            flowcore::discovery::discover_services(
+                                flowrlib::services::COORDINATOR_SERVICE_NAME,
+                                std::time::Duration::from_secs(5),
+                            )
+                            .unwrap_or_default()
+                        })
+                        .await
+                        .unwrap_or_default()
+                    },
+                    Message::CoordinatorsDiscovered,
+                );
+            }
+            Message::CoordinatorsDiscovered(coordinators) => {
+                self.discovered_coordinators = coordinators;
+                self.discovering = false;
+            }
+            Message::CoordinatorSelected(address) => {
+                self.show_coordinator_picker = false;
+                self.coordinator_state =
+                    CoordinatorState::Disconnected(format!("Connecting to {address}..."));
+                info!("User selected coordinator at {address}");
+            }
+            Message::CloseCoordinatorPicker => {
+                self.show_coordinator_picker = false;
+            }
             Message::TabSelected(_)
             | Message::StdioAutoScrollTogglerChanged(_, _)
             | Message::ClearTab(_)
@@ -948,6 +994,17 @@ impl FlowrGui {
             return stack![
                 main_content,
                 opaque(mouse_area(center(opaque(popup))).on_press(Message::CloseInspectPopup))
+            ]
+            .into();
+        }
+
+        if self.show_coordinator_picker {
+            let picker = self.coordinator_picker_card();
+            return stack![
+                main_content,
+                opaque(
+                    mouse_area(center(opaque(picker))).on_press(Message::CloseCoordinatorPicker)
+                )
             ]
             .into();
         }
@@ -1105,6 +1162,52 @@ impl FlowrGui {
             .push(max_jobs)
             .push(play)
             .push(debug_play)
+            .push(
+                Button::new(Text::new("\u{1F50D} Connect"))
+                    .style(theme::styled_button)
+                    .padding([6, 16])
+                    .on_press(Message::DiscoverCoordinators),
+            )
+    }
+
+    fn coordinator_picker_card(&self) -> Card<'_, Message> {
+        use iced::widget::scrollable::Scrollable;
+        use iced::Length;
+
+        let mut items = Column::new().spacing(4);
+
+        if self.discovering {
+            items = items.push(
+                Text::new("Discovering coordinators...")
+                    .size(14)
+                    .color(iced::Color::from_rgb(0.6, 0.6, 0.6)),
+            );
+        } else if self.discovered_coordinators.is_empty() {
+            items = items.push(
+                Text::new("No coordinators found on the network")
+                    .size(14)
+                    .color(iced::Color::from_rgb(0.8, 0.4, 0.4)),
+            );
+        } else {
+            for (address, port) in &self.discovered_coordinators {
+                let btn = Button::new(Text::new(format!("{address} (port {port})")).size(14))
+                    .width(Length::Fill)
+                    .padding([6, 10])
+                    .style(theme::list_button)
+                    .on_press(Message::CoordinatorSelected(address.clone()));
+                items = items.push(btn);
+            }
+        }
+
+        let list = Scrollable::new(items)
+            .height(Length::Fixed(200.0))
+            .width(Length::Fill);
+
+        let body = Column::new().spacing(8).push(list);
+
+        Card::new(Text::new("Discover Coordinators"), body)
+            .on_close(Message::CloseCoordinatorPicker)
+            .max_width(450.0)
     }
 
     #[cfg(feature = "debugger")]
@@ -2563,6 +2666,9 @@ mod test {
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
+            show_coordinator_picker: false,
+            discovered_coordinators: Vec::new(),
+            discovering: false,
         }
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -568,7 +568,6 @@ pub enum CoordinatorSettings {
 enum DebugMode {
     Off,
     GuiLocal,
-    GuiRemote(String),
     External,
 }
 
@@ -1075,7 +1074,6 @@ impl FlowrGui {
         #[cfg(feature = "debugger")]
         if self.debug_client_active {
             let address = match &self.submission_settings.debug_mode {
-                DebugMode::GuiRemote(addr) => Some(addr.clone()),
                 DebugMode::GuiLocal => {
                     let port = connection_manager::get_debug_port();
                     if port > 0 {
@@ -1825,20 +1823,8 @@ impl FlowrGui {
         #[cfg(feature = "debugger")]
         let debug_mode = if matches.get_flag("external-debugger") {
             DebugMode::External
-        } else if let Some(val) = matches.get_one::<String>("debugger") {
-            if val.is_empty() {
-                DebugMode::GuiLocal
-            } else if val.contains(':')
-                && val.split(':').count() == 2
-                && val
-                    .split(':')
-                    .next_back()
-                    .is_some_and(|p| p.parse::<u16>().is_ok())
-            {
-                DebugMode::GuiRemote(val.clone())
-            } else {
-                DebugMode::GuiLocal
-            }
+        } else if matches.get_flag("debugger") {
+            DebugMode::GuiLocal
         } else {
             DebugMode::Off
         };
@@ -1910,10 +1896,8 @@ impl FlowrGui {
                 Arg::new("debugger")
                     .short('d')
                     .long("debugger")
-                    .num_args(0..=1)
-                    .default_missing_value("")
-                    .value_name("HOST:PORT")
-                    .help("Debug with GUI debugger. No value: local. With HOST:PORT: remote"),
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Enable debugging (use with -c for remote, or alone for local)"),
             )
             .arg(
                 Arg::new("external-debugger")


### PR DESCRIPTION
## Summary
- New `discover_services()` in flowcore scans for all matching mDNS services within a timeout
- `-c` flag (client-only mode) — no local coordinator, discovers remote services
- `-d` changed to simple flag (no longer eats the flow path argument)
- Play/Debug buttons trigger discovery in client mode when not connected
- Discovery picker shows coordinators and (with -d) debug servers
- Coordinator selection marked with checkmark, picker stays open for debug server
- After both selected, auto-submits the flow

### Known Limitations
- Remote debugging connection is fragile — timing between coordinator submission and debug client attachment can cause "Resource temporarily unavailable" errors
- Needs proper sequencing: connect coordinator → submit flow → wait for debug ready → connect debug client

Closes #2762

## Test plan
- [x] `make clippy` passes
- [ ] `make test`
- [x] Discovery finds remote coordinator and debug server
- [ ] Full remote debug session (needs connection sequencing fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)