### PR TITLE
Add interactive run process command to debugger (#2021)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-interactive-run-process.md
+++ b/docs/superpowers/plans/2026-06-08-interactive-run-process.md
@@ -1,0 +1,980 @@
+# Interactive Run Process Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the debugger's `r` command to run a specific function or sub-flow interactively with user-supplied inputs and sandboxed execution.
+
+**Architecture:** Add a `ProcessTarget` enum and extend `DebugCommand::RunReset` to carry an optional target and args. Add a `coerce_value` module for type heuristics. The CLI debugger prompts for inputs with pre-filled defaults; the GUI shows a slideout input panel. Execution requires init state, auto-resets after completion.
+
+**Tech Stack:** Rust, serde_json, iced (GUI), rustyline (CLI)
+
+---
+
+### Task 1: Add `ProcessTarget` enum and extend `DebugCommand::RunReset`
+
+**Files:**
+- Modify: `flowcore/src/model/debug_command.rs`
+
+- [ ] **Step 1: Add `ProcessTarget` enum**
+
+Add above the `DebugCommand` enum:
+
+```rust
+/// Identifies a process (function or sub-flow) for the `run` command
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum ProcessTarget {
+    /// A process identified by its numeric ID
+    Id(usize),
+    /// A process identified by its route path (e.g., "/flow/add")
+    Route(String),
+    /// A process identified by its name
+    Name(String),
+}
+```
+
+- [ ] **Step 2: Change `RunReset` variant to carry data**
+
+Change:
+```rust
+RunReset,
+```
+To:
+```rust
+RunReset(Option<ProcessTarget>, Vec<String>),
+```
+
+Where `None` target means "run root flow" (preserving current behavior) and `Vec<String>` carries inline input args (empty vec when none provided).
+
+- [ ] **Step 3: Fix all compilation errors from the variant change**
+
+Every match on `RunReset` must now match `RunReset(_, _)` or `RunReset(target, args)`. Key locations:
+- `flowr/src/lib/debugger.rs` lines 394-403: match arm for `RunReset`
+- `flowr/src/lib/debug_client.rs` line 284: `Some(RunReset)` → parse target+args
+- `flowr/src/bin/flowrgui/main.rs` line 2149: `DebugCommand::RunReset` → `DebugCommand::RunReset(None, vec![])`
+- `flowcore/src/model/debug_command.rs` tests: `DebugCommand::RunReset` → `DebugCommand::RunReset(None, vec![])`
+
+- [ ] **Step 4: Update CLI parsing to extract target and args**
+
+In `debug_client.rs`, change the `"r" | "run" | "reset"` arm of `get_server_command()`:
+
+```rust
+"r" | "run" | "reset" => {
+    match params {
+        None => Some(RunReset(None, vec![])),
+        Some(parts) if parts.is_empty() => Some(RunReset(None, vec![])),
+        Some(parts) => {
+            let target_str = &parts[0];
+            let args = parts.get(1..).unwrap_or_default().to_vec();
+            let target = if let Ok(id) = target_str.parse::<usize>() {
+                ProcessTarget::Id(id)
+            } else if target_str.starts_with('/') {
+                ProcessTarget::Route(target_str.clone())
+            } else {
+                ProcessTarget::Name(target_str.clone())
+            };
+            Some(RunReset(Some(target), args))
+        }
+    }
+}
+```
+
+Add `ProcessTarget` to the imports at top of file.
+
+- [ ] **Step 5: Update help string**
+
+In `debug_client.rs`, update the `'r'` line in `HELP_STRING`:
+
+```
+'r' | 'reset' or 'run' [target] [args]  - Reset/run: no args runs root flow,
+                                 target can be function ID, /route, or name
+                                 args are space-separated input values
+```
+
+- [ ] **Step 6: Run `make clippy` and `cargo fmt`**
+
+Run: `cargo fmt && make clippy`
+
+- [ ] **Step 7: Run tests**
+
+Run: `make test`
+Expected: All tests pass (behavior unchanged for `RunReset(None, vec![])`)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add flowcore/src/model/debug_command.rs flowr/src/lib/debugger.rs \
+  flowr/src/lib/debug_client.rs flowr/src/bin/flowrgui/main.rs
+git commit -m "feat: extend RunReset command with optional process target and args (#2021)"
+```
+
+---
+
+### Task 2: Add `Input::is_generic()` accessor
+
+**Files:**
+- Modify: `flowcore/src/model/input.rs`
+
+- [ ] **Step 1: Add the accessor method**
+
+In the `impl Input` block (after the `name()` method around line 171), add:
+
+```rust
+/// Return whether this input accepts generic types
+#[must_use]
+pub fn is_generic(&self) -> bool {
+    self.generic
+}
+```
+
+- [ ] **Step 2: Run `cargo fmt` and `make clippy`**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flowcore/src/model/input.rs
+git commit -m "feat: add Input::is_generic() accessor for debugger input prompts (#2021)"
+```
+
+---
+
+### Task 3: Add `coerce_value` module for type conversion
+
+**Files:**
+- Create: `flowr/src/lib/coerce_value.rs`
+- Modify: `flowr/src/lib/lib.rs` (add `mod coerce_value;`)
+
+- [ ] **Step 1: Write tests for the coercion module**
+
+Create `flowr/src/lib/coerce_value.rs`:
+
+```rust
+use serde_json::Value;
+
+use flowcore::errors::Result;
+
+/// Coerce a string value using heuristic rules for generic inputs
+pub(crate) fn coerce_generic(raw: &str) -> Value {
+    let trimmed = raw.trim();
+
+    if trimmed == "null" || trimmed == "Null" {
+        return Value::Null;
+    }
+
+    if trimmed == "true" {
+        return Value::Bool(true);
+    }
+    if trimmed == "false" {
+        return Value::Bool(false);
+    }
+
+    // Quoted string: strip quotes, always string
+    if trimmed.len() >= 2
+        && trimmed.starts_with('"')
+        && trimmed.ends_with('"')
+    {
+        return Value::String(trimmed[1..trimmed.len() - 1].to_string());
+    }
+
+    // Try number
+    if let Ok(n) = trimmed.parse::<i64>() {
+        return Value::Number(n.into());
+    }
+    if let Ok(n) = trimmed.parse::<f64>() {
+        if let Some(num) = serde_json::Number::from_f64(n) {
+            return Value::Number(num);
+        }
+    }
+
+    // Try JSON array or object
+    if (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        || (trimmed.starts_with('{') && trimmed.ends_with('}'))
+    {
+        if let Ok(val) = serde_json::from_str::<Value>(trimmed) {
+            return val;
+        }
+    }
+
+    // Fallback: plain string
+    Value::String(trimmed.to_string())
+}
+
+/// Coerce a string to a Value, validating against an expected JSON type keyword.
+/// `expected_type` is a hint like "Number", "String", "Bool", "Array", "Object", "Null".
+/// Returns an error with a descriptive message if coercion fails.
+pub(crate) fn coerce_typed(raw: &str, expected_type: &str, input_name: &str) -> Result<Value> {
+    let value = coerce_generic(raw);
+    let ok = match expected_type {
+        "Number" => value.is_number(),
+        "String" => value.is_string(),
+        "Bool" => value.is_boolean(),
+        "Array" => value.is_array(),
+        "Object" => value.is_object(),
+        "Null" => value.is_null(),
+        _ => true, // unknown type, accept anything
+    };
+    if ok {
+        Ok(value)
+    } else {
+        Err(format!(
+            "Cannot coerce '{}' to {} for input '{}'",
+            raw, expected_type, input_name
+        ).into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn coerce_bool_true() {
+        assert_eq!(coerce_generic("true"), json!(true));
+    }
+
+    #[test]
+    fn coerce_bool_false() {
+        assert_eq!(coerce_generic("false"), json!(false));
+    }
+
+    #[test]
+    fn coerce_null() {
+        assert_eq!(coerce_generic("null"), Value::Null);
+        assert_eq!(coerce_generic("Null"), Value::Null);
+    }
+
+    #[test]
+    fn coerce_integer() {
+        assert_eq!(coerce_generic("42"), json!(42));
+        assert_eq!(coerce_generic("-7"), json!(-7));
+    }
+
+    #[test]
+    fn coerce_float() {
+        assert_eq!(coerce_generic("3.14"), json!(3.14));
+    }
+
+    #[test]
+    fn coerce_quoted_string() {
+        assert_eq!(coerce_generic("\"hello\""), json!("hello"));
+        assert_eq!(coerce_generic("\"42\""), json!("42"));
+    }
+
+    #[test]
+    fn coerce_unquoted_string() {
+        assert_eq!(coerce_generic("hello"), json!("hello"));
+    }
+
+    #[test]
+    fn coerce_array() {
+        assert_eq!(coerce_generic("[1,2,3]"), json!([1, 2, 3]));
+        assert_eq!(coerce_generic("[]"), json!([]));
+    }
+
+    #[test]
+    fn coerce_object() {
+        assert_eq!(coerce_generic("{\"a\":1}"), json!({"a": 1}));
+    }
+
+    #[test]
+    fn coerce_typed_number_ok() {
+        assert!(coerce_typed("42", "Number", "count").is_ok());
+    }
+
+    #[test]
+    fn coerce_typed_number_fail() {
+        let result = coerce_typed("hello", "Number", "count");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Cannot coerce"));
+        assert!(msg.contains("Number"));
+        assert!(msg.contains("count"));
+    }
+
+    #[test]
+    fn coerce_typed_string_ok() {
+        assert!(coerce_typed("hello", "String", "name").is_ok());
+    }
+
+    #[test]
+    fn coerce_typed_unknown_type_passes() {
+        assert!(coerce_typed("anything", "CustomType", "x").is_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Add the module declaration**
+
+In `flowr/src/lib/lib.rs`, add:
+
+```rust
+#[cfg(feature = "debugger")]
+pub(crate) mod coerce_value;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `make test`
+Expected: All coercion tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add flowr/src/lib/coerce_value.rs flowr/src/lib/lib.rs
+git commit -m "feat: add coerce_value module for input type conversion (#2021)"
+```
+
+---
+
+### Task 4: Add target resolution in the debugger
+
+**Files:**
+- Modify: `flowr/src/lib/debugger.rs`
+
+- [ ] **Step 1: Add resolve_target method**
+
+Add a method to `Debugger` that resolves a `ProcessTarget` to a process ID:
+
+```rust
+/// Resolve a ProcessTarget to a function process_id
+fn resolve_target(state: &RunState, target: &ProcessTarget) -> Result<usize> {
+    match target {
+        ProcessTarget::Id(id) => {
+            if state.get_function(*id).is_some()
+                || state.submission.manifest.flows().contains_key(id)
+            {
+                Ok(*id)
+            } else {
+                bail!("No process found matching '#{id}'")
+            }
+        }
+        ProcessTarget::Route(route) => {
+            Self::find_by_route(state, route)
+                .ok_or_else(|| format!("No process found matching '{route}'").into())
+        }
+        ProcessTarget::Name(name) => {
+            let matches: Vec<usize> = state
+                .get_functions()
+                .values()
+                .filter(|f| f.name() == name)
+                .map(|f| f.id())
+                .collect();
+            match matches.len() {
+                0 => bail!("No process found matching '{name}'"),
+                1 => Ok(matches[0]),
+                _ => {
+                    let mut msg = format!(
+                        "Multiple processes match '{name}'. Use ID or route:\n"
+                    );
+                    for id in &matches {
+                        if let Some(f) = state.get_function(*id) {
+                            msg.push_str(&format!(
+                                "  #{} @ '{}'\n",
+                                f.id(),
+                                f.route()
+                            ));
+                        }
+                    }
+                    bail!(msg)
+                }
+            }
+        }
+    }
+}
+```
+
+Add `use crate::debug_command::ProcessTarget;` to imports.
+
+- [ ] **Step 2: Update the `RunReset` match arm in `wait_for_command`**
+
+Change the existing `Ok(RunReset)` arm (lines ~394-403) to:
+
+```rust
+Ok(RunReset(None, _)) => {
+    return if state.get_number_of_jobs_created() > 0 {
+        self.reset();
+        self.debug_server.debugger_resetting();
+        Ok((false, true))
+    } else {
+        self.debug_server.execution_starting();
+        Ok((false, false))
+    };
+}
+Ok(RunReset(Some(target), args)) => {
+    if state.get_number_of_jobs_created() > 0 {
+        self.debug_server.debugger_error(
+            "Cannot run a process mid-execution. Reset first with 'r'.".into(),
+        );
+    } else {
+        match Self::resolve_target(state, &target) {
+            Ok(process_id) => {
+                self.debug_server.message(format!(
+                    "Resolved target to process #{process_id}"
+                ));
+                // TODO: Task 5 will add input gathering and execution here
+            }
+            Err(e) => self.debug_server.debugger_error(e.to_string()),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run `cargo fmt` and `make clippy`**
+
+- [ ] **Step 4: Run tests**
+
+Run: `make test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flowr/src/lib/debugger.rs
+git commit -m "feat: add process target resolution for run command (#2021)"
+```
+
+---
+
+### Task 5: Implement CLI input gathering and execution
+
+**Files:**
+- Modify: `flowr/src/lib/debugger.rs`
+- Modify: `flowr/src/lib/debugger_handler.rs`
+- Modify: `flowr/src/lib/debug_client.rs` (CLI handler)
+- Modify: `flowr/src/lib/debug_zmq_handler.rs` (ZMQ handler)
+- Modify: `flowr/src/lib/debug_gui_handler.rs` (GUI channel handler)
+- Modify: `flowr/src/lib/debug_server_message.rs` (new message variant)
+
+This is the core task. The debugger needs to:
+1. Look up the function's inputs (names, types, initializers)
+2. Ask the handler to gather input values from the user
+3. Coerce values
+4. Fill the function's inputs
+5. Trigger execution and capture outputs
+6. Display outputs and reset
+
+- [ ] **Step 1: Add `DebugServerMessage::GatherInputs` variant**
+
+In `flowr/src/lib/debug_server_message.rs`, add a new variant to represent the input gathering request:
+
+```rust
+/// Request the client to gather input values for running a process
+/// Contains: (process_id, Vec<(input_name, type_hint, default_value)>)
+GatherInputs(usize, Vec<(String, String, Option<String>)>),
+/// Display the output of a sandboxed process run
+/// Contains: Vec<(output_route, value_string)>
+ProcessOutput(Vec<(String, String)>),
+```
+
+- [ ] **Step 2: Add `gather_inputs` and `process_output` to `DebuggerHandler` trait**
+
+In `debugger_handler.rs`, add:
+
+```rust
+/// Gather input values from the user for running a specific process.
+/// `inputs` contains (name, type_hint, default_value) for each input.
+/// Returns the user-provided values as strings, or None if cancelled.
+fn gather_inputs(
+    &mut self,
+    process_id: usize,
+    inputs: &[(String, String, Option<String>)],
+) -> Option<Vec<String>>;
+
+/// Display the outputs from a sandboxed process run
+fn process_output(&mut self, outputs: &[(String, String)]);
+```
+
+- [ ] **Step 3: Implement `gather_inputs` in the CLI debug client**
+
+In `debug_client.rs`, handle the new message in `process_server_message()`:
+
+```rust
+DebugServerMessage::GatherInputs(process_id, inputs) => {
+    println!("Running process #{process_id}");
+    let mut values = Vec::new();
+    for (name, type_hint, default) in &inputs {
+        let prompt = if type_hint.is_empty() {
+            if let Some(def) = default {
+                format!("{name} [{def}]: ")
+            } else {
+                format!("{name}: ")
+            }
+        } else if let Some(def) = default {
+            format!("{name} ({type_hint}) [{def}]: ")
+        } else {
+            format!("{name} ({type_hint}): ")
+        };
+
+        match self.editor.readline(&prompt) {
+            Ok(line) => {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    if let Some(def) = default {
+                        values.push(def.clone());
+                    } else {
+                        values.push(String::new());
+                    }
+                } else {
+                    values.push(line);
+                }
+            }
+            Err(_) => {
+                println!("Input cancelled");
+                return Ok(Ack);
+            }
+        }
+    }
+    // Send the gathered values back as a RunReset command with the values
+    // The debugger will use these to fill inputs and execute
+    return Ok(DebugCommand::Modify(Some(
+        std::iter::once(format!("__run_inputs:{process_id}"))
+            .chain(values)
+            .collect(),
+    )));
+}
+```
+
+Wait — this approach is awkward because `process_server_message` returns a `DebugCommand` to respond with. A cleaner approach: add the `gather_inputs` method to the `DebuggerHandler` trait so the debugger can call it directly during `wait_for_command`.
+
+Let me revise. The `DebuggerHandler` trait already has `get_command()` which blocks waiting for user input. We can add `gather_inputs()` as a separate blocking call the debugger makes directly.
+
+**Revised Step 3:** Implement in the ZMQ handler (`debug_zmq_handler.rs`) — this is what the CLI client actually talks to. The ZMQ handler sends a `GatherInputs` message to the client, and the client responds with the values.
+
+Actually, looking at the architecture more carefully: the `DebuggerHandler` is called by the `Debugger` on the coordinator side. For the CLI flow:
+- `DebugZmqHandler` implements `DebuggerHandler` on the coordinator side
+- `DebugClient` is the separate process that talks over ZMQ
+
+For the GUI:
+- `DebugGuiHandler` implements `DebuggerHandler` using channels to the GUI in the same process
+
+So `gather_inputs` on `DebuggerHandler` needs to:
+- **ZMQ handler**: send a `GatherInputs` message, wait for client response
+- **GUI handler**: send via channel, wait for channel response
+- **CLI client**: handle `GatherInputs` message by prompting user, send values back
+
+- [ ] **Step 3 (revised): Add `gather_inputs` and `process_output` to `DebuggerHandler` trait**
+
+In `debugger_handler.rs`:
+
+```rust
+/// Gather input values from the user for running a specific process.
+/// `inputs` contains (name, type_hint, default_value) for each input.
+/// Returns the user-provided values as strings, or None if cancelled.
+fn gather_inputs(
+    &mut self,
+    process_id: usize,
+    inputs: &[(String, String, Option<String>)],
+) -> Option<Vec<String>>;
+
+/// Display the outputs from a sandboxed process run
+fn process_output(&mut self, outputs: &[(String, String)]);
+```
+
+- [ ] **Step 4: Implement in ZMQ handler**
+
+In `debug_zmq_handler.rs`, implement:
+
+```rust
+fn gather_inputs(
+    &mut self,
+    process_id: usize,
+    inputs: &[(String, String, Option<String>)],
+) -> Option<Vec<String>> {
+    let msg = DebugServerMessage::GatherInputs(process_id, inputs.to_vec());
+    self.send(&msg);
+    // Wait for the client to respond with gathered values
+    match self.receive() {
+        Ok(DebugCommand::Modify(Some(values))) => {
+            // First element is the marker, rest are values
+            if values.first().map_or(false, |v| v.starts_with("__run_inputs:")) {
+                Some(values.into_iter().skip(1).collect())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn process_output(&mut self, outputs: &[(String, String)]) {
+    let msg = DebugServerMessage::ProcessOutput(outputs.to_vec());
+    self.send(&msg);
+}
+```
+
+- [ ] **Step 5: Implement in GUI handler**
+
+In `debug_gui_handler.rs`, implement using the existing channel mechanism. The GUI will need a new message type for gathering inputs — but for now, return `None` (GUI panel will be added in Task 7):
+
+```rust
+fn gather_inputs(
+    &mut self,
+    _process_id: usize,
+    _inputs: &[(String, String, Option<String>)],
+) -> Option<Vec<String>> {
+    // TODO: Task 7 will implement GUI panel for input gathering
+    None
+}
+
+fn process_output(&mut self, outputs: &[(String, String)]) {
+    let mut msg = String::from("Process output:\n");
+    for (route, value) in outputs {
+        msg.push_str(&format!("  {route}: {value}\n"));
+    }
+    self.send_message(msg);
+}
+```
+
+- [ ] **Step 6: Handle `GatherInputs` and `ProcessOutput` in the CLI client**
+
+In `debug_client.rs` `process_server_message()`, add handling for the new message variants:
+
+```rust
+DebugServerMessage::GatherInputs(process_id, inputs) => {
+    println!("Running process #{process_id}");
+    let mut values = Vec::new();
+    for (name, type_hint, default) in &inputs {
+        let prompt = if type_hint.is_empty() {
+            if let Some(def) = default {
+                format!("{name} [{def}]: ")
+            } else {
+                format!("{name}: ")
+            }
+        } else if let Some(def) = default {
+            format!("{name} ({type_hint}) [{def}]: ")
+        } else {
+            format!("{name} ({type_hint}): ")
+        };
+
+        match self.editor.readline(&prompt) {
+            Ok(line) => {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    values.push(default.clone().unwrap_or_default());
+                } else {
+                    values.push(line);
+                }
+            }
+            Err(_) => {
+                println!("Input cancelled");
+                return Ok(Ack);
+            }
+        }
+    }
+    return Ok(DebugCommand::Modify(Some(
+        std::iter::once(format!("__run_inputs:{process_id}")).chain(values).collect(),
+    )));
+}
+DebugServerMessage::ProcessOutput(outputs) => {
+    if outputs.is_empty() {
+        println!("(no output)");
+    } else {
+        for (route, value) in outputs {
+            println!("{route}: {value}");
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Implement the core run logic in debugger.rs**
+
+In the `RunReset(Some(target), args)` arm (from Task 4), replace the TODO with the full logic:
+
+```rust
+Ok(RunReset(Some(target), args)) => {
+    if state.get_number_of_jobs_created() > 0 {
+        self.debug_server.debugger_error(
+            "Cannot run a process mid-execution. Reset first with 'r'.".into(),
+        );
+    } else {
+        match Self::resolve_target(state, &target) {
+            Ok(process_id) => {
+                if let Err(e) = self.run_process(state, process_id, &args) {
+                    self.debug_server.debugger_error(e.to_string());
+                }
+            }
+            Err(e) => self.debug_server.debugger_error(e.to_string()),
+        }
+    }
+}
+```
+
+Add the `run_process` method:
+
+```rust
+fn run_process(
+    &mut self,
+    state: &mut RunState,
+    process_id: usize,
+    inline_args: &[String],
+) -> Result<()> {
+    let function = state
+        .get_function(process_id)
+        .ok_or("Could not get function")?
+        .clone();
+
+    let inputs = function.inputs();
+    if inline_args.len() > inputs.len() {
+        bail!(
+            "Process has {} inputs but {} values were provided",
+            inputs.len(),
+            inline_args.len()
+        );
+    }
+
+    // Build input descriptors: (name, type_hint, default_value)
+    let input_descriptors: Vec<(String, String, Option<String>)> = inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            let name = if input.name().is_empty() {
+                format!("input_{i}")
+            } else {
+                input.name().to_string()
+            };
+            let type_hint = if input.is_generic() {
+                String::new()
+            } else {
+                // For now use a generic type hint; could be refined later
+                String::from("Value")
+            };
+            let default = if i < inline_args.len() {
+                Some(inline_args[i].clone())
+            } else {
+                input.initializer().as_ref().map(|init| {
+                    init.get_value().to_string()
+                }).or_else(|| {
+                    input.flow_initializer().as_ref().map(|init| {
+                        init.get_value().to_string()
+                    })
+                })
+            };
+            (name, type_hint, default)
+        })
+        .collect();
+
+    // Gather inputs from the user
+    let Some(raw_values) = self.debug_server.gather_inputs(process_id, &input_descriptors)
+    else {
+        self.debug_server.message("Run cancelled".into());
+        return Ok(());
+    };
+
+    if raw_values.len() != inputs.len() {
+        bail!(
+            "Expected {} input values but got {}",
+            inputs.len(),
+            raw_values.len()
+        );
+    }
+
+    // Coerce values
+    let mut coerced_values = Vec::new();
+    for (i, raw) in raw_values.iter().enumerate() {
+        let input = &inputs[i];
+        let name = if input.name().is_empty() {
+            format!("input_{i}")
+        } else {
+            input.name().to_string()
+        };
+
+        let value = if input.is_generic() {
+            crate::coerce_value::coerce_generic(raw)
+        } else {
+            crate::coerce_value::coerce_typed(raw, "Value", &name)?
+        };
+        coerced_values.push(value);
+    }
+
+    // Fill the function's inputs with the coerced values
+    let func = state
+        .get_mut(process_id)
+        .ok_or("Could not get mutable function")?;
+    for (i, value) in coerced_values.into_iter().enumerate() {
+        func.send(i, value)?;
+    }
+
+    // The function should now be ready to run — the coordinator will
+    // create and dispatch the job on the next iteration.
+    // Signal to continue execution, then reset after it completes.
+    self.debug_server.execution_starting();
+    return Ok(());
+}
+```
+
+Note: `get_mut` is private to `RunState`. We need to either make it `pub(crate)` or add a public method. Check Task 5b.
+
+- [ ] **Step 8: Make `RunState::get_mut` accessible**
+
+In `flowr/src/lib/run_state.rs`, change `get_mut` visibility:
+
+```rust
+// Before:
+fn get_mut(&mut self, id: usize) -> Option<&mut RuntimeFunction> {
+
+// After:
+#[cfg(feature = "debugger")]
+pub(crate) fn get_mut(&mut self, id: usize) -> Option<&mut RuntimeFunction> {
+```
+
+Keep the non-debugger version as `fn get_mut` for existing callers.
+
+- [ ] **Step 9: Also implement `DummyServer` stubs in test code**
+
+In `debugger.rs` test module, add stubs to `DummyServer`:
+
+```rust
+fn gather_inputs(&mut self, _: usize, _: &[(String, String, Option<String>)]) -> Option<Vec<String>> {
+    None
+}
+fn process_output(&mut self, _: &[(String, String)]) {}
+```
+
+Similarly in `coordinator.rs` test module's `DummyDebugServer`.
+
+- [ ] **Step 10: Run `cargo fmt` and `make clippy`**
+
+- [ ] **Step 11: Run tests**
+
+Run: `make test`
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add flowr/src/lib/debugger.rs flowr/src/lib/debugger_handler.rs \
+  flowr/src/lib/debug_client.rs flowr/src/lib/debug_zmq_handler.rs \
+  flowr/src/lib/debug_gui_handler.rs flowr/src/lib/debug_server_message.rs \
+  flowr/src/lib/run_state.rs
+git commit -m "feat: implement CLI input gathering and process execution (#2021)"
+```
+
+---
+
+### Task 6: Handle sub-flow execution
+
+**Files:**
+- Modify: `flowr/src/lib/debugger.rs`
+
+Sub-flows are identified by being in the `flows()` map of the manifest. When the target is a sub-flow, we need to fill the entry-point inputs of all functions inside that sub-flow, then let the coordinator run until those functions complete.
+
+- [ ] **Step 1: Extend `run_process` to detect sub-flows**
+
+In the `run_process` method, after resolving the process_id, check if it's a flow:
+
+```rust
+let is_flow = state.submission.manifest.flows().contains_key(&process_id);
+
+if is_flow {
+    return self.run_sub_flow(state, process_id, inline_args);
+}
+```
+
+- [ ] **Step 2: Implement `run_sub_flow`**
+
+```rust
+fn run_sub_flow(
+    &mut self,
+    state: &mut RunState,
+    flow_id: usize,
+    inline_args: &[String],
+) -> Result<()> {
+    // For a sub-flow, we need to identify the entry-point functions
+    // (those that have inputs with initializers or that have inputs
+    // connected from outside the flow).
+    // For now, display a message that sub-flow execution is not yet supported.
+    self.debug_server.message(
+        "Sub-flow execution is not yet implemented. \
+         Use a function ID or route to run individual functions.".into()
+    );
+    Ok(())
+}
+```
+
+This is a placeholder — full sub-flow execution is complex and can be implemented incrementally. The core function execution path is the priority.
+
+- [ ] **Step 3: Run `cargo fmt` and `make clippy`**
+
+- [ ] **Step 4: Run tests**
+
+Run: `make test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flowr/src/lib/debugger.rs
+git commit -m "feat: add sub-flow execution stub with informative message (#2021)"
+```
+
+---
+
+### Task 7: Add GUI input panel (stub)
+
+**Files:**
+- Modify: `flowr/src/bin/flowrgui/main.rs`
+
+The GUI needs a slideout panel for gathering inputs. This is a significant UI task. For the initial PR, we'll wire up the plumbing so the GUI handler responds to `gather_inputs` calls, with the actual panel implementation as a follow-up (potentially part of #2767).
+
+- [ ] **Step 1: Update the GUI's `DebugReset` message handling**
+
+In `main.rs`, the `Message::DebugReset` handler currently sends `DebugCommand::RunReset`. Update it to send `DebugCommand::RunReset(None, vec![])`.
+
+- [ ] **Step 2: Update the GUI handler's `gather_inputs` to send a message**
+
+For now, the GUI handler returns `None` (from Task 5 step 5), meaning the run is cancelled with a message. This is acceptable for the initial PR — the CLI is the primary interface.
+
+A future PR can add the slideout panel with text fields for each input.
+
+- [ ] **Step 3: Run `cargo fmt` and `make clippy`**
+
+- [ ] **Step 4: Run tests**
+
+Run: `make test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flowr/src/bin/flowrgui/main.rs flowr/src/lib/debug_gui_handler.rs
+git commit -m "feat: wire up GUI for RunReset with target, stub input panel (#2021)"
+```
+
+---
+
+### Task 8: Final integration testing and PR
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+
+- [ ] **Step 2: Run clippy**
+
+Run: `make clippy`
+
+- [ ] **Step 3: Run fmt**
+
+Run: `cargo fmt`
+
+- [ ] **Step 4: Push and create PR**
+
+```bash
+git push -u origin interactive_run_process_2021
+gh pr create --title "Add interactive run process command to debugger (#2021)" \
+  --body "## Summary
+- Extended the \`r\` (run/reset) debugger command to accept an optional process target (by ID, route, or name) and inline input arguments
+- Added type coercion module for converting user input strings to JSON values
+- CLI debugger prompts for each input with pre-filled defaults from initializers
+- GUI stub wired up (actual input panel is a follow-up)
+- Sub-flow execution stub with informative message (follow-up for full implementation)
+
+## Test plan
+- [ ] Verify \`r\` with no args still runs/resets the root flow as before
+- [ ] Verify \`r 5\` resolves function by ID and prompts for inputs
+- [ ] Verify \`r /flow/add\` resolves by route
+- [ ] Verify \`r add\` resolves by name, errors on ambiguity
+- [ ] Verify inline args pre-fill the prompts
+- [ ] Verify type coercion: numbers, bools, strings, null, arrays
+- [ ] Verify error on mid-execution run attempt
+- [ ] Verify existing tests pass (\`make test\`)
+"
+```
+
+- [ ] **Step 5: Request code review**

--- a/docs/superpowers/plans/2026-06-08-interactive-run-process.md
+++ b/docs/superpowers/plans/2026-06-08-interactive-run-process.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add `ProcessTarget` enum and extend `DebugCommand::RunReset`
+## Task 1: Add `ProcessTarget` enum and extend `DebugCommand::RunReset`
 
 **Files:**
 - Modify: `flowcore/src/model/debug_command.rs`
@@ -84,7 +84,7 @@ Add `ProcessTarget` to the imports at top of file.
 
 In `debug_client.rs`, update the `'r'` line in `HELP_STRING`:
 
-```
+```text
 'r' | 'reset' or 'run' [target] [args]  - Reset/run: no args runs root flow,
                                  target can be function ID, /route, or name
                                  args are space-separated input values
@@ -109,7 +109,7 @@ git commit -m "feat: extend RunReset command with optional process target and ar
 
 ---
 
-### Task 2: Add `Input::is_generic()` accessor
+## Task 2: Add `Input::is_generic()` accessor
 
 **Files:**
 - Modify: `flowcore/src/model/input.rs`
@@ -137,7 +137,7 @@ git commit -m "feat: add Input::is_generic() accessor for debugger input prompts
 
 ---
 
-### Task 3: Add `coerce_value` module for type conversion
+## Task 3: Add `coerce_value` module for type conversion
 
 **Files:**
 - Create: `flowr/src/lib/coerce_value.rs`
@@ -327,7 +327,7 @@ git commit -m "feat: add coerce_value module for input type conversion (#2021)"
 
 ---
 
-### Task 4: Add target resolution in the debugger
+## Task 4: Add target resolution in the debugger
 
 **Files:**
 - Modify: `flowr/src/lib/debugger.rs`
@@ -435,7 +435,7 @@ git commit -m "feat: add process target resolution for run command (#2021)"
 
 ---
 
-### Task 5: Implement CLI input gathering and execution
+## Task 5: Implement CLI input gathering and execution
 
 **Files:**
 - Modify: `flowr/src/lib/debugger.rs`
@@ -850,7 +850,7 @@ git commit -m "feat: implement CLI input gathering and process execution (#2021)
 
 ---
 
-### Task 6: Handle sub-flow execution
+## Task 6: Handle sub-flow execution
 
 **Files:**
 - Modify: `flowr/src/lib/debugger.rs`
@@ -907,7 +907,7 @@ git commit -m "feat: add sub-flow execution stub with informative message (#2021
 
 ---
 
-### Task 7: Add GUI input panel (stub)
+## Task 7: Add GUI input panel (stub)
 
 **Files:**
 - Modify: `flowr/src/bin/flowrgui/main.rs`
@@ -939,7 +939,7 @@ git commit -m "feat: wire up GUI for RunReset with target, stub input panel (#20
 
 ---
 
-### Task 8: Final integration testing and PR
+## Task 8: Final integration testing and PR
 
 - [ ] **Step 1: Run full test suite**
 

--- a/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
+++ b/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
@@ -92,9 +92,10 @@ flow is automatically reset back to init state.
 4. Apply type coercion; error on failure
 5. **Function:** create a Job with coerced inputs, push to head of ready queue,
    execute one job, capture result
-6. **Sub-flow:** fill entry-point inputs of the sub-flow's internal functions,
-   run the coordinator loop over the sub-flow's internal graph to completion
-   (auto-run). Breakpoints inside the sub-flow are honored if set.
+6. **Sub-flow:** *(deferred — not implemented in the initial version)* fill
+   entry-point inputs of the sub-flow's internal functions, run the coordinator
+   loop over the sub-flow's internal graph to completion (auto-run). Breakpoints
+   inside the sub-flow are honored if set.
 7. Capture outputs
 8. Display outputs
 9. Reset back to init state

--- a/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
+++ b/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
@@ -42,7 +42,7 @@ Prompt for every input, one at a time. Pre-fill with defaults where available:
 - Else no default (user must provide a value)
 
 Prompt format:
-```
+```text
 input_name (Type) [default_value]: _
 input_name: _                          # generic, no default
 ```
@@ -105,7 +105,7 @@ flow is automatically reset back to init state.
 ### CLI
 
 Print each output prefixed with its route:
-```
+```text
 /flow/add/output: 42
 /flow/add/remainder: 2
 ```
@@ -127,17 +127,17 @@ Panel has a close/dismiss button. Disappears on close or next command.
 
 ## DebugCommand Changes
 
-`RunReset` changes from a unit variant to:
+`RunReset` changes from a unit variant to a tuple variant:
 
 ```rust
-RunReset {
-    target: Option<ProcessTarget>,  // None = root flow
-    args: Vec<String>,              // inline input values
-}
+RunReset(Option<ProcessTarget>, Vec<String>)
 ```
+
+Where the first field is the optional target (`None` = root flow) and the second
+is inline input values (empty vec when none provided).
 
 ## Scope
 
-- Both functions and sub-flows supported
+- Functions supported; sub-flow execution deferred to a follow-up
 - Both CLI (flowrdb) and GUI (flowrgui)
 - Sandboxed execution via init-state requirement + auto-reset

--- a/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
+++ b/docs/superpowers/specs/2026-06-08-interactive-run-process-design.md
@@ -1,0 +1,142 @@
+# Interactive Run Process in Debugger (#2021)
+
+## Overview
+
+Extend the debugger's `r` (run/reset) command to allow running a specific
+function or sub-flow (process) interactively, with user-supplied inputs and
+sandboxed execution via reset.
+
+## Command Syntax
+
+- `r` — run the root flow from init (unchanged behavior)
+- `r <id>` — run a specific process by numeric ID
+- `r <route>` — run a specific process by route (e.g., `r /flow/add`)
+- `r <name>` — run a specific process by name
+- `r <target> <arg1> <arg2> ...` — run with inline input values
+
+### Target Resolution
+
+`ProcessTarget` enum: `Id(usize)`, `Route(String)`, or `Name(String)`.
+
+Resolution order: try parsing as usize (ID), then check if it starts with `/`
+(route), otherwise treat as name. Names are matched against function names.
+If no match: error. If multiple matches: list the matching processes with their
+IDs and routes so the user can re-run with a more specific target.
+
+### Precondition
+
+The flow must be in init/reset state (`get_number_of_jobs_created() == 0`).
+If not, return: `"Cannot run a process mid-execution. Reset first with 'r'."`
+
+## Input Capture
+
+When `r <target>` is issued, the debugger resolves the target process and
+retrieves its input list (name, type, initializer).
+
+### CLI (flowrdb)
+
+Prompt for every input, one at a time. Pre-fill with defaults where available:
+
+- If an inline arg was provided for this input (positional), show it as default
+- Else if the input has an initializer (`Once`/`Always`), show that as default
+- Else no default (user must provide a value)
+
+Prompt format:
+```
+input_name (Type) [default_value]: _
+input_name: _                          # generic, no default
+```
+
+Pressing Enter accepts the pre-filled default. Typing a new value overrides it.
+
+### GUI (flowrgui)
+
+Always open a pre-fill panel (slideout) showing all inputs:
+
+- Each input shown as a label (`name (Type)`) with a text field
+- Pre-fill with: inline arg if provided, otherwise initializer value if present,
+  otherwise empty
+- User can edit any field before clicking "Run"
+- Closing the panel without clicking Run cancels the operation
+
+## Type Coercion
+
+### When input has a declared type
+
+Attempt to coerce the user's string to the declared type. On failure:
+`"Cannot coerce '<value>' to <Type> for input '<name>'"`
+
+### Generic inputs (heuristic rules)
+
+- `true`/`false` → Bool
+- Parses as number → Number
+- Quoted string (`"hello"`) → String (even if contents look numeric)
+- `null` or `Null` → Null
+- `[...]` → Array, element type inferred recursively from first element;
+  `[]` for empty array
+- `{...}` → Object (parsed as JSON)
+- Anything else unquoted → String
+
+## Execution
+
+### Approach: Execute-in-init-state with reset
+
+Requires the flow to be in init/reset state. After execution completes, the
+flow is automatically reset back to init state.
+
+### Steps
+
+1. Resolve target to a process ID
+2. Validate the process exists (function or sub-flow)
+3. Gather inputs via CLI prompting or GUI panel
+4. Apply type coercion; error on failure
+5. **Function:** create a Job with coerced inputs, push to head of ready queue,
+   execute one job, capture result
+6. **Sub-flow:** fill entry-point inputs of the sub-flow's internal functions,
+   run the coordinator loop over the sub-flow's internal graph to completion
+   (auto-run). Breakpoints inside the sub-flow are honored if set.
+7. Capture outputs
+8. Display outputs
+9. Reset back to init state
+
+## Output Display
+
+### CLI
+
+Print each output prefixed with its route:
+```
+/flow/add/output: 42
+/flow/add/remainder: 2
+```
+
+If no output: `(no output)`
+
+### GUI
+
+A slideout panel appears showing the outputs. Each line: `route: value`.
+Panel has a close/dismiss button. Disappears on close or next command.
+
+## Error Handling
+
+- Target not found: `"No process found matching '<target>'"`
+- Too many inline args: `"Process has N inputs but M values were provided"`
+- Type coercion failure: `"Cannot coerce '<value>' to <Type> for input '<name>'"`
+- Flow not in init state: `"Cannot run a process mid-execution. Reset first with 'r'."`
+- Execution error: display the Job result error, then reset
+
+## DebugCommand Changes
+
+`RunReset` changes from a unit variant to:
+
+```rust
+RunReset {
+    target: Option<ProcessTarget>,  // None = root flow
+    args: Vec<String>,              // inline input values
+}
+```
+
+## Scope
+
+- Both functions and sub-flows supported
+- Both CLI (flowrdb) and GUI (flowrgui)
+- Sandboxed execution via init-state requirement + auto-reset

--- a/flowcore/src/model/debug_command.rs
+++ b/flowcore/src/model/debug_command.rs
@@ -2,6 +2,17 @@ use std::fmt;
 
 use serde_derive::{Deserialize, Serialize};
 
+/// Identifies a process (function or sub-flow) for the `run` command
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum ProcessTarget {
+    /// A process identified by its numeric ID
+    Id(usize),
+    /// A process identified by its route path (e.g., "/flow/add")
+    Route(String),
+    /// A process identified by its name
+    Name(String),
+}
+
 /// Types of `Params` used in communications between the debugger and the `debug_client`
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum BreakpointSpec {
@@ -60,8 +71,9 @@ pub enum DebugCommand {
     List,
     /// `modify` a debugger or runtime state value e.g. jobs=1 to set parallel jobs to 1
     Modify(Option<Vec<String>>),
-    /// `reset` flow execution back to the initial state, or run the flow from the start
-    RunReset,
+    /// `reset` flow execution back to the initial state, run the flow from the start,
+    /// or run a specific process with optional inline input arguments
+    RunReset(Option<ProcessTarget>, Vec<String>),
     /// `step` forward in flow execution by executing one (default) or more `Jobs`
     Step(Option<usize>),
     /// `validate` the current state
@@ -118,7 +130,7 @@ mod test {
         println!("{}", DebugCommand::InspectBlock(None, None));
         println!("{}", DebugCommand::Invalid);
         println!("{}", DebugCommand::List);
-        println!("{}", DebugCommand::RunReset);
+        println!("{}", DebugCommand::RunReset(None, vec![]));
         println!("{}", DebugCommand::Step(None));
         println!("{}", DebugCommand::Validate);
         println!("{}", DebugCommand::DebugClientStarting);

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -172,6 +172,12 @@ impl Input {
         &self.name
     }
 
+    /// Return whether this input accepts generic types
+    #[must_use]
+    pub fn is_generic(&self) -> bool {
+        self.generic
+    }
+
     /// Return a reference to the initializer
     #[must_use]
     pub fn initializer(&self) -> &Option<InputInitializer> {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -436,6 +436,22 @@ fn rewrite_for_gui(msg: &str) -> String {
         "State variables that can be modified are:",
         "Modifiable state variables:",
     )
+    .replace(
+        "Cannot run a process mid-execution. Reset first with 'r'.",
+        "Cannot run a process mid-execution. Click Reset first.",
+    )
+    .replace(
+        "'break' command must specify a breakpoint",
+        "A breakpoint target must be specified",
+    )
+    .replace(
+        "To break on every Function, you can just single step using 's' command",
+        "To break on every Function, use the Step button",
+    )
+    .replace(
+        "Supply them as arguments: r <target> <val1> <val2> ...",
+        "Fill in values in the input panel and click Execute.",
+    )
 }
 
 /// Format a `DebugServerMessage` into colored lines for the debug tab
@@ -723,11 +739,11 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                         let func_data: Vec<crate::CachedFunction> = functions
                             .iter()
                             .map(|f| {
-                                let inputs: Vec<(usize, String)> = f
+                                let inputs: Vec<(usize, String, bool)> = f
                                     .inputs()
                                     .iter()
                                     .enumerate()
-                                    .map(|(i, inp)| (i, inp.name().to_string()))
+                                    .map(|(i, inp)| (i, inp.name().to_string(), inp.is_generic()))
                                     .collect();
                                 let mut outputs: Vec<String> = Vec::new();
                                 for conn in f.get_output_connections() {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -555,7 +555,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             format!("Function #{source_id} sending '{value}' to {dest_id}:{input_number}"),
             Some(debug_colors::DATA_FLOW),
         ),
-        DebugServerMessage::Error(msg) => line(msg.clone(), Some(debug_colors::ERROR)),
+        DebugServerMessage::Error(ref msg) => line(rewrite_for_gui(msg), Some(debug_colors::ERROR)),
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
         DebugServerMessage::FunctionStates((function, states)) => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2146,7 +2146,7 @@ impl FlowrGui {
             Message::DebugReset => {
                 self.debug_waiting = false;
                 self.debug_separator("Run / Reset");
-                connection_manager::send_debug_command(DebugCommand::RunReset);
+                connection_manager::send_debug_command(DebugCommand::RunReset(None, vec![]));
             }
             Message::DebugExit => {
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1524,10 +1524,7 @@ impl FlowrGui {
 
         for (i, name) in self.run_input_names.iter().enumerate() {
             let value = self.run_input_values.get(i).cloned().unwrap_or_default();
-            let type_hint = self
-                .run_input_types
-                .get(i)
-                .map_or("Value", String::as_str);
+            let type_hint = self.run_input_types.get(i).map_or("Value", String::as_str);
             let tooltip = type_hint.to_string();
             let idx = i;
             let input = Self::tip(
@@ -2328,6 +2325,7 @@ impl FlowrGui {
                         } else {
                             let args: Vec<String> = parts.get(1..).unwrap_or_default().to_vec();
                             self.debug_waiting = false;
+                            self.debug_spec_text.clear();
                             self.debug_separator(&format!("Run process #{id}"));
                             connection_manager::send_debug_command(DebugCommand::RunReset(
                                 Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
@@ -2359,6 +2357,7 @@ impl FlowrGui {
                 if let Some(id) = self.run_target_id.take() {
                     let args = self.run_input_values.clone();
                     self.debug_waiting = false;
+                    self.debug_spec_text.clear();
                     self.debug_separator(&format!("Run process #{id}"));
                     connection_manager::send_debug_command(DebugCommand::RunReset(
                         Some(flowcore::model::debug_command::ProcessTarget::Id(id)),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -596,8 +596,8 @@ pub struct CachedFunction {
     pub name: String,
     /// Function route
     pub route: String,
-    /// Input names (index, name)
-    pub inputs: Vec<(usize, String)>,
+    /// Input info (index, name, `is_generic`)
+    pub inputs: Vec<(usize, String, bool)>,
     /// Output routes
     pub outputs: Vec<String>,
 }
@@ -733,6 +733,8 @@ struct FlowrGui {
     run_input_values: Vec<String>,
     #[cfg(feature = "debugger")]
     run_input_names: Vec<String>,
+    #[cfg(feature = "debugger")]
+    run_input_types: Vec<String>,
     show_coordinator_picker: bool,
     discovered_services: Vec<(String, String)>,
     discovering: bool,
@@ -789,6 +791,8 @@ impl FlowrGui {
             run_input_values: Vec::new(),
             #[cfg(feature = "debugger")]
             run_input_names: Vec::new(),
+            #[cfg(feature = "debugger")]
+            run_input_types: Vec::new(),
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,
@@ -1484,6 +1488,7 @@ impl FlowrGui {
             ))
             .push(Self::tip(step_btn, "Execute the next job(s) then pause"))
             .push(Self::tip(step_count, "Number of jobs to step"))
+            .push(Self::tip(pause_btn, "Pause execution and enter debugger"))
             .push(Self::tip(
                 reset_btn,
                 if has_run_target {
@@ -1492,8 +1497,6 @@ impl FlowrGui {
                     "Reset flow state and re-run from start"
                 },
             ))
-            .push(Self::tip(pause_btn, "Pause execution and enter debugger"))
-            .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
             .push(Self::tip(
                 spec_input,
                 "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
@@ -1508,6 +1511,8 @@ impl FlowrGui {
             .push(Self::tip(funcs_btn, "List all functions"))
             .push(Self::tip(procs_btn, "Show flow/function hierarchy"))
             .push(Self::tip(validate_btn, "Validate flow state for deadlocks"))
+            .push(iced::widget::container(iced::widget::text("")).width(iced::Length::Fill))
+            .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
     }
 
     #[cfg(feature = "debugger")]
@@ -1628,7 +1633,7 @@ impl FlowrGui {
                         btn = btn.on_press(Message::BpCycleFunction(f.id));
                         items = items.push(btn);
 
-                        for (idx, input_name) in &f.inputs {
+                        for (idx, input_name, _generic) in &f.inputs {
                             let input_spec = format!("{}:{idx}", f.id);
                             let name_part = if input_name.is_empty() {
                                 String::new()
@@ -1669,7 +1674,7 @@ impl FlowrGui {
                 }
                 BpTab::Input => {
                     for f in &self.cached_functions {
-                        for (idx, input_name) in &f.inputs {
+                        for (idx, input_name, _generic) in &f.inputs {
                             let spec = format!("{}:{idx}", f.id);
                             let marker = bp_marker(&spec);
                             let name_part = if input_name.is_empty() {
@@ -1779,7 +1784,7 @@ impl FlowrGui {
             }
             InspectTab::Input => {
                 for f in &self.cached_functions {
-                    for (idx, input_name) in &f.inputs {
+                    for (idx, input_name, _generic) in &f.inputs {
                         let name_part = if input_name.is_empty() {
                             String::new()
                         } else {
@@ -2277,11 +2282,22 @@ impl FlowrGui {
                                 .inputs
                                 .iter()
                                 .enumerate()
-                                .map(|(i, (_, name))| {
+                                .map(|(i, (_, name, _))| {
                                     if name.is_empty() {
                                         format!("input_{i}")
                                     } else {
                                         name.clone()
+                                    }
+                                })
+                                .collect();
+                            self.run_input_types = func
+                                .inputs
+                                .iter()
+                                .map(|(_, _, generic)| {
+                                    if *generic {
+                                        "Generic".to_string()
+                                    } else {
+                                        "Value".to_string()
                                     }
                                 })
                                 .collect();
@@ -2928,6 +2944,8 @@ mod test {
             run_input_values: Vec::new(),
             #[cfg(feature = "debugger")]
             run_input_names: Vec::new(),
+            #[cfg(feature = "debugger")]
+            run_input_types: Vec::new(),
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2842,4 +2842,108 @@ mod test {
         drop(gui.update(Message::Submitted));
         assert!(gui.tab_set.flow_name.is_empty());
     }
+
+    // ---- iced_test view rendering tests ----
+
+    #[test]
+    fn main_view_renders_without_panic() {
+        use iced_test::simulator::simulator;
+        let gui = test_gui();
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_view_renders_when_active() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_view_renders_when_not_waiting() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = false;
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_reset_clears_waiting() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugReset));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[test]
+    fn view_renders_after_submitted() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.submission_settings.flow_manifest_url = "flowr/examples/fibonacci/manifest.json".into();
+        drop(gui.update(Message::Submitted));
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[test]
+    fn view_renders_with_error_modal() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        drop(gui.update(Message::SubmitError("test error".into())));
+        assert!(gui.show_modal);
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[test]
+    fn view_renders_after_tab_switch() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        drop(gui.update(Message::TabSelected(1)));
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn view_renders_with_breakpoint_popup() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        gui.show_bp_popup = true;
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn view_renders_with_inspect_popup() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        gui.show_inspect_popup = true;
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[test]
+    fn view_renders_with_coordinator_picker() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.show_coordinator_picker = true;
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -410,6 +410,9 @@ pub enum Message {
     /// User clicked Run/Reset in the debug controls
     #[cfg(feature = "debugger")]
     DebugReset,
+    /// User clicked Run Process — runs a specific process using the spec field
+    #[cfg(feature = "debugger")]
+    DebugRunProcess,
     /// User clicked Exit Debugger in the debug controls
     #[cfg(feature = "debugger")]
     DebugExit,
@@ -956,6 +959,7 @@ impl FlowrGui {
             | Message::DebugContinue
             | Message::DebugStep
             | Message::DebugReset
+            | Message::DebugRunProcess
             | Message::DebugExit
             | Message::DebugStepCountChanged(_)
             | Message::DebugSpecChanged(_)
@@ -1348,6 +1352,13 @@ impl FlowrGui {
             reset_btn = reset_btn.on_press(Message::DebugReset);
         }
 
+        let mut run_btn = Button::new(Text::new("\u{25B6} Run"))
+            .style(theme::styled_button)
+            .padding([4, 10]);
+        if can_cmd && !self.debug_spec_text.is_empty() {
+            run_btn = run_btn.on_press(Message::DebugRunProcess);
+        }
+
         let mut exit_btn = Button::new(Text::new("\u{23F9} Exit"))
             .style(theme::styled_button)
             .padding([4, 10]);
@@ -1431,7 +1442,11 @@ impl FlowrGui {
             .push(Text::new("|").size(13))
             .push(Self::tip(
                 spec_input,
-                "Enter breakpoint spec (e.g. 3, 3+, 1:0, 1/sum)",
+                "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
+            ))
+            .push(Self::tip(
+                run_btn,
+                "Run a specific process (enter ID, /route, or name in spec field)",
             ))
             .push(Self::tip(bp_btn, "Open breakpoint picker"))
             .push(Self::tip(del_btn, "Delete all breakpoints"))
@@ -2147,6 +2162,32 @@ impl FlowrGui {
                 self.debug_waiting = false;
                 self.debug_separator("Run / Reset");
                 connection_manager::send_debug_command(DebugCommand::RunReset(None, vec![]));
+            }
+            Message::DebugRunProcess => {
+                if self.debug_spec_text.is_empty() {
+                    return iced::Task::none();
+                }
+                self.debug_waiting = false;
+                let parts: Vec<String> = self
+                    .debug_spec_text
+                    .split_whitespace()
+                    .map(String::from)
+                    .collect();
+                if let Some(target_str) = parts.first() {
+                    let args: Vec<String> = parts.get(1..).unwrap_or_default().to_vec();
+                    let target = if let Ok(id) = target_str.parse::<usize>() {
+                        flowcore::model::debug_command::ProcessTarget::Id(id)
+                    } else if target_str.starts_with('/') {
+                        flowcore::model::debug_command::ProcessTarget::Route(target_str.clone())
+                    } else {
+                        flowcore::model::debug_command::ProcessTarget::Name(target_str.clone())
+                    };
+                    self.debug_separator(&format!("Run process: {target_str}"));
+                    connection_manager::send_debug_command(DebugCommand::RunReset(
+                        Some(target),
+                        args,
+                    ));
+                }
             }
             Message::DebugExit => {
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1335,9 +1335,10 @@ impl FlowrGui {
             continue_btn = continue_btn.on_press(Message::DebugContinue);
         }
 
-        let mut step_btn = Button::new(Text::new("\u{23ED} Step"))
-            .style(theme::styled_button)
-            .padding([4, 10]);
+        let mut step_btn =
+            Button::new(Text::new("\u{2BA9} Step").shaping(iced::widget::text::Shaping::Advanced))
+                .style(theme::styled_button)
+                .padding([4, 10]);
         if can_cmd {
             step_btn = step_btn.on_press(Message::DebugStep);
         }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -419,6 +419,15 @@ pub enum Message {
     /// User clicked Pause to break into the debugger mid-execution
     #[cfg(feature = "debugger")]
     DebugPause,
+    /// User changed a value in the run input panel
+    #[cfg(feature = "debugger")]
+    RunInputChanged(usize, String),
+    /// User clicked Execute in the run input panel
+    #[cfg(feature = "debugger")]
+    RunInputExecute,
+    /// User cancelled the run input panel
+    #[cfg(feature = "debugger")]
+    RunInputCancel,
     /// The step count text input changed
     #[cfg(feature = "debugger")]
     DebugStepCountChanged(String),
@@ -716,6 +725,14 @@ struct FlowrGui {
     suppress_next_output: bool,
     #[cfg(feature = "debugger")]
     inspect_tab: InspectTab,
+    #[cfg(feature = "debugger")]
+    show_run_inputs: bool,
+    #[cfg(feature = "debugger")]
+    run_target_id: Option<usize>,
+    #[cfg(feature = "debugger")]
+    run_input_values: Vec<String>,
+    #[cfg(feature = "debugger")]
+    run_input_names: Vec<String>,
     show_coordinator_picker: bool,
     discovered_services: Vec<(String, String)>,
     discovering: bool,
@@ -764,6 +781,14 @@ impl FlowrGui {
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
+            #[cfg(feature = "debugger")]
+            show_run_inputs: false,
+            #[cfg(feature = "debugger")]
+            run_target_id: None,
+            #[cfg(feature = "debugger")]
+            run_input_values: Vec::new(),
+            #[cfg(feature = "debugger")]
+            run_input_names: Vec::new(),
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,
@@ -965,6 +990,9 @@ impl FlowrGui {
             | Message::DebugRunProcess
             | Message::DebugExit
             | Message::DebugPause
+            | Message::RunInputChanged(_, _)
+            | Message::RunInputExecute
+            | Message::RunInputCancel
             | Message::DebugStepCountChanged(_)
             | Message::DebugSpecChanged(_)
             | Message::DebugSetBreakpoint
@@ -1031,6 +1059,9 @@ impl FlowrGui {
         #[cfg(feature = "debugger")]
         if self.submission_settings.debug_this_flow && self.debug_client_active {
             main_content = main_content.push(self.debug_row());
+            if self.show_run_inputs {
+                main_content = main_content.push(self.run_input_row());
+            }
         }
 
         let main_content = main_content
@@ -1477,6 +1508,39 @@ impl FlowrGui {
             .push(Self::tip(funcs_btn, "List all functions"))
             .push(Self::tip(procs_btn, "Show flow/function hierarchy"))
             .push(Self::tip(validate_btn, "Validate flow state for deadlocks"))
+    }
+
+    #[cfg(feature = "debugger")]
+    fn run_input_row(&self) -> Row<'_, Message> {
+        let mut row = Row::new()
+            .spacing(6)
+            .padding([4, 8])
+            .align_y(iced::alignment::Vertical::Center);
+
+        for (i, name) in self.run_input_names.iter().enumerate() {
+            let value = self.run_input_values.get(i).cloned().unwrap_or_default();
+            let idx = i;
+            let input = Self::tip(
+                text_input(name, &value)
+                    .on_input(move |v| Message::RunInputChanged(idx, v))
+                    .on_submit(Message::RunInputExecute)
+                    .width(100),
+                name,
+            );
+            row = row.push(input);
+        }
+
+        let exec_btn = Button::new(Text::new("Execute"))
+            .style(theme::styled_button)
+            .padding([3, 8])
+            .on_press(Message::RunInputExecute);
+        let cancel_btn = Button::new(Text::new("Cancel"))
+            .style(theme::styled_button)
+            .padding([3, 8])
+            .on_press(Message::RunInputCancel);
+
+        row = row.push(exec_btn).push(cancel_btn);
+        row
     }
 
     #[cfg(feature = "debugger")]
@@ -2186,27 +2250,84 @@ impl FlowrGui {
                 if self.debug_spec_text.trim().is_empty() {
                     return iced::Task::none();
                 }
-                self.debug_waiting = false;
                 let parts: Vec<String> = self
                     .debug_spec_text
                     .split_whitespace()
                     .map(String::from)
                     .collect();
                 if let Some(target_str) = parts.first() {
-                    let args: Vec<String> = parts.get(1..).unwrap_or_default().to_vec();
-                    let target = if let Ok(id) = target_str.parse::<usize>() {
-                        flowcore::model::debug_command::ProcessTarget::Id(id)
+                    let target_id = if let Ok(id) = target_str.parse::<usize>() {
+                        Some(id)
                     } else if target_str.starts_with('/') {
-                        flowcore::model::debug_command::ProcessTarget::Route(target_str.clone())
+                        self.cached_functions
+                            .iter()
+                            .find(|f| f.route == *target_str)
+                            .map(|f| f.id)
                     } else {
-                        flowcore::model::debug_command::ProcessTarget::Name(target_str.clone())
+                        self.cached_functions
+                            .iter()
+                            .find(|f| f.name == *target_str)
+                            .map(|f| f.id)
                     };
-                    self.debug_separator(&format!("Run process: {target_str}"));
+                    if let Some(id) = target_id {
+                        if let Some(func) = self.cached_functions.iter().find(|f| f.id == id) {
+                            let inline_args: Vec<String> =
+                                parts.get(1..).unwrap_or_default().to_vec();
+                            self.run_input_names = func
+                                .inputs
+                                .iter()
+                                .enumerate()
+                                .map(|(i, (_, name))| {
+                                    if name.is_empty() {
+                                        format!("input_{i}")
+                                    } else {
+                                        name.clone()
+                                    }
+                                })
+                                .collect();
+                            self.run_input_values = (0..func.inputs.len())
+                                .map(|i| inline_args.get(i).cloned().unwrap_or_default())
+                                .collect();
+                            self.run_target_id = Some(id);
+                            self.show_run_inputs = true;
+                        }
+                    } else {
+                        self.debug_waiting = false;
+                        let target = if target_str.starts_with('/') {
+                            flowcore::model::debug_command::ProcessTarget::Route(target_str.clone())
+                        } else {
+                            flowcore::model::debug_command::ProcessTarget::Name(target_str.clone())
+                        };
+                        self.debug_separator(&format!("Run process: {target_str}"));
+                        connection_manager::send_debug_command(DebugCommand::RunReset(
+                            Some(target),
+                            vec![],
+                        ));
+                    }
+                }
+            }
+            Message::RunInputChanged(index, value) => {
+                if let Some(v) = self.run_input_values.get_mut(index) {
+                    *v = value;
+                }
+            }
+            Message::RunInputExecute => {
+                self.show_run_inputs = false;
+                if let Some(id) = self.run_target_id.take() {
+                    let args = self.run_input_values.clone();
+                    self.debug_waiting = false;
+                    self.debug_separator(&format!("Run process #{id}"));
                     connection_manager::send_debug_command(DebugCommand::RunReset(
-                        Some(target),
+                        Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
                         args,
                     ));
                 }
+            }
+            Message::RunInputCancel => {
+                self.show_run_inputs = false;
+                self.run_target_id = None;
+                self.run_input_values.clear();
+                self.run_input_names.clear();
             }
             Message::DebugPause => {
                 self.debug_separator("Pause");
@@ -2799,6 +2920,14 @@ mod test {
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
             inspect_tab: InspectTab::Function,
+            #[cfg(feature = "debugger")]
+            show_run_inputs: false,
+            #[cfg(feature = "debugger")]
+            run_target_id: None,
+            #[cfg(feature = "debugger")]
+            run_input_values: Vec::new(),
+            #[cfg(feature = "debugger")]
+            run_input_names: Vec::new(),
             show_coordinator_picker: false,
             discovered_services: Vec::new(),
             discovering: false,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -416,6 +416,9 @@ pub enum Message {
     /// User clicked Exit Debugger in the debug controls
     #[cfg(feature = "debugger")]
     DebugExit,
+    /// User clicked Pause to break into the debugger mid-execution
+    #[cfg(feature = "debugger")]
+    DebugPause,
     /// The step count text input changed
     #[cfg(feature = "debugger")]
     DebugStepCountChanged(String),
@@ -961,6 +964,7 @@ impl FlowrGui {
             | Message::DebugReset
             | Message::DebugRunProcess
             | Message::DebugExit
+            | Message::DebugPause
             | Message::DebugStepCountChanged(_)
             | Message::DebugSpecChanged(_)
             | Message::DebugSetBreakpoint
@@ -1364,11 +1368,17 @@ impl FlowrGui {
             });
         }
 
-        let mut exit_btn = Button::new(Text::new("\u{23F9} Exit"))
-            .style(theme::styled_button)
-            .padding([4, 10]);
-        if can_cmd {
-            exit_btn = exit_btn.on_press(Message::DebugExit);
+        let (exit_label, exit_msg): (&str, Message) = if can_cmd {
+            ("\u{23F9} Exit", Message::DebugExit)
+        } else {
+            ("\u{23F8} Pause", Message::DebugPause)
+        };
+        let mut exit_btn =
+            Button::new(Text::new(exit_label).shaping(iced::widget::text::Shaping::Advanced))
+                .style(theme::styled_button)
+                .padding([4, 10]);
+        if can_cmd || self.running {
+            exit_btn = exit_btn.on_press(exit_msg);
         }
 
         let spec_input = text_input("breakpoint spec", &self.debug_spec_text)
@@ -1447,7 +1457,14 @@ impl FlowrGui {
                     "Reset flow state and re-run from start"
                 },
             ))
-            .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
+            .push(Self::tip(
+                exit_btn,
+                if can_cmd {
+                    "Stop execution and exit debugger"
+                } else {
+                    "Pause execution and enter debugger"
+                },
+            ))
             .push(Text::new("|").size(13))
             .push(Self::tip(
                 spec_input,
@@ -2193,6 +2210,10 @@ impl FlowrGui {
                         args,
                     ));
                 }
+            }
+            Message::DebugPause => {
+                self.debug_separator("Pause");
+                self.send(ClientMessage::EnterDebugger);
             }
             Message::DebugExit => {
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1353,7 +1353,7 @@ impl FlowrGui {
             .on_input(Message::DebugStepCountChanged)
             .width(35);
 
-        let has_run_target = !self.debug_spec_text.is_empty();
+        let has_run_target = !self.debug_spec_text.trim().is_empty();
         let is_run = has_run_target || !jobs_started;
         let reset_label = if is_run {
             "\u{25B6} Run"
@@ -2183,7 +2183,7 @@ impl FlowrGui {
                 connection_manager::send_debug_command(DebugCommand::RunReset(None, vec![]));
             }
             Message::DebugRunProcess => {
-                if self.debug_spec_text.is_empty() {
+                if self.debug_spec_text.trim().is_empty() {
                     return iced::Task::none();
                 }
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -448,7 +448,7 @@ pub enum Message {
     DebugInspect,
     /// User clicked Functions list
     #[cfg(feature = "debugger")]
-    DebugFunctions,
+    DebugFunctions(bool),
     /// User clicked Processes tree
     #[cfg(feature = "debugger")]
     DebugProcesses,
@@ -1003,7 +1003,7 @@ impl FlowrGui {
             | Message::DebugDeleteBreakpoints
             | Message::DebugListBreakpoints
             | Message::DebugInspect
-            | Message::DebugFunctions
+            | Message::DebugFunctions(_)
             | Message::DebugProcesses
             | Message::DebugValidate
             | Message::ShowBpPopup
@@ -1398,7 +1398,7 @@ impl FlowrGui {
         let mut reset_btn = Button::new(Text::new(reset_label))
             .style(theme::styled_button)
             .padding(bp);
-        if can_cmd {
+        if self.debug_client_active {
             reset_btn = reset_btn.on_press(if has_run_target {
                 Message::DebugRunProcess
             } else {
@@ -1461,7 +1461,7 @@ impl FlowrGui {
             .style(theme::styled_button)
             .padding(sp);
         if can_cmd {
-            funcs_btn = funcs_btn.on_press(Message::DebugFunctions);
+            funcs_btn = funcs_btn.on_press(Message::DebugFunctions(true));
         }
 
         let mut procs_btn = Button::new(Text::new("Processes"))
@@ -1524,13 +1524,18 @@ impl FlowrGui {
 
         for (i, name) in self.run_input_names.iter().enumerate() {
             let value = self.run_input_values.get(i).cloned().unwrap_or_default();
+            let type_hint = self
+                .run_input_types
+                .get(i)
+                .map_or("Value", String::as_str);
+            let tooltip = type_hint.to_string();
             let idx = i;
             let input = Self::tip(
                 text_input(name, &value)
                     .on_input(move |v| Message::RunInputChanged(idx, v))
                     .on_submit(Message::RunInputExecute)
                     .width(100),
-                name,
+                &tooltip,
             );
             row = row.push(input);
         }
@@ -1852,7 +1857,18 @@ impl FlowrGui {
             }
             CoordinatorState::Connected(_) => match (self.submitted, self.running) {
                 (false, false) => ("\u{1F7E2}", "Ready".to_string()),
-                (_, true) => ("\u{1F535}", "Running".to_string()),
+                (_, true) => {
+                    #[cfg(feature = "debugger")]
+                    if self.debug_waiting {
+                        ("\u{1F7E3}", "Debugging".to_string())
+                    } else {
+                        ("\u{1F535}", "Running".to_string())
+                    }
+                    #[cfg(not(feature = "debugger"))]
+                    {
+                        ("\u{1F535}", "Running".to_string())
+                    }
+                }
                 (true, false) => {
                     #[cfg(feature = "debugger")]
                     if self.debug_client_active {
@@ -2210,6 +2226,9 @@ impl FlowrGui {
             }
             Message::DebugWaiting => {
                 self.debug_waiting = true;
+                if self.cached_functions.is_empty() {
+                    return self.process_debug_message(Message::DebugFunctions(false));
+                }
             }
             Message::DebugConnected => {
                 self.tab_set
@@ -2415,9 +2434,12 @@ impl FlowrGui {
                     self.debug_waiting = true;
                 }
             }
-            Message::DebugFunctions => {
-                self.debug_waiting = false;
-                self.debug_separator("Functions List");
+            Message::DebugFunctions(display) => {
+                if display {
+                    self.debug_waiting = false;
+                    self.debug_separator("Functions List");
+                }
+                self.suppress_next_output = !display;
                 connection_manager::send_debug_command(DebugCommand::FunctionList);
             }
             Message::DebugProcesses => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2306,6 +2306,14 @@ impl FlowrGui {
                                 .collect();
                             self.run_target_id = Some(id);
                             self.show_run_inputs = true;
+                        } else {
+                            let args: Vec<String> = parts.get(1..).unwrap_or_default().to_vec();
+                            self.debug_waiting = false;
+                            self.debug_separator(&format!("Run process #{id}"));
+                            connection_manager::send_debug_command(DebugCommand::RunReset(
+                                Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
+                                args,
+                            ));
                         }
                     } else {
                         self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1327,10 +1327,11 @@ impl FlowrGui {
     fn debug_row(&self) -> Row<'_, Message> {
         let can_cmd = self.debug_waiting;
 
-        let mut continue_btn = Button::new(Text::new("\u{25B6} Continue"))
+        let jobs_started = connection_manager::get_job_count() > 0;
+        let mut continue_btn = Button::new(Text::new("\u{23E9} Continue"))
             .style(theme::styled_button)
             .padding([4, 10]);
-        if can_cmd {
+        if can_cmd && jobs_started {
             continue_btn = continue_btn.on_press(Message::DebugContinue);
         }
 
@@ -1345,18 +1346,21 @@ impl FlowrGui {
             .on_input(Message::DebugStepCountChanged)
             .width(40);
 
-        let mut reset_btn = Button::new(Text::new("\u{21BB} Reset"))
+        let has_run_target = !self.debug_spec_text.is_empty();
+        let reset_label = if has_run_target {
+            "\u{25B6} Run"
+        } else {
+            "\u{21BB} Reset"
+        };
+        let mut reset_btn = Button::new(Text::new(reset_label))
             .style(theme::styled_button)
             .padding([4, 10]);
         if can_cmd {
-            reset_btn = reset_btn.on_press(Message::DebugReset);
-        }
-
-        let mut run_btn = Button::new(Text::new("\u{25B6} Run"))
-            .style(theme::styled_button)
-            .padding([4, 10]);
-        if can_cmd && !self.debug_spec_text.is_empty() {
-            run_btn = run_btn.on_press(Message::DebugRunProcess);
+            reset_btn = reset_btn.on_press(if has_run_target {
+                Message::DebugRunProcess
+            } else {
+                Message::DebugReset
+            });
         }
 
         let mut exit_btn = Button::new(Text::new("\u{23F9} Exit"))
@@ -1436,17 +1440,17 @@ impl FlowrGui {
             .push(Self::tip(step_count, "Number of jobs to step"))
             .push(Self::tip(
                 reset_btn,
-                "Reset flow state and re-run from start",
+                if has_run_target {
+                    "Run a specific process (spec field has target)"
+                } else {
+                    "Reset flow state and re-run from start"
+                },
             ))
             .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
             .push(Text::new("|").size(13))
             .push(Self::tip(
                 spec_input,
                 "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
-            ))
-            .push(Self::tip(
-                run_btn,
-                "Run a specific process (enter ID, /route, or name in spec field)",
             ))
             .push(Self::tip(bp_btn, "Open breakpoint picker"))
             .push(Self::tip(del_btn, "Delete all breakpoints"))

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1332,34 +1332,37 @@ impl FlowrGui {
         let can_cmd = self.debug_waiting;
 
         let jobs_started = connection_manager::get_job_count() > 0;
-        let mut continue_btn = Button::new(Text::new("\u{23E9} Continue"))
+        let bp = [3, 6]; // button padding for execution controls
+        let sp = [3, 5]; // button padding for smaller controls
+
+        let mut continue_btn = Button::new(Text::new("\u{25B6} Continue"))
             .style(theme::styled_button)
-            .padding([4, 10]);
+            .padding(bp);
         if can_cmd && jobs_started {
             continue_btn = continue_btn.on_press(Message::DebugContinue);
         }
 
-        let mut step_btn =
-            Button::new(Text::new("\u{2BA9} Step").shaping(iced::widget::text::Shaping::Advanced))
-                .style(theme::styled_button)
-                .padding([4, 10]);
+        let mut step_btn = Button::new(Text::new("\u{23ED} Step"))
+            .style(theme::styled_button)
+            .padding(bp);
         if can_cmd {
             step_btn = step_btn.on_press(Message::DebugStep);
         }
 
         let step_count = text_input("n", &self.debug_step_count)
             .on_input(Message::DebugStepCountChanged)
-            .width(40);
+            .width(35);
 
         let has_run_target = !self.debug_spec_text.is_empty();
-        let reset_label = if has_run_target {
+        let is_run = has_run_target || !jobs_started;
+        let reset_label = if is_run {
             "\u{25B6} Run"
         } else {
             "\u{21BB} Reset"
         };
         let mut reset_btn = Button::new(Text::new(reset_label))
             .style(theme::styled_button)
-            .padding([4, 10]);
+            .padding(bp);
         if can_cmd {
             reset_btn = reset_btn.on_press(if has_run_target {
                 Message::DebugRunProcess
@@ -1368,48 +1371,49 @@ impl FlowrGui {
             });
         }
 
-        let (exit_label, exit_msg): (&str, Message) = if can_cmd {
-            ("\u{23F9} Exit", Message::DebugExit)
-        } else {
-            ("\u{23F8} Pause", Message::DebugPause)
-        };
-        let mut exit_btn =
-            Button::new(Text::new(exit_label).shaping(iced::widget::text::Shaping::Advanced))
-                .style(theme::styled_button)
-                .padding([4, 10]);
-        if can_cmd || self.running {
-            exit_btn = exit_btn.on_press(exit_msg);
+        let mut pause_btn = Button::new(Text::new("\u{23F8} Pause"))
+            .style(theme::styled_button)
+            .padding(bp);
+        if self.debug_client_active && !can_cmd && jobs_started {
+            pause_btn = pause_btn.on_press(Message::DebugPause);
         }
 
-        let spec_input = text_input("breakpoint spec", &self.debug_spec_text)
+        let mut exit_btn = Button::new(Text::new("\u{23F9} Exit"))
+            .style(theme::styled_button)
+            .padding(bp);
+        if can_cmd {
+            exit_btn = exit_btn.on_press(Message::DebugExit);
+        }
+
+        let spec_input = text_input("spec", &self.debug_spec_text)
             .on_input(Message::DebugSpecChanged)
             .on_submit(Message::DebugSetBreakpoint)
-            .width(120);
+            .width(100);
 
         let mut bp_btn = Button::new(Text::new("Set BP"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             bp_btn = bp_btn.on_press(Message::ShowBpPopup);
         }
 
         let mut del_btn = Button::new(Text::new("Del All"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             del_btn = del_btn.on_press(Message::DebugDeleteBreakpoints);
         }
 
         let mut list_btn = Button::new(Text::new("List BPs"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             list_btn = list_btn.on_press(Message::DebugListBreakpoints);
         }
 
         let mut inspect_btn = Button::new(Text::new("Inspect"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             inspect_btn = inspect_btn.on_press(if self.debug_spec_text.is_empty() {
                 Message::ShowInspectPopup
@@ -1420,28 +1424,28 @@ impl FlowrGui {
 
         let mut funcs_btn = Button::new(Text::new("Functions"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             funcs_btn = funcs_btn.on_press(Message::DebugFunctions);
         }
 
         let mut procs_btn = Button::new(Text::new("Processes"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             procs_btn = procs_btn.on_press(Message::DebugProcesses);
         }
 
         let mut validate_btn = Button::new(Text::new("Validate"))
             .style(theme::styled_button)
-            .padding([4, 8]);
+            .padding(sp);
         if can_cmd {
             validate_btn = validate_btn.on_press(Message::DebugValidate);
         }
 
         Row::new()
-            .spacing(6)
-            .padding(5)
+            .spacing(4)
+            .padding(4)
             .align_y(iced::alignment::Vertical::Center)
             .push(Self::tip(
                 continue_btn,
@@ -1457,15 +1461,8 @@ impl FlowrGui {
                     "Reset flow state and re-run from start"
                 },
             ))
-            .push(Self::tip(
-                exit_btn,
-                if can_cmd {
-                    "Stop execution and exit debugger"
-                } else {
-                    "Pause execution and enter debugger"
-                },
-            ))
-            .push(Text::new("|").size(13))
+            .push(Self::tip(pause_btn, "Pause execution and enter debugger"))
+            .push(Self::tip(exit_btn, "Stop execution and exit debugger"))
             .push(Self::tip(
                 spec_input,
                 "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
@@ -1473,7 +1470,6 @@ impl FlowrGui {
             .push(Self::tip(bp_btn, "Open breakpoint picker"))
             .push(Self::tip(del_btn, "Delete all breakpoints"))
             .push(Self::tip(list_btn, "List active breakpoints"))
-            .push(Text::new("|").size(13))
             .push(Self::tip(
                 inspect_btn,
                 "Inspect state (use spec field for specific target)",
@@ -1819,7 +1815,7 @@ impl FlowrGui {
         }
 
         #[cfg(feature = "debugger")]
-        if self.submission_settings.debug_this_flow {
+        if self.submission_settings.debug_mode == DebugMode::External && !self.debug_client_active {
             let debug_port = connection_manager::get_debug_port();
             if debug_port > 0 {
                 row = row.push(
@@ -2182,6 +2178,7 @@ impl FlowrGui {
             }
             Message::DebugReset => {
                 self.debug_waiting = false;
+                connection_manager::set_job_count(0);
                 self.debug_separator("Run / Reset");
                 connection_manager::send_debug_command(DebugCommand::RunReset(None, vec![]));
             }

--- a/flowr/src/lib/coerce_value.rs
+++ b/flowr/src/lib/coerce_value.rs
@@ -1,0 +1,143 @@
+use serde_json::Value;
+
+use flowcore::errors::Result;
+
+/// Coerce a string value using heuristic rules for generic inputs
+pub(crate) fn coerce_generic(raw: &str) -> Value {
+    let trimmed = raw.trim();
+
+    if trimmed == "null" || trimmed == "Null" {
+        return Value::Null;
+    }
+
+    if trimmed == "true" {
+        return Value::Bool(true);
+    }
+    if trimmed == "false" {
+        return Value::Bool(false);
+    }
+
+    if trimmed.len() >= 2 && trimmed.starts_with('"') && trimmed.ends_with('"') {
+        return Value::String(trimmed[1..trimmed.len() - 1].to_string());
+    }
+
+    if let Ok(n) = trimmed.parse::<i64>() {
+        return Value::Number(n.into());
+    }
+    if let Ok(n) = trimmed.parse::<f64>() {
+        if let Some(num) = serde_json::Number::from_f64(n) {
+            return Value::Number(num);
+        }
+    }
+
+    if (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        || (trimmed.starts_with('{') && trimmed.ends_with('}'))
+    {
+        if let Ok(val) = serde_json::from_str::<Value>(trimmed) {
+            return val;
+        }
+    }
+
+    Value::String(trimmed.to_string())
+}
+
+/// Coerce a string to a Value, validating against an expected JSON type keyword.
+/// Returns an error with a descriptive message if coercion fails.
+pub(crate) fn coerce_typed(raw: &str, expected_type: &str, input_name: &str) -> Result<Value> {
+    let value = coerce_generic(raw);
+    let ok = match expected_type {
+        "Number" => value.is_number(),
+        "String" => value.is_string(),
+        "Bool" => value.is_boolean(),
+        "Array" => value.is_array(),
+        "Object" => value.is_object(),
+        "Null" => value.is_null(),
+        _ => true,
+    };
+    if ok {
+        Ok(value)
+    } else {
+        Err(format!("Cannot coerce '{raw}' to {expected_type} for input '{input_name}'").into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn coerce_bool_true() {
+        assert_eq!(coerce_generic("true"), json!(true));
+    }
+
+    #[test]
+    fn coerce_bool_false() {
+        assert_eq!(coerce_generic("false"), json!(false));
+    }
+
+    #[test]
+    fn coerce_null() {
+        assert_eq!(coerce_generic("null"), Value::Null);
+        assert_eq!(coerce_generic("Null"), Value::Null);
+    }
+
+    #[test]
+    fn coerce_integer() {
+        assert_eq!(coerce_generic("42"), json!(42));
+        assert_eq!(coerce_generic("-7"), json!(-7));
+    }
+
+    #[test]
+    fn coerce_float() {
+        assert_eq!(coerce_generic("1.5"), json!(1.5));
+    }
+
+    #[test]
+    fn coerce_quoted_string() {
+        assert_eq!(coerce_generic("\"hello\""), json!("hello"));
+        assert_eq!(coerce_generic("\"42\""), json!("42"));
+    }
+
+    #[test]
+    fn coerce_unquoted_string() {
+        assert_eq!(coerce_generic("hello"), json!("hello"));
+    }
+
+    #[test]
+    fn coerce_array() {
+        assert_eq!(coerce_generic("[1,2,3]"), json!([1, 2, 3]));
+        assert_eq!(coerce_generic("[]"), json!([]));
+    }
+
+    #[test]
+    fn coerce_object() {
+        assert_eq!(coerce_generic("{\"a\":1}"), json!({"a": 1}));
+    }
+
+    #[test]
+    fn coerce_typed_number_ok() {
+        assert!(coerce_typed("42", "Number", "count").is_ok());
+    }
+
+    #[test]
+    fn coerce_typed_number_fail() {
+        let result = coerce_typed("hello", "Number", "count");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Cannot coerce"));
+        assert!(msg.contains("Number"));
+        assert!(msg.contains("count"));
+    }
+
+    #[test]
+    fn coerce_typed_string_ok() {
+        assert!(coerce_typed("hello", "String", "name").is_ok());
+    }
+
+    #[test]
+    fn coerce_typed_unknown_type_passes() {
+        assert!(coerce_typed("anything", "CustomType", "x").is_ok());
+    }
+}

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -13,6 +13,7 @@ use crate::debug_command::DebugCommand::{
     InspectBlock, InspectFunction, InspectInput, InspectOutput, List, Modify, RunReset, Step,
     Validate,
 };
+use crate::debug_command::ProcessTarget;
 use crate::run_state::RunState;
 use flowcore::errors::Result;
 use flowcore::model::runtime_function::RuntimeFunction;
@@ -53,7 +54,9 @@ const HELP_STRING: &str = "Debugger commands:
 'm' | 'modify' [name]=[value] - Modify a debugger or runtime variable named 'name' to value 'value'
 'p' | 'processes'             - Show flows and functions in a hierarchical tree
 'q' | 'quit'                  - Stop flow execution and exit debugger
-'r' | 'reset' or 'run'        - Reset the state and re-run the flow
+'r' | 'reset' or 'run' [target] [args] - No args: reset/run root flow
+                                 target: function ID, /route, or name
+                                 args: space-separated input values
 's' | 'step' [n]              - Step over the next 'n' jobs (default = 1) then break
 'v' | 'validate'              - Validate the state of the flow by running a series of checks
 ";
@@ -281,7 +284,25 @@ impl DebugClient {
             "l" | "list" => Some(List),
             "p" | "processes" => Some(DebugCommand::ProcessList),
             "m" | "modify" => Some(Modify(params)),
-            "r" | "run" | "reset" => Some(RunReset),
+            "r" | "run" | "reset" => {
+                let parts = params.unwrap_or_default();
+                if parts.is_empty() {
+                    Some(RunReset(None, vec![]))
+                } else {
+                    let Some(target_str) = parts.first() else {
+                        return Some(RunReset(None, vec![]));
+                    };
+                    let args = parts.get(1..).unwrap_or_default().to_vec();
+                    let target = if let Ok(id) = target_str.parse::<usize>() {
+                        ProcessTarget::Id(id)
+                    } else if target_str.starts_with('/') {
+                        ProcessTarget::Route(target_str.clone())
+                    } else {
+                        ProcessTarget::Name(target_str.clone())
+                    };
+                    Some(RunReset(Some(target), args))
+                }
+            }
             "s" | "step" => Some(Step(Self::parse_optional_int(params))),
             "v" | "validate" => Some(Validate),
             _ => {

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -285,7 +285,11 @@ impl DebugClient {
             "p" | "processes" => Some(DebugCommand::ProcessList),
             "m" | "modify" => Some(Modify(params)),
             "r" | "run" | "reset" => {
-                let parts = params.unwrap_or_default();
+                let parts: Vec<String> = params
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 if parts.is_empty() {
                     Some(RunReset(None, vec![]))
                 } else {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -402,17 +402,20 @@ impl<'a> Debugger<'a> {
                         Ok((false, false))
                     };
                 }
-                Ok(RunReset(Some(target), _args)) => {
+                Ok(RunReset(Some(target), args)) => {
                     if state.get_number_of_jobs_created() > 0 {
                         self.debug_server.debugger_error(
                             "Cannot run a process mid-execution. Reset first with 'r'.".into(),
                         );
                     } else {
                         match Self::resolve_target(state, &target) {
-                            Ok(process_id) => {
-                                self.debug_server
-                                    .message(format!("Resolved target to process #{process_id}"));
-                            }
+                            Ok(process_id) => match self.run_process(state, process_id, &args) {
+                                Ok(()) => {
+                                    self.debug_server.execution_starting();
+                                    return Ok((false, false));
+                                }
+                                Err(e) => self.debug_server.debugger_error(e.to_string()),
+                            },
                             Err(e) => self.debug_server.debugger_error(e.to_string()),
                         }
                     }
@@ -728,6 +731,90 @@ impl<'a> Debugger<'a> {
                 }
             }
         }
+    }
+
+    #[allow(clippy::unused_self)]
+    fn run_process(
+        &mut self,
+        state: &mut RunState,
+        process_id: usize,
+        inline_args: &[String],
+    ) -> Result<()> {
+        if state.submission.manifest.flows().contains_key(&process_id) {
+            bail!(
+                "Sub-flow execution is not yet implemented. \
+                 Use a function ID or route to run individual functions."
+            );
+        }
+
+        let function = state
+            .get_function(process_id)
+            .ok_or("Could not get function")?;
+        let num_inputs = function.inputs().len();
+        let parent_id = function.get_parent_id();
+
+        if inline_args.len() > num_inputs {
+            bail!(
+                "Process has {num_inputs} inputs but {} values were provided",
+                inline_args.len()
+            );
+        }
+
+        let mut input_info: Vec<(String, bool, Option<String>)> = Vec::new();
+        for (i, input) in function.inputs().iter().enumerate() {
+            let name = if input.name().is_empty() {
+                format!("input_{i}")
+            } else {
+                input.name().to_string()
+            };
+            let generic = input.is_generic();
+            let default = if i < inline_args.len() {
+                Some(inline_args.get(i).ok_or("Could not get arg")?.clone())
+            } else {
+                input
+                    .initializer()
+                    .as_ref()
+                    .map(|init| init.get_value().to_string())
+                    .or_else(|| {
+                        input
+                            .flow_initializer()
+                            .as_ref()
+                            .map(|init| init.get_value().to_string())
+                    })
+            };
+            input_info.push((name, generic, default));
+        }
+
+        let missing: Vec<&str> = input_info
+            .iter()
+            .filter(|(_, _, default)| default.is_none())
+            .map(|(name, _, _)| name.as_str())
+            .collect();
+        if !missing.is_empty() {
+            bail!(
+                "Missing values for inputs: {}. Supply them as arguments: r <target> <val1> <val2> ...",
+                missing.join(", ")
+            );
+        }
+
+        let mut coerced_values = Vec::new();
+        for (name, generic, default) in &input_info {
+            let raw = default.as_ref().ok_or("Missing input value")?;
+            let value = if *generic {
+                crate::coerce_value::coerce_generic(raw)
+            } else {
+                crate::coerce_value::coerce_typed(raw, "Value", name)?
+            };
+            coerced_values.push(value);
+        }
+
+        let func = state.get_mut(process_id).ok_or("Could not get function")?;
+        for (i, value) in coerced_values.into_iter().enumerate() {
+            func.send(i, value)?;
+        }
+
+        state.create_jobs(process_id, parent_id)?;
+        Ok(())
     }
 
     fn inspect_flow(state: &RunState, flow_id: usize) -> String {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -796,14 +796,9 @@ impl<'a> Debugger<'a> {
         }
 
         let mut coerced_values = Vec::new();
-        for (name, generic, default) in &input_info {
+        for (_name, _generic, default) in &input_info {
             let raw = default.as_ref().ok_or("Missing input value")?;
-            let value = if *generic {
-                crate::coerce_value::coerce_generic(raw)
-            } else {
-                crate::coerce_value::coerce_typed(raw, "Value", name)?
-            };
-            coerced_values.push(value);
+            coerced_values.push(crate::coerce_value::coerce_generic(raw));
         }
 
         let func = state.get_mut(process_id).ok_or("Could not get function")?;

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -405,7 +405,7 @@ impl<'a> Debugger<'a> {
                 Ok(RunReset(Some(target), args)) => {
                     if state.get_number_of_jobs_created() > 0 {
                         self.reset();
-                        state.init()?;
+                        state.reset();
                     }
                     match Self::resolve_target(state, &target) {
                         Ok(process_id) => match self.run_process(state, process_id, &args) {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -18,6 +18,7 @@ use crate::debug_command::DebugCommand::{
     InspectBlock, InspectFunction, InspectInput, InspectOutput, Invalid, List, Modify, RunReset,
     Step, Validate,
 };
+use crate::debug_command::ProcessTarget;
 use crate::debugger_handler::DebuggerHandler;
 use crate::job::Job;
 use crate::run_state::{RunState, State};
@@ -391,7 +392,7 @@ impl<'a> Debugger<'a> {
                         return Ok((false, false));
                     }
                 }
-                Ok(RunReset) => {
+                Ok(RunReset(None, _)) => {
                     return if state.get_number_of_jobs_created() > 0 {
                         self.reset();
                         self.debug_server.debugger_resetting();
@@ -400,6 +401,21 @@ impl<'a> Debugger<'a> {
                         self.debug_server.execution_starting();
                         Ok((false, false))
                     };
+                }
+                Ok(RunReset(Some(target), _args)) => {
+                    if state.get_number_of_jobs_created() > 0 {
+                        self.debug_server.debugger_error(
+                            "Cannot run a process mid-execution. Reset first with 'r'.".into(),
+                        );
+                    } else {
+                        match Self::resolve_target(state, &target) {
+                            Ok(process_id) => {
+                                self.debug_server
+                                    .message(format!("Resolved target to process #{process_id}"));
+                            }
+                            Err(e) => self.debug_server.debugger_error(e.to_string()),
+                        }
+                    }
                 }
                 Ok(Step(param)) => {
                     self.step(state, param);
@@ -673,6 +689,45 @@ impl<'a> Debugger<'a> {
             .values()
             .find(|f| f.route() == route)
             .map(RuntimeFunction::id)
+    }
+
+    fn resolve_target(state: &RunState, target: &ProcessTarget) -> Result<usize> {
+        match target {
+            ProcessTarget::Id(id) => {
+                if state.get_function(*id).is_some()
+                    || state.submission.manifest.flows().contains_key(id)
+                {
+                    Ok(*id)
+                } else {
+                    bail!("No process found matching '#{id}'")
+                }
+            }
+            ProcessTarget::Route(route) => Self::find_by_route(state, route)
+                .ok_or_else(|| format!("No process found matching '{route}'").into()),
+            ProcessTarget::Name(name) => {
+                let matches: Vec<usize> = state
+                    .get_functions()
+                    .values()
+                    .filter(|f| f.name() == name)
+                    .map(RuntimeFunction::id)
+                    .collect();
+                match matches.as_slice() {
+                    [] => bail!("No process found matching '{name}'"),
+                    [id] => Ok(*id),
+                    _ => {
+                        let mut msg =
+                            format!("Multiple processes match '{name}'. Use ID or route:\n");
+                        for id in &matches {
+                            if let Some(f) = state.get_function(*id) {
+                                use std::fmt::Write;
+                                let _ = writeln!(msg, "  #{} @ '{}'", f.id(), f.route());
+                            }
+                        }
+                        bail!(msg)
+                    }
+                }
+            }
+        }
     }
 
     fn inspect_flow(state: &RunState, flow_id: usize) -> String {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -404,20 +404,18 @@ impl<'a> Debugger<'a> {
                 }
                 Ok(RunReset(Some(target), args)) => {
                     if state.get_number_of_jobs_created() > 0 {
-                        self.debug_server.debugger_error(
-                            "Cannot run a process mid-execution. Reset first with 'r'.".into(),
-                        );
-                    } else {
-                        match Self::resolve_target(state, &target) {
-                            Ok(process_id) => match self.run_process(state, process_id, &args) {
-                                Ok(()) => {
-                                    self.debug_server.execution_starting();
-                                    return Ok((false, false));
-                                }
-                                Err(e) => self.debug_server.debugger_error(e.to_string()),
-                            },
+                        self.reset();
+                        state.init()?;
+                    }
+                    match Self::resolve_target(state, &target) {
+                        Ok(process_id) => match self.run_process(state, process_id, &args) {
+                            Ok(()) => {
+                                self.debug_server.execution_starting();
+                                return Ok((false, false));
+                            }
                             Err(e) => self.debug_server.debugger_error(e.to_string()),
-                        }
+                        },
+                        Err(e) => self.debug_server.debugger_error(e.to_string()),
                     }
                 }
                 Ok(Step(param)) => {

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -81,6 +81,10 @@ pub mod debug_client;
 pub mod debug_gui_handler;
 
 #[cfg(feature = "debugger")]
+#[allow(dead_code)]
+mod coerce_value;
+
+#[cfg(feature = "debugger")]
 mod debugger;
 
 /// `wasmtime` module contains a number of implementations of the wasm execution

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -203,9 +203,8 @@ impl RunState {
         self.submission.manifest.functions()
     }
 
-    // Reset all values back to initial ones to enable debugging to restart from the initial state
     #[cfg(feature = "debugger")]
-    fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         debug!("Resetting RunState");
         for function in self.submission.manifest.get_functions().values_mut() {
             function.reset();

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -290,8 +290,7 @@ impl RunState {
         self.submission.manifest.functions().get(&id)
     }
 
-    // Get a mutable reference to the function with `id`
-    fn get_mut(&mut self, id: usize) -> Option<&mut RuntimeFunction> {
+    pub(crate) fn get_mut(&mut self, id: usize) -> Option<&mut RuntimeFunction> {
         self.submission.manifest.get_functions().get_mut(&id)
     }
 


### PR DESCRIPTION
## Summary

Extends the debugger's `r` (run/reset) command to run a specific function interactively with user-supplied inputs and sandboxed execution.

- **New `ProcessTarget` enum** — identifies processes by numeric ID, route path, or name
- **Extended `r` command** — `r` alone runs root flow (unchanged), `r <target> [args...]` runs a specific function
- **Type coercion module** — converts user input strings to JSON values using heuristic rules (bool, number, quoted string, array, object, null)
- **Target resolution** — resolves by ID, route, or name with helpful error for ambiguous names
- **Input handling** — inline args fill inputs positionally, initializer values used as defaults for unspecified inputs
- **Init-state precondition** — run command requires flow to be in init/reset state for sandboxed execution
- **Sub-flow stub** — clear message that sub-flow execution is not yet implemented

### What's included
- CLI `flowrdb`: full support for `r <target> [args...]` with inline args
- GUI `flowrgui`: `RunReset(None, vec![])` wiring for the reset button (GUI input panel is a follow-up)

### What's deferred (follow-up PRs)
- Interactive prompting for missing inputs (CLI readline prompts)
- GUI slideout input panel for gathering inputs
- Full sub-flow execution (running all internal functions to completion)

## Test plan
- [ ] `r` with no args still runs/resets root flow as before
- [ ] `r 5 Hello 1` resolves function by ID, fills inputs, executes
- [ ] `r /flow/add Hello 1` resolves by route
- [ ] `r add Hello 1` resolves by name, errors on ambiguity
- [ ] Type coercion: numbers, bools, quoted strings, null, arrays, objects
- [ ] Error on mid-execution run attempt
- [ ] Error on unknown target
- [ ] Existing tests pass (`make test`)

Closes #2021 (partially — interactive prompting and sub-flow execution deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended the debugger's run/reset (`r`) command to support running a specific process (by ID, route, or name) with optional inline arguments
  * Added a run-input panel to the GUI debugger for entering and editing process input values

* **Tests**
  * Added smoke tests for debugger UI interactions and workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->