### PR TITLE
Visual review batch 2: popup styling, consistent radii (#2767)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1115,9 +1115,11 @@ impl FlowrGui {
                 Row::new().spacing(10).padding(5).width(Fill).push(
                     Button::new(Text::new("OK").align_x(Center))
                         .width(Fill)
+                        .style(theme::pill_button)
                         .on_press(Message::CloseModal),
                 ),
             )
+            .style(theme::popup_card)
             .max_width(300.0);
 
             stack![
@@ -1340,9 +1342,10 @@ impl FlowrGui {
                 Button::new(Text::new("Close").align_x(Center))
                     .width(Fill)
                     .on_press(Message::CloseCoordinatorPicker)
-                    .style(theme::styled_button)
-                    .padding([4, 8]),
+                    .style(theme::pill_button)
+                    .padding([4.0, 8.0]),
             )
+            .style(theme::popup_card)
             .max_width(450.0)
     }
 
@@ -1590,10 +1593,19 @@ impl FlowrGui {
             .spacing(4)
             .align_y(iced::alignment::Vertical::Center);
         let type_row = BP_TABS.iter().fold(type_row, |row, &bt| {
-            let mut btn = Button::new(Text::new(bt.to_string()).size(13)).padding([3, 6]);
-            if bt == self.bp_tab {
-                btn = btn.style(theme::styled_button);
-            } else {
+            let is_active = bt == self.bp_tab;
+            let mut btn = Button::new(Text::new(bt.to_string()).size(theme::FONT_MD))
+                .padding(theme::BUTTON_PAD)
+                .style(if is_active {
+                    theme::pill_button_active
+                        as fn(
+                            &iced::Theme,
+                            iced::widget::button::Status,
+                        ) -> iced::widget::button::Style
+                } else {
+                    theme::pill_button
+                });
+            if !is_active {
                 btn = btn.on_press(Message::BpTabChanged(bt));
             }
             row.push(btn)
@@ -1758,8 +1770,23 @@ impl FlowrGui {
 
         let body = Column::new().spacing(8).push(type_row).push(list);
 
-        Card::new(Text::new("Breakpoints"), body)
-            .on_close(Message::CloseBpPopup)
+        let bp_header = Row::new()
+            .push(Text::new("Breakpoints"))
+            .push(iced::widget::container(Text::new("")).width(iced::Length::Fill))
+            .push(
+                Button::new(
+                    Text::new("\u{2715}")
+                        .font(iced::Font::with_name("icons"))
+                        .size(theme::FONT_MD),
+                )
+                .on_press(Message::CloseBpPopup)
+                .style(theme::list_button)
+                .padding(theme::BUTTON_PAD_SM),
+            )
+            .align_y(iced::alignment::Vertical::Center);
+
+        Card::new(bp_header, body)
+            .style(theme::popup_card)
             .max_width(500.0)
     }
 
@@ -1773,10 +1800,19 @@ impl FlowrGui {
             .spacing(4)
             .align_y(iced::alignment::Vertical::Center);
         let tab_row = INSPECT_TABS.iter().fold(tab_row, |row, &tab| {
-            let mut btn = Button::new(Text::new(tab.to_string()).size(13)).padding([3, 6]);
-            if tab == self.inspect_tab {
-                btn = btn.style(theme::styled_button);
-            } else {
+            let is_active = tab == self.inspect_tab;
+            let mut btn = Button::new(Text::new(tab.to_string()).size(theme::FONT_MD))
+                .padding(theme::BUTTON_PAD)
+                .style(if is_active {
+                    theme::pill_button_active
+                        as fn(
+                            &iced::Theme,
+                            iced::widget::button::Status,
+                        ) -> iced::widget::button::Style
+                } else {
+                    theme::pill_button
+                });
+            if !is_active {
                 btn = btn.on_press(Message::InspectTabChanged(tab));
             }
             row.push(btn)
@@ -1872,8 +1908,23 @@ impl FlowrGui {
 
         let body = Column::new().spacing(8).push(tab_row).push(list);
 
-        Card::new(Text::new("Inspect"), body)
-            .on_close(Message::CloseInspectPopup)
+        let inspect_header = Row::new()
+            .push(Text::new("Inspect"))
+            .push(iced::widget::container(Text::new("")).width(iced::Length::Fill))
+            .push(
+                Button::new(
+                    Text::new("\u{2715}")
+                        .font(iced::Font::with_name("icons"))
+                        .size(theme::FONT_MD),
+                )
+                .on_press(Message::CloseInspectPopup)
+                .style(theme::list_button)
+                .padding(theme::BUTTON_PAD_SM),
+            )
+            .align_y(iced::alignment::Vertical::Center);
+
+        Card::new(inspect_header, body)
+            .style(theme::popup_card)
             .max_width(500.0)
     }
 

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -284,8 +284,8 @@ fn tab_button_style(
         ..palette.text
     };
     let top_only = iced::border::Radius {
-        top_left: 4.0,
-        top_right: 4.0,
+        top_left: crate::theme::RADIUS_MD,
+        top_right: crate::theme::RADIUS_MD,
         bottom_right: 0.0,
         bottom_left: 0.0,
     };

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -241,6 +241,24 @@ pub fn pill_button(theme: &Theme, status: button::Status) -> button::Style {
     }
 }
 
+pub fn pill_button_active(theme: &Theme, status: button::Status) -> button::Style {
+    let _palette = theme.palette();
+    let border = Border {
+        radius: 12.0.into(),
+        width: 1.0,
+        color: lighten(ACCENT, 0.3),
+    };
+    match status {
+        button::Status::Active | button::Status::Disabled => button::Style {
+            background: Some(Background::Color(ACCENT)),
+            text_color: Color::WHITE,
+            border,
+            ..button::Style::default()
+        },
+        _ => pill_button(theme, status),
+    }
+}
+
 pub(crate) fn list_button(theme: &Theme, status: button::Status) -> button::Style {
     let palette = theme.palette();
     match status {
@@ -349,7 +367,7 @@ pub fn pill_input(
     match status {
         iced::widget::text_input::Status::Focused { .. } => iced::widget::text_input::Style {
             border: Border {
-                color: ACCENT,
+                color: lighten(ACCENT, 0.3),
                 ..base.border
             },
             ..base
@@ -365,6 +383,25 @@ pub fn pill_input(
             ..base
         },
         _ => base,
+    }
+}
+
+// ── Card/popup style ────────────────────────────────────────────────────────
+
+pub fn popup_card(theme: &Theme, _status: iced_aw::style::Status) -> iced_aw::style::card::Style {
+    let palette = theme.palette();
+    iced_aw::style::card::Style {
+        background: Background::Color(SURFACE_BUTTON),
+        border_radius: RADIUS_MD,
+        border_width: 1.5,
+        border_color: Color { a: 0.5, ..ACCENT },
+        head_background: Background::Color(Color { a: 0.3, ..ACCENT }),
+        head_text_color: Color::WHITE,
+        body_background: Background::Color(SURFACE_BUTTON),
+        body_text_color: palette.text,
+        foot_background: Background::Color(SURFACE_BUTTON),
+        foot_text_color: palette.text,
+        close_color: Color::WHITE,
     }
 }
 


### PR DESCRIPTION
## Summary

Second batch of the comprehensive visual review (#2767):

- **Popup dialog styling** — custom dark card style with soft lilac header, accent border, and custom ✕ close button (replacing broken iced_aw default)
- **Consistent button radii** — pill_button_active style for selected popup tabs; tab bar top corners match toolbar buttons (RADIUS_MD)
- **Input border consistency** — focused text input border uses same lightened accent as button hover borders
- **Spacing** — main column spacing reduced, status bar separator removed, tighter padding

## Test plan
- [ ] All 78 iced_test GUI tests pass
- [ ] `make clippy` passes
- [ ] Popup dialogs (Inspect, Breakpoints, Coordinator) render with new style
- [ ] Custom ✕ close button works in popups
- [ ] Tab button radii consistent across popups and tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced modal and popup dialog styling with refined button designs, improved spacing, and better visual hierarchy.
  * Updated button state styling (active/inactive) for clearer visual feedback across dialogs.
  * Improved tab styling and visual consistency with the application's design system throughout the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->