### PR TITLE
Visual review batch 3: chip-style links, polish (#2767)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -346,8 +346,8 @@ impl DebugEventLine {
             }
         }
 
-        // Match Busy Count entries like "1: 1, 0: 1" — the keys are function IDs
-        if let Some(after_colon) = text.strip_prefix("Busy Count:") {
+        // Match Busy Functions entries like "1: 1, 0: 1" — the keys are function IDs
+        if let Some(after_colon) = text.strip_prefix("Busy Functions:") {
             for part in after_colon.split(',') {
                 let part = part.trim().trim_start_matches(['{', ' ']);
                 if let Some(colon_pos) = part.find(':') {
@@ -811,7 +811,7 @@ impl FlowrGui {
             #[cfg(feature = "debugger")]
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
-            inspect_tab: InspectTab::Function,
+            inspect_tab: InspectTab::State,
             #[cfg(feature = "debugger")]
             show_run_inputs: false,
             #[cfg(feature = "debugger")]
@@ -3060,7 +3060,7 @@ mod test {
             #[cfg(feature = "debugger")]
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
-            inspect_tab: InspectTab::Function,
+            inspect_tab: InspectTab::State,
             #[cfg(feature = "debugger")]
             show_run_inputs: false,
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -78,6 +78,21 @@ mod theme;
 
 /// A clickable link in debug output
 #[cfg(feature = "debugger")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum LinkType {
+    Function,
+    Flow,
+    Job,
+    Input,
+    Output,
+    Route,
+    State,
+    Other,
+}
+
+/// A clickable link in debug output
+#[cfg(feature = "debugger")]
 #[derive(Debug, Clone)]
 pub struct DebugLink {
     /// Byte range in the text
@@ -86,6 +101,8 @@ pub struct DebugLink {
     pub end: usize,
     /// Inspect spec to trigger on click
     pub spec: String,
+    /// Entity type for color coding
+    pub link_type: LinkType,
 }
 
 /// A line of debug output with optional color and clickable links
@@ -155,6 +172,7 @@ impl DebugEventLine {
                     start: abs_pos,
                     end: digit_end,
                     spec: id_str.to_string(),
+                    link_type: LinkType::Function,
                 });
             }
             search_from = digit_end;
@@ -175,6 +193,7 @@ impl DebugEventLine {
                         start: hash_pos,
                         end: digit_end,
                         spec: id_str.to_string(),
+                        link_type: LinkType::Function,
                     });
                 }
             }
@@ -194,6 +213,7 @@ impl DebugEventLine {
                     start: abs_pos,
                     end: digit_end,
                     spec: id_str.to_string(),
+                    link_type: LinkType::Flow,
                 });
             }
             search_from = digit_end;
@@ -223,6 +243,7 @@ impl DebugEventLine {
                         start: abs_pos,
                         end: digit_end,
                         spec: func_id.to_string(),
+                        link_type: LinkType::Job,
                     });
                 }
             }
@@ -244,6 +265,7 @@ impl DebugEventLine {
                         start: abs_pos,
                         end: digit_end,
                         spec: format!("{func_id}:{input_num}"),
+                        link_type: LinkType::Input,
                     });
                 }
             }
@@ -262,6 +284,7 @@ impl DebugEventLine {
                     start: abs_pos,
                     end: output_text_end.min(abs_pos + 20),
                     spec: format!("{func_id}/"),
+                    link_type: LinkType::Output,
                 });
             }
             search_from = output_text_end;
@@ -283,6 +306,7 @@ impl DebugEventLine {
                     start: abs_pos,
                     end: abs_pos + keyword.len(),
                     spec: state_name.to_lowercase(),
+                    link_type: LinkType::State,
                 });
                 kw_from = abs_pos + keyword.len();
             }
@@ -298,6 +322,7 @@ impl DebugEventLine {
                     start: abs_pos,
                     end: abs_pos + end_quote,
                     spec: route.to_string(),
+                    link_type: LinkType::Route,
                 });
                 search_from = abs_pos + end_quote;
             } else {
@@ -316,6 +341,7 @@ impl DebugEventLine {
                     start: pos,
                     end: pos + label.len(),
                     spec: (*spec).to_string(),
+                    link_type: LinkType::Other,
                 });
             }
         }
@@ -332,6 +358,7 @@ impl DebugEventLine {
                                 start: abs_pos,
                                 end: abs_pos + key.len(),
                                 spec: key.to_string(),
+                                link_type: LinkType::Function,
                             });
                         }
                     }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -616,6 +616,20 @@ impl Tab for StdInTab {
 }
 
 #[cfg(feature = "debugger")]
+fn chip_color_for(link_type: crate::LinkType) -> iced::Color {
+    use crate::theme::entity_colors;
+    match link_type {
+        crate::LinkType::Function | crate::LinkType::Route => entity_colors::FUNCTION,
+        crate::LinkType::Flow => entity_colors::FLOW,
+        crate::LinkType::Job => entity_colors::JOB,
+        crate::LinkType::Input => entity_colors::INPUT,
+        crate::LinkType::Output => entity_colors::OUTPUT,
+        crate::LinkType::State => crate::theme::TEXT_SECONDARY,
+        crate::LinkType::Other => crate::theme::TEXT_LINK,
+    }
+}
+
+#[cfg(feature = "debugger")]
 pub(crate) struct DebugTab {
     pub name: String,
     pub id: Id,
@@ -729,7 +743,6 @@ impl Tab for DebugTab {
                         Element::from(t)
                     } else {
                         let base_color = line.color;
-                        let link_color = crate::theme::TEXT_LINK;
                         let mut spans: Vec<iced::widget::text::Span<'_, String>> = Vec::new();
                         let mut pos = 0;
                         for link in &line.links {
@@ -741,12 +754,26 @@ impl Tab for DebugTab {
                                 }
                                 spans.push(s);
                             }
+                            let chip_color = chip_color_for(link.link_type);
+                            spans.push(iced::widget::span(" ".to_string()));
                             spans.push(
-                                iced::widget::span(line.text[link.start..link.end].to_string())
-                                    .color(link_color)
-                                    .underline(true)
-                                    .link(link.spec.clone()),
+                                iced::widget::span(format!(
+                                    " {} ",
+                                    &line.text[link.start..link.end]
+                                ))
+                                .color(iced::Color::WHITE)
+                                .background(iced::Background::Color(iced::Color {
+                                    a: 0.4,
+                                    ..chip_color
+                                }))
+                                .border(iced::Border {
+                                    radius: 8.0.into(),
+                                    ..Default::default()
+                                })
+                                .padding([2, 4])
+                                .link(link.spec.clone()),
                             );
+                            spans.push(iced::widget::span(" ".to_string()));
                             pos = link.end;
                         }
                         if pos < line.text.len() {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -716,7 +716,7 @@ impl Tab for DebugTab {
                                 .shaping(iced::widget::text::Shaping::Advanced),
                         )
                         .on_press(Message::DebugToggleSection(section_id))
-                        .style(crate::theme::list_button)
+                        .style(crate::theme::ghost_button)
                         .padding([2, 6]);
                         let rule_left = iced::widget::rule::horizontal(1);
                         let rule_right = iced::widget::rule::horizontal(1);
@@ -767,10 +767,10 @@ impl Tab for DebugTab {
                                     ..chip_color
                                 }))
                                 .border(iced::Border {
-                                    radius: 8.0.into(),
+                                    radius: 99.0.into(),
                                     ..Default::default()
                                 })
-                                .padding([2, 4])
+                                .padding([2, 6])
                                 .link(link.spec.clone()),
                             );
                             spans.push(iced::widget::span(" ".to_string()));
@@ -790,6 +790,7 @@ impl Tab for DebugTab {
                 }),
         )
         .width(Length::Fill)
+        .spacing(6)
         .padding(1);
 
         let scrollable = Scrollable::new(text_column)

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -59,33 +59,33 @@ pub mod entity_colors {
     use iced::Color;
 
     pub const FUNCTION: Color = Color {
-        r: 0.3,
-        g: 0.6,
+        r: 0.2,
+        g: 0.55,
         b: 1.0,
         a: 1.0,
     };
     pub const FLOW: Color = Color {
-        r: 0.6,
-        g: 0.4,
-        b: 0.9,
+        r: 0.65,
+        g: 0.35,
+        b: 1.0,
         a: 1.0,
     };
     pub const JOB: Color = Color {
-        r: 0.4,
-        g: 0.8,
-        b: 0.4,
+        r: 0.2,
+        g: 0.85,
+        b: 0.35,
         a: 1.0,
     };
     pub const INPUT: Color = Color {
-        r: 0.9,
-        g: 0.6,
-        b: 0.3,
+        r: 1.0,
+        g: 0.55,
+        b: 0.15,
         a: 1.0,
     };
     pub const OUTPUT: Color = Color {
-        r: 0.3,
-        g: 0.8,
-        b: 0.7,
+        r: 0.1,
+        g: 0.85,
+        b: 0.75,
         a: 1.0,
     };
 }

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -259,6 +259,22 @@ pub fn pill_button_active(theme: &Theme, status: button::Status) -> button::Styl
     }
 }
 
+pub fn ghost_button(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.palette();
+    match status {
+        button::Status::Hovered => button::Style {
+            background: None,
+            text_color: ACCENT,
+            ..button::Style::default()
+        },
+        _ => button::Style {
+            background: None,
+            text_color: palette.text,
+            ..button::Style::default()
+        },
+    }
+}
+
 pub(crate) fn list_button(theme: &Theme, status: button::Status) -> button::Style {
     let palette = theme.palette();
     match status {

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -785,7 +785,7 @@ impl fmt::Display for RunState {
                 .collect::<Vec<usize>>()
         )?;
         writeln!(f, "   Functions Completed: {:?}", self.completed)?;
-        write!(f, "            Busy Count: {:?}", self.busy_count)
+        write!(f, "            Busy Functions: {:?}", self.busy_count)
     }
 }
 


### PR DESCRIPTION
## Summary

Third batch of the comprehensive visual review (#2767):

- **Chip-style links** — debug output links rendered as colored pill badges with entity-type colors (Function=blue, Flow=purple, Job=green, Input=orange, Output=teal)
- **LinkType enum** — all DebugLinks tagged with entity type for consistent color coding
- **Ghost button** — collapse triangles use accent-on-hover with no background change  
- **Line spacing** — debug output lines spaced 6px apart to prevent chip overlap
- **Vivid entity colors** — more saturated colors in design system
- **Inspect popup** defaults to State tab
- **"Busy Count"** renamed to **"Busy Functions"**

## Test plan
- [ ] `make clippy` passes
- [ ] Chip-style links render in debug output with correct entity colors
- [ ] Collapse triangles show lilac on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Debug links are now categorized by type for improved organization and clarity.

* **UI Improvements**
  * Debug links now display as colored chips instead of underlined text for better visual distinction.
  * Updated entity color palette for improved visual consistency.
  * Enhanced button styling with a new ghost button design.
  * Inspect popup now defaults to the State tab view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->