### PR TITLE
Add Flow tab to Inspect dialog (#2776)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -758,6 +758,7 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                     route: f.route().to_string(),
                                     inputs,
                                     outputs,
+                                    is_flow: false,
                                 }
                             })
                             .collect();

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -699,6 +699,8 @@ pub struct CachedFunction {
     pub inputs: Vec<(usize, String, bool)>,
     /// Output routes
     pub outputs: Vec<String>,
+    /// Whether this is a flow (not a leaf function)
+    pub is_flow: bool,
 }
 
 /// Tabs in the breakpoint popup
@@ -747,6 +749,8 @@ pub enum InspectTab {
     State,
     /// Inspect a function
     Function,
+    /// Inspect a flow
+    Flow,
     /// Inspect an input
     Input,
     /// Inspect an output
@@ -761,6 +765,7 @@ impl std::fmt::Display for InspectTab {
         match self {
             Self::State => write!(f, "State"),
             Self::Function => write!(f, "Function"),
+            Self::Flow => write!(f, "Flow"),
             Self::Input => write!(f, "Input"),
             Self::Output => write!(f, "Output"),
             Self::Route => write!(f, "Route"),
@@ -769,9 +774,10 @@ impl std::fmt::Display for InspectTab {
 }
 
 #[cfg(feature = "debugger")]
-const INSPECT_TABS: [InspectTab; 5] = [
+const INSPECT_TABS: [InspectTab; 6] = [
     InspectTab::State,
     InspectTab::Function,
+    InspectTab::Flow,
     InspectTab::Input,
     InspectTab::Output,
     InspectTab::Route,
@@ -1957,6 +1963,18 @@ impl FlowrGui {
                 for f in &self.cached_functions {
                     let btn = Button::new(
                         Text::new(format!("#{} '{}' @ '{}'", f.id, f.name, f.route)).size(13),
+                    )
+                    .width(Length::Fill)
+                    .padding([3, 8])
+                    .style(theme::list_button)
+                    .on_press(Message::InspectPopupSelect(format!("{}", f.id)));
+                    items = items.push(btn);
+                }
+            }
+            InspectTab::Flow => {
+                for f in &self.cached_functions {
+                    let btn = Button::new(
+                        Text::new(format!("#{} '{}' @ {}", f.id, f.name, f.route)).size(13),
                     )
                     .width(Length::Fill)
                     .padding([3, 8])


### PR DESCRIPTION
## Summary

Add a Flow tab to the Inspect popup for browsing and inspecting flows.

- New `InspectTab::Flow` variant
- Flow tab lists all processes — clicking sends InspectFunction which
  delegates to inspect_flow for actual flows
- `is_flow` field added to CachedFunction (foundation for future filtering)

Verified locally: `make clippy` ✅, `make features` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Flow tab to the debugger inspect interface, allowing users to view and inspect flow entities with dedicated flow-specific formatting and labels for improved debugging organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->