### PR TITLE
Add Flow tab to inspect dialog, review type display (#2776)

### DIFF
--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -80,6 +80,10 @@ fn emit_flow_hierarchy(
         process_id: flow.id,
         parent_id,
         sub_flow_ids,
+        #[cfg(feature = "debugger")]
+        name: flow.name.clone(),
+        #[cfg(feature = "debugger")]
+        route: flow.route.to_string(),
     });
 }
 

--- a/flowcore/src/model/debug_command.rs
+++ b/flowcore/src/model/debug_command.rs
@@ -51,6 +51,8 @@ pub enum DebugCommand {
     FunctionList,
     /// `inspect` a function
     InspectFunction(usize),
+    /// Inspect a job by `job_id`
+    InspectJob(usize),
     /// Inspect overall state
     Inspect,
     /// Inspect an Input (`function_id`, `input_number`)

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -40,6 +40,14 @@ pub struct FlowInfo {
     pub parent_id: Option<usize>,
     /// IDs of direct child sub-flows
     pub sub_flow_ids: Vec<usize>,
+    #[cfg(feature = "debugger")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// The name of this flow (for debugging display)
+    pub name: String,
+    #[cfg(feature = "debugger")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// The route of this flow (for debugging display)
+    pub route: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -643,6 +643,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             format_inspect_by_state(state_name, state)
         }
         DebugServerMessage::InspectFlow(flow_id, ref state) => format_inspect_flow(*flow_id, state),
+        DebugServerMessage::JobInspect(ref job) => format_inspect_job(job),
         DebugServerMessage::Invalid => line(
             "Invalid message from debug server".into(),
             Some(debug_colors::ERROR),
@@ -1107,8 +1108,8 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
         sorted_running.sort_by_key(|(id, _)| *id);
         for (job_id, job) in &sorted_running {
             b = b.text(" ").chip(
-                &format!("Job #{job_id}"),
-                &job.process_id.to_string(),
+                &format!("Job #{job_id} ({})", job.function_name),
+                &format!("job:{job_id}"),
                 LinkType::Job,
             );
         }
@@ -1124,8 +1125,8 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
     );
     for job in ready {
         b = b.text(" ").chip(
-            &format!("Job #{}", job.payload.job_id),
-            &job.process_id.to_string(),
+            &format!("Job #{} ({})", job.payload.job_id, job.function_name),
+            &format!("job:{}", job.payload.job_id),
             LinkType::Job,
         );
     }
@@ -1260,6 +1261,60 @@ fn format_inspect_by_state(
             lines.push(DebugEventLine::new("  (none)".into(), None));
         }
     }
+    lines
+}
+
+#[cfg(feature = "debugger")]
+#[cfg(feature = "debugger")]
+fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventLine> {
+    use crate::{DebugLineBuilder, LinkType};
+
+    let mut lines = Vec::new();
+
+    lines.push(
+        DebugLineBuilder::new()
+            .chip(
+                &format!("job #{}", job.payload.job_id),
+                &format!("job:{}", job.payload.job_id),
+                LinkType::Job,
+            )
+            .finish(),
+    );
+
+    lines.push(
+        DebugLineBuilder::new()
+            .text("  Function: ")
+            .chip(
+                &format!("function #{} '{}'", job.process_id, job.function_name),
+                &job.process_id.to_string(),
+                LinkType::Function,
+            )
+            .finish(),
+    );
+
+    lines.push(
+        DebugLineBuilder::new()
+            .text("  Parent: ")
+            .chip(
+                &format!("flow #{}", job.parent_id),
+                &job.parent_id.to_string(),
+                LinkType::Flow,
+            )
+            .finish(),
+    );
+
+    lines.push(crate::DebugEventLine::new(
+        format!("  Inputs: {:?}", job.payload.input_set),
+        None,
+    ));
+
+    if !job.connections.is_empty() {
+        lines.push(crate::DebugEventLine::new(
+            format!("  Connections: {}", job.connections.len()),
+            None,
+        ));
+    }
+
     lines
 }
 

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -648,6 +648,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             "Invalid message from debug server".into(),
             Some(debug_colors::ERROR),
         ),
+        DebugServerMessage::FlowList(_) => vec![],
         DebugServerMessage::BreakpointList(specs) => {
             if specs.is_empty() {
                 line("No breakpoints set".into(), None)
@@ -765,6 +766,21 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                             .collect();
                         let _ =
                             blocking_sender.try_send(Message::DebugFunctionListReceived(func_data));
+                    }
+
+                    if let DebugServerMessage::FlowList(ref flows) = message {
+                        let flow_data: Vec<crate::CachedFunction> = flows
+                            .iter()
+                            .map(|(id, name, route)| crate::CachedFunction {
+                                id: *id,
+                                name: name.clone(),
+                                route: route.clone(),
+                                inputs: Vec::new(),
+                                outputs: Vec::new(),
+                                is_flow: true,
+                            })
+                            .collect();
+                        let _ = blocking_sender.try_send(Message::DebugFlowsReceived(flow_data));
                     }
 
                     if let DebugServerMessage::BreakpointList(ref specs) = message {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -977,7 +977,6 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
     ) {
         use crate::TreeSegment;
         let manifest = &run_state.get_submission().manifest;
-        let functions = run_state.get_functions();
 
         // Build this node's prefix: ancestors + own connector
         let mut prefix: Vec<TreeSegment> = ancestors.to_vec();
@@ -986,8 +985,17 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
         }
 
         // Emit the flow node — collapsible only if it has a connector (not root)
-        let mut flow_line = if let Some(func) = functions.get(&flow_id) {
-            entity_line(func, "", crate::LinkType::Flow, "")
+        let mut flow_line = if let Some(fi) = manifest.flows().get(&flow_id) {
+            let mut b = crate::DebugLineBuilder::new().chip(
+                &format!("flow #{flow_id}"),
+                &flow_id.to_string(),
+                crate::LinkType::Flow,
+            );
+            if !fi.name.is_empty() {
+                b = b.text(&format!(" '{}' @ ", fi.name));
+                b = b.chip(&fi.route, &fi.route, crate::LinkType::Route);
+            }
+            b.finish()
         } else {
             crate::DebugLineBuilder::new()
                 .chip(
@@ -1367,19 +1375,18 @@ fn format_inspect_flow(
     let functions = run_state.get_functions();
     let manifest = &run_state.get_submission().manifest;
 
-    if let Some(func) = functions.get(&flow_id) {
-        lines.push(entity_line(func, "", LinkType::Flow, ""));
-    } else {
-        lines.push(
-            DebugLineBuilder::new()
-                .chip(
-                    &format!("flow #{flow_id}"),
-                    &flow_id.to_string(),
-                    LinkType::Flow,
-                )
-                .finish(),
-        );
+    let mut b = DebugLineBuilder::new().chip(
+        &format!("flow #{flow_id}"),
+        &flow_id.to_string(),
+        LinkType::Flow,
+    );
+    if let Some(fi) = manifest.flows().get(&flow_id) {
+        if !fi.name.is_empty() {
+            b = b.text(&format!(" '{}' @ ", fi.name));
+            b = b.chip(&fi.route, &fi.route, LinkType::Route);
+        }
     }
+    lines.push(b.finish());
 
     if let Some(flow_info) = manifest.flows().get(&flow_id) {
         if let Some(parent) = flow_info.parent_id {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1310,9 +1310,31 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
 
     if !job.connections.is_empty() {
         lines.push(crate::DebugEventLine::new(
-            format!("  Connections: {}", job.connections.len()),
+            format!("  Connections ({}):", job.connections.len()),
             None,
         ));
+        for conn in &job.connections {
+            let source_label = match &conn.source {
+                flowcore::model::output_connection::Source::Output(route) => {
+                    format!("output {route}")
+                }
+                flowcore::model::output_connection::Source::Input(n) => format!("input #{n}"),
+            };
+            let mut b = DebugLineBuilder::new()
+                .text(&format!("    {source_label} \u{2192} "))
+                .chip(
+                    &format!("function #{}", conn.destination_id),
+                    &conn.destination_id.to_string(),
+                    LinkType::Function,
+                );
+            if !conn.destination.is_empty() {
+                b = b
+                    .text(" @ ")
+                    .chip(&conn.destination, &conn.destination, LinkType::Route);
+            }
+            b = b.text(&format!(" input:{}", conn.destination_io_number));
+            lines.push(b.finish());
+        }
     }
 
     lines

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -804,16 +804,30 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                     | DebugServerMessage::InspectFlow(_, ref state)
                     | DebugServerMessage::OverallState(ref state) = message
                     {
-                        let flow_ids: Vec<usize> = state
+                        let functions = state.get_functions();
+                        let flows: Vec<crate::CachedFunction> = state
                             .get_submission()
                             .manifest
                             .flows()
                             .keys()
-                            .copied()
+                            .map(|id| {
+                                let (name, route) = if let Some(f) = functions.get(id) {
+                                    (f.name().to_string(), f.route().to_string())
+                                } else {
+                                    (format!("flow_{id}"), format!("/flow/{id}"))
+                                };
+                                crate::CachedFunction {
+                                    id: *id,
+                                    name,
+                                    route,
+                                    inputs: Vec::new(),
+                                    outputs: Vec::new(),
+                                    is_flow: true,
+                                }
+                            })
                             .collect();
-                        if !flow_ids.is_empty() {
-                            let _ =
-                                blocking_sender.try_send(Message::DebugFlowIdsReceived(flow_ids));
+                        if !flows.is_empty() {
+                            let _ = blocking_sender.try_send(Message::DebugFlowsReceived(flows));
                         }
                     }
 

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -799,6 +799,24 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                             .try_send(Message::DebugBreakpointListReceived(spec_strings));
                     }
 
+                    if let DebugServerMessage::ProcessTree(ref state)
+                    | DebugServerMessage::InspectByState(_, ref state)
+                    | DebugServerMessage::InspectFlow(_, ref state)
+                    | DebugServerMessage::OverallState(ref state) = message
+                    {
+                        let flow_ids: Vec<usize> = state
+                            .get_submission()
+                            .manifest
+                            .flows()
+                            .keys()
+                            .copied()
+                            .collect();
+                        if !flow_ids.is_empty() {
+                            let _ =
+                                blocking_sender.try_send(Message::DebugFlowIdsReceived(flow_ids));
+                        }
+                    }
+
                     if !is_waiting {
                         let _ = blocking_sender
                             .try_send(Message::DebugEvent(format_debug_event(&message)));

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -814,7 +814,7 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                 let (name, route) = if let Some(f) = functions.get(id) {
                                     (f.name().to_string(), f.route().to_string())
                                 } else {
-                                    (format!("flow_{id}"), format!("/flow/{id}"))
+                                    (String::new(), String::new())
                                 };
                                 crate::CachedFunction {
                                     id: *id,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2450,7 +2450,7 @@ impl FlowrGui {
     #[cfg(feature = "debugger")]
     #[cfg(feature = "debugger")]
     fn ensure_functions_cached(&mut self, action: Message) -> bool {
-        if self.cached_functions.is_empty() {
+        if self.cached_functions.iter().all(|f| f.is_flow) {
             self.pending_action = Some(action);
             self.suppress_next_output = true;
             connection_manager::send_debug_command(

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2728,7 +2728,18 @@ impl FlowrGui {
                 connection_manager::send_debug_command(DebugCommand::Validate);
             }
             Message::DebugFunctionListReceived(functions) => {
+                let flows: Vec<_> = self
+                    .cached_functions
+                    .drain(..)
+                    .filter(|f| f.is_flow)
+                    .collect();
                 self.cached_functions = functions;
+                for flow in flows {
+                    if !self.cached_functions.iter().any(|f| f.id == flow.id) {
+                        self.cached_functions.push(flow);
+                    }
+                }
+                self.cached_functions.sort_by_key(|f| f.id);
                 if let Some(action) = self.pending_action.take() {
                     return self.process_debug_message(action);
                 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2746,23 +2746,32 @@ impl FlowrGui {
             }
             Message::DebugInspectLink(ref spec) => {
                 self.debug_waiting = false;
-                let label = if spec.parse::<usize>().is_ok() {
-                    format!("Inspect #{spec}")
-                } else if spec.contains(':') {
-                    format!("Inspect Input ({spec})")
-                } else if spec.starts_with('/') {
-                    format!("Inspect Route ({spec})")
-                } else if spec.contains('/') {
-                    format!("Inspect Output ({spec})")
+                if let Some(job_id_str) = spec.strip_prefix("job:") {
+                    if let Ok(job_id) = job_id_str.parse::<usize>() {
+                        self.debug_separator(&format!("Inspect Job #{job_id}"));
+                        connection_manager::send_debug_command(
+                            flowcore::model::debug_command::DebugCommand::InspectJob(job_id),
+                        );
+                    }
                 } else {
-                    format!("Inspect {spec}")
-                };
-                let params = Some(vec![spec.clone()]);
-                if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
-                    self.debug_separator(&label);
-                    connection_manager::send_debug_command(cmd);
-                } else {
-                    self.debug_waiting = true;
+                    let label = if spec.parse::<usize>().is_ok() {
+                        format!("Inspect #{spec}")
+                    } else if spec.contains(':') {
+                        format!("Inspect Input ({spec})")
+                    } else if spec.starts_with('/') {
+                        format!("Inspect Route ({spec})")
+                    } else if spec.contains('/') {
+                        format!("Inspect Output ({spec})")
+                    } else {
+                        format!("Inspect {spec}")
+                    };
+                    let params = Some(vec![spec.clone()]);
+                    if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
+                        self.debug_separator(&label);
+                        connection_manager::send_debug_command(cmd);
+                    } else {
+                        self.debug_waiting = true;
+                    }
                 }
             }
             Message::DebugToggleSection(section_id) => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2740,10 +2740,6 @@ impl FlowrGui {
                     }
                 }
                 self.cached_functions.sort_by_key(|f| f.id);
-                if !self.cached_functions.iter().any(|f| f.is_flow) {
-                    self.suppress_next_output = true;
-                    connection_manager::send_debug_command(DebugCommand::ProcessList);
-                }
                 if let Some(action) = self.pending_action.take() {
                     return self.process_debug_message(action);
                 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2013,13 +2013,16 @@ impl FlowrGui {
             }
             InspectTab::Flow => {
                 for f in self.cached_functions.iter().filter(|f| f.is_flow) {
-                    let btn = Button::new(
-                        Text::new(format!("Flow #{} '{}' @ {}", f.id, f.name, f.route)).size(13),
-                    )
-                    .width(Length::Fill)
-                    .padding([3, 8])
-                    .style(theme::list_button)
-                    .on_press(Message::InspectPopupSelect(format!("{}", f.id)));
+                    let label = if f.name.is_empty() {
+                        format!("Flow #{}", f.id)
+                    } else {
+                        format!("Flow #{} '{}' @ {}", f.id, f.name, f.route)
+                    };
+                    let btn = Button::new(Text::new(label).size(13))
+                        .width(Length::Fill)
+                        .padding([3, 8])
+                        .style(theme::list_button)
+                        .on_press(Message::InspectPopupSelect(format!("{}", f.id)));
                     items = items.push(btn);
                 }
             }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2740,6 +2740,10 @@ impl FlowrGui {
                     }
                 }
                 self.cached_functions.sort_by_key(|f| f.id);
+                if !self.cached_functions.iter().any(|f| f.is_flow) {
+                    self.suppress_next_output = true;
+                    connection_manager::send_debug_command(DebugCommand::ProcessList);
+                }
                 if let Some(action) = self.pending_action.take() {
                     return self.process_debug_message(action);
                 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -604,8 +604,8 @@ pub enum Message {
     /// Function list received from debug server
     #[cfg(feature = "debugger")]
     DebugFunctionListReceived(Vec<CachedFunction>),
-    /// Flow IDs received from a RunState-carrying message
-    DebugFlowIdsReceived(Vec<usize>),
+    /// Flow entries received from a RunState-carrying message
+    DebugFlowsReceived(Vec<CachedFunction>),
     /// Breakpoint list received from debug server
     #[cfg(feature = "debugger")]
     DebugBreakpointListReceived(Vec<String>),
@@ -1150,7 +1150,7 @@ impl FlowrGui {
             | Message::BpPopupConfirm
             | Message::BpCycleFunction(_)
             | Message::DebugFunctionListReceived(_)
-            | Message::DebugFlowIdsReceived(_)
+            | Message::DebugFlowsReceived(_)
             | Message::DebugBreakpointListReceived(_)
             | Message::DebugInspectLink(_)
             | Message::DebugToggleSection(_)
@@ -2730,12 +2730,13 @@ impl FlowrGui {
                     return self.process_debug_message(action);
                 }
             }
-            Message::DebugFlowIdsReceived(flow_ids) => {
-                for f in &mut self.cached_functions {
-                    if flow_ids.contains(&f.id) {
-                        f.is_flow = true;
+            Message::DebugFlowsReceived(flows) => {
+                for flow in flows {
+                    if !self.cached_functions.iter().any(|f| f.id == flow.id) {
+                        self.cached_functions.push(flow);
                     }
                 }
+                self.cached_functions.sort_by_key(|f| f.id);
             }
             Message::DebugBreakpointListReceived(specs) => {
                 self.active_breakpoints = specs.into_iter().collect();

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -605,6 +605,7 @@ pub enum Message {
     #[cfg(feature = "debugger")]
     DebugFunctionListReceived(Vec<CachedFunction>),
     /// Flow entries received from a RunState-carrying message
+    #[cfg(feature = "debugger")]
     DebugFlowsReceived(Vec<CachedFunction>),
     /// Breakpoint list received from debug server
     #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -604,6 +604,8 @@ pub enum Message {
     /// Function list received from debug server
     #[cfg(feature = "debugger")]
     DebugFunctionListReceived(Vec<CachedFunction>),
+    /// Flow IDs received from a RunState-carrying message
+    DebugFlowIdsReceived(Vec<usize>),
     /// Breakpoint list received from debug server
     #[cfg(feature = "debugger")]
     DebugBreakpointListReceived(Vec<String>),
@@ -1148,6 +1150,7 @@ impl FlowrGui {
             | Message::BpPopupConfirm
             | Message::BpCycleFunction(_)
             | Message::DebugFunctionListReceived(_)
+            | Message::DebugFlowIdsReceived(_)
             | Message::DebugBreakpointListReceived(_)
             | Message::DebugInspectLink(_)
             | Message::DebugToggleSection(_)
@@ -1997,7 +2000,7 @@ impl FlowrGui {
                 }
             }
             InspectTab::Function => {
-                for f in &self.cached_functions {
+                for f in self.cached_functions.iter().filter(|f| !f.is_flow) {
                     let btn = Button::new(
                         Text::new(format!("#{} '{}' @ '{}'", f.id, f.name, f.route)).size(13),
                     )
@@ -2009,9 +2012,9 @@ impl FlowrGui {
                 }
             }
             InspectTab::Flow => {
-                for f in &self.cached_functions {
+                for f in self.cached_functions.iter().filter(|f| f.is_flow) {
                     let btn = Button::new(
-                        Text::new(format!("#{} '{}' @ {}", f.id, f.name, f.route)).size(13),
+                        Text::new(format!("Flow #{} '{}' @ {}", f.id, f.name, f.route)).size(13),
                     )
                     .width(Length::Fill)
                     .padding([3, 8])
@@ -2725,6 +2728,13 @@ impl FlowrGui {
                 self.cached_functions = functions;
                 if let Some(action) = self.pending_action.take() {
                     return self.process_debug_message(action);
+                }
+            }
+            Message::DebugFlowIdsReceived(flow_ids) => {
+                for f in &mut self.cached_functions {
+                    if flow_ids.contains(&f.id) {
+                        f.is_flow = true;
+                    }
                 }
             }
             Message::DebugBreakpointListReceived(specs) => {

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -457,6 +457,7 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> flowcore::errors::Result<DebugCommand> {
             Ok(DebugCommand::Continue)
         }

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -456,6 +456,7 @@ mod test {
         fn process_tree(&mut self, _: &RunState) {}
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
+        fn job_inspect(&mut self, _: Job) {}
         fn get_command(&mut self, _state: &RunState) -> flowcore::errors::Result<DebugCommand> {
             Ok(DebugCommand::Continue)
         }

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -395,6 +395,7 @@ impl DebugClient {
             DebugServerMessage::InspectFlow(flow_id, ref state) => {
                 println!("{}", Debugger::inspect_flow(state, flow_id));
             }
+            DebugServerMessage::FlowList(_) => {}
             DebugServerMessage::JobInspect(ref job) => {
                 println!("Job #{}", job.payload.job_id);
                 println!("  Function: #{} '{}'", job.process_id, job.function_name);

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -395,6 +395,13 @@ impl DebugClient {
             DebugServerMessage::InspectFlow(flow_id, ref state) => {
                 println!("{}", Debugger::inspect_flow(state, flow_id));
             }
+            DebugServerMessage::JobInspect(ref job) => {
+                println!("Job #{}", job.payload.job_id);
+                println!("  Function: #{} '{}'", job.process_id, job.function_name);
+                println!("  Parent Flow: #{}", job.parent_id);
+                println!("  Inputs: {:?}", job.payload.input_set);
+                println!("  Connections: {}", job.connections.len());
+            }
         }
 
         Ok(Ack)

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -140,6 +140,21 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::JobInspect(job));
     }
 
+    fn flow_list(&mut self, flow_ids: &[usize], state: &RunState) {
+        let functions = state.get_functions();
+        let flows: Vec<(usize, String, String)> = flow_ids
+            .iter()
+            .map(|id| {
+                if let Some(f) = functions.get(id) {
+                    (*id, f.name().to_string(), f.route().to_string())
+                } else {
+                    (*id, String::new(), String::new())
+                }
+            })
+            .collect();
+        self.send_event(DebugServerMessage::FlowList(flows));
+    }
+
     fn panic(&mut self, state: &RunState, error_message: String) {
         self.send_event(DebugServerMessage::Panic(
             error_message,

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -140,17 +140,12 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::JobInspect(job));
     }
 
-    fn flow_list(&mut self, flow_ids: &[usize], state: &RunState) {
-        let functions = state.get_functions();
-        let flows: Vec<(usize, String, String)> = flow_ids
-            .iter()
-            .map(|id| {
-                if let Some(f) = functions.get(id) {
-                    (*id, f.name().to_string(), f.route().to_string())
-                } else {
-                    (*id, String::new(), String::new())
-                }
-            })
+    fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
+        let manifest = &state.get_submission().manifest;
+        let flows: Vec<(usize, String, String)> = manifest
+            .flows()
+            .values()
+            .map(|fi| (fi.process_id, fi.name.clone(), fi.route.clone()))
             .collect();
         self.send_event(DebugServerMessage::FlowList(flows));
     }

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -136,6 +136,10 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::InspectFlow(flow_id, state.clone()));
     }
 
+    fn job_inspect(&mut self, job: Job) {
+        self.send_event(DebugServerMessage::JobInspect(job));
+    }
+
     fn panic(&mut self, state: &RunState, error_message: String) {
         self.send_event(DebugServerMessage::Panic(
             error_message,

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -62,6 +62,8 @@ pub enum DebugServerMessage {
     InspectByState(String, RunState),
     /// Inspect a flow — carries flow ID and `RunState`
     InspectFlow(usize, RunState),
+    /// Inspect a job — carries the Job
+    JobInspect(Job),
     /// The list of active breakpoints
     BreakpointList(Vec<BreakpointSpec>),
     /// The run-time is resetting the status back to the initial state
@@ -104,6 +106,7 @@ impl fmt::Display for DebugServerMessage {
                 DebugServerMessage::ProcessTree(_) => "ProcessTree",
                 DebugServerMessage::InspectByState(_, _) => "InspectByState",
                 DebugServerMessage::InspectFlow(_, _) => "InspectFlow",
+                DebugServerMessage::JobInspect(_) => "JobInspect",
             }
         )
     }

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -64,6 +64,8 @@ pub enum DebugServerMessage {
     InspectFlow(usize, RunState),
     /// Inspect a job — carries the Job
     JobInspect(Job),
+    /// List of flows with names and routes
+    FlowList(Vec<(usize, String, String)>),
     /// The list of active breakpoints
     BreakpointList(Vec<BreakpointSpec>),
     /// The run-time is resetting the status back to the initial state
@@ -107,6 +109,7 @@ impl fmt::Display for DebugServerMessage {
                 DebugServerMessage::InspectByState(_, _) => "InspectByState",
                 DebugServerMessage::InspectFlow(_, _) => "InspectFlow",
                 DebugServerMessage::JobInspect(_) => "JobInspect",
+                DebugServerMessage::FlowList(_) => "FlowList",
             }
         )
     }

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -106,17 +106,12 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(Functions(functions.to_vec()));
     }
 
-    fn flow_list(&mut self, flow_ids: &[usize], state: &RunState) {
-        let functions = state.get_functions();
-        let flows: Vec<(usize, String, String)> = flow_ids
-            .iter()
-            .map(|id| {
-                if let Some(f) = functions.get(id) {
-                    (*id, f.name().to_string(), f.route().to_string())
-                } else {
-                    (*id, String::new(), String::new())
-                }
-            })
+    fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
+        let manifest = &state.get_submission().manifest;
+        let flows: Vec<(usize, String, String)> = manifest
+            .flows()
+            .values()
+            .map(|fi| (fi.process_id, fi.name.clone(), fi.route.clone()))
             .collect();
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -149,6 +149,12 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(DebugServerMessage::InspectFlow(flow_id, state.clone()));
     }
 
+    fn job_inspect(&mut self, job: Job) {
+        let _: flowcore::errors::Result<DebugCommand> = self
+            .debug_server_connection
+            .send_and_receive_response(DebugServerMessage::JobInspect(job));
+    }
+
     fn panic(&mut self, state: &RunState, error_message: String) {
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -106,6 +106,23 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(Functions(functions.to_vec()));
     }
 
+    fn flow_list(&mut self, flow_ids: &[usize], state: &RunState) {
+        let functions = state.get_functions();
+        let flows: Vec<(usize, String, String)> = flow_ids
+            .iter()
+            .map(|id| {
+                if let Some(f) = functions.get(id) {
+                    (*id, f.name().to_string(), f.route().to_string())
+                } else {
+                    (*id, String::new(), String::new())
+                }
+            })
+            .collect();
+        let _: flowcore::errors::Result<DebugCommand> = self
+            .debug_server_connection
+            .send_and_receive_response(DebugServerMessage::FlowList(flows));
+    }
+
     fn function_states(&mut self, function: RuntimeFunction, function_states: Vec<State>) {
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -13,7 +13,8 @@ use crate::debug_command::BreakpointSpec;
 use crate::debug_command::DebugCommand;
 use crate::debug_command::DebugCommand::{
     Ack, Breakpoint, Continue, DebugClientStarting, Delete, Error, ExitDebugger, Inspect,
-    InspectFunction, InspectInput, InspectOutput, Invalid, List, Modify, RunReset, Step, Validate,
+    InspectFunction, InspectInput, InspectJob, InspectOutput, Invalid, List, Modify, RunReset,
+    Step, Validate,
 };
 use crate::debug_command::ProcessTarget;
 use crate::debugger_handler::DebuggerHandler;
@@ -252,6 +253,20 @@ impl<'a> Debugger<'a> {
                         self.debug_server.debugger_error(format!(
                             "No function or flow found at route '{route}'"
                         ));
+                    }
+                }
+                Ok(InspectJob(job_id)) => {
+                    if let Some(job) = state.get_running().get(&job_id) {
+                        self.debug_server.job_inspect(job.clone());
+                    } else if let Some(job) = state
+                        .get_ready_jobs()
+                        .iter()
+                        .find(|j| j.payload.job_id == job_id)
+                    {
+                        self.debug_server.job_inspect(job.clone());
+                    } else {
+                        self.debug_server
+                            .debugger_error(format!("No job with id = {job_id}"));
                     }
                 }
                 Ok(InspectFunction(function_id)) => {
@@ -1130,6 +1145,7 @@ mod test {
         fn process_tree(&mut self, _: &RunState) {}
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
+        fn job_inspect(&mut self, _: Job) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             Ok(DebugCommand::Step(None))
         }

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -228,6 +228,9 @@ impl<'a> Debugger<'a> {
                         state.get_functions().values().cloned().collect();
                     functions.sort_by_key(RuntimeFunction::id);
                     self.debug_server.function_list(&functions);
+                    let flow_ids: Vec<usize> =
+                        state.submission.manifest.flows().keys().copied().collect();
+                    self.debug_server.flow_list(&flow_ids, state);
                 }
                 Ok(DebugCommand::ProcessList) => {
                     self.debug_server.process_tree(state);
@@ -1146,6 +1149,7 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             Ok(DebugCommand::Step(None))
         }

--- a/flowr/src/lib/debugger_handler.rs
+++ b/flowr/src/lib/debugger_handler.rs
@@ -72,6 +72,8 @@ pub trait DebuggerHandler {
     fn inspect_by_state(&mut self, state_name: &str, state: &RunState);
     /// Inspect a flow — structured data for rendering
     fn inspect_flow(&mut self, flow_id: usize, state: &RunState);
+    /// Inspect a job — structured data for rendering
+    fn job_inspect(&mut self, job: Job);
     /// Get a command for the debugger to perform
     ///
     /// # Errors

--- a/flowr/src/lib/debugger_handler.rs
+++ b/flowr/src/lib/debugger_handler.rs
@@ -46,6 +46,8 @@ pub trait DebuggerHandler {
     fn input(&mut self, input: Input);
     /// lists all functions
     fn function_list(&mut self, functions: &[RuntimeFunction]);
+    /// Lists flow IDs with access to `RunState` for names/routes
+    fn flow_list(&mut self, flow_ids: &[usize], state: &RunState);
     /// returns the state of a function
     fn function_states(&mut self, function: RuntimeFunction, function_states: Vec<State>);
     /// returns the global run state

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1020,6 +1020,7 @@ mod test {
         fn process_tree(&mut self, _: &RunState) {}
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
+        fn job_inspect(&mut self, _: Job) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             unimplemented!();
         }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1021,6 +1021,7 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             unimplemented!();
         }


### PR DESCRIPTION
## Summary
- Filter inspect dialog: Flow tab shows only flows, Function tab excludes flows
- Extract flow IDs from ProcessTree/RunState messages to set `is_flow` on cached functions
- Flow tab entries prefixed with "Flow #" for clarity

## Test plan
- [ ] Open inspect dialog, verify Flow tab shows only flow entries
- [ ] Verify Function tab no longer shows flow entries
- [ ] Click a flow in the Flow tab, verify it triggers flow inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job inspection capability to the debugger, allowing users to request detailed information about specific jobs during execution.
  * Enhanced debugger GUI to display detailed job information including associated functions, parent flows, input sets, and connections.
  * Improved job identification in the debugger interface with better labeling and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->