### PR TITLE
Entity type display consistency — chips everywhere (#2776)

### DIFF
--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -389,6 +389,13 @@ impl Input {
         self.values_available() == 0
     }
 
+    /// Get the queued values for inspection
+    #[cfg(feature = "debugger")]
+    #[must_use]
+    pub fn received_values(&self) -> &[Value] {
+        &self.received
+    }
+
     /// Return true if this input has pending internal values
     #[must_use]
     pub fn has_internal(&self) -> bool {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1339,7 +1339,11 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
         let flows_map = manifest.flows();
         let mut sorted_busy: Vec<_> = busy.iter().collect();
         sorted_busy.sort_by_key(|(id, _)| *id);
-        let mut b = DebugLineBuilder::new().text(&format!("  Busy ({}):", busy.len()));
+        let mut b = DebugLineBuilder::new().text("  ").chip(
+            &format!("busy ({}):", busy.len()),
+            "busy",
+            LinkType::StateBusy,
+        );
         for (id, _count) in &sorted_busy {
             let lt = if flows_map.contains_key(id) {
                 LinkType::Flow

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -516,7 +516,7 @@ fn entity_line(
             link_type,
         )
         .text(&format!(" '{}' @ ", func.name()))
-        .chip(func.route(), func.route(), crate::LinkType::Route)
+        .chip(func.route(), func.route(), link_type)
         .text(suffix)
         .finish()
 }
@@ -540,7 +540,7 @@ fn entity_line_with_states(
             link_type,
         )
         .text(&format!(" '{}' @ ", func.name()))
-        .chip(func.route(), func.route(), crate::LinkType::Route);
+        .chip(func.route(), func.route(), link_type);
     append_state_chips(b, states).finish()
 }
 
@@ -1088,7 +1088,7 @@ fn format_flows_only(run_state: &flowrlib::run_state::RunState) -> Vec<crate::De
         b = if let Some(func) = functions.get(id) {
             b.chip(&format!("flow #{id}"), &id.to_string(), LinkType::Flow)
                 .text(&format!(" '{}' @ ", func.name()))
-                .chip(func.route(), func.route(), LinkType::Route)
+                .chip(func.route(), func.route(), LinkType::Flow)
         } else {
             b.chip(&format!("flow #{id}"), &id.to_string(), LinkType::Flow)
         };
@@ -1161,7 +1161,7 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
             );
             if !fi.name.is_empty() {
                 b = b.text(&format!(" '{}' @ ", fi.name));
-                b = b.chip(&fi.route, &fi.route, crate::LinkType::Route);
+                b = b.chip(&fi.route, &fi.route, crate::LinkType::Flow);
             }
             b.finish()
         } else {
@@ -1520,7 +1520,7 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
             if !conn.destination.is_empty() {
                 b = b
                     .text(" @ ")
-                    .chip(&conn.destination, &conn.destination, LinkType::Route);
+                    .chip(&conn.destination, &conn.destination, LinkType::Function);
             }
             b = b.text(&format!(" input:{}", conn.destination_io_number));
             lines.push(b.finish());
@@ -1549,7 +1549,7 @@ fn format_inspect_flow(
     if let Some(fi) = manifest.flows().get(&flow_id) {
         if !fi.name.is_empty() {
             b = b.text(&format!(" '{}' @ ", fi.name));
-            b = b.chip(&fi.route, &fi.route, LinkType::Route);
+            b = b.chip(&fi.route, &fi.route, LinkType::Flow);
         }
     }
     lines.push(b.finish());

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -466,6 +466,38 @@ fn rewrite_for_gui(msg: &str) -> String {
 
 /// Format a `DebugServerMessage` into colored lines for the debug tab
 #[cfg(feature = "debugger")]
+fn state_link_type(state: &flowrlib::run_state::State) -> crate::LinkType {
+    match state {
+        flowrlib::run_state::State::Ready => crate::LinkType::StateReady,
+        flowrlib::run_state::State::Waiting => crate::LinkType::StateWaiting,
+        flowrlib::run_state::State::Running => crate::LinkType::StateRunning,
+        flowrlib::run_state::State::Completed => crate::LinkType::StateCompleted,
+    }
+}
+
+#[cfg(feature = "debugger")]
+fn state_label(state: &flowrlib::run_state::State) -> &'static str {
+    match state {
+        flowrlib::run_state::State::Ready => "ready",
+        flowrlib::run_state::State::Waiting => "waiting",
+        flowrlib::run_state::State::Running => "running",
+        flowrlib::run_state::State::Completed => "completed",
+    }
+}
+
+#[cfg(feature = "debugger")]
+fn append_state_chips(
+    mut b: crate::DebugLineBuilder,
+    states: &[flowrlib::run_state::State],
+) -> crate::DebugLineBuilder {
+    for s in states {
+        let label = state_label(s);
+        b = b.text(" ").chip(label, label, state_link_type(s));
+    }
+    b
+}
+
+#[cfg(feature = "debugger")]
 fn entity_line(
     func: &flowcore::model::runtime_function::RuntimeFunction,
     indent: &str,
@@ -487,6 +519,29 @@ fn entity_line(
         .chip(func.route(), func.route(), crate::LinkType::Route)
         .text(suffix)
         .finish()
+}
+
+#[cfg(feature = "debugger")]
+fn entity_line_with_states(
+    func: &flowcore::model::runtime_function::RuntimeFunction,
+    indent: &str,
+    link_type: crate::LinkType,
+    states: &[flowrlib::run_state::State],
+) -> crate::DebugEventLine {
+    let entity = match link_type {
+        crate::LinkType::Flow => "flow",
+        _ => "function",
+    };
+    let b = crate::DebugLineBuilder::new()
+        .text(indent)
+        .chip(
+            &format!("{entity} #{}", func.id()),
+            &func.id().to_string(),
+            link_type,
+        )
+        .text(&format!(" '{}' @ ", func.name()))
+        .chip(func.route(), func.route(), crate::LinkType::Route);
+    append_state_chips(b, states).finish()
 }
 
 #[cfg(feature = "debugger")]
@@ -649,11 +704,11 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
         DebugServerMessage::FunctionStates((function, states)) => {
-            vec![entity_line(
+            vec![entity_line_with_states(
                 function,
                 "",
                 crate::LinkType::Function,
-                &format!(" {states:?}"),
+                states,
             )]
         }
         DebugServerMessage::OverallState(ref run_state) => format_state_only(run_state),
@@ -1180,12 +1235,7 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
                 TreeSegment::Branch
             };
             let states = run_state.get_function_states(child.id());
-            let mut line = entity_line(
-                child,
-                "",
-                crate::LinkType::Function,
-                &format!(" {states:?}"),
-            );
+            let mut line = entity_line_with_states(child, "", crate::LinkType::Function, &states);
             let mut child_prefix = child_ancestors.clone();
             child_prefix.push(conn);
             line.tree_prefix = child_prefix;
@@ -1360,10 +1410,13 @@ fn format_inspect_by_state(
     sorted.sort_by_key(|f| f.id());
 
     if let Some(ref target) = target_state {
-        lines.push(DebugEventLine::new(
-            format!("Functions in '{state_name}' state:"),
-            None,
-        ));
+        lines.push(
+            crate::DebugLineBuilder::new()
+                .text("Functions in ")
+                .chip(state_name, state_name, state_link_type(target))
+                .text(" state:")
+                .finish(),
+        );
         let mut count = 0;
         for func in &sorted {
             let states = run_state.get_function_states(func.id());
@@ -1553,11 +1606,11 @@ fn format_inspect_flow(
         lines.push(DebugEventLine::new("  Functions:".into(), None));
         for func in funcs {
             let states = run_state.get_function_states(func.id());
-            lines.push(entity_line(
+            lines.push(entity_line_with_states(
                 func,
                 "    ",
                 LinkType::Function,
-                &format!(" {states:?}"),
+                &states,
             ));
         }
     }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1621,7 +1621,11 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
         for conn in &job.connections {
             let source_label = match &conn.source {
                 flowcore::model::output_connection::Source::Output(route) => {
-                    format!("output '{route}'")
+                    if route.is_empty() {
+                        "output".to_string()
+                    } else {
+                        format!("output '{route}'")
+                    }
                 }
                 flowcore::model::output_connection::Source::Input(n) => {
                     format!("input #{n}")

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -473,8 +473,8 @@ fn entity_line(
     suffix: &str,
 ) -> crate::DebugEventLine {
     let entity = match link_type {
-        crate::LinkType::Flow => "Flow",
-        _ => "Function",
+        crate::LinkType::Flow => "flow",
+        _ => "function",
     };
     crate::DebugLineBuilder::new()
         .text(indent)
@@ -493,35 +493,64 @@ fn entity_line(
 #[allow(clippy::too_many_lines)]
 fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine> {
     use crate::theme::debug_colors;
-    use crate::DebugEventLine;
+    use crate::{DebugEventLine, DebugLineBuilder, LinkType};
 
     let line = |text: String, color: Option<iced::Color>| vec![DebugEventLine::new(text, color)];
 
     match message {
         DebugServerMessage::JobCompleted(job) => {
-            let mut lines = vec![DebugEventLine::new(
-                format!(
-                    "Job #{} completed by Function #{} (Flow #{}) '{}'",
-                    job.payload.job_id, job.process_id, job.parent_id, job.function_name
-                ),
-                Some(debug_colors::COMPLETION),
-            )];
+            let mut lines = vec![DebugLineBuilder::new()
+                .color(debug_colors::COMPLETION)
+                .chip(
+                    &format!("job #{}", job.payload.job_id),
+                    &format!("job:{}", job.payload.job_id),
+                    LinkType::Job,
+                )
+                .text(" completed by ")
+                .chip(
+                    &format!("function #{} '{}'", job.process_id, job.function_name),
+                    &job.process_id.to_string(),
+                    LinkType::Function,
+                )
+                .text(" (")
+                .chip(
+                    &format!("flow #{}", job.parent_id),
+                    &job.parent_id.to_string(),
+                    LinkType::Flow,
+                )
+                .text(")")
+                .finish()];
             if let Ok((Some(output), _)) = &job.result {
                 lines.push(DebugEventLine::new(
-                    format!("\tOutput value: '{output}'"),
+                    format!("  Output: '{output}'"),
                     Some(debug_colors::COMPLETION),
                 ));
             }
             lines
         }
         DebugServerMessage::PriorToSendingJob(job) => vec![
-            DebugEventLine::new(
-                format!(
-                    "About to send Job #{} to Function #{} (Flow #{}) '{}'",
-                    job.payload.job_id, job.process_id, job.parent_id, job.function_name
-                ),
-                Some(debug_colors::DATA_FLOW),
-            ),
+            DebugLineBuilder::new()
+                .color(debug_colors::DATA_FLOW)
+                .text("About to send ")
+                .chip(
+                    &format!("job #{}", job.payload.job_id),
+                    &format!("job:{}", job.payload.job_id),
+                    LinkType::Job,
+                )
+                .text(" to ")
+                .chip(
+                    &format!("function #{} '{}'", job.process_id, job.function_name),
+                    &job.process_id.to_string(),
+                    LinkType::Function,
+                )
+                .text(" (")
+                .chip(
+                    &format!("flow #{}", job.parent_id),
+                    &job.parent_id.to_string(),
+                    LinkType::Flow,
+                )
+                .text(")")
+                .finish(),
             DebugEventLine::new(
                 format!("Inputs: {:?}", job.payload.input_set),
                 Some(debug_colors::DATA_FLOW),
@@ -536,24 +565,48 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             dest_name,
             io_name,
             input_number,
-        ) => line(
-            format!(
-                "Data breakpoint: Function #{source_id} '{source_name}{output_route}' \
-                --{value}-> Function #{dest_id}:{input_number} '{dest_name}'/'{io_name}'"
-            ),
-            Some(debug_colors::BREAKPOINT),
-        ),
+        ) => vec![DebugLineBuilder::new()
+            .color(debug_colors::BREAKPOINT)
+            .text("Data breakpoint: ")
+            .chip(
+                &format!("function #{source_id} '{source_name}'"),
+                &source_id.to_string(),
+                LinkType::Function,
+            )
+            .text(&format!("{output_route} --{value}-> "))
+            .chip(
+                &format!("function #{dest_id} '{dest_name}'"),
+                &dest_id.to_string(),
+                LinkType::Function,
+            )
+            .text(&format!(":{input_number} '{io_name}'"))
+            .finish()],
         DebugServerMessage::Panic(message, jobs_created) => line(
             format!("Function panicked after {jobs_created} jobs created: {message}"),
             Some(debug_colors::ERROR),
         ),
-        DebugServerMessage::JobError(job) => line(
-            format!(
-                "Error executing Job #{} on Function #{} (Flow #{}) '{}': '{job}'",
-                job.payload.job_id, job.process_id, job.parent_id, job.function_name
-            ),
-            Some(debug_colors::ERROR),
-        ),
+        DebugServerMessage::JobError(job) => vec![DebugLineBuilder::new()
+            .color(debug_colors::ERROR)
+            .text("Error executing ")
+            .chip(
+                &format!("job #{}", job.payload.job_id),
+                &format!("job:{}", job.payload.job_id),
+                LinkType::Job,
+            )
+            .text(" on ")
+            .chip(
+                &format!("function #{} '{}'", job.process_id, job.function_name),
+                &job.process_id.to_string(),
+                LinkType::Function,
+            )
+            .text(" (")
+            .chip(
+                &format!("flow #{}", job.parent_id),
+                &job.parent_id.to_string(),
+                LinkType::Flow,
+            )
+            .text(&format!("): '{job}'"))
+            .finish()],
         DebugServerMessage::Deadlock(message) => line(
             format!("Deadlock detected: {message}"),
             Some(debug_colors::ERROR),
@@ -575,10 +628,23 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             .iter()
             .map(|f| entity_line(f, "  ", crate::LinkType::Function, ""))
             .collect(),
-        DebugServerMessage::SendingValue(source_id, value, dest_id, input_number) => line(
-            format!("Function #{source_id} sending '{value}' to {dest_id}:{input_number}"),
-            Some(debug_colors::DATA_FLOW),
-        ),
+        DebugServerMessage::SendingValue(source_id, value, dest_id, input_number) => {
+            vec![DebugLineBuilder::new()
+                .color(debug_colors::DATA_FLOW)
+                .chip(
+                    &format!("function #{source_id}"),
+                    &source_id.to_string(),
+                    LinkType::Function,
+                )
+                .text(&format!(" sending '{value}' to "))
+                .chip(
+                    &format!("function #{dest_id}"),
+                    &dest_id.to_string(),
+                    LinkType::Function,
+                )
+                .text(&format!(":{input_number}"))
+                .finish()]
+        }
         DebugServerMessage::Error(ref msg) => line(rewrite_for_gui(msg), Some(debug_colors::ERROR)),
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
@@ -624,14 +690,25 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
                     .collect()
             }
         }
-        DebugServerMessage::FlowUnblockBreakpoint(flow_id) => line(
-            format!("Flow #{flow_id} was busy and has now gone idle, unblocking senders"),
-            Some(debug_colors::STATUS),
-        ),
-        DebugServerMessage::WaitingForCommand(job_id) => line(
-            format!("Waiting for command (Job #{job_id})"),
-            Some(debug_colors::STATUS),
-        ),
+        DebugServerMessage::FlowUnblockBreakpoint(flow_id) => vec![DebugLineBuilder::new()
+            .color(debug_colors::STATUS)
+            .chip(
+                &format!("flow #{flow_id}"),
+                &flow_id.to_string(),
+                LinkType::Flow,
+            )
+            .text(" was busy and has now gone idle, unblocking senders")
+            .finish()],
+        DebugServerMessage::WaitingForCommand(job_id) => vec![DebugLineBuilder::new()
+            .color(debug_colors::STATUS)
+            .text("Waiting for command (")
+            .chip(
+                &format!("job #{job_id}"),
+                &format!("job:{job_id}"),
+                LinkType::Job,
+            )
+            .text(")")
+            .finish()],
         DebugServerMessage::ProcessTree(ref state) => {
             if FLOWS_ONLY.swap(false, Ordering::Relaxed) {
                 format_flows_only(state)
@@ -655,26 +732,62 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             } else {
                 let mut lines = Vec::new();
                 for spec in specs {
-                    let text = match spec {
-                        flowcore::model::debug_command::BreakpointSpec::Numeric(id) => {
-                            format!("  Function #{id}")
-                        }
-                        flowcore::model::debug_command::BreakpointSpec::Completed(id) => {
-                            format!("  Function #{id}+ (completion)")
-                        }
-                        flowcore::model::debug_command::BreakpointSpec::Input((id, num)) => {
-                            format!("  Input #{id}:{num}")
-                        }
-                        flowcore::model::debug_command::BreakpointSpec::Output((id, route)) => {
-                            format!("  Output #{id}{route}")
-                        }
-                        flowcore::model::debug_command::BreakpointSpec::Route(route) => {
-                            format!("  Route {route}")
-                        }
-                        flowcore::model::debug_command::BreakpointSpec::All => String::new(),
+                    use flowcore::model::debug_command::BreakpointSpec;
+                    let line = match spec {
+                        BreakpointSpec::Numeric(id) => Some(
+                            DebugLineBuilder::new()
+                                .text("  ")
+                                .chip(
+                                    &format!("function #{id}"),
+                                    &id.to_string(),
+                                    LinkType::Function,
+                                )
+                                .finish(),
+                        ),
+                        BreakpointSpec::Completed(id) => Some(
+                            DebugLineBuilder::new()
+                                .text("  ")
+                                .chip(
+                                    &format!("function #{id}"),
+                                    &id.to_string(),
+                                    LinkType::Function,
+                                )
+                                .text(" (completion)")
+                                .finish(),
+                        ),
+                        BreakpointSpec::Input((id, num)) => Some(
+                            DebugLineBuilder::new()
+                                .text("  ")
+                                .chip(
+                                    &format!("function #{id}"),
+                                    &id.to_string(),
+                                    LinkType::Function,
+                                )
+                                .text(&format!(" input:{num}"))
+                                .finish(),
+                        ),
+                        BreakpointSpec::Output((id, route)) => Some(
+                            DebugLineBuilder::new()
+                                .text("  ")
+                                .chip(
+                                    &format!("function #{id}"),
+                                    &id.to_string(),
+                                    LinkType::Function,
+                                )
+                                .text(" ")
+                                .chip(route, route, LinkType::Route)
+                                .finish(),
+                        ),
+                        BreakpointSpec::Route(route) => Some(
+                            DebugLineBuilder::new()
+                                .text("  ")
+                                .chip(route, route, LinkType::Route)
+                                .finish(),
+                        ),
+                        BreakpointSpec::All => None,
                     };
-                    if !text.is_empty() {
-                        lines.push(DebugEventLine::new(text, None));
+                    if let Some(l) = line {
+                        lines.push(l);
                     }
                 }
                 lines
@@ -1197,7 +1310,7 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
             if i > 0 {
                 b = b.text(", ");
             }
-            b = b.chip(&format!("Flow #{id}"), &id.to_string(), LinkType::Flow);
+            b = b.chip(&format!("flow #{id}"), &id.to_string(), LinkType::Flow);
         }
         lines.push(b.finish());
     }
@@ -1209,7 +1322,7 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
                 b = b.text(", ");
             }
             b = b.chip(
-                &format!("Function #{id}"),
+                &format!("function #{id}"),
                 &id.to_string(),
                 LinkType::Function,
             );
@@ -1393,13 +1506,13 @@ fn format_inspect_flow(
             let mut b = DebugLineBuilder::new().text("  Parent: ");
             if let Some(pf) = functions.get(&parent) {
                 b = b.chip(
-                    &format!("Flow #{parent} '{}'", pf.name()),
+                    &format!("flow #{parent} '{}'", pf.name()),
                     &parent.to_string(),
                     LinkType::Flow,
                 );
             } else {
                 b = b.chip(
-                    &format!("Flow #{parent}"),
+                    &format!("flow #{parent}"),
                     &parent.to_string(),
                     LinkType::Flow,
                 );
@@ -1415,12 +1528,12 @@ fn format_inspect_flow(
                 }
                 if let Some(sf_func) = functions.get(sf) {
                     b = b.chip(
-                        &format!("Flow #{sf} '{}'", sf_func.name()),
+                        &format!("flow #{sf} '{}'", sf_func.name()),
                         &sf.to_string(),
                         LinkType::Flow,
                     );
                 } else {
-                    b = b.chip(&format!("Flow #{sf}"), &sf.to_string(), LinkType::Flow);
+                    b = b.chip(&format!("flow #{sf}"), &sf.to_string(), LinkType::Flow);
                 }
             }
             lines.push(b.finish());

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1587,22 +1587,45 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
             .finish(),
     );
 
-    lines.push(crate::DebugEventLine::new(
-        format!("  Inputs: {:?}", job.payload.input_set),
-        None,
-    ));
+    // Input values — show each value with index
+    if job.payload.input_set.is_empty() {
+        lines.push(crate::DebugEventLine::new(
+            "  Input values: (none)".into(),
+            None,
+        ));
+    } else {
+        lines.push(crate::DebugEventLine::new(
+            format!("  Input values ({}):", job.payload.input_set.len()),
+            None,
+        ));
+        for (i, val) in job.payload.input_set.iter().enumerate() {
+            lines.push(
+                DebugLineBuilder::new()
+                    .text("    ")
+                    .chip(
+                        &format!("input:{i}"),
+                        &format!("{}:{i}", job.process_id),
+                        LinkType::Input,
+                    )
+                    .text(&format!(" = {val}"))
+                    .finish(),
+            );
+        }
+    }
 
     if !job.connections.is_empty() {
         lines.push(crate::DebugEventLine::new(
-            format!("  Connections ({}):", job.connections.len()),
+            format!("  Output connections ({}):", job.connections.len()),
             None,
         ));
         for conn in &job.connections {
             let source_label = match &conn.source {
                 flowcore::model::output_connection::Source::Output(route) => {
-                    format!("output {route}")
+                    format!("output '{route}'")
                 }
-                flowcore::model::output_connection::Source::Input(n) => format!("input #{n}"),
+                flowcore::model::output_connection::Source::Input(n) => {
+                    format!("input #{n}")
+                }
             };
             let mut b = DebugLineBuilder::new()
                 .text(&format!("    {source_label} \u{2192} "))
@@ -1616,7 +1639,11 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
                     .text(" @ ")
                     .chip(&conn.destination, &conn.destination, LinkType::Function);
             }
-            b = b.text(&format!(" input:{}", conn.destination_io_number));
+            b = b.text(" ").chip(
+                &format!("input:{}", conn.destination_io_number),
+                &format!("{}:{}", conn.destination_id, conn.destination_io_number),
+                LinkType::Input,
+            );
             lines.push(b.finish());
         }
     }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1298,6 +1298,68 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
     // RunState stats
     lines.push(DebugEventLine::new("RunState:".into(), None));
 
+    // Functions by state
+    let all_functions = run_state.get_functions();
+    let mut waiting_funcs = Vec::new();
+    let mut ready_funcs = Vec::new();
+    let mut running_funcs = Vec::new();
+    for func in all_functions.values() {
+        let states = run_state.get_function_states(func.id());
+        if states.contains(&flowrlib::run_state::State::Waiting) {
+            waiting_funcs.push(func.id());
+        }
+        if states.contains(&flowrlib::run_state::State::Ready) {
+            ready_funcs.push(func.id());
+        }
+        if states.contains(&flowrlib::run_state::State::Running) {
+            running_funcs.push(func.id());
+        }
+    }
+    waiting_funcs.sort_unstable();
+    ready_funcs.sort_unstable();
+    running_funcs.sort_unstable();
+
+    // Functions waiting
+    let mut b = DebugLineBuilder::new().text("  ").chip(
+        &format!("functions waiting ({}):", waiting_funcs.len()),
+        "waiting",
+        LinkType::StateWaiting,
+    );
+    for id in &waiting_funcs {
+        b = b
+            .text(" ")
+            .chip(&format!("#{id}"), &id.to_string(), LinkType::Function);
+    }
+    lines.push(b.finish());
+
+    // Functions ready
+    let mut b = DebugLineBuilder::new().text("  ").chip(
+        &format!("functions ready ({}):", ready_funcs.len()),
+        "ready",
+        LinkType::StateReady,
+    );
+    for id in &ready_funcs {
+        b = b
+            .text(" ")
+            .chip(&format!("#{id}"), &id.to_string(), LinkType::Function);
+    }
+    lines.push(b.finish());
+
+    // Functions running
+    if !running_funcs.is_empty() {
+        let mut b = DebugLineBuilder::new().text("  ").chip(
+            &format!("functions running ({}):", running_funcs.len()),
+            "running",
+            LinkType::StateRunning,
+        );
+        for id in &running_funcs {
+            b = b
+                .text(" ")
+                .chip(&format!("#{id}"), &id.to_string(), LinkType::Function);
+        }
+        lines.push(b.finish());
+    }
+
     // Running jobs
     let running = run_state.get_running();
     let mut b = DebugLineBuilder::new().text("  ").chip(

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1278,24 +1278,20 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
 
     // RunState stats
     lines.push(DebugEventLine::new("RunState:".into(), None));
-    lines.push(DebugEventLine::new(
-        format!("  Jobs Created: {}", run_state.get_number_of_jobs_created()),
-        None,
-    ));
 
     // Running jobs
     let running = run_state.get_running();
     let mut b = DebugLineBuilder::new().text("  ").chip(
-        &format!("Jobs Running ({}):", running.len()),
+        &format!("jobs running ({}):", running.len()),
         "running",
-        LinkType::State,
+        LinkType::StateRunning,
     );
     if !running.is_empty() {
         let mut sorted_running: Vec<_> = running.iter().collect();
         sorted_running.sort_by_key(|(id, _)| *id);
         for (job_id, job) in &sorted_running {
             b = b.text(" ").chip(
-                &format!("Job #{job_id} ({})", job.function_name),
+                &format!("job #{job_id} ({})", job.function_name),
                 &format!("job:{job_id}"),
                 LinkType::Job,
             );
@@ -1306,13 +1302,13 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
     // Ready jobs
     let ready = run_state.get_ready_jobs();
     let mut b = DebugLineBuilder::new().text("  ").chip(
-        &format!("Jobs Ready ({}):", ready.len()),
+        &format!("jobs ready ({}):", ready.len()),
         "ready",
-        LinkType::State,
+        LinkType::StateReady,
     );
     for job in ready {
         b = b.text(" ").chip(
-            &format!("Job #{} ({})", job.payload.job_id, job.function_name),
+            &format!("job #{} ({})", job.payload.job_id, job.function_name),
             &format!("job:{}", job.payload.job_id),
             LinkType::Job,
         );
@@ -1322,9 +1318,9 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
     // Completed functions
     let completed = run_state.get_completed();
     let mut b = DebugLineBuilder::new().text("  ").chip(
-        &format!("Functions Completed ({}):", completed.len()),
+        &format!("functions completed ({}):", completed.len()),
         "completed",
-        LinkType::State,
+        LinkType::StateCompleted,
     );
     if !completed.is_empty() {
         let mut sorted: Vec<_> = completed.iter().collect();
@@ -1334,48 +1330,28 @@ fn format_run_state(run_state: &flowrlib::run_state::RunState) -> Vec<crate::Deb
                 .text(" ")
                 .chip(&format!("#{id}"), &id.to_string(), LinkType::Function);
         }
-        b = b.text("]");
     }
     lines.push(b.finish());
 
-    // Busy functions and flows (separated)
+    // Busy — combined flows and functions
     let busy = run_state.get_busy_count();
-    let flows_map = manifest.flows();
-    let mut busy_flows = Vec::new();
-    let mut busy_funcs = Vec::new();
-    for (id, count) in busy {
-        if flows_map.contains_key(id) {
-            busy_flows.push((*id, *count));
-        } else {
-            busy_funcs.push((*id, *count));
-        }
-    }
-
-    busy_flows.sort_by_key(|(id, _)| *id);
-    busy_funcs.sort_by_key(|(id, _)| *id);
-
-    if !busy_flows.is_empty() {
-        let mut b = DebugLineBuilder::new().text("  Busy Flows: ");
-        for (i, (id, _count)) in busy_flows.iter().enumerate() {
-            if i > 0 {
-                b = b.text(", ");
-            }
-            b = b.chip(&format!("flow #{id}"), &id.to_string(), LinkType::Flow);
-        }
-        lines.push(b.finish());
-    }
-
-    if !busy_funcs.is_empty() {
-        let mut b = DebugLineBuilder::new().text("  Busy Functions: ");
-        for (i, (id, _count)) in busy_funcs.iter().enumerate() {
-            if i > 0 {
-                b = b.text(", ");
-            }
-            b = b.chip(
-                &format!("function #{id}"),
-                &id.to_string(),
-                LinkType::Function,
-            );
+    if !busy.is_empty() {
+        let flows_map = manifest.flows();
+        let mut sorted_busy: Vec<_> = busy.iter().collect();
+        sorted_busy.sort_by_key(|(id, _)| *id);
+        let mut b = DebugLineBuilder::new().text(&format!("  Busy ({}):", busy.len()));
+        for (id, _count) in &sorted_busy {
+            let lt = if flows_map.contains_key(id) {
+                LinkType::Flow
+            } else {
+                LinkType::Function
+            };
+            let label = if flows_map.contains_key(id) {
+                format!("flow #{id}")
+            } else {
+                format!("function #{id}")
+            };
+            b = b.text(" ").chip(&label, &id.to_string(), lt);
         }
         lines.push(b.finish());
     }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1390,6 +1390,22 @@ fn format_inspect_by_state(
     use crate::DebugEventLine;
 
     let target_state = match state_name {
+        "all" => {
+            let mut lines = Vec::new();
+            let functions = run_state.get_functions();
+            let mut sorted: Vec<_> = functions.values().collect();
+            sorted.sort_by_key(|f| f.id());
+            for func in &sorted {
+                let states = run_state.get_function_states(func.id());
+                lines.push(entity_line_with_states(
+                    func,
+                    "  ",
+                    crate::LinkType::Function,
+                    &states,
+                ));
+            }
+            return lines;
+        }
         "ready" => Some(flowrlib::run_state::State::Ready),
         "waiting" => Some(flowrlib::run_state::State::Waiting),
         "running" => Some(flowrlib::run_state::State::Running),
@@ -1421,7 +1437,12 @@ fn format_inspect_by_state(
             let states = run_state.get_function_states(func.id());
             if states.contains(target) {
                 count += 1;
-                lines.push(entity_line(func, "  ", crate::LinkType::Function, ""));
+                lines.push(entity_line_with_states(
+                    func,
+                    "  ",
+                    crate::LinkType::Function,
+                    &states,
+                ));
             }
         }
         if count == 0 {
@@ -1436,12 +1457,24 @@ fn format_inspect_by_state(
                 if let Ok(blockers) = run_state.get_input_blockers(func.id()) {
                     if !blockers.is_empty() {
                         count += 1;
-                        lines.push(entity_line(
-                            func,
-                            "  ",
+                        let mut b = crate::DebugLineBuilder::new().text("  ");
+                        b = b.chip(
+                            &format!("function #{}", func.id()),
+                            &func.id().to_string(),
                             crate::LinkType::Function,
-                            &format!(" — blocked by: {blockers:?}"),
-                        ));
+                        );
+                        b = b.text(" — blocked by: ");
+                        for (j, bid) in blockers.iter().enumerate() {
+                            if j > 0 {
+                                b = b.text(", ");
+                            }
+                            b = b.chip(
+                                &format!("function #{bid}"),
+                                &bid.to_string(),
+                                crate::LinkType::Function,
+                            );
+                        }
+                        lines.push(b.finish());
                     }
                 }
             }
@@ -1530,7 +1563,6 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
 }
 
 #[cfg(feature = "debugger")]
-#[cfg(feature = "debugger")]
 fn format_inspect_function(
     func_id: usize,
     run_state: &flowrlib::run_state::RunState,
@@ -1556,11 +1588,12 @@ fn format_inspect_function(
     ));
 
     for (i, input) in func.inputs().iter().enumerate() {
-        let name = if input.name().is_empty() {
+        let input_label = if input.name().is_empty() {
             format!("input:{i}")
         } else {
             format!("input:{i} '{}'", input.name())
         };
+        let input_spec = format!("{func_id}:{i}");
 
         if input.is_empty() {
             let mut senders: Vec<usize> = Vec::new();
@@ -1576,10 +1609,13 @@ fn format_inspect_function(
             }
             senders.sort_unstable();
 
-            let mut b = DebugLineBuilder::new().text(&format!("  {name} — empty, waiting for: "));
+            let mut b = DebugLineBuilder::new()
+                .text("  ")
+                .chip(&input_label, &input_spec, LinkType::Input)
+                .text(" — empty, waiting for: ");
             for (j, sid) in senders.iter().enumerate() {
                 if j > 0 {
-                    b = b.text(", ");
+                    b = b.text(" or ");
                 }
                 b = b.chip(
                     &format!("function #{sid}"),
@@ -1594,14 +1630,17 @@ fn format_inspect_function(
         } else {
             let vals = input.received_values();
             let val_str: Vec<String> = vals.iter().map(|v| format!("{v}")).collect();
-            lines.push(DebugEventLine::new(
-                format!(
-                    "  {name} — {} value(s): [{}]",
-                    vals.len(),
-                    val_str.join(", ")
-                ),
-                None,
-            ));
+            lines.push(
+                DebugLineBuilder::new()
+                    .text("  ")
+                    .chip(&input_label, &input_spec, LinkType::Input)
+                    .text(&format!(
+                        " — {} value(s): [{}]",
+                        vals.len(),
+                        val_str.join(", ")
+                    ))
+                    .finish(),
+            );
         }
 
         if let Some(init) = input.initializer() {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -703,13 +703,28 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::Error(ref msg) => line(rewrite_for_gui(msg), Some(debug_colors::ERROR)),
         DebugServerMessage::Message(msg) => line(rewrite_for_gui(msg), None),
         DebugServerMessage::Resetting => line("Resetting state".into(), Some(debug_colors::STATUS)),
-        DebugServerMessage::FunctionStates((function, states)) => {
-            vec![entity_line_with_states(
+        DebugServerMessage::FunctionStates((function, states, blockers)) => {
+            let mut lines = vec![entity_line_with_states(
                 function,
                 "",
                 crate::LinkType::Function,
                 states,
-            )]
+            )];
+            if !blockers.is_empty() {
+                let mut b = crate::DebugLineBuilder::new().text("  Waiting for: ");
+                for (i, id) in blockers.iter().enumerate() {
+                    if i > 0 {
+                        b = b.text(", ");
+                    }
+                    b = b.chip(
+                        &format!("function #{id}"),
+                        &id.to_string(),
+                        crate::LinkType::Function,
+                    );
+                }
+                lines.push(b.finish());
+            }
+            lines
         }
         DebugServerMessage::OverallState(ref run_state) => format_state_only(run_state),
         DebugServerMessage::InputState(input) => {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -789,6 +789,9 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
         DebugServerMessage::InspectByState(ref state_name, ref state) => {
             format_inspect_by_state(state_name, state)
         }
+        DebugServerMessage::InspectFunction(func_id, ref state) => {
+            format_inspect_function(*func_id, state)
+        }
         DebugServerMessage::InspectFlow(flow_id, ref state) => format_inspect_flow(*flow_id, state),
         DebugServerMessage::JobInspect(ref job) => format_inspect_job(job),
         DebugServerMessage::Invalid => line(
@@ -1001,6 +1004,7 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
 
                     if let DebugServerMessage::ProcessTree(ref state)
                     | DebugServerMessage::InspectByState(_, ref state)
+                    | DebugServerMessage::InspectFunction(_, ref state)
                     | DebugServerMessage::InspectFlow(_, ref state)
                     | DebugServerMessage::OverallState(ref state) = message
                     {
@@ -1519,6 +1523,106 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
             }
             b = b.text(&format!(" input:{}", conn.destination_io_number));
             lines.push(b.finish());
+        }
+    }
+
+    lines
+}
+
+#[cfg(feature = "debugger")]
+#[cfg(feature = "debugger")]
+fn format_inspect_function(
+    func_id: usize,
+    run_state: &flowrlib::run_state::RunState,
+) -> Vec<crate::DebugEventLine> {
+    use crate::{DebugEventLine, DebugLineBuilder, LinkType};
+
+    let mut lines = Vec::new();
+    let functions = run_state.get_functions();
+
+    let Some(func) = functions.get(&func_id) else {
+        return vec![DebugEventLine::new(
+            format!("Function #{func_id} not found"),
+            Some(crate::theme::debug_colors::ERROR),
+        )];
+    };
+
+    let states = run_state.get_function_states(func_id);
+    lines.push(entity_line_with_states(
+        func,
+        "",
+        LinkType::Function,
+        &states,
+    ));
+
+    for (i, input) in func.inputs().iter().enumerate() {
+        let name = if input.name().is_empty() {
+            format!("input:{i}")
+        } else {
+            format!("input:{i} '{}'", input.name())
+        };
+
+        if input.is_empty() {
+            let mut senders: Vec<usize> = Vec::new();
+            for sender in functions.values() {
+                for conn in sender.get_output_connections() {
+                    if conn.destination_id == func_id
+                        && conn.destination_io_number == i
+                        && !senders.contains(&sender.id())
+                    {
+                        senders.push(sender.id());
+                    }
+                }
+            }
+            senders.sort_unstable();
+
+            let mut b = DebugLineBuilder::new().text(&format!("  {name} — empty, waiting for: "));
+            for (j, sid) in senders.iter().enumerate() {
+                if j > 0 {
+                    b = b.text(", ");
+                }
+                b = b.chip(
+                    &format!("function #{sid}"),
+                    &sid.to_string(),
+                    LinkType::Function,
+                );
+            }
+            if senders.is_empty() {
+                b = b.text("(no senders)");
+            }
+            lines.push(b.finish());
+        } else {
+            let vals = input.received_values();
+            let val_str: Vec<String> = vals.iter().map(|v| format!("{v}")).collect();
+            lines.push(DebugEventLine::new(
+                format!(
+                    "  {name} — {} value(s): [{}]",
+                    vals.len(),
+                    val_str.join(", ")
+                ),
+                None,
+            ));
+        }
+
+        if let Some(init) = input.initializer() {
+            let (kind, val) = match init {
+                flowcore::model::input::InputInitializer::Once(v) => ("once", v),
+                flowcore::model::input::InputInitializer::Always(v) => ("always", v),
+            };
+            lines.push(DebugEventLine::new(
+                format!("    initializer ({kind}): {val}"),
+                Some(crate::theme::TEXT_SECONDARY),
+            ));
+        }
+        if let Some(init) = input.flow_initializer() {
+            let (kind, val) = match init {
+                flowcore::model::input::InputInitializer::Once(v) => ("once", v),
+                flowcore::model::input::InputInitializer::Always(v) => ("always", v),
+            };
+            lines.push(DebugEventLine::new(
+                format!("    flow initializer ({kind}): {val}"),
+                Some(crate::theme::TEXT_SECONDARY),
+            ));
         }
     }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -92,6 +92,7 @@ pub enum LinkType {
     StateWaiting,
     StateRunning,
     StateCompleted,
+    StateBusy,
     Other,
 }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -88,6 +88,10 @@ pub enum LinkType {
     Output,
     Route,
     State,
+    StateReady,
+    StateWaiting,
+    StateRunning,
+    StateCompleted,
     Other,
 }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2705,12 +2705,16 @@ impl FlowrGui {
                 }
             }
             Message::DebugFunctions(display) => {
+                self.debug_waiting = false;
                 if display {
-                    self.debug_waiting = false;
                     self.debug_separator("Functions List");
+                    connection_manager::send_debug_command(DebugCommand::InspectState(
+                        "all".to_string(),
+                    ));
+                } else {
+                    self.suppress_next_output = true;
+                    connection_manager::send_debug_command(DebugCommand::FunctionList);
                 }
-                self.suppress_next_output = !display;
-                connection_manager::send_debug_command(DebugCommand::FunctionList);
             }
             Message::DebugFlows => {
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -932,7 +932,7 @@ impl Tab for DebugTab {
                                     spans.push(s);
                                 }
                                 let chip_color = chip_color_for(link.link_type);
-                                spans.push(iced::widget::span("  ".to_string()));
+                                spans.push(iced::widget::span(" ".to_string()).padding([0, 4]));
                                 spans.push(
                                     iced::widget::span(format!(
                                         " {} ",
@@ -955,7 +955,7 @@ impl Tab for DebugTab {
                                     .padding([2, 6])
                                     .link(link.spec.clone()),
                                 );
-                                spans.push(iced::widget::span("  ".to_string()));
+                                spans.push(iced::widget::span(" ".to_string()).padding([0, 4]));
                                 pos = link.end;
                             }
                             if pos < line.text.len() {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -932,7 +932,7 @@ impl Tab for DebugTab {
                                     spans.push(s);
                                 }
                                 let chip_color = chip_color_for(link.link_type);
-                                spans.push(iced::widget::span(" ".to_string()).padding([0, 4]));
+                                spans.push(iced::widget::span("   ".to_string()));
                                 spans.push(
                                     iced::widget::span(format!(
                                         " {} ",
@@ -952,10 +952,10 @@ impl Tab for DebugTab {
                                         radius: 99.0.into(),
                                         ..Default::default()
                                     })
-                                    .padding([2, 6])
+                                    .padding([2, 10])
                                     .link(link.spec.clone()),
                                 );
-                                spans.push(iced::widget::span(" ".to_string()).padding([0, 4]));
+                                spans.push(iced::widget::span("   ".to_string()));
                                 pos = link.end;
                             }
                             if pos < line.text.len() {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -734,6 +734,7 @@ fn chip_color_for(link_type: crate::LinkType) -> iced::Color {
         crate::LinkType::StateWaiting => entity_colors::STATE_WAITING,
         crate::LinkType::StateRunning => entity_colors::STATE_RUNNING,
         crate::LinkType::StateCompleted => entity_colors::STATE_COMPLETED,
+        crate::LinkType::StateBusy => entity_colors::STATE_BUSY,
         crate::LinkType::Other => crate::theme::TEXT_LINK,
     }
 }
@@ -931,7 +932,7 @@ impl Tab for DebugTab {
                                     spans.push(s);
                                 }
                                 let chip_color = chip_color_for(link.link_type);
-                                spans.push(iced::widget::span(" ".to_string()));
+                                spans.push(iced::widget::span("  ".to_string()));
                                 spans.push(
                                     iced::widget::span(format!(
                                         " {} ",
@@ -954,7 +955,7 @@ impl Tab for DebugTab {
                                     .padding([2, 6])
                                     .link(link.spec.clone()),
                                 );
-                                spans.push(iced::widget::span(" ".to_string()));
+                                spans.push(iced::widget::span("  ".to_string()));
                                 pos = link.end;
                             }
                             if pos < line.text.len() {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -932,10 +932,9 @@ impl Tab for DebugTab {
                                     spans.push(s);
                                 }
                                 let chip_color = chip_color_for(link.link_type);
-                                spans.push(iced::widget::span("   ".to_string()));
                                 spans.push(
                                     iced::widget::span(format!(
-                                        " {} ",
+                                        "  {}  ",
                                         line.text[link.start..link.end].to_lowercase()
                                     ))
                                     .color(iced::Color::WHITE)
@@ -952,10 +951,10 @@ impl Tab for DebugTab {
                                         radius: 99.0.into(),
                                         ..Default::default()
                                     })
-                                    .padding([2, 10])
+                                    .padding([2, 0])
                                     .link(link.spec.clone()),
                                 );
-                                spans.push(iced::widget::span("   ".to_string()));
+                                spans.push(iced::widget::span(" ".to_string()));
                                 pos = link.end;
                             }
                             if pos < line.text.len() {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -730,6 +730,10 @@ fn chip_color_for(link_type: crate::LinkType) -> iced::Color {
         crate::LinkType::Input => entity_colors::INPUT,
         crate::LinkType::Output => entity_colors::OUTPUT,
         crate::LinkType::State => crate::theme::TEXT_SECONDARY,
+        crate::LinkType::StateReady => entity_colors::STATE_READY,
+        crate::LinkType::StateWaiting => entity_colors::STATE_WAITING,
+        crate::LinkType::StateRunning => entity_colors::STATE_RUNNING,
+        crate::LinkType::StateCompleted => entity_colors::STATE_COMPLETED,
         crate::LinkType::Other => crate::theme::TEXT_LINK,
     }
 }

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -112,6 +112,12 @@ pub mod entity_colors {
         b: 1.0,
         a: 1.0,
     };
+    pub const STATE_BUSY: Color = Color {
+        r: 0.9,
+        g: 0.4,
+        b: 0.4,
+        a: 1.0,
+    };
 }
 
 // ── Debug event colors ──────────────────────────────────────────────────────

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -88,6 +88,30 @@ pub mod entity_colors {
         b: 0.75,
         a: 1.0,
     };
+    pub const STATE_READY: Color = Color {
+        r: 0.3,
+        g: 0.85,
+        b: 0.5,
+        a: 1.0,
+    };
+    pub const STATE_WAITING: Color = Color {
+        r: 0.6,
+        g: 0.6,
+        b: 0.7,
+        a: 1.0,
+    };
+    pub const STATE_RUNNING: Color = Color {
+        r: 1.0,
+        g: 0.75,
+        b: 0.2,
+        a: 1.0,
+    };
+    pub const STATE_COMPLETED: Color = Color {
+        r: 0.5,
+        g: 0.8,
+        b: 1.0,
+        a: 1.0,
+    };
 }
 
 // ── Debug event colors ──────────────────────────────────────────────────────

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -443,7 +443,7 @@ mod test {
         fn outputs(&mut self, _output: Vec<OutputConnection>) {}
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
-        fn function_states(&mut self, _function: RuntimeFunction, _function_states: Vec<State>) {}
+        fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<crate::debug_command::BreakpointSpec>) {}

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -444,6 +444,7 @@ mod test {
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
         fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
+        fn inspect_function(&mut self, _: usize, _: &RunState) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<crate::debug_command::BreakpointSpec>) {}

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -306,6 +306,7 @@ impl DebugClient {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn process_server_message(&mut self, message: DebugServerMessage) -> Result<DebugCommand> {
         match message {
             JobCompleted(job) => {
@@ -362,9 +363,14 @@ impl DebugClient {
             Resetting => println!("Resetting state"),
             WaitingForCommand(job_id) => return self.get_user_command(job_id),
             DebugServerMessage::Invalid => println!("Invalid message received from debug server"),
-            FunctionStates((function, state)) => {
+            FunctionStates((function, state, blockers)) => {
                 print!("{function}");
                 println!("\tState: {state:?}");
+                if !blockers.is_empty() {
+                    let blocker_list: Vec<String> =
+                        blockers.iter().map(|id| format!("#{id}")).collect();
+                    println!("\tWaiting for: {}", blocker_list.join(", "));
+                }
             }
             OverallState(run_state) => Self::display_state(&run_state),
             InputState(input) => println!("{input}"),

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -401,6 +401,28 @@ impl DebugClient {
             DebugServerMessage::InspectFlow(flow_id, ref state) => {
                 println!("{}", Debugger::inspect_flow(state, flow_id));
             }
+            DebugServerMessage::InspectFunction(func_id, ref state) => {
+                if let Some(func) = state.get_function(func_id) {
+                    print!("{func}");
+                    println!("\tState: {:?}", state.get_function_states(func_id));
+                    for (i, input) in func.inputs().iter().enumerate() {
+                        let name = if input.name().is_empty() {
+                            format!("input:{i}")
+                        } else {
+                            format!("input:{i} '{}'", input.name())
+                        };
+                        if input.is_empty() {
+                            println!("\t{name} — empty (waiting)");
+                        } else {
+                            println!(
+                                "\t{name} — {} value(s): {:?}",
+                                input.values_available(),
+                                input.received_values()
+                            );
+                        }
+                    }
+                }
+            }
             DebugServerMessage::FlowList(_) => {}
             DebugServerMessage::JobInspect(ref job) => {
                 println!("Job #{}", job.payload.job_id);

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -52,6 +52,7 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::FunctionStates((
             function.clone(),
             states,
+            vec![],
         )));
     }
 
@@ -102,10 +103,16 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::Functions(functions.to_vec()));
     }
 
-    fn function_states(&mut self, function: RuntimeFunction, function_states: Vec<State>) {
+    fn function_states(
+        &mut self,
+        function: RuntimeFunction,
+        function_states: Vec<State>,
+        input_blockers: Vec<usize>,
+    ) {
         self.send_event(DebugServerMessage::FunctionStates((
             function,
             function_states,
+            input_blockers,
         )));
     }
 

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -139,6 +139,13 @@ impl DebuggerHandler for DebugGuiHandler {
         ));
     }
 
+    fn inspect_function(&mut self, function_id: usize, state: &RunState) {
+        self.send_event(DebugServerMessage::InspectFunction(
+            function_id,
+            state.clone(),
+        ));
+    }
+
     fn inspect_flow(&mut self, flow_id: usize, state: &RunState) {
         self.send_event(DebugServerMessage::InspectFlow(flow_id, state.clone()));
     }

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -45,7 +45,7 @@ pub enum DebugServerMessage {
     /// A list of all functions
     Functions(Vec<RuntimeFunction>),
     /// The state of a function
-    FunctionStates((RuntimeFunction, Vec<State>)),
+    FunctionStates((RuntimeFunction, Vec<State>, Vec<usize>)),
     /// A value is being sent from one function to another
     SendingValue(usize, Value, usize, usize),
     /// The overall state

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -46,6 +46,8 @@ pub enum DebugServerMessage {
     Functions(Vec<RuntimeFunction>),
     /// The state of a function
     FunctionStates((RuntimeFunction, Vec<State>, Vec<usize>)),
+    /// Inspect a function — carries function ID and `RunState` for detailed view
+    InspectFunction(usize, RunState),
     /// A value is being sent from one function to another
     SendingValue(usize, Value, usize, usize),
     /// The overall state
@@ -108,6 +110,7 @@ impl fmt::Display for DebugServerMessage {
                 DebugServerMessage::ProcessTree(_) => "ProcessTree",
                 DebugServerMessage::InspectByState(_, _) => "InspectByState",
                 DebugServerMessage::InspectFlow(_, _) => "InspectFlow",
+                DebugServerMessage::InspectFunction(_, _) => "InspectFunction",
                 DebugServerMessage::JobInspect(_) => "JobInspect",
                 DebugServerMessage::FlowList(_) => "FlowList",
             }

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -160,6 +160,13 @@ impl DebuggerHandler for DebugZmqHandler {
             );
     }
 
+    fn inspect_function(&mut self, function_id: usize, state: &RunState) {
+        let _: flowcore::errors::Result<DebugCommand> =
+            self.debug_server_connection.send_and_receive_response(
+                DebugServerMessage::InspectFunction(function_id, state.clone()),
+            );
+    }
+
     fn inspect_flow(&mut self, flow_id: usize, state: &RunState) {
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -42,7 +42,7 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(PriorToSendingJob(job.clone()));
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection
-            .send_and_receive_response(FunctionStates((function.clone(), states)));
+            .send_and_receive_response(FunctionStates((function.clone(), states, vec![])));
     }
 
     fn flow_unblock_breakpoint(&mut self, flow_id: usize) {
@@ -118,10 +118,15 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(DebugServerMessage::FlowList(flows));
     }
 
-    fn function_states(&mut self, function: RuntimeFunction, function_states: Vec<State>) {
+    fn function_states(
+        &mut self,
+        function: RuntimeFunction,
+        function_states: Vec<State>,
+        input_blockers: Vec<usize>,
+    ) {
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection
-            .send_and_receive_response(FunctionStates((function, function_states)));
+            .send_and_receive_response(FunctionStates((function, function_states, input_blockers)));
     }
 
     fn run_state(&mut self, run_state: &RunState) {

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -244,12 +244,14 @@ impl<'a> Debugger<'a> {
                         if state.submission.manifest.flows().contains_key(&func_id) {
                             self.debug_server.inspect_flow(func_id, state);
                         } else if state.get_function(func_id).is_some() {
+                            let blockers = state.get_input_blockers(func_id).unwrap_or_default();
                             self.debug_server.function_states(
                                 state
                                     .get_function(func_id)
                                     .ok_or("Could not get function")?
                                     .clone(),
                                 state.get_function_states(func_id),
+                                blockers,
                             );
                         }
                     } else {
@@ -274,12 +276,14 @@ impl<'a> Debugger<'a> {
                 }
                 Ok(InspectFunction(function_id)) => {
                     if state.get_function(function_id).is_some() {
+                        let blockers = state.get_input_blockers(function_id).unwrap_or_default();
                         self.debug_server.function_states(
                             state
                                 .get_function(function_id)
                                 .ok_or("Could not get function")?
                                 .clone(),
                             state.get_function_states(function_id),
+                            blockers,
                         );
                     } else if state.submission.manifest.flows().contains_key(&function_id) {
                         self.debug_server.inspect_flow(function_id, state);
@@ -1133,7 +1137,7 @@ mod test {
         fn outputs(&mut self, _output: Vec<OutputConnection>) {}
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
-        fn function_states(&mut self, _function: RuntimeFunction, _function_states: Vec<State>) {}
+        fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<BreakpointSpec>) {}

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -244,15 +244,7 @@ impl<'a> Debugger<'a> {
                         if state.submission.manifest.flows().contains_key(&func_id) {
                             self.debug_server.inspect_flow(func_id, state);
                         } else if state.get_function(func_id).is_some() {
-                            let blockers = state.get_input_blockers(func_id).unwrap_or_default();
-                            self.debug_server.function_states(
-                                state
-                                    .get_function(func_id)
-                                    .ok_or("Could not get function")?
-                                    .clone(),
-                                state.get_function_states(func_id),
-                                blockers,
-                            );
+                            self.debug_server.inspect_function(func_id, state);
                         }
                     } else {
                         self.debug_server.debugger_error(format!(
@@ -276,15 +268,7 @@ impl<'a> Debugger<'a> {
                 }
                 Ok(InspectFunction(function_id)) => {
                     if state.get_function(function_id).is_some() {
-                        let blockers = state.get_input_blockers(function_id).unwrap_or_default();
-                        self.debug_server.function_states(
-                            state
-                                .get_function(function_id)
-                                .ok_or("Could not get function")?
-                                .clone(),
-                            state.get_function_states(function_id),
-                            blockers,
-                        );
+                        self.debug_server.inspect_function(function_id, state);
                     } else if state.submission.manifest.flows().contains_key(&function_id) {
                         self.debug_server.inspect_flow(function_id, state);
                     } else {
@@ -1138,6 +1122,7 @@ mod test {
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
         fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
+        fn inspect_function(&mut self, _: usize, _: &RunState) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<BreakpointSpec>) {}

--- a/flowr/src/lib/debugger_handler.rs
+++ b/flowr/src/lib/debugger_handler.rs
@@ -77,6 +77,8 @@ pub trait DebuggerHandler {
     fn process_tree(&mut self, state: &RunState);
     /// Inspect functions by state — structured data for rendering
     fn inspect_by_state(&mut self, state_name: &str, state: &RunState);
+    /// Inspect a function — structured data for detailed rendering
+    fn inspect_function(&mut self, function_id: usize, state: &RunState);
     /// Inspect a flow — structured data for rendering
     fn inspect_flow(&mut self, flow_id: usize, state: &RunState);
     /// Inspect a job — structured data for rendering

--- a/flowr/src/lib/debugger_handler.rs
+++ b/flowr/src/lib/debugger_handler.rs
@@ -49,7 +49,12 @@ pub trait DebuggerHandler {
     /// Lists flow IDs with access to `RunState` for names/routes
     fn flow_list(&mut self, flow_ids: &[usize], state: &RunState);
     /// returns the state of a function
-    fn function_states(&mut self, function: RuntimeFunction, function_states: Vec<State>);
+    fn function_states(
+        &mut self,
+        function: RuntimeFunction,
+        function_states: Vec<State>,
+        input_blockers: Vec<usize>,
+    );
     /// returns the global run state
     fn run_state(&mut self, run_state: &RunState);
     /// a string message from the Debugger

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1007,7 +1007,7 @@ mod test {
         fn outputs(&mut self, _output: Vec<OutputConnection>) {}
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
-        fn function_states(&mut self, _function: RuntimeFunction, _function_states: Vec<State>) {}
+        fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<crate::debug_command::BreakpointSpec>) {}

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1008,6 +1008,7 @@ mod test {
         fn input(&mut self, _input: Input) {}
         fn function_list(&mut self, _functions: &[RuntimeFunction]) {}
         fn function_states(&mut self, _: RuntimeFunction, _: Vec<State>, _: Vec<usize>) {}
+        fn inspect_function(&mut self, _: usize, _: &RunState) {}
         fn run_state(&mut self, _run_state: &RunState) {}
         fn message(&mut self, _message: String) {}
         fn breakpoint_list(&mut self, _breakpoints: Vec<crate::debug_command::BreakpointSpec>) {}


### PR DESCRIPTION
## Summary
- Convert all 8 debug text messages to use entity-typed chips (job, function, flow, route)
- Standardize all chip labels to lowercase for consistency
- Messages converted: JobCompleted, PriorToSendingJob, DataBreakpoint, JobError, SendingValue, FlowUnblockBreakpoint, WaitingForCommand, BreakpointList
- Remove extra space before closing parenthesis in chip-adjacent text

## Test plan
- [ ] Step through fibonacci — verify "About to send" message has colored job/function/flow chips
- [ ] Set a breakpoint, verify breakpoint list shows function chips
- [ ] Check all chip labels are lowercase in debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspect view now shows per-function details and per-input values; REPL/debugger indicates which function IDs are blocking execution and handles function inspection immediately.

* **Style**
  * Redesigned debugger output using structured, colored "chips" with distinct state colors (ready/waiting/running/completed/busy).
  * Standardized lowercase labels for flows/functions, improved process-tree, inspect views and breakpoint list rendering for clearer, more consistent UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->