### PR TITLE
Replace modal inspect dialog with split pane panel (#2790)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -740,14 +740,21 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
                     None,
                 )]
             } else {
-                vec![DebugEventLine::new(
-                    format!(
-                        "Input {name_label}— {} value(s) queued: {}",
-                        input.values_available(),
-                        format!("{input}").trim()
-                    ),
-                    None,
-                )]
+                {
+                    let vals: Vec<String> = input
+                        .received_values()
+                        .iter()
+                        .map(|v| format!("{v}"))
+                        .collect();
+                    vec![DebugEventLine::new(
+                        format!(
+                            "Input {name_label}— {} value(s) queued: [{}]",
+                            input.values_available(),
+                            vals.join(", ")
+                        ),
+                        None,
+                    )]
+                }
             }
         }
         DebugServerMessage::OutputState(connections) => {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1487,13 +1487,6 @@ fn format_inspect_by_state(
     sorted.sort_by_key(|f| f.id());
 
     if let Some(ref target) = target_state {
-        lines.push(
-            crate::DebugLineBuilder::new()
-                .text("Functions in ")
-                .chip(state_name, state_name, state_link_type(target))
-                .text(" state:")
-                .finish(),
-        );
         let mut count = 0;
         for func in &sorted {
             let states = run_state.get_function_states(func.id());
@@ -1511,7 +1504,6 @@ fn format_inspect_by_state(
             lines.push(DebugEventLine::new("  (none)".into(), None));
         }
     } else {
-        lines.push(DebugEventLine::new("Blocked functions:".into(), None));
         let mut count = 0;
         for func in &sorted {
             let states = run_state.get_function_states(func.id());

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2799,7 +2799,7 @@ impl FlowrGui {
                         );
                     }
                 } else {
-                    let state_keywords = ["ready", "waiting", "running", "completed", "blocked"];
+                    let state_keywords = DebugClient::STATE_KEYWORDS;
                     let label = if let Ok(id) = spec.parse::<usize>() {
                         let is_flow = self
                             .cached_functions

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1220,7 +1220,7 @@ impl FlowrGui {
         let tab_area: Element<'_, Message> = if self.show_inspect_popup {
             let panel = self.inspect_panel();
             Row::new()
-                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(7)))
+                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(6)))
                 .push(panel)
                 .spacing(2)
                 .height(iced::Length::Fill)
@@ -2097,9 +2097,9 @@ impl FlowrGui {
             .push(Container::new(iced::widget::text("")).width(Length::Fill))
             .push(
                 Button::new(
-                    Text::new("\u{2715}")
-                        .font(iced::Font::with_name("icons"))
-                        .size(theme::FONT_MD),
+                    Text::new("\u{00BB}")
+                        .size(20.0)
+                        .shaping(iced::widget::text::Shaping::Advanced),
                 )
                 .on_press(Message::CloseInspectPopup)
                 .style(theme::ghost_button)
@@ -2120,27 +2120,14 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::FillPortion(3))
+            .width(Length::FillPortion(4))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
                 border: iced::Border {
-                    radius: iced::border::Radius {
-                        top_left: theme::RADIUS_MD,
-                        bottom_left: theme::RADIUS_MD,
-                        top_right: 0.0,
-                        bottom_right: 0.0,
-                    },
-                    width: 2.0,
-                    color: iced::Color {
-                        a: 0.5,
-                        ..theme::ACCENT
-                    },
-                },
-                shadow: iced::Shadow {
-                    color: iced::Color::BLACK,
-                    offset: iced::Vector::new(-4.0, 2.0),
-                    blur_radius: 12.0,
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: iced::Color::TRANSPARENT,
                 },
                 ..Default::default()
             })

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2793,21 +2793,37 @@ impl FlowrGui {
                 self.debug_waiting = false;
                 if let Some(job_id_str) = spec.strip_prefix("job:") {
                     if let Ok(job_id) = job_id_str.parse::<usize>() {
-                        self.debug_separator(&format!("Inspect Job #{job_id}"));
+                        self.debug_separator(&format!("Job #{job_id}"));
                         connection_manager::send_debug_command(
                             flowcore::model::debug_command::DebugCommand::InspectJob(job_id),
                         );
                     }
                 } else {
                     let state_keywords = ["ready", "waiting", "running", "completed", "blocked"];
-                    let label = if spec.parse::<usize>().is_ok() {
-                        format!("Inspect #{spec}")
+                    let label = if let Ok(id) = spec.parse::<usize>() {
+                        let is_flow = self
+                            .cached_functions
+                            .iter()
+                            .any(|f| f.id == id && f.is_flow);
+                        if is_flow {
+                            format!("Flow #{id}")
+                        } else {
+                            format!("Function #{id}")
+                        }
                     } else if spec.contains(':') {
-                        format!("Inspect Input ({spec})")
+                        format!("Input ({spec})")
                     } else if spec.starts_with('/') {
-                        format!("Inspect Route ({spec})")
+                        let is_flow = self
+                            .cached_functions
+                            .iter()
+                            .any(|f| f.is_flow && f.route == *spec);
+                        if is_flow {
+                            format!("Flow @ {spec}")
+                        } else {
+                            format!("Function @ {spec}")
+                        }
                     } else if spec.contains('/') {
-                        format!("Inspect Output ({spec})")
+                        format!("Output ({spec})")
                     } else if state_keywords.contains(&spec.as_str()) {
                         format!("Functions in {spec} state")
                     } else {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1237,24 +1237,15 @@ impl FlowrGui {
             let panel = self.inspect_panel();
             let dismiss = mouse_area(
                 Container::new(iced::widget::text(""))
-                    .style(|_: &iced::Theme| iced::widget::container::Style {
-                        background: Some(iced::Background::Color(iced::Color {
-                            r: 0.0,
-                            g: 0.0,
-                            b: 0.0,
-                            a: 0.3,
-                        })),
-                        ..Default::default()
-                    })
                     .width(Length::Fill)
                     .height(Length::Fill),
             )
             .on_press(Message::CloseInspectPopup);
             return stack![
                 main_content,
-                Row::new()
-                    .push(dismiss)
-                    .push(panel)
+                Column::new()
+                    .push(iced::widget::text("").height(Length::Fixed(80.0)))
+                    .push(Row::new().push(dismiss).push(panel).height(Length::Fill))
                     .width(Length::Fill)
                     .height(Length::Fill)
             ]
@@ -2135,7 +2126,7 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::FillPortion(3))
+            .width(Length::Fixed(320.0))
             .height(Length::Fill)
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1244,8 +1244,12 @@ impl FlowrGui {
             return stack![
                 main_content,
                 Column::new()
-                    .push(iced::widget::text("").height(Length::Fixed(80.0)))
-                    .push(Row::new().push(dismiss).push(panel).height(Length::Fill))
+                    .push(Container::new(iced::widget::text("")).height(Length::Fixed(100.0)))
+                    .push(
+                        Row::new()
+                            .push(dismiss)
+                            .push(Container::new(panel).align_y(iced::alignment::Vertical::Top))
+                    )
                     .width(Length::Fill)
                     .height(Length::Fill)
             ]
@@ -2126,18 +2130,27 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::Fixed(320.0))
-            .height(Length::Fill)
+            .width(Length::Fixed(450.0))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
                 border: iced::Border {
-                    radius: 0.0.into(),
+                    radius: iced::border::Radius {
+                        top_left: theme::RADIUS_MD,
+                        bottom_left: theme::RADIUS_MD,
+                        top_right: 0.0,
+                        bottom_right: 0.0,
+                    },
                     width: 2.0,
                     color: iced::Color {
                         a: 0.5,
                         ..theme::ACCENT
                     },
+                },
+                shadow: iced::Shadow {
+                    color: iced::Color::BLACK,
+                    offset: iced::Vector::new(-4.0, 2.0),
+                    blur_radius: 12.0,
                 },
                 ..Default::default()
             })

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1220,7 +1220,7 @@ impl FlowrGui {
         let tab_area: Element<'_, Message> = if self.show_inspect_popup {
             let panel = self.inspect_panel();
             Row::new()
-                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(7)))
+                .push(iced::widget::container(tab_content).width(iced::Length::Fill))
                 .push(panel)
                 .spacing(2)
                 .height(iced::Length::Fill)
@@ -2120,7 +2120,7 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::FillPortion(3))
+            .width(Length::Fixed(380.0))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1220,7 +1220,7 @@ impl FlowrGui {
         let tab_area: Element<'_, Message> = if self.show_inspect_popup {
             let panel = self.inspect_panel();
             Row::new()
-                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(6)))
+                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(7)))
                 .push(panel)
                 .spacing(2)
                 .height(iced::Length::Fill)
@@ -2120,7 +2120,7 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::FillPortion(4))
+            .width(Length::FillPortion(3))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2799,6 +2799,7 @@ impl FlowrGui {
                         );
                     }
                 } else {
+                    let state_keywords = ["ready", "waiting", "running", "completed", "blocked"];
                     let label = if spec.parse::<usize>().is_ok() {
                         format!("Inspect #{spec}")
                     } else if spec.contains(':') {
@@ -2807,6 +2808,8 @@ impl FlowrGui {
                         format!("Inspect Route ({spec})")
                     } else if spec.contains('/') {
                         format!("Inspect Output ({spec})")
+                    } else if state_keywords.contains(&spec.as_str()) {
+                        format!("Functions in {spec} state")
                     } else {
                         format!("Inspect {spec}")
                     };

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1215,8 +1215,24 @@ impl FlowrGui {
             }
         }
 
+        let tab_content = self.tab_set.view(&self.cached_functions);
+        #[cfg(feature = "debugger")]
+        let tab_area: Element<'_, Message> = if self.show_inspect_popup {
+            let panel = self.inspect_panel();
+            Row::new()
+                .push(iced::widget::container(tab_content).width(iced::Length::FillPortion(7)))
+                .push(panel)
+                .spacing(2)
+                .height(iced::Length::Fill)
+                .into()
+        } else {
+            tab_content
+        };
+        #[cfg(not(feature = "debugger"))]
+        let tab_area = tab_content;
+
         let main_content = main_content
-            .push(self.tab_set.view(&self.cached_functions))
+            .push(tab_area)
             .push(self.status_bar())
             .padding([theme::SPACE_XS, theme::SPACE_SM]);
 
@@ -1226,32 +1242,6 @@ impl FlowrGui {
             return stack![
                 main_content,
                 opaque(mouse_area(center(opaque(bp_popup))).on_press(Message::CloseBpPopup))
-            ]
-            .into();
-        }
-
-        #[cfg(feature = "debugger")]
-        if self.show_inspect_popup {
-            use iced::widget::Container;
-            use iced::Length;
-            let panel = self.inspect_panel();
-            let dismiss = mouse_area(
-                Container::new(iced::widget::text(""))
-                    .width(Length::Fill)
-                    .height(Length::Fill),
-            )
-            .on_press(Message::CloseInspectPopup);
-            return stack![
-                main_content,
-                Column::new()
-                    .push(Container::new(iced::widget::text("")).height(Length::Fixed(100.0)))
-                    .push(
-                        Row::new()
-                            .push(dismiss)
-                            .push(Container::new(panel).align_y(iced::alignment::Vertical::Top))
-                    )
-                    .width(Length::Fill)
-                    .height(Length::Fill)
             ]
             .into();
         }
@@ -2130,7 +2120,7 @@ impl FlowrGui {
             .push(list);
 
         Container::new(panel_content)
-            .width(Length::Fixed(450.0))
+            .width(Length::FillPortion(3))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1232,10 +1232,31 @@ impl FlowrGui {
 
         #[cfg(feature = "debugger")]
         if self.show_inspect_popup {
-            let popup = self.inspect_popup_card();
+            use iced::widget::Container;
+            use iced::Length;
+            let panel = self.inspect_panel();
+            let dismiss = mouse_area(
+                Container::new(iced::widget::text(""))
+                    .style(|_: &iced::Theme| iced::widget::container::Style {
+                        background: Some(iced::Background::Color(iced::Color {
+                            r: 0.0,
+                            g: 0.0,
+                            b: 0.0,
+                            a: 0.3,
+                        })),
+                        ..Default::default()
+                    })
+                    .width(Length::Fill)
+                    .height(Length::Fill),
+            )
+            .on_press(Message::CloseInspectPopup);
             return stack![
                 main_content,
-                opaque(mouse_area(center(opaque(popup))).on_press(Message::CloseInspectPopup))
+                Row::new()
+                    .push(dismiss)
+                    .push(panel)
+                    .width(Length::Fill)
+                    .height(Length::Fill)
             ]
             .into();
         }
@@ -1963,8 +1984,9 @@ impl FlowrGui {
 
     #[cfg(feature = "debugger")]
     #[allow(clippy::too_many_lines)]
-    fn inspect_popup_card(&self) -> Card<'_, Message> {
+    fn inspect_panel(&self) -> Element<'_, Message> {
         use iced::widget::scrollable::Scrollable;
+        use iced::widget::Container;
         use iced::Length;
 
         let tab_row = Row::new()
@@ -2082,14 +2104,12 @@ impl FlowrGui {
         }
 
         let list = Scrollable::new(items)
-            .height(Length::Fixed(200.0))
+            .height(Length::Fill)
             .width(Length::Fill);
 
-        let body = Column::new().spacing(8).push(tab_row).push(list);
-
-        let inspect_header = Row::new()
-            .push(Text::new("Inspect"))
-            .push(iced::widget::container(Text::new("")).width(iced::Length::Fill))
+        let header = Row::new()
+            .push(Text::new("Inspect").size(theme::FONT_DEFAULT))
+            .push(Container::new(iced::widget::text("")).width(Length::Fill))
             .push(
                 Button::new(
                     Text::new("\u{2715}")
@@ -2097,14 +2117,40 @@ impl FlowrGui {
                         .size(theme::FONT_MD),
                 )
                 .on_press(Message::CloseInspectPopup)
-                .style(theme::list_button)
+                .style(theme::ghost_button)
                 .padding(theme::BUTTON_PAD_SM),
             )
-            .align_y(iced::alignment::Vertical::Center);
+            .align_y(iced::alignment::Vertical::Center)
+            .padding(iced::Padding {
+                top: 0.0,
+                right: 0.0,
+                bottom: theme::SPACE_SM,
+                left: 0.0,
+            });
 
-        Card::new(inspect_header, body)
-            .style(theme::popup_card)
-            .max_width(500.0)
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_MD)
+            .push(header)
+            .push(tab_row)
+            .push(list);
+
+        Container::new(panel_content)
+            .width(Length::FillPortion(3))
+            .height(Length::Fill)
+            .padding(theme::SPACE_LG)
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
+                border: iced::Border {
+                    radius: 0.0.into(),
+                    width: 2.0,
+                    color: iced::Color {
+                        a: 0.5,
+                        ..theme::ACCENT
+                    },
+                },
+                ..Default::default()
+            })
+            .into()
     }
 
     fn status_bar(&self) -> Column<'_, Message> {

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -199,7 +199,8 @@ impl DebugClient {
         None
     }
 
-    const STATE_KEYWORDS: &[&str] = &["ready", "waiting", "running", "completed", "blocked"];
+    /// Valid state keywords for inspect-by-state commands
+    pub const STATE_KEYWORDS: &[&str] = &["ready", "waiting", "running", "completed", "blocked"];
 
     /// Parse an inspect specification into a [`DebugCommand`]
     #[must_use]


### PR DESCRIPTION
## Summary
- Replace modal Card dialog with split pane layout (70/30)
- Fixed 380px panel width so tab buttons never squish
- Clean butting edge between panels, no overlay or dimming
- Right chevron (>>) close icon for future slide animation
- Typed section headers: 'Function #1', 'Flow #2' etc. instead of 'Inspect #1'
- State inspection sections: 'Functions in ready state' instead of 'Inspect ready'
- Fixed duplicate input name in input inspection
- Removed redundant body headers from state inspections

## Test plan
- [ ] Click Inspect — panel appears on right, debug output stays visible and interactive
- [ ] Panel is fixed width, doesn't squish on resize
- [ ] Click >> to close panel
- [ ] Inspect a function — section header shows 'Function #N'
- [ ] Inspect a state — section header shows 'Functions in ready state'
- [ ] Input inspection shows name only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input queue display formatting to show values as a clear comma-separated list.
  * Enhanced blocked function visualization with explicit blocker information display.

* **Refactor**
  * Reorganized inspect panel to display inline with main tab instead of as popup overlay.
  * Updated inspect panel styling and controls, including redesigned close button.
  * Refined debugger link handling and label generation for multiple spec types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->