### PR TITLE
Settings panel with gear icon (#2780)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -484,6 +484,8 @@ pub enum Message {
     UrlChanged(String),
     /// The arguments to send to the flow when executed have been edited by the UI
     FlowArgsChanged(String),
+    /// The job timeout setting has been edited
+    JobTimeoutChanged(String),
     /// The max parallel jobs setting has been edited by the UI
     MaxJobsChanged(String),
     /// The UI has requested to submit the flow in debug mode
@@ -684,6 +686,7 @@ struct SubmissionSettings {
     flow_manifest_url: String,
     flow_args: String,
     max_jobs_text: String,
+    job_timeout_text: String,
     debug_this_flow: bool,
     display_metrics: bool,
     parallel_jobs_limit: Option<usize>,
@@ -1016,6 +1019,9 @@ impl FlowrGui {
             Message::MaxJobsChanged(value) => {
                 self.submission_settings.parallel_jobs_limit = value.trim().parse::<usize>().ok();
                 self.submission_settings.max_jobs_text = value;
+            }
+            Message::JobTimeoutChanged(value) => {
+                self.submission_settings.job_timeout_text = value;
             }
             Message::DebugSubmitFlow => {
                 if matches!(self.coordinator_state, CoordinatorState::Disconnected(_))
@@ -1359,10 +1365,16 @@ impl FlowrGui {
         let (flow_manifest, _) = FlowManifest::load(provider, &url)
             .map_err(|e| format!("Could not load flow manifest: {e}"))?;
 
+        let job_timeout = settings
+            .job_timeout_text
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .map(std::time::Duration::from_secs);
         let submission = Submission::new(
             flow_manifest,
             settings.parallel_jobs_limit,
-            None,
+            job_timeout,
             #[cfg(feature = "debugger")]
             settings.debug_this_flow,
         );
@@ -2220,10 +2232,23 @@ impl FlowrGui {
             .push(Text::new("Max parallel jobs:").size(theme::FONT_MD))
             .push(max_jobs_input);
 
+        let timeout_input =
+            iced::widget::text_input("seconds", &self.submission_settings.job_timeout_text)
+                .on_input(Message::JobTimeoutChanged)
+                .style(theme::pill_input)
+                .width(Length::Fill);
+
+        let timeout_row = Row::new()
+            .spacing(theme::SPACE_MD)
+            .align_y(iced::alignment::Vertical::Center)
+            .push(Text::new("Job timeout (s):").size(theme::FONT_MD))
+            .push(timeout_input);
+
         let panel_content = Column::new()
             .spacing(theme::SPACE_LG)
             .push(header)
-            .push(max_jobs_row);
+            .push(max_jobs_row)
+            .push(timeout_row);
 
         Container::new(panel_content)
             .width(Length::Fixed(300.0))
@@ -2405,6 +2430,7 @@ impl FlowrGui {
                 flow_manifest_url,
                 flow_args,
                 max_jobs_text: parallel_jobs_limit.map_or(String::new(), |n| n.to_string()),
+                job_timeout_text: String::new(),
                 debug_this_flow,
                 display_metrics: matches.get_flag("metrics"),
                 parallel_jobs_limit,
@@ -3388,6 +3414,7 @@ mod test {
                 flow_manifest_url: String::new(),
                 flow_args: String::new(),
                 max_jobs_text: String::new(),
+                job_timeout_text: String::new(),
                 debug_this_flow: false,
                 display_metrics: false,
                 parallel_jobs_limit: None,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -510,6 +510,8 @@ pub enum Message {
     SaveError(String),
     /// closing of the Modal was requested
     CloseModal,
+    /// Toggle settings panel
+    ToggleSettings,
     /// Formatted debug event lines from the debug server
     #[cfg(feature = "debugger")]
     DebugEvent(Vec<DebugEventLine>),
@@ -835,6 +837,7 @@ struct FlowrGui {
     running: bool,
     submitted: bool,
     show_modal: bool,
+    show_settings: bool,
     modal_content: (String, String),
     pending_getline: bool,
     #[cfg(feature = "debugger")]
@@ -894,6 +897,7 @@ impl FlowrGui {
             submitted: false,
             running: false,
             show_modal: false,
+            show_settings: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
             #[cfg(feature = "debugger")]
@@ -1121,6 +1125,14 @@ impl FlowrGui {
                 return self.process_coordinator_message(coord_msg);
             }
             Message::CloseModal => self.show_modal = false,
+            Message::ToggleSettings => {
+                self.show_settings = !self.show_settings;
+                #[cfg(feature = "debugger")]
+                {
+                    self.show_inspect_popup = false;
+                    self.show_bp_popup = false;
+                }
+            }
             #[cfg(feature = "debugger")]
             msg @ (Message::DebugEvent(_)
             | Message::DebugWaiting
@@ -1238,6 +1250,18 @@ impl FlowrGui {
         };
         #[cfg(not(feature = "debugger"))]
         let tab_area = tab_content;
+
+        let tab_area: Element<'_, Message> = if self.show_settings {
+            let panel = self.settings_panel();
+            Row::new()
+                .push(iced::widget::container(tab_area).width(iced::Length::Fill))
+                .push(panel)
+                .spacing(2)
+                .height(iced::Length::Fill)
+                .into()
+        } else {
+            tab_area
+        };
 
         let main_content = main_content
             .push(tab_area)
@@ -1380,10 +1404,14 @@ impl FlowrGui {
         .style(theme::pill_input)
         .width(iced::Length::FillPortion(3));
 
-        let max_jobs = text_input("Max jobs", &self.submission_settings.max_jobs_text)
-            .on_input(Message::MaxJobsChanged)
-            .style(theme::pill_input)
-            .width(80);
+        let settings_btn = Button::new(
+            Text::new("\u{2699}")
+                .size(18.0)
+                .shaping(iced::widget::text::Shaping::Advanced),
+        )
+        .on_press(Message::ToggleSettings)
+        .style(theme::styled_button)
+        .padding(theme::BUTTON_PAD);
 
         let is_client_mode = matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly);
         let can_run = (matches!(self.coordinator_state, CoordinatorState::Connected(_))
@@ -1431,7 +1459,7 @@ impl FlowrGui {
             .align_y(iced::alignment::Vertical::Center)
             .push(url)
             .push(args)
-            .push(max_jobs)
+            .push(settings_btn)
             .push(play)
             .push(debug_play)
     }
@@ -2142,6 +2170,63 @@ impl FlowrGui {
 
         Container::new(panel_content)
             .width(Length::Fixed(380.0))
+            .padding(theme::SPACE_LG)
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
+                border: iced::Border {
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: iced::Color::TRANSPARENT,
+                },
+                ..Default::default()
+            })
+            .into()
+    }
+
+    fn settings_panel(&self) -> Element<'_, Message> {
+        use iced::widget::Container;
+        use iced::Length;
+
+        let header = Row::new()
+            .push(Text::new("Settings").size(theme::FONT_DEFAULT))
+            .push(Container::new(iced::widget::text("")).width(Length::Fill))
+            .push(
+                Button::new(
+                    Text::new("\u{00BB}")
+                        .size(20.0)
+                        .shaping(iced::widget::text::Shaping::Advanced),
+                )
+                .on_press(Message::ToggleSettings)
+                .style(theme::ghost_button)
+                .padding(theme::BUTTON_PAD_SM),
+            )
+            .align_y(iced::alignment::Vertical::Center)
+            .padding(iced::Padding {
+                top: 0.0,
+                right: 0.0,
+                bottom: theme::SPACE_SM,
+                left: 0.0,
+            });
+
+        let max_jobs_input =
+            iced::widget::text_input("Max jobs", &self.submission_settings.max_jobs_text)
+                .on_input(Message::MaxJobsChanged)
+                .style(theme::pill_input)
+                .width(Length::Fill);
+
+        let max_jobs_row = Row::new()
+            .spacing(theme::SPACE_MD)
+            .align_y(iced::alignment::Vertical::Center)
+            .push(Text::new("Max parallel jobs:").size(theme::FONT_MD))
+            .push(max_jobs_input);
+
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_LG)
+            .push(header)
+            .push(max_jobs_row);
+
+        Container::new(panel_content)
+            .width(Length::Fixed(300.0))
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
@@ -3319,6 +3404,7 @@ mod test {
             submitted: false,
             running: false,
             show_modal: false,
+            show_settings: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
             #[cfg(feature = "debugger")]


### PR DESCRIPTION
Replaced inline Max jobs text input with a gear icon button. Clicking opens a settings split pane with Max parallel jobs and Job timeout inputs. Job timeout is used in submissions.

- Gear icon in toolbar replaces Max jobs input
- Settings panel mutually exclusive with Inspect/BP panels
- Job timeout parsed as seconds, empty = no timeout
- Filed #2796 (metrics display) and #2797 (coordinator settings) for future work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Settings panel accessible via new gear icon in the interface
  * Job timeout is now user-configurable through the Settings panel (previously fixed)
  * Settings panel also provides control for maximum parallel jobs configuration
  * Settings panel automatically closes debug-related popups when opened

<!-- end of auto-generated comment: release notes by coderabbit.ai -->