### PR TITLE
Metrics display panel with status bar button (#2796)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -264,7 +264,6 @@ async fn handle_running(
 
     if is_flow_end {
         *running = false;
-        return Ok(());
     }
 
     if let Some(client_message) = app_receiver.recv().await {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -667,6 +667,8 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             Some(debug_colors::ERROR),
         ),
         DebugServerMessage::EnteringDebugger | DebugServerMessage::FlowList(_) => vec![],
+        #[cfg(feature = "metrics")]
+        DebugServerMessage::ExecutionMetrics(_) => vec![],
         DebugServerMessage::ExitingDebugger => {
             line("Debugger is exiting".into(), Some(debug_colors::STATUS))
         }
@@ -970,6 +972,12 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                             })
                             .collect();
                         let _ = blocking_sender.try_send(Message::DebugFlowsReceived(flow_data));
+                    }
+
+                    #[cfg(feature = "metrics")]
+                    if let DebugServerMessage::ExecutionMetrics(ref metrics) = message {
+                        let _ = blocking_sender
+                            .try_send(Message::DebugMetricsReceived(metrics.clone()));
                     }
 
                     if let DebugServerMessage::BreakpointList(ref specs) = message {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -666,10 +666,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             format!("Deadlock detected: {message}"),
             Some(debug_colors::ERROR),
         ),
-        DebugServerMessage::EnteringDebugger => line(
-            "Entering debugger. Use the controls above to debug.".into(),
-            Some(debug_colors::STATUS),
-        ),
+        DebugServerMessage::EnteringDebugger => vec![],
         DebugServerMessage::ExitingDebugger => {
             line("Debugger is exiting".into(), Some(debug_colors::STATUS))
         }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -666,7 +666,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             format!("Deadlock detected: {message}"),
             Some(debug_colors::ERROR),
         ),
-        DebugServerMessage::EnteringDebugger => vec![],
+        DebugServerMessage::EnteringDebugger | DebugServerMessage::FlowList(_) => vec![],
         DebugServerMessage::ExitingDebugger => {
             line("Debugger is exiting".into(), Some(debug_colors::STATUS))
         }
@@ -802,7 +802,6 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             "Invalid message from debug server".into(),
             Some(debug_colors::ERROR),
         ),
-        DebugServerMessage::FlowList(_) => vec![],
         DebugServerMessage::BreakpointList(specs) => {
             if specs.is_empty() {
                 vec![]

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -264,6 +264,7 @@ async fn handle_running(
 
     if is_flow_end {
         *running = false;
+        return Ok(());
     }
 
     if let Some(client_message) = app_receiver.recv().await {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3210,7 +3210,9 @@ impl FlowrGui {
                 connection_manager::set_job_count(0);
                 self.tab_set.stdin_tab.waiting_for_input = false;
                 self.last_metrics = Some(metrics);
-                self.show_metrics = true;
+                if !self.show_settings {
+                    self.show_metrics = true;
+                }
                 // NO response - so we can use next request sent to submit another flow
                 if self.ui_settings.auto_exit {
                     self.info("Auto exiting on flow completion");

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -514,6 +514,8 @@ pub enum Message {
     CloseModal,
     /// Toggle settings panel
     ToggleSettings,
+    /// Toggle metrics panel
+    ToggleMetrics,
     /// Formatted debug event lines from the debug server
     #[cfg(feature = "debugger")]
     DebugEvent(Vec<DebugEventLine>),
@@ -688,7 +690,7 @@ struct SubmissionSettings {
     max_jobs_text: String,
     job_timeout_text: String,
     debug_this_flow: bool,
-    display_metrics: bool,
+    _display_metrics: bool,
     parallel_jobs_limit: Option<usize>,
     #[cfg(feature = "debugger")]
     debug_mode: DebugMode,
@@ -841,6 +843,8 @@ struct FlowrGui {
     submitted: bool,
     show_modal: bool,
     show_settings: bool,
+    last_metrics: Option<flowcore::model::metrics::Metrics>,
+    show_metrics: bool,
     modal_content: (String, String),
     pending_getline: bool,
     #[cfg(feature = "debugger")]
@@ -901,6 +905,8 @@ impl FlowrGui {
             running: false,
             show_modal: false,
             show_settings: false,
+            last_metrics: None,
+            show_metrics: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
             #[cfg(feature = "debugger")]
@@ -1131,6 +1137,17 @@ impl FlowrGui {
                 return self.process_coordinator_message(coord_msg);
             }
             Message::CloseModal => self.show_modal = false,
+            Message::ToggleMetrics => {
+                self.show_metrics = !self.show_metrics;
+                if self.show_metrics {
+                    self.show_settings = false;
+                    #[cfg(feature = "debugger")]
+                    {
+                        self.show_inspect_popup = false;
+                        self.show_bp_popup = false;
+                    }
+                }
+            }
             Message::ToggleSettings => {
                 self.show_settings = !self.show_settings;
                 #[cfg(feature = "debugger")]
@@ -1259,6 +1276,14 @@ impl FlowrGui {
 
         let tab_area: Element<'_, Message> = if self.show_settings {
             let panel = self.settings_panel();
+            Row::new()
+                .push(iced::widget::container(tab_area).width(iced::Length::Fill))
+                .push(panel)
+                .spacing(2)
+                .height(iced::Length::Fill)
+                .into()
+        } else if self.show_metrics {
+            let panel = self.metrics_panel();
             Row::new()
                 .push(iced::widget::container(tab_area).width(iced::Length::Fill))
                 .push(panel)
@@ -2195,6 +2220,66 @@ impl FlowrGui {
             .into()
     }
 
+    fn metrics_panel(&self) -> Element<'_, Message> {
+        use iced::widget::Container;
+        use iced::Length;
+
+        let header = Row::new()
+            .push(Text::new("Metrics").size(theme::FONT_DEFAULT))
+            .push(Container::new(iced::widget::text("")).width(Length::Fill))
+            .push(
+                Button::new(
+                    Text::new("\u{00BB}")
+                        .size(20.0)
+                        .shaping(iced::widget::text::Shaping::Advanced),
+                )
+                .on_press(Message::ToggleMetrics)
+                .style(theme::ghost_button)
+                .padding(theme::BUTTON_PAD_SM),
+            )
+            .align_y(iced::alignment::Vertical::Center)
+            .padding(iced::Padding {
+                top: 0.0,
+                right: 0.0,
+                bottom: theme::SPACE_SM,
+                left: 0.0,
+            });
+
+        let content = if let Some(ref metrics) = self.last_metrics {
+            let text = format!("{metrics}");
+            let mut col = Column::new().spacing(theme::SPACE_SM);
+            for line in text.lines() {
+                col = col.push(Text::new(line.to_string()).size(theme::FONT_MD));
+            }
+            col
+        } else {
+            Column::new().push(
+                Text::new("No metrics available yet")
+                    .size(theme::FONT_MD)
+                    .color(theme::TEXT_SECONDARY),
+            )
+        };
+
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_MD)
+            .push(header)
+            .push(content);
+
+        Container::new(panel_content)
+            .width(Length::Fixed(300.0))
+            .padding(theme::SPACE_LG)
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
+                border: iced::Border {
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: iced::Color::TRANSPARENT,
+                },
+                ..Default::default()
+            })
+            .into()
+    }
+
     fn settings_panel(&self) -> Element<'_, Message> {
         use iced::widget::Container;
         use iced::Length;
@@ -2330,6 +2415,16 @@ impl FlowrGui {
             }
         }
 
+        if self.last_metrics.is_some() {
+            row = row.push(iced::widget::container(Text::new("")).width(iced::Length::Fill));
+            row = row.push(
+                Button::new(Text::new("Metrics").size(theme::FONT_SM))
+                    .on_press(Message::ToggleMetrics)
+                    .style(theme::pill_button)
+                    .padding([2, 8]),
+            );
+        }
+
         Column::new().push(
             iced::widget::Container::new(row)
                 .padding([theme::SPACE_XS, theme::SPACE_MD])
@@ -2432,7 +2527,7 @@ impl FlowrGui {
                 max_jobs_text: parallel_jobs_limit.map_or(String::new(), |n| n.to_string()),
                 job_timeout_text: String::new(),
                 debug_this_flow,
-                display_metrics: matches.get_flag("metrics"),
+                _display_metrics: matches.get_flag("metrics"),
                 parallel_jobs_limit,
                 #[cfg(feature = "debugger")]
                 debug_mode,
@@ -3114,10 +3209,8 @@ impl FlowrGui {
                 self.pending_getline = false;
                 connection_manager::set_job_count(0);
                 self.tab_set.stdin_tab.waiting_for_input = false;
-                if self.submission_settings.display_metrics {
-                    self.show_modal = true;
-                    self.modal_content = ("Flow Ended - Metrics".into(), format!("{metrics}"));
-                }
+                self.last_metrics = Some(metrics);
+                self.show_metrics = true;
                 // NO response - so we can use next request sent to submit another flow
                 if self.ui_settings.auto_exit {
                     self.info("Auto exiting on flow completion");
@@ -3416,7 +3509,7 @@ mod test {
                 max_jobs_text: String::new(),
                 job_timeout_text: String::new(),
                 debug_this_flow: false,
-                display_metrics: false,
+                _display_metrics: false,
                 parallel_jobs_limit: None,
                 #[cfg(feature = "debugger")]
                 debug_mode: DebugMode::Off,
@@ -3432,6 +3525,8 @@ mod test {
             running: false,
             show_modal: false,
             show_settings: false,
+            last_metrics: None,
+            show_metrics: false,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -690,7 +690,6 @@ struct SubmissionSettings {
     max_jobs_text: String,
     job_timeout_text: String,
     debug_this_flow: bool,
-    _display_metrics: bool,
     parallel_jobs_limit: Option<usize>,
     #[cfg(feature = "debugger")]
     debug_mode: DebugMode,
@@ -981,6 +980,8 @@ impl FlowrGui {
                 }
             }
             Message::SubmitFlow => {
+                self.last_metrics = None;
+                self.show_metrics = false;
                 if matches!(self.coordinator_state, CoordinatorState::Disconnected(_))
                     && matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly)
                 {
@@ -2528,7 +2529,6 @@ impl FlowrGui {
                 max_jobs_text: parallel_jobs_limit.map_or(String::new(), |n| n.to_string()),
                 job_timeout_text: String::new(),
                 debug_this_flow,
-                _display_metrics: matches.get_flag("metrics"),
                 parallel_jobs_limit,
                 #[cfg(feature = "debugger")]
                 debug_mode,
@@ -3509,7 +3509,6 @@ mod test {
                 max_jobs_text: String::new(),
                 job_timeout_text: String::new(),
                 debug_this_flow: false,
-                _display_metrics: false,
                 parallel_jobs_limit: None,
                 #[cfg(feature = "debugger")]
                 debug_mode: DebugMode::Off,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2267,6 +2267,7 @@ impl FlowrGui {
 
         Container::new(panel_content)
             .width(Length::Fixed(300.0))
+            .height(Length::Fill)
             .padding(theme::SPACE_LG)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
@@ -3210,9 +3211,6 @@ impl FlowrGui {
                 connection_manager::set_job_count(0);
                 self.tab_set.stdin_tab.waiting_for_input = false;
                 self.last_metrics = Some(metrics);
-                if !self.show_settings {
-                    self.show_metrics = true;
-                }
                 // NO response - so we can use next request sent to submit another flow
                 if self.ui_settings.auto_exit {
                     self.info("Auto exiting on flow completion");

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -516,6 +516,9 @@ pub enum Message {
     ToggleSettings,
     /// Toggle metrics panel
     ToggleMetrics,
+    /// Metrics received from debug channel
+    #[cfg(feature = "metrics")]
+    DebugMetricsReceived(flowcore::model::metrics::Metrics),
     /// Formatted debug event lines from the debug server
     #[cfg(feature = "debugger")]
     DebugEvent(Vec<DebugEventLine>),
@@ -1138,6 +1141,10 @@ impl FlowrGui {
                 return self.process_coordinator_message(coord_msg);
             }
             Message::CloseModal => self.show_modal = false,
+            #[cfg(feature = "metrics")]
+            Message::DebugMetricsReceived(metrics) => {
+                self.last_metrics = Some(metrics);
+            }
             Message::ToggleMetrics => {
                 self.show_metrics = !self.show_metrics;
                 if self.show_metrics {

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -172,7 +172,16 @@ impl<'a> Coordinator<'a> {
                 }
             } // jobs loop end
 
-            // flow execution has ended
+            // flow execution has ended — send metrics before entering post-mortem debugger
+            #[cfg(feature = "metrics")]
+            if !restart {
+                metrics.stop_timer();
+                metrics.set_jobs_created(state.get_number_of_jobs_created());
+                #[cfg(feature = "submission")]
+                self.submission_handler
+                    .flow_execution_ended(&state, metrics.clone())?;
+            }
+
             #[allow(clippy::collapsible_if)]
             #[cfg(feature = "debugger")]
             if !restart {
@@ -190,15 +199,12 @@ impl<'a> Coordinator<'a> {
             if !restart {
                 break 'flow_execution;
             }
+
+            #[cfg(feature = "metrics")]
+            metrics.reset();
         }
 
-        #[cfg(feature = "metrics")]
-        metrics.stop_timer();
-        #[cfg(feature = "metrics")]
-        metrics.set_jobs_created(state.get_number_of_jobs_created());
-        #[cfg(all(feature = "submission", feature = "metrics"))]
-        self.submission_handler
-            .flow_execution_ended(&state, metrics)?;
+        // Send final metrics for non-debug or non-metrics builds
         #[cfg(all(feature = "submission", not(feature = "metrics")))]
         self.submission_handler.flow_execution_ended(&state)?;
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -125,6 +125,15 @@ impl<'a> Coordinator<'a> {
 
                 #[cfg(feature = "submission")]
                 if self.submission_handler.should_stop()? {
+                    #[cfg(feature = "metrics")]
+                    {
+                        metrics.stop_timer();
+                        metrics.set_jobs_created(state.get_number_of_jobs_created());
+                        self.submission_handler
+                            .flow_execution_ended(&state, metrics.clone())?;
+                    }
+                    #[cfg(not(feature = "metrics"))]
+                    self.submission_handler.flow_execution_ended(&state)?;
                     break 'flow_execution;
                 }
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -173,12 +173,19 @@ impl<'a> Coordinator<'a> {
             } // jobs loop end
 
             // flow execution has ended
+            #[cfg(feature = "metrics")]
+            if !restart {
+                metrics.stop_timer();
+                metrics.set_jobs_created(state.get_number_of_jobs_created());
+            }
+
             #[allow(clippy::collapsible_if)]
             #[cfg(feature = "debugger")]
             if !restart {
                 {
-                    // If debugging then enter the debugger for a final time before ending flow execution
                     if state.submission.debug_enabled {
+                        #[cfg(feature = "metrics")]
+                        self.debugger.send_metrics(&metrics);
                         (display_next_output, restart) =
                             self.debugger.execution_ended(&mut state)?;
                     }
@@ -458,6 +465,8 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        #[cfg(feature = "metrics")]
+        fn execution_metrics(&mut self, _: flowcore::model::metrics::Metrics) {}
         fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> flowcore::errors::Result<DebugCommand> {
             Ok(DebugCommand::Continue)

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -125,15 +125,6 @@ impl<'a> Coordinator<'a> {
 
                 #[cfg(feature = "submission")]
                 if self.submission_handler.should_stop()? {
-                    #[cfg(feature = "metrics")]
-                    {
-                        metrics.stop_timer();
-                        metrics.set_jobs_created(state.get_number_of_jobs_created());
-                        self.submission_handler
-                            .flow_execution_ended(&state, metrics.clone())?;
-                    }
-                    #[cfg(not(feature = "metrics"))]
-                    self.submission_handler.flow_execution_ended(&state)?;
                     break 'flow_execution;
                 }
 
@@ -181,16 +172,7 @@ impl<'a> Coordinator<'a> {
                 }
             } // jobs loop end
 
-            // flow execution has ended — send metrics before entering post-mortem debugger
-            #[cfg(feature = "metrics")]
-            if !restart {
-                metrics.stop_timer();
-                metrics.set_jobs_created(state.get_number_of_jobs_created());
-                #[cfg(feature = "submission")]
-                self.submission_handler
-                    .flow_execution_ended(&state, metrics.clone())?;
-            }
-
+            // flow execution has ended
             #[allow(clippy::collapsible_if)]
             #[cfg(feature = "debugger")]
             if !restart {
@@ -208,12 +190,15 @@ impl<'a> Coordinator<'a> {
             if !restart {
                 break 'flow_execution;
             }
-
-            #[cfg(feature = "metrics")]
-            metrics.reset();
         }
 
-        // Send final metrics for non-debug or non-metrics builds
+        #[cfg(feature = "metrics")]
+        metrics.stop_timer();
+        #[cfg(feature = "metrics")]
+        metrics.set_jobs_created(state.get_number_of_jobs_created());
+        #[cfg(all(feature = "submission", feature = "metrics"))]
+        self.submission_handler
+            .flow_execution_ended(&state, metrics)?;
         #[cfg(all(feature = "submission", not(feature = "metrics")))]
         self.submission_handler.flow_execution_ended(&state)?;
 

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -424,6 +424,10 @@ impl DebugClient {
                     }
                 }
             }
+            #[cfg(feature = "metrics")]
+            DebugServerMessage::ExecutionMetrics(ref metrics) => {
+                println!("\nMetrics:\n{metrics}");
+            }
             DebugServerMessage::FlowList(_) => {}
             DebugServerMessage::JobInspect(ref job) => {
                 println!("Job #{}", job.payload.job_id);

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -154,6 +154,11 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::JobInspect(job));
     }
 
+    #[cfg(feature = "metrics")]
+    fn execution_metrics(&mut self, metrics: flowcore::model::metrics::Metrics) {
+        self.send_event(DebugServerMessage::ExecutionMetrics(metrics));
+    }
+
     fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
         let manifest = &state.get_submission().manifest;
         let flows: Vec<(usize, String, String)> = manifest

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -47,13 +47,8 @@ impl DebuggerHandler for DebugGuiHandler {
         self.send_event(DebugServerMessage::EnteringDebugger);
     }
 
-    fn job_breakpoint(&mut self, job: &Job, function: &RuntimeFunction, states: Vec<State>) {
+    fn job_breakpoint(&mut self, job: &Job, _function: &RuntimeFunction, _states: Vec<State>) {
         self.send_event(DebugServerMessage::PriorToSendingJob(job.clone()));
-        self.send_event(DebugServerMessage::FunctionStates((
-            function.clone(),
-            states,
-            vec![],
-        )));
     }
 
     fn flow_unblock_breakpoint(&mut self, flow_id: usize) {

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -66,6 +66,9 @@ pub enum DebugServerMessage {
     InspectFlow(usize, RunState),
     /// Inspect a job — carries the Job
     JobInspect(Job),
+    /// Execution metrics snapshot
+    #[cfg(feature = "metrics")]
+    ExecutionMetrics(flowcore::model::metrics::Metrics),
     /// List of flows with names and routes
     FlowList(Vec<(usize, String, String)>),
     /// The list of active breakpoints
@@ -112,6 +115,8 @@ impl fmt::Display for DebugServerMessage {
                 DebugServerMessage::InspectFlow(_, _) => "InspectFlow",
                 DebugServerMessage::InspectFunction(_, _) => "InspectFunction",
                 DebugServerMessage::JobInspect(_) => "JobInspect",
+                #[cfg(feature = "metrics")]
+                DebugServerMessage::ExecutionMetrics(_) => "ExecutionMetrics",
                 DebugServerMessage::FlowList(_) => "FlowList",
             }
         )

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -36,13 +36,10 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(EnteringDebugger);
     }
 
-    fn job_breakpoint(&mut self, job: &Job, function: &RuntimeFunction, states: Vec<State>) {
+    fn job_breakpoint(&mut self, job: &Job, _function: &RuntimeFunction, _states: Vec<State>) {
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection
             .send_and_receive_response(PriorToSendingJob(job.clone()));
-        let _: flowcore::errors::Result<DebugCommand> = self
-            .debug_server_connection
-            .send_and_receive_response(FunctionStates((function.clone(), states, vec![])));
     }
 
     fn flow_unblock_breakpoint(&mut self, flow_id: usize) {

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -106,6 +106,13 @@ impl DebuggerHandler for DebugZmqHandler {
             .send_and_receive_response(Functions(functions.to_vec()));
     }
 
+    #[cfg(feature = "metrics")]
+    fn execution_metrics(&mut self, metrics: flowcore::model::metrics::Metrics) {
+        let _: flowcore::errors::Result<DebugCommand> = self
+            .debug_server_connection
+            .send_and_receive_response(DebugServerMessage::ExecutionMetrics(metrics));
+    }
+
     fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
         let manifest = &state.get_submission().manifest;
         let flows: Vec<(usize, String, String)> = manifest

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -185,6 +185,12 @@ impl<'a> Debugger<'a> {
         self.wait_for_command(state)
     }
 
+    /// Send execution metrics via the debug channel
+    #[cfg(feature = "metrics")]
+    pub fn send_metrics(&mut self, metrics: &flowcore::model::metrics::Metrics) {
+        self.debug_server.execution_metrics(metrics.clone());
+    }
+
     /// Execution of the flow ended, report it and wait for command
     /// Return values are (display next output, reset execution)
     pub fn execution_ended(&mut self, state: &mut RunState) -> Result<(bool, bool)> {
@@ -1136,6 +1142,8 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        #[cfg(feature = "metrics")]
+        fn execution_metrics(&mut self, _: flowcore::model::metrics::Metrics) {}
         fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             Ok(DebugCommand::Step(None))

--- a/flowr/src/lib/debugger_handler.rs
+++ b/flowr/src/lib/debugger_handler.rs
@@ -46,6 +46,9 @@ pub trait DebuggerHandler {
     fn input(&mut self, input: Input);
     /// lists all functions
     fn function_list(&mut self, functions: &[RuntimeFunction]);
+    /// Send execution metrics
+    #[cfg(feature = "metrics")]
+    fn execution_metrics(&mut self, metrics: flowcore::model::metrics::Metrics);
     /// Lists flow IDs with access to `RunState` for names/routes
     fn flow_list(&mut self, flow_ids: &[usize], state: &RunState);
     /// returns the state of a function

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1022,6 +1022,8 @@ mod test {
         fn inspect_by_state(&mut self, _: &str, _: &RunState) {}
         fn inspect_flow(&mut self, _: usize, _: &RunState) {}
         fn job_inspect(&mut self, _: Job) {}
+        #[cfg(feature = "metrics")]
+        fn execution_metrics(&mut self, _: flowcore::model::metrics::Metrics) {}
         fn flow_list(&mut self, _: &[usize], _: &RunState) {}
         fn get_command(&mut self, _state: &RunState) -> Result<DebugCommand> {
             unimplemented!();


### PR DESCRIPTION
Add metrics panel accessible via a Metrics button in the status bar after flow completion.

- Metrics stored on FlowEnd, button appears in status bar when available
- Split pane panel shows: functions, jobs created, values sent, elapsed time, max parallel jobs
- FlowEnd now sent before debugger post-mortem so metrics are available immediately
- Metrics reset on flow restart
- Removed redundant 'Entering debugger' message from debug tab
- Removed old modal metrics display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metrics panel to display flow completion metrics, accessible via a "Metrics" button in the status bar.
  * Metrics panel can be toggled to show or hide metrics information.

* **Changes**
  * Updated metrics display from modal dialog to a dedicated panel interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->