### PR TITLE
Flow browser panel for inspection and breakpoints (#2793)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -952,6 +952,7 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                     inputs,
                                     outputs,
                                     is_flow: false,
+                                    parent_id: Some(f.get_parent_id()),
                                 }
                             })
                             .collect();
@@ -962,13 +963,14 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                     if let DebugServerMessage::FlowList(ref flows) = message {
                         let flow_data: Vec<crate::CachedFunction> = flows
                             .iter()
-                            .map(|(id, name, route)| crate::CachedFunction {
+                            .map(|(id, name, route, parent)| crate::CachedFunction {
                                 id: *id,
                                 name: name.clone(),
                                 route: route.clone(),
                                 inputs: Vec::new(),
                                 outputs: Vec::new(),
                                 is_flow: true,
+                                parent_id: *parent,
                             })
                             .collect();
                         let _ = blocking_sender.try_send(Message::DebugFlowsReceived(flow_data));
@@ -1031,6 +1033,12 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                 } else {
                                     (String::new(), String::new())
                                 };
+                                let parent = state
+                                    .get_submission()
+                                    .manifest
+                                    .flows()
+                                    .get(id)
+                                    .and_then(|fi| fi.parent_id);
                                 crate::CachedFunction {
                                     id: *id,
                                     name,
@@ -1038,6 +1046,7 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                     inputs: Vec::new(),
                                     outputs: Vec::new(),
                                     is_flow: true,
+                                    parent_id: parent,
                                 }
                             })
                             .collect();

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1079,6 +1079,29 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                         if !flows.is_empty() {
                             let _ = blocking_sender.try_send(Message::DebugFlowsReceived(flows));
                         }
+
+                        let mut states_map = std::collections::HashMap::new();
+                        for &id in functions.keys() {
+                            let fn_states = state.get_function_states(id);
+                            let chips: Vec<(char, String)> = fn_states
+                                .iter()
+                                .map(|s| match s {
+                                    flowrlib::run_state::State::Ready => ('R', "Ready".into()),
+                                    flowrlib::run_state::State::Waiting => ('W', "Waiting".into()),
+                                    flowrlib::run_state::State::Running => ('X', "Running".into()),
+                                    flowrlib::run_state::State::Completed => {
+                                        ('C', "Completed".into())
+                                    }
+                                })
+                                .collect();
+                            if !chips.is_empty() {
+                                states_map.insert(id, chips);
+                            }
+                        }
+                        if !states_map.is_empty() {
+                            let _ =
+                                blocking_sender.try_send(Message::DebugStatesReceived(states_map));
+                        }
                     }
 
                     if !is_waiting {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -935,13 +935,15 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                         ref route,
                                     ) = conn.source
                                     {
-                                        let route = if route.starts_with('/') {
-                                            route.clone()
-                                        } else {
-                                            format!("/{route}")
-                                        };
-                                        if !outputs.contains(&route) {
-                                            outputs.push(route);
+                                        if !route.is_empty() {
+                                            let route = if route.starts_with('/') {
+                                                route.clone()
+                                            } else {
+                                                format!("/{route}")
+                                            };
+                                            if !outputs.contains(&route) {
+                                                outputs.push(route);
+                                            }
                                         }
                                     }
                                 }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -106,6 +106,25 @@ pub fn set_flows_only(v: bool) {
     FLOWS_ONLY.store(v, Ordering::Relaxed);
 }
 
+/// Last output-inspect source process ID (set by GUI before sending `InspectOutput`)
+#[cfg(feature = "debugger")]
+static LAST_OUTPUT_INSPECT_PID: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+#[cfg(feature = "debugger")]
+pub fn set_last_output_inspect_pid(pid: usize) {
+    LAST_OUTPUT_INSPECT_PID.store(pid, Ordering::Relaxed);
+}
+
+#[cfg(feature = "debugger")]
+fn take_last_output_inspect_pid() -> Option<usize> {
+    let v = LAST_OUTPUT_INSPECT_PID.swap(usize::MAX, Ordering::Relaxed);
+    if v == usize::MAX {
+        None
+    } else {
+        Some(v)
+    }
+}
+
 /// Global counter for jobs created, updated by the coordinator thread
 static JOB_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -757,42 +776,13 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             }
         }
         DebugServerMessage::OutputState(connections) => {
+            let source_pid = take_last_output_inspect_pid();
             if connections.is_empty() {
                 line("No output connections from that sub-route".into(), None)
             } else {
                 connections
                     .iter()
-                    .map(|c| {
-                        let source_label = format!("output '{}'", c.source);
-                        let mut b = crate::DebugLineBuilder::new()
-                            .chip(&source_label, "", crate::LinkType::Output)
-                            .text("  ->  ")
-                            .chip(
-                                &format!("function #{}", c.destination_id),
-                                &c.destination_id.to_string(),
-                                crate::LinkType::Function,
-                            )
-                            .text("  (  ")
-                            .chip(
-                                &format!("flow #{}", c.destination_parent_id),
-                                &c.destination_parent_id.to_string(),
-                                crate::LinkType::Flow,
-                            )
-                            .text("  )  ")
-                            .chip(
-                                &format!("input:{}", c.destination_io_number),
-                                &format!("{}:{}", c.destination_id, c.destination_io_number),
-                                crate::LinkType::Input,
-                            );
-                        if !c.destination.is_empty() {
-                            b = b.text(" @ ").chip(
-                                &c.destination,
-                                &c.destination,
-                                crate::LinkType::Function,
-                            );
-                        }
-                        b.finish()
-                    })
+                    .map(|c| format_output_connection(c, source_pid, ""))
                     .collect()
             }
         }
@@ -1598,6 +1588,7 @@ fn format_inspect_by_state(
 
 #[cfg(feature = "debugger")]
 #[cfg(feature = "debugger")]
+#[allow(clippy::too_many_lines)]
 fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventLine> {
     use crate::{DebugLineBuilder, LinkType};
 
@@ -1667,36 +1658,7 @@ fn format_inspect_job(job: &flowcore::model::job::Job) -> Vec<crate::DebugEventL
             None,
         ));
         for conn in &job.connections {
-            let source_label = match &conn.source {
-                flowcore::model::output_connection::Source::Output(route) => {
-                    if route.is_empty() {
-                        "output".to_string()
-                    } else {
-                        format!("output '{route}'")
-                    }
-                }
-                flowcore::model::output_connection::Source::Input(n) => {
-                    format!("input #{n}")
-                }
-            };
-            let mut b = DebugLineBuilder::new()
-                .text(&format!("    {source_label} \u{2192} "))
-                .chip(
-                    &format!("function #{}", conn.destination_id),
-                    &conn.destination_id.to_string(),
-                    LinkType::Function,
-                );
-            if !conn.destination.is_empty() {
-                b = b
-                    .text(" @ ")
-                    .chip(&conn.destination, &conn.destination, LinkType::Function);
-            }
-            b = b.text(" ").chip(
-                &format!("input:{}", conn.destination_io_number),
-                &format!("{}:{}", conn.destination_id, conn.destination_io_number),
-                LinkType::Input,
-            );
-            lines.push(b.finish());
+            lines.push(format_output_connection(conn, Some(job.process_id), "    "));
         }
     }
 
@@ -1932,4 +1894,66 @@ fn get_four_ports() -> Result<(u16, u16, u16, u16)> {
         pick_unused_port().chain_err(|| "No ports free")?,
         pick_unused_port().chain_err(|| "No ports free")?,
     ))
+}
+
+#[cfg(feature = "debugger")]
+fn format_output_connection(
+    c: &flowcore::model::output_connection::OutputConnection,
+    source_process_id: Option<usize>,
+    indent: &str,
+) -> crate::DebugEventLine {
+    use crate::{DebugLineBuilder, LinkType};
+
+    let source_label = match &c.source {
+        flowcore::model::output_connection::Source::Output(route) => {
+            if route.is_empty() {
+                "output (default)".to_string()
+            } else {
+                format!("output '{route}'")
+            }
+        }
+        flowcore::model::output_connection::Source::Input(n) => format!("input #{n}"),
+    };
+
+    let source_spec = match (&c.source, source_process_id) {
+        (flowcore::model::output_connection::Source::Output(route), Some(pid)) => {
+            let r = if route.is_empty() {
+                "/"
+            } else {
+                route.as_str()
+            };
+            format!("{pid}{r}")
+        }
+        _ => String::new(),
+    };
+
+    let mut b =
+        DebugLineBuilder::new()
+            .text(indent)
+            .chip(&source_label, &source_spec, LinkType::Output);
+    b = b
+        .text("  ->  ")
+        .chip(
+            &format!("function #{}", c.destination_id),
+            &c.destination_id.to_string(),
+            LinkType::Function,
+        )
+        .text("  (  ")
+        .chip(
+            &format!("flow #{}", c.destination_parent_id),
+            &c.destination_parent_id.to_string(),
+            LinkType::Flow,
+        )
+        .text("  )  ")
+        .chip(
+            &format!("input:{}", c.destination_io_number),
+            &format!("{}:{}", c.destination_id, c.destination_io_number),
+            LinkType::Input,
+        );
+    if !c.destination.is_empty() {
+        b = b
+            .text(" @ ")
+            .chip(&c.destination, &c.destination, LinkType::Function);
+    }
+    b.finish()
 }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -762,7 +762,37 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             } else {
                 connections
                     .iter()
-                    .map(|c| DebugEventLine::new(format!("{c}"), None))
+                    .map(|c| {
+                        let source_label = format!("output '{}'", c.source);
+                        let mut b = crate::DebugLineBuilder::new()
+                            .chip(&source_label, "", crate::LinkType::Output)
+                            .text("  ->  ")
+                            .chip(
+                                &format!("function #{}", c.destination_id),
+                                &c.destination_id.to_string(),
+                                crate::LinkType::Function,
+                            )
+                            .text("  (  ")
+                            .chip(
+                                &format!("flow #{}", c.destination_parent_id),
+                                &c.destination_parent_id.to_string(),
+                                crate::LinkType::Flow,
+                            )
+                            .text("  )  ")
+                            .chip(
+                                &format!("input:{}", c.destination_io_number),
+                                &format!("{}:{}", c.destination_id, c.destination_io_number),
+                                crate::LinkType::Input,
+                            );
+                        if !c.destination.is_empty() {
+                            b = b.text(" @ ").chip(
+                                &c.destination,
+                                &c.destination,
+                                crate::LinkType::Function,
+                            );
+                        }
+                        b.finish()
+                    })
                     .collect()
             }
         }
@@ -929,23 +959,27 @@ fn debug_client_stream(address: String) -> impl iced::futures::Stream<Item = Mes
                                     .enumerate()
                                     .map(|(i, inp)| (i, inp.name().to_string(), inp.is_generic()))
                                     .collect();
-                                let mut outputs: Vec<String> = Vec::new();
+                                let mut outputs: Vec<(String, usize, usize)> = Vec::new();
                                 for conn in f.get_output_connections() {
-                                    if let flowcore::model::output_connection::Source::Output(
-                                        ref route,
-                                    ) = conn.source
-                                    {
-                                        if !route.is_empty() {
-                                            let route = if route.starts_with('/') {
-                                                route.clone()
+                                    let route = match &conn.source {
+                                        flowcore::model::output_connection::Source::Output(r) => {
+                                            if r.is_empty() || r == "/" {
+                                                String::new()
+                                            } else if r.starts_with('/') {
+                                                r.clone()
                                             } else {
-                                                format!("/{route}")
-                                            };
-                                            if !outputs.contains(&route) {
-                                                outputs.push(route);
+                                                format!("/{r}")
                                             }
                                         }
-                                    }
+                                        flowcore::model::output_connection::Source::Input(_) => {
+                                            continue;
+                                        }
+                                    };
+                                    outputs.push((
+                                        route,
+                                        conn.destination_id,
+                                        conn.destination_io_number,
+                                    ));
                                 }
                                 crate::CachedFunction {
                                     id: f.id(),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -594,24 +594,9 @@ pub enum Message {
     /// User clicked Validate
     #[cfg(feature = "debugger")]
     DebugValidate,
-    /// Show the breakpoint spec popup
-    #[cfg(feature = "debugger")]
-    ShowBpPopup,
-    /// Close the breakpoint spec popup
-    #[cfg(feature = "debugger")]
-    CloseBpPopup,
-    /// Breakpoint type changed in popup
-    #[cfg(feature = "debugger")]
-    BpTabChanged(BpTab),
-    /// Breakpoint target changed in popup
+    /// Breakpoint target toggled in browser tree
     #[cfg(feature = "debugger")]
     BpTargetChanged(String),
-    /// Confirm and set breakpoint from popup
-    #[cfg(feature = "debugger")]
-    BpPopupConfirm,
-    /// Cycle before/after breakpoint on a function in Route tab
-    #[cfg(feature = "debugger")]
-    BpCycleFunction(usize),
     /// A clickable link in the debug output was clicked (spec to inspect)
     #[cfg(feature = "debugger")]
     DebugInspectLink(String),
@@ -737,50 +722,10 @@ pub struct CachedFunction {
 }
 
 /// Tabs in the breakpoint popup
-#[cfg(feature = "debugger")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BpTab {
-    /// Break before a function executes
-    Before,
-    /// Break after a function completes
-    After,
-    /// Break when data arrives at an input
-    Input,
-    /// Break when data is sent from an output
-    Output,
-    /// Full hierarchical route view
-    Route,
-}
-
-#[cfg(feature = "debugger")]
-impl std::fmt::Display for BpTab {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Before => write!(f, "Before"),
-            Self::After => write!(f, "After"),
-            Self::Input => write!(f, "Input"),
-            Self::Output => write!(f, "Output"),
-            Self::Route => write!(f, "Route"),
-        }
-    }
-}
-
-#[cfg(feature = "debugger")]
-const BP_TABS: [BpTab; 5] = [
-    BpTab::Before,
-    BpTab::After,
-    BpTab::Input,
-    BpTab::Output,
-    BpTab::Route,
-];
-
-/// Tabs in the inspect popup
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PanelKind {
     Settings,
     Metrics,
-    #[cfg(feature = "debugger")]
-    Breakpoints,
     #[cfg(feature = "debugger")]
     Browser,
 }
@@ -820,11 +765,6 @@ struct FlowrGui {
     debug_step_count: String,
     #[cfg(feature = "debugger")]
     debug_client_active: bool,
-    #[cfg(feature = "debugger")]
-    #[cfg(feature = "debugger")]
-    bp_tab: BpTab,
-    #[cfg(feature = "debugger")]
-    bp_target: String,
     cached_functions: Vec<CachedFunction>,
     #[cfg(feature = "debugger")]
     active_breakpoints: std::collections::HashSet<String>,
@@ -879,11 +819,6 @@ impl FlowrGui {
             debug_step_count: String::new(),
             #[cfg(feature = "debugger")]
             debug_client_active: false,
-            #[cfg(feature = "debugger")]
-            #[cfg(feature = "debugger")]
-            bp_tab: BpTab::Before,
-            #[cfg(feature = "debugger")]
-            bp_target: String::new(),
             cached_functions: Vec::new(),
             #[cfg(feature = "debugger")]
             active_breakpoints: std::collections::HashSet::new(),
@@ -1146,12 +1081,7 @@ impl FlowrGui {
             | Message::DebugProcesses
             | Message::DebugState
             | Message::DebugValidate
-            | Message::ShowBpPopup
-            | Message::CloseBpPopup
-            | Message::BpTabChanged(_)
             | Message::BpTargetChanged(_)
-            | Message::BpPopupConfirm
-            | Message::BpCycleFunction(_)
             | Message::DebugFunctionListReceived(_)
             | Message::DebugFlowsReceived(_)
             | Message::DebugBreakpointListReceived(_)
@@ -1264,8 +1194,6 @@ impl FlowrGui {
                     let panel: Element<'_, Message> = match kind {
                         PanelKind::Settings => self.settings_panel(),
                         PanelKind::Metrics => self.metrics_panel(),
-                        #[cfg(feature = "debugger")]
-                        PanelKind::Breakpoints => self.bp_panel(),
                         #[cfg(feature = "debugger")]
                         PanelKind::Browser => unreachable!(),
                     };
@@ -1671,13 +1599,6 @@ impl FlowrGui {
             .style(theme::pill_input)
             .width(100);
 
-        let mut bp_btn = Button::new(Text::new("Set BP"))
-            .style(theme::styled_button)
-            .padding(sp);
-        if can_cmd {
-            bp_btn = bp_btn.on_press(Message::ShowBpPopup);
-        }
-
         let mut del_btn = Button::new(Text::new("Del All"))
             .style(theme::styled_button)
             .padding(sp);
@@ -1755,7 +1676,6 @@ impl FlowrGui {
                 spec_input,
                 "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
             ))
-            .push(Self::tip(bp_btn, "Open breakpoint picker"))
             .push(Self::tip(del_btn, "Delete all breakpoints"))
             .push(Self::tip(list_btn, "List active breakpoints"))
             .push(Self::tip(funcs_btn, "List all functions"))
@@ -1806,234 +1726,6 @@ impl FlowrGui {
 
         row = row.push(exec_btn).push(cancel_btn);
         row
-    }
-
-    #[cfg(feature = "debugger")]
-    #[allow(clippy::too_many_lines)]
-    fn bp_panel(&self) -> Element<'_, Message> {
-        use iced::widget::scrollable::Scrollable;
-        use iced::widget::Container;
-        use iced::Length;
-
-        let type_row = Row::new()
-            .spacing(4)
-            .align_y(iced::alignment::Vertical::Center);
-        let type_row = BP_TABS.iter().fold(type_row, |row, &bt| {
-            let is_active = bt == self.bp_tab;
-            let mut btn = Button::new(Text::new(bt.to_string()).size(theme::FONT_MD))
-                .padding(theme::BUTTON_PAD)
-                .style(if is_active {
-                    theme::pill_button_active
-                        as fn(
-                            &iced::Theme,
-                            iced::widget::button::Status,
-                        ) -> iced::widget::button::Style
-                } else {
-                    theme::pill_button
-                });
-            if !is_active {
-                btn = btn.on_press(Message::BpTabChanged(bt));
-            }
-            row.push(btn)
-        });
-
-        let mut items = Column::new().spacing(2);
-
-        if self.cached_functions.is_empty() {
-            items = items.push(
-                Text::new("Loading function list...")
-                    .size(13)
-                    .color(crate::theme::TEXT_SECONDARY),
-            );
-        } else {
-            let bp_marker = |spec: &str| -> &str {
-                if self.active_breakpoints.contains(spec) {
-                    "\u{1F534} "
-                } else {
-                    "  "
-                }
-            };
-
-            match self.bp_tab {
-                BpTab::Before | BpTab::After => {
-                    for f in self.cached_functions.iter().filter(|f| !f.is_flow) {
-                        let spec = match self.bp_tab {
-                            BpTab::Before => format!("{}", f.id),
-                            BpTab::After => format!("{}+", f.id),
-                            _ => unreachable!(),
-                        };
-                        let marker = bp_marker(&spec);
-                        let label = format!("{marker}#{} '{}' @ '{}'", f.id, f.name, f.route);
-                        let mut btn = Button::new(Text::new(label).size(13))
-                            .width(Length::Fill)
-                            .padding([3, 8]);
-                        if self.active_breakpoints.contains(&spec) {
-                            btn = btn.style(theme::styled_button);
-                        } else {
-                            btn = btn.style(theme::list_button);
-                        }
-                        btn = btn.on_press(Message::BpTargetChanged(spec.clone()));
-                        items = items.push(btn);
-                    }
-                }
-                BpTab::Route => {
-                    for f in self.cached_functions.iter().filter(|f| !f.is_flow) {
-                        let before_spec = format!("{}", f.id);
-                        let after_spec = format!("{}+", f.id);
-                        let has_before = self.active_breakpoints.contains(&before_spec);
-                        let has_after = self.active_breakpoints.contains(&after_spec);
-                        let before_dot = if has_before { "\u{1F534}" } else { "  " };
-                        let after_dot = if has_after { " \u{1F534}" } else { "" };
-                        let label = format!(
-                            "{before_dot} {} (#{} '{}'){after_dot}",
-                            f.route, f.id, f.name
-                        );
-                        let mut btn = Button::new(
-                            Text::new(label)
-                                .size(13)
-                                .shaping(iced::widget::text::Shaping::Advanced),
-                        )
-                        .width(Length::Fill)
-                        .padding([3, 8]);
-                        if has_before || has_after {
-                            btn = btn.style(theme::styled_button);
-                        } else {
-                            btn = btn.style(theme::list_button);
-                        }
-                        btn = btn.on_press(Message::BpCycleFunction(f.id));
-                        items = items.push(btn);
-
-                        for (idx, input_name, _generic) in &f.inputs {
-                            let input_spec = format!("{}:{idx}", f.id);
-                            let name_part = if input_name.is_empty() {
-                                String::new()
-                            } else {
-                                format!(" '{input_name}'")
-                            };
-                            let im = bp_marker(&input_spec);
-                            let input_label =
-                                format!("  {im}input:{idx}{name_part} on '{}'", f.route);
-                            let mut ibtn = Button::new(Text::new(input_label).size(12))
-                                .width(Length::Fill)
-                                .padding([2, 16]);
-                            if self.active_breakpoints.contains(&input_spec) {
-                                ibtn = ibtn.style(theme::styled_button);
-                            } else {
-                                ibtn = ibtn.style(theme::list_button);
-                            }
-                            ibtn = ibtn.on_press(Message::BpTargetChanged(input_spec));
-                            items = items.push(ibtn);
-                        }
-                        for (output_route, _dest_id, _dest_io) in &f.outputs {
-                            let out_spec = format!("{}{output_route}", f.id);
-                            let om = bp_marker(&out_spec);
-                            let out_label =
-                                format!("  {om}output:'{output_route}' on '{}'", f.route);
-                            let mut obtn = Button::new(Text::new(out_label).size(12))
-                                .width(Length::Fill)
-                                .padding([2, 16]);
-                            if self.active_breakpoints.contains(&out_spec) {
-                                obtn = obtn.style(theme::styled_button);
-                            } else {
-                                obtn = obtn.style(theme::list_button);
-                            }
-                            obtn = obtn.on_press(Message::BpTargetChanged(out_spec));
-                            items = items.push(obtn);
-                        }
-                    }
-                }
-                BpTab::Input => {
-                    for f in &self.cached_functions {
-                        for (idx, input_name, _generic) in &f.inputs {
-                            let spec = format!("{}:{idx}", f.id);
-                            let marker = bp_marker(&spec);
-                            let name_part = if input_name.is_empty() {
-                                String::new()
-                            } else {
-                                format!(" '{input_name}'")
-                            };
-                            let label =
-                                format!("{marker}#{} '{}' input:{idx}{name_part}", f.id, f.name);
-                            let mut btn = Button::new(Text::new(label).size(13))
-                                .width(Length::Fill)
-                                .padding([3, 8]);
-                            if self.active_breakpoints.contains(&spec) {
-                                btn = btn.style(theme::styled_button);
-                            } else {
-                                btn = btn.style(theme::list_button);
-                            }
-                            btn = btn.on_press(Message::BpTargetChanged(spec));
-                            items = items.push(btn);
-                        }
-                    }
-                }
-                BpTab::Output => {
-                    for f in &self.cached_functions {
-                        for (output_route, _dest_id, _dest_io) in &f.outputs {
-                            let spec = format!("{}{output_route}", f.id);
-                            let marker = bp_marker(&spec);
-                            let label =
-                                format!("{marker}#{} '{}' output:'{output_route}'", f.id, f.name);
-                            let mut btn = Button::new(Text::new(label).size(13))
-                                .width(Length::Fill)
-                                .padding([3, 8]);
-                            if self.active_breakpoints.contains(&spec) {
-                                btn = btn.style(theme::styled_button);
-                            } else {
-                                btn = btn.style(theme::list_button);
-                            }
-                            btn = btn.on_press(Message::BpTargetChanged(spec));
-                            items = items.push(btn);
-                        }
-                    }
-                }
-            }
-        }
-
-        let list = Scrollable::new(items)
-            .height(Length::Fill)
-            .width(Length::Fill);
-
-        let header = Row::new()
-            .push(Text::new("Breakpoints").size(theme::FONT_DEFAULT))
-            .push(iced::widget::container(iced::widget::text("")).width(Length::Fill))
-            .push(
-                Button::new(
-                    Text::new("\u{00BB}")
-                        .size(20.0)
-                        .shaping(iced::widget::text::Shaping::Advanced),
-                )
-                .on_press(Message::CloseBpPopup)
-                .style(theme::ghost_button)
-                .padding(theme::BUTTON_PAD_SM),
-            )
-            .align_y(iced::alignment::Vertical::Center)
-            .padding(iced::Padding {
-                top: 0.0,
-                right: 0.0,
-                bottom: theme::SPACE_SM,
-                left: 0.0,
-            });
-
-        let panel_content = Column::new()
-            .spacing(theme::SPACE_MD)
-            .push(header)
-            .push(type_row)
-            .push(list);
-
-        Container::new(panel_content)
-            .width(Length::Fixed(380.0))
-            .padding(theme::SPACE_LG)
-            .style(|_: &iced::Theme| iced::widget::container::Style {
-                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
-                border: iced::Border {
-                    radius: 0.0.into(),
-                    width: 0.0,
-                    color: iced::Color::TRANSPARENT,
-                },
-                ..Default::default()
-            })
-            .into()
     }
 
     fn metrics_panel(&self) -> Element<'_, Message> {
@@ -2176,13 +1868,19 @@ impl FlowrGui {
         let header = Row::new()
             .push(
                 Button::new(
-                    Text::new("Flow Browser")
-                        .size(theme::FONT_DEFAULT)
-                        .color(iced::Color::WHITE)
-                        .font(iced::Font {
-                            weight: iced::font::Weight::Bold,
-                            ..iced::Font::DEFAULT
-                        }),
+                    Row::new()
+                        .spacing(6)
+                        .align_y(iced::alignment::Vertical::Center)
+                        .push(crate::icons::list().size(16.0).color(iced::Color::WHITE))
+                        .push(
+                            Text::new("Flow Browser")
+                                .size(theme::FONT_DEFAULT)
+                                .color(iced::Color::WHITE)
+                                .font(iced::Font {
+                                    weight: iced::font::Weight::Bold,
+                                    ..iced::Font::DEFAULT
+                                }),
+                        ),
                 )
                 .on_press(Message::ToggleFlowBrowser)
                 .style(theme::chip_button(theme::ACCENT))
@@ -2200,6 +1898,31 @@ impl FlowrGui {
         let mut tree_items = Column::new().spacing(1);
         let funcs = &self.cached_functions;
         let bps = &self.active_breakpoints;
+
+        #[allow(clippy::items_after_statements)]
+        fn bp_tooltip<'a>(btn: Button<'a, Message>, tip: &str) -> Element<'a, Message> {
+            iced::widget::tooltip(
+                btn,
+                Text::new(tip.to_string()).size(theme::FONT_SM),
+                iced::widget::tooltip::Position::Top,
+            )
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                text_color: Some(iced::Color::WHITE),
+                border: iced::Border {
+                    radius: theme::RADIUS_SM.into(),
+                    width: 1.0,
+                    color: iced::Color {
+                        a: 0.3,
+                        ..theme::ACCENT
+                    },
+                },
+                ..Default::default()
+            })
+            .padding(4)
+            .gap(4)
+            .into()
+        }
 
         // Build tree with fold/unfold triangles and outputs
         #[allow(clippy::items_after_statements)]
@@ -2229,12 +1952,6 @@ impl FlowrGui {
                 };
                 let has_before = bps.contains(&child.id.to_string());
                 let has_after = bps.contains(&format!("{}+", child.id));
-                let bp_symbol = match (has_before, has_after) {
-                    (true, true) => "\u{23FA}",
-                    (true, false) => "\u{1F534}",
-                    (false, true) => "\u{1F7E0}",
-                    (false, false) => "\u{25CB}",
-                };
                 let name_part = if child.name.is_empty() {
                     format!("{prefix} #{}", child.id)
                 } else {
@@ -2247,7 +1964,7 @@ impl FlowrGui {
 
                 // Indent
                 if depth > 0 {
-                    row = row.push(Text::new(indent).size(theme::FONT_MD));
+                    row = row.push(Text::new(indent).size(theme::FONT_DEFAULT));
                 }
 
                 // Triangle toggle
@@ -2273,53 +1990,55 @@ impl FlowrGui {
                     row = row.push(Text::new("  ").size(12.0));
                 }
 
-                // Breakpoint indicator (clickable, cycles: none→before→after→both→none)
-                let mut bp_btn = Button::new(
-                    Text::new(bp_symbol)
-                        .size(10.0)
+                // Before-breakpoint indicator
+                let before_sym = if has_before { "\u{1F534}" } else { "\u{25CB}" };
+                let before_spec = child.id.to_string();
+                let mut before_btn = Button::new(
+                    Text::new(before_sym)
+                        .size(11.0)
                         .shaping(iced::widget::text::Shaping::Advanced),
                 )
                 .style(theme::ghost_button)
                 .padding([1, 2]);
                 if can_bp {
-                    bp_btn = bp_btn.on_press(Message::BpCycleFunction(child.id));
+                    before_btn = before_btn.on_press(Message::BpTargetChanged(before_spec));
                 }
-                let bp_tooltip_text = match (has_before, has_after) {
-                    (true, true) => "BP: before+after (click to cycle)",
-                    (true, false) => "BP: before (click to cycle)",
-                    (false, true) => "BP: after (click to cycle)",
-                    (false, false) => "Click to set breakpoint",
+                let before_tip = if has_before {
+                    "Remove breakpoint before this function"
+                } else {
+                    "Set breakpoint before executing this function"
                 };
-                row = row.push(
-                    iced::widget::tooltip(
-                        bp_btn,
-                        Text::new(bp_tooltip_text).size(theme::FONT_SM),
-                        iced::widget::tooltip::Position::Right,
-                    )
-                    .style(|_: &iced::Theme| iced::widget::container::Style {
-                        background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
-                        text_color: Some(iced::Color::WHITE),
-                        border: iced::Border {
-                            radius: theme::RADIUS_SM.into(),
-                            width: 1.0,
-                            color: iced::Color {
-                                a: 0.3,
-                                ..theme::ACCENT
-                            },
-                        },
-                        ..Default::default()
-                    })
-                    .padding(4)
-                    .gap(4),
-                );
+                row = row.push(bp_tooltip(before_btn, before_tip));
 
                 // Label button
                 row = row.push(
-                    Button::new(Text::new(name_part).size(theme::FONT_MD).color(color))
+                    Button::new(Text::new(name_part).size(theme::FONT_DEFAULT).color(color))
                         .on_press(Message::DebugInspectLink(child.id.to_string()))
                         .style(theme::list_button)
                         .padding([2, 4]),
                 );
+
+                // After-breakpoint indicator
+                if !child.is_flow {
+                    let after_sym = if has_after { "\u{1F7E0}" } else { "\u{25CB}" };
+                    let after_spec = format!("{}+", child.id);
+                    let mut after_btn = Button::new(
+                        Text::new(after_sym)
+                            .size(11.0)
+                            .shaping(iced::widget::text::Shaping::Advanced),
+                    )
+                    .style(theme::ghost_button)
+                    .padding([1, 2]);
+                    if can_bp {
+                        after_btn = after_btn.on_press(Message::BpTargetChanged(after_spec));
+                    }
+                    let after_tip = if has_after {
+                        "Remove breakpoint after this function"
+                    } else {
+                        "Set breakpoint after executing this function"
+                    };
+                    row = row.push(bp_tooltip(after_btn, after_tip));
+                }
 
                 *items = std::mem::replace(items, Column::new()).push(Element::from(row));
 
@@ -2351,7 +2070,7 @@ impl FlowrGui {
                         let bp_sym = if has_bp { "\u{1F534}" } else { "\u{25CB}" };
                         let mut bp_btn = Button::new(
                             Text::new(bp_sym)
-                                .size(10.0)
+                                .size(11.0)
                                 .shaping(iced::widget::text::Shaping::Advanced),
                         )
                         .style(theme::ghost_button)
@@ -2359,15 +2078,20 @@ impl FlowrGui {
                         if can_bp {
                             bp_btn = bp_btn.on_press(Message::BpTargetChanged(spec.clone()));
                         }
+                        let inp_tip = if has_bp {
+                            "Remove breakpoint on this input"
+                        } else {
+                            "Set breakpoint when data arrives at this input"
+                        };
                         let irow = Row::new()
                             .spacing(4)
                             .align_y(iced::alignment::Vertical::Center)
-                            .push(Text::new(format!("{inp_indent}    ")).size(theme::FONT_MD))
-                            .push(bp_btn)
+                            .push(Text::new(format!("{inp_indent}    ")).size(theme::FONT_DEFAULT))
+                            .push(bp_tooltip(bp_btn, inp_tip))
                             .push(
                                 Button::new(
                                     Text::new(iname)
-                                        .size(theme::FONT_MD)
+                                        .size(theme::FONT_DEFAULT)
                                         .color(theme::entity_colors::INPUT),
                                 )
                                 .on_press(Message::DebugInspectLink(spec))
@@ -2399,7 +2123,7 @@ impl FlowrGui {
                         let bp_sym = if has_bp { "\u{1F534}" } else { "\u{25CB}" };
                         let mut bp_btn = Button::new(
                             Text::new(bp_sym)
-                                .size(10.0)
+                                .size(11.0)
                                 .shaping(iced::widget::text::Shaping::Advanced),
                         )
                         .style(theme::ghost_button)
@@ -2407,15 +2131,20 @@ impl FlowrGui {
                         if can_bp {
                             bp_btn = bp_btn.on_press(Message::BpTargetChanged(spec.clone()));
                         }
+                        let out_tip = if has_bp {
+                            "Remove breakpoint on this output"
+                        } else {
+                            "Set breakpoint when data is sent from this output"
+                        };
                         let orow = Row::new()
                             .spacing(4)
                             .align_y(iced::alignment::Vertical::Center)
-                            .push(Text::new(format!("{out_indent}    ")).size(theme::FONT_MD))
-                            .push(bp_btn)
+                            .push(Text::new(format!("{out_indent}    ")).size(theme::FONT_DEFAULT))
+                            .push(bp_tooltip(bp_btn, out_tip))
                             .push(
                                 Button::new(
                                     Text::new(format!("output {display_route}"))
-                                        .size(theme::FONT_MD)
+                                        .size(theme::FONT_DEFAULT)
                                         .color(theme::entity_colors::OUTPUT),
                                 )
                                 .on_press(Message::DebugInspectLink(spec))
@@ -3197,85 +2926,19 @@ impl FlowrGui {
             Message::DebugToggleSection(section_id) => {
                 self.tab_set.debug_tab.toggle_section(section_id);
             }
-            Message::CloseBpPopup => self.close_panel(),
-            Message::ShowBpPopup => {
-                if !self.ensure_functions_cached(Message::ShowBpPopup) {
-                    return iced::Task::none();
-                }
-                if self.active_panel == Some(PanelKind::Breakpoints) {
-                    self.close_panel();
-                    return iced::Task::none();
-                }
-                self.open_panel(PanelKind::Breakpoints);
-                self.bp_target.clear();
-                if self.debug_waiting {
+            Message::BpTargetChanged(spec_str) if self.debug_waiting => {
+                if self.active_breakpoints.contains(&spec_str) {
+                    self.active_breakpoints.remove(&spec_str);
                     self.debug_waiting = false;
-                    self.suppress_next_output = true;
-                    connection_manager::send_debug_command(DebugCommand::List);
-                }
-            }
-            Message::BpTabChanged(tab) => {
-                self.bp_tab = tab;
-                self.bp_target.clear();
-            }
-            Message::BpTargetChanged(value) => {
-                if self.debug_waiting {
-                    let spec_str = if self.bp_tab == BpTab::After {
-                        format!("{value}+")
-                    } else {
-                        value.clone()
-                    };
-                    if self.active_breakpoints.contains(&spec_str) {
-                        self.active_breakpoints.remove(&spec_str);
-                        self.debug_waiting = false;
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![spec_str.clone()]));
-                        self.debug_separator(&format!("Delete Breakpoint ({spec_str})"));
-                        connection_manager::send_debug_command(DebugCommand::Delete(spec));
-                    } else {
-                        self.active_breakpoints.insert(spec_str.clone());
-                        self.debug_waiting = false;
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![spec_str.clone()]));
-                        self.debug_separator(&format!("Set Breakpoint ({spec_str})"));
-                        connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
-                    }
-                }
-                self.bp_target = value;
-            }
-            Message::BpPopupConfirm => {
-                self.close_panel();
-            }
-            Message::BpCycleFunction(func_id) if self.debug_waiting => {
-                let before_spec = format!("{func_id}");
-                let after_spec = format!("{func_id}+");
-                let has_before = self.active_breakpoints.contains(&before_spec);
-                let has_after = self.active_breakpoints.contains(&after_spec);
-
-                self.debug_waiting = false;
-                match (has_before, has_after) {
-                    (true, true) => {
-                        self.active_breakpoints.remove(&before_spec);
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![before_spec]));
-                        self.debug_separator("Remove before breakpoint");
-                        connection_manager::send_debug_command(DebugCommand::Delete(spec));
-                    }
-                    (false, true) => {
-                        self.active_breakpoints.remove(&after_spec);
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![after_spec]));
-                        self.debug_separator("Remove after breakpoint");
-                        connection_manager::send_debug_command(DebugCommand::Delete(spec));
-                    }
-                    (false, false) => {
-                        self.active_breakpoints.insert(before_spec.clone());
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![before_spec]));
-                        self.debug_separator("Set before breakpoint");
-                        connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
-                    }
-                    (true, false) => {
-                        self.active_breakpoints.insert(after_spec.clone());
-                        let spec = DebugClient::parse_breakpoint_spec(Some(vec![after_spec]));
-                        self.debug_separator("Set after breakpoint");
-                        connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
-                    }
+                    let spec = DebugClient::parse_breakpoint_spec(Some(vec![spec_str.clone()]));
+                    self.debug_separator(&format!("Delete Breakpoint ({spec_str})"));
+                    connection_manager::send_debug_command(DebugCommand::Delete(spec));
+                } else {
+                    self.active_breakpoints.insert(spec_str.clone());
+                    self.debug_waiting = false;
+                    let spec = DebugClient::parse_breakpoint_spec(Some(vec![spec_str.clone()]));
+                    self.debug_separator(&format!("Set Breakpoint ({spec_str})"));
+                    connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
                 }
             }
             _ => {}
@@ -3628,11 +3291,6 @@ mod test {
             debug_step_count: String::new(),
             #[cfg(feature = "debugger")]
             debug_client_active: false,
-            #[cfg(feature = "debugger")]
-            #[cfg(feature = "debugger")]
-            bp_tab: BpTab::Before,
-            #[cfg(feature = "debugger")]
-            bp_target: String::new(),
             cached_functions: Vec::new(),
             #[cfg(feature = "debugger")]
             active_breakpoints: std::collections::HashSet::new(),
@@ -3837,7 +3495,7 @@ mod test {
         let mut gui = test_gui();
         gui.debug_client_active = true;
         gui.debug_waiting = true;
-        gui.active_panel = Some(PanelKind::Breakpoints);
+        gui.active_panel = Some(PanelKind::Browser);
         let view = gui.view();
         let _ui = simulator(view);
     }
@@ -3849,7 +3507,7 @@ mod test {
         let mut gui = test_gui();
         gui.debug_client_active = true;
         gui.debug_waiting = true;
-        gui.active_panel = Some(PanelKind::Breakpoints);
+        gui.active_panel = Some(PanelKind::Browser);
         let view = gui.view();
         let _ui = simulator(view);
     }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -514,6 +514,9 @@ pub enum Message {
     CloseModal,
     /// Toggle settings panel
     ToggleSettings,
+    /// Toggle flow browser panel
+    #[cfg(feature = "debugger")]
+    ToggleFlowBrowser,
     /// Toggle metrics panel
     ToggleMetrics,
     /// Metrics received from debug channel
@@ -831,6 +834,8 @@ enum PanelKind {
     Inspect,
     #[cfg(feature = "debugger")]
     Breakpoints,
+    #[cfg(feature = "debugger")]
+    Browser,
 }
 
 struct UiSettings {
@@ -1150,6 +1155,13 @@ impl FlowrGui {
                 self.last_metrics = Some(metrics);
             }
             Message::ToggleMetrics => self.toggle_panel(PanelKind::Metrics),
+            #[cfg(feature = "debugger")]
+            Message::ToggleFlowBrowser => {
+                if !self.ensure_functions_cached(Message::ToggleFlowBrowser) {
+                    return iced::Task::none();
+                }
+                self.toggle_panel(PanelKind::Browser);
+            }
             Message::ToggleSettings => self.toggle_panel(PanelKind::Settings),
             #[cfg(feature = "debugger")]
             msg @ (Message::DebugEvent(_)
@@ -1234,6 +1246,7 @@ impl FlowrGui {
         Task::none()
     }
 
+    #[allow(clippy::too_many_lines)]
     fn view(&self) -> Element<'_, Message> {
         let mut main_content = Column::new().spacing(4).push(self.command_row());
 
@@ -1246,27 +1259,77 @@ impl FlowrGui {
         }
 
         let tab_content = self.tab_set.view(&self.cached_functions);
+
+        // Left panel (flow browser) or vertical chip
+        #[cfg(feature = "debugger")]
+        let browser_open = self.active_panel == Some(PanelKind::Browser);
+        #[cfg(feature = "debugger")]
+        let left_element: Element<'_, Message> = if browser_open {
+            self.flow_browser_panel()
+        } else if self.debug_client_active {
+            // Vertical "Flow Browser" chip on the left edge
+            iced::widget::container(
+                Button::new(
+                    Text::new("Flow Browser")
+                        .size(theme::FONT_SM)
+                        .color(iced::Color::WHITE)
+                        .font(iced::Font {
+                            weight: iced::font::Weight::Bold,
+                            ..iced::Font::DEFAULT
+                        }),
+                )
+                .on_press(Message::ToggleFlowBrowser)
+                .style(theme::chip_button(theme::ACCENT))
+                .padding([6, 4]),
+            )
+            .height(iced::Length::Fill)
+            .align_y(iced::alignment::Vertical::Center)
+            .into()
+        } else {
+            iced::widget::text("").into()
+        };
+
+        // Right panels (settings, metrics, inspect, breakpoints)
         let tab_area: Element<'_, Message> = if let Some(kind) = self.active_panel {
-            let panel: Element<'_, Message> = match kind {
-                PanelKind::Settings => self.settings_panel(),
-                PanelKind::Metrics => self.metrics_panel(),
+            match kind {
                 #[cfg(feature = "debugger")]
-                PanelKind::Inspect => self.inspect_panel(),
-                #[cfg(feature = "debugger")]
-                PanelKind::Breakpoints => self.bp_panel(),
-            };
-            Row::new()
-                .push(iced::widget::container(tab_content).width(iced::Length::Fill))
-                .push(panel)
-                .spacing(2)
-                .height(iced::Length::Fill)
-                .into()
+                PanelKind::Browser => tab_content,
+                _ => {
+                    let panel: Element<'_, Message> = match kind {
+                        PanelKind::Settings => self.settings_panel(),
+                        PanelKind::Metrics => self.metrics_panel(),
+                        #[cfg(feature = "debugger")]
+                        PanelKind::Inspect => self.inspect_panel(),
+                        #[cfg(feature = "debugger")]
+                        PanelKind::Breakpoints => self.bp_panel(),
+                        #[cfg(feature = "debugger")]
+                        PanelKind::Browser => unreachable!(),
+                    };
+                    Row::new()
+                        .push(iced::widget::container(tab_content).width(iced::Length::Fill))
+                        .push(panel)
+                        .spacing(2)
+                        .height(iced::Length::Fill)
+                        .into()
+                }
+            }
         } else {
             tab_content
         };
 
-        let main_content = main_content
+        // Compose: left browser + tab area
+        #[cfg(feature = "debugger")]
+        let content_row: Element<'_, Message> = Row::new()
+            .push(left_element)
             .push(tab_area)
+            .spacing(2)
+            .height(iced::Length::Fill)
+            .into();
+        #[cfg(not(feature = "debugger"))]
+        let content_row = tab_area;
+
+        let main_content = main_content
+            .push(content_row)
             .push(self.status_bar())
             .padding([theme::SPACE_XS, theme::SPACE_SM]);
 
@@ -2310,6 +2373,138 @@ impl FlowrGui {
         Container::new(panel_content)
             .width(Length::Fixed(300.0))
             .padding(theme::SPACE_LG)
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
+                border: iced::Border {
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: iced::Color::TRANSPARENT,
+                },
+                ..Default::default()
+            })
+            .into()
+    }
+
+    #[cfg(feature = "debugger")]
+    #[allow(clippy::too_many_lines)]
+    fn flow_browser_panel(&self) -> Element<'_, Message> {
+        use iced::widget::{Container, Scrollable};
+        use iced::Length;
+
+        let header = Row::new()
+            .push(
+                Button::new(
+                    Text::new("Flow Browser")
+                        .size(theme::FONT_DEFAULT)
+                        .color(iced::Color::WHITE)
+                        .font(iced::Font {
+                            weight: iced::font::Weight::Bold,
+                            ..iced::Font::DEFAULT
+                        }),
+                )
+                .on_press(Message::ToggleFlowBrowser)
+                .style(theme::chip_button(theme::ACCENT))
+                .padding([4, 12]),
+            )
+            .align_y(iced::alignment::Vertical::Center)
+            .padding(iced::Padding {
+                top: 0.0,
+                right: 0.0,
+                bottom: theme::SPACE_SM,
+                left: 0.0,
+            });
+
+        // Build tree from cached functions
+        let mut tree_items = Column::new().spacing(2);
+        let mut sorted: Vec<_> = self.cached_functions.iter().collect();
+        sorted.sort_by_key(|f| f.id);
+
+        // Show flows first, then functions under them
+        for f in &sorted {
+            if !f.is_flow {
+                continue;
+            }
+            let bp_dot = if self.active_breakpoints.contains(&f.id.to_string()) {
+                "\u{1F534} "
+            } else {
+                ""
+            };
+            let label = if f.name.is_empty() {
+                format!("{bp_dot}Flow #{}", f.id)
+            } else {
+                format!("{bp_dot}Flow #{} '{}'", f.id, f.name)
+            };
+            tree_items = tree_items.push(
+                Button::new(
+                    Text::new(label)
+                        .size(theme::FONT_MD)
+                        .color(theme::entity_colors::FLOW),
+                )
+                .on_press(Message::DebugInspectLink(f.id.to_string()))
+                .style(theme::list_button)
+                .padding([3, 8])
+                .width(Length::Fill),
+            );
+
+            // Show functions under this flow (indented)
+            for func in &sorted {
+                if func.is_flow {
+                    continue;
+                }
+                // Simple: show all functions (proper parent tracking needs RunState)
+                let fbp_dot = if self.active_breakpoints.contains(&func.id.to_string()) {
+                    "\u{1F534} "
+                } else {
+                    ""
+                };
+                let flabel = format!("  {fbp_dot}#{} '{}'", func.id, func.name);
+                tree_items = tree_items.push(
+                    Button::new(
+                        Text::new(flabel)
+                            .size(theme::FONT_SM)
+                            .color(theme::entity_colors::FUNCTION),
+                    )
+                    .on_press(Message::DebugInspectLink(func.id.to_string()))
+                    .style(theme::list_button)
+                    .padding([2, 16])
+                    .width(Length::Fill),
+                );
+            }
+            break; // Only show root flow for now — proper hierarchy needs FlowInfo
+        }
+
+        // If no flows, just list all functions
+        if !sorted.iter().any(|f| f.is_flow) {
+            for f in &sorted {
+                let bp_dot = if self.active_breakpoints.contains(&f.id.to_string()) {
+                    "\u{1F534} "
+                } else {
+                    ""
+                };
+                let label = format!("{bp_dot}#{} '{}'", f.id, f.name);
+                tree_items = tree_items.push(
+                    Button::new(Text::new(label).size(theme::FONT_MD))
+                        .on_press(Message::DebugInspectLink(f.id.to_string()))
+                        .style(theme::list_button)
+                        .padding([3, 8])
+                        .width(Length::Fill),
+                );
+            }
+        }
+
+        let list = Scrollable::new(tree_items)
+            .height(Length::Fill)
+            .width(Length::Fill);
+
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_MD)
+            .push(header)
+            .push(list);
+
+        Container::new(panel_content)
+            .width(Length::Fixed(280.0))
+            .height(Length::Fill)
+            .padding(theme::SPACE_MD)
             .style(|_: &iced::Theme| iced::widget::container::Style {
                 background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
                 border: iced::Border {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -528,6 +528,9 @@ pub enum Message {
     /// Metrics received from debug channel
     #[cfg(feature = "metrics")]
     DebugMetricsReceived(flowcore::model::metrics::Metrics),
+    /// Cached function states from `RunState` (id to state letters)
+    #[cfg(feature = "debugger")]
+    DebugStatesReceived(std::collections::HashMap<usize, Vec<(char, String)>>),
     /// Formatted debug event lines from the debug server
     #[cfg(feature = "debugger")]
     DebugEvent(Vec<DebugEventLine>),
@@ -760,6 +763,8 @@ struct FlowrGui {
     debug_client_active: bool,
     cached_functions: Vec<CachedFunction>,
     #[cfg(feature = "debugger")]
+    cached_states: std::collections::HashMap<usize, Vec<(char, String)>>,
+    #[cfg(feature = "debugger")]
     active_breakpoints: std::collections::HashSet<String>,
     #[cfg(feature = "debugger")]
     #[cfg(feature = "debugger")]
@@ -811,6 +816,8 @@ impl FlowrGui {
             #[cfg(feature = "debugger")]
             debug_client_active: false,
             cached_functions: Vec::new(),
+            #[cfg(feature = "debugger")]
+            cached_states: std::collections::HashMap::new(),
             #[cfg(feature = "debugger")]
             active_breakpoints: std::collections::HashSet::new(),
             #[cfg(feature = "debugger")]
@@ -1028,6 +1035,8 @@ impl FlowrGui {
                 self.last_metrics = Some(metrics);
             }
             Message::ToggleMetrics => self.toggle_panel(PanelKind::Metrics),
+            #[cfg(feature = "debugger")]
+            Message::DebugStatesReceived(states) => self.cached_states = states,
             #[cfg(feature = "debugger")]
             Message::BrowserToggleNode(id) => {
                 if self.browser_collapsed.contains(&id) {
@@ -1935,17 +1944,21 @@ impl FlowrGui {
         }
 
         // Build tree with fold/unfold triangles and outputs
-        #[allow(clippy::items_after_statements)]
+        #[allow(clippy::items_after_statements, clippy::type_complexity)]
         fn add_tree_nodes(
             items: &mut Column<'_, Message>,
             funcs: &[CachedFunction],
             collapsed: &std::collections::HashSet<usize>,
-            bps: &std::collections::HashSet<String>,
-            actions: (bool, bool),
+            data: (
+                &std::collections::HashSet<String>,
+                &std::collections::HashMap<usize, Vec<(char, String)>>,
+                bool,
+                bool,
+            ),
             parent: Option<usize>,
             depth: usize,
         ) {
-            let (can_bp, can_run) = actions;
+            let (bps, states, can_bp, can_run) = data;
             let mut children: Vec<_> = funcs.iter().filter(|f| f.parent_id == parent).collect();
             children.sort_by_key(|f| f.id);
 
@@ -2064,21 +2077,59 @@ impl FlowrGui {
                     }
                 }
 
+                // State chips
+                if let Some(fn_states) = states.get(&child.id) {
+                    for (letter, full_name) in fn_states {
+                        let state_color = match *letter {
+                            'R' => theme::entity_colors::STATE_READY,
+                            'W' => theme::entity_colors::STATE_WAITING,
+                            'X' => theme::entity_colors::STATE_RUNNING,
+                            'C' => theme::entity_colors::STATE_COMPLETED,
+                            _ => theme::TEXT_SECONDARY,
+                        };
+                        let chip = Button::new(
+                            Text::new(letter.to_string())
+                                .size(theme::FONT_SM)
+                                .color(iced::Color::WHITE)
+                                .font(iced::Font {
+                                    weight: iced::font::Weight::Bold,
+                                    ..iced::Font::DEFAULT
+                                }),
+                        )
+                        .style(theme::chip_button(state_color))
+                        .padding([1, 5]);
+                        row = row.push(
+                            iced::widget::tooltip(
+                                chip,
+                                Text::new(full_name.clone()).size(theme::FONT_SM),
+                                iced::widget::tooltip::Position::Top,
+                            )
+                            .style(|_: &iced::Theme| iced::widget::container::Style {
+                                background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                                text_color: Some(iced::Color::WHITE),
+                                border: iced::Border {
+                                    radius: theme::RADIUS_SM.into(),
+                                    width: 1.0,
+                                    color: iced::Color {
+                                        a: 0.3,
+                                        ..theme::ACCENT
+                                    },
+                                },
+                                ..Default::default()
+                            })
+                            .padding(4)
+                            .gap(4),
+                        );
+                    }
+                }
+
                 *items = std::mem::replace(items, Column::new()).push(Element::from(row));
 
                 // Children (if not collapsed)
                 if !is_collapsed {
                     // Sub-flows and functions
                     if child.is_flow {
-                        add_tree_nodes(
-                            items,
-                            funcs,
-                            collapsed,
-                            bps,
-                            actions,
-                            Some(child.id),
-                            depth + 1,
-                        );
+                        add_tree_nodes(items, funcs, collapsed, data, Some(child.id), depth + 1);
                     }
 
                     // Inputs
@@ -2184,13 +2235,13 @@ impl FlowrGui {
         let has_roots = funcs.iter().any(|f| f.is_flow && f.parent_id.is_none());
         let can_bp = self.debug_waiting;
         let can_run = self.debug_waiting && connection_manager::get_job_count() == 0;
+        let fn_states = &self.cached_states;
         if has_roots {
             add_tree_nodes(
                 &mut tree_items,
                 funcs,
                 &self.browser_collapsed,
-                bps,
-                (can_bp, can_run),
+                (bps, fn_states, can_bp, can_run),
                 None,
                 0,
             );
@@ -2644,6 +2695,12 @@ impl FlowrGui {
             }
             Message::DebugWaiting => {
                 self.debug_waiting = true;
+                if self.active_panel == Some(PanelKind::Browser) {
+                    self.suppress_next_output = true;
+                    connection_manager::send_debug_command(
+                        flowcore::model::debug_command::DebugCommand::ProcessList,
+                    );
+                }
             }
             Message::DebugConnected => {
                 self.tab_set
@@ -3211,6 +3268,8 @@ mod test {
             #[cfg(feature = "debugger")]
             debug_client_active: false,
             cached_functions: Vec::new(),
+            #[cfg(feature = "debugger")]
+            cached_states: std::collections::HashMap::new(),
             #[cfg(feature = "debugger")]
             active_breakpoints: std::collections::HashSet::new(),
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1174,10 +1174,14 @@ impl FlowrGui {
             }
             #[cfg(feature = "debugger")]
             Message::ToggleFlowBrowser => {
-                if !self.ensure_functions_cached(Message::ToggleFlowBrowser) {
-                    return iced::Task::none();
+                if self.active_panel == Some(PanelKind::Browser) {
+                    self.close_panel();
+                } else {
+                    if !self.ensure_functions_cached(Message::ToggleFlowBrowser) {
+                        return iced::Task::none();
+                    }
+                    self.open_panel(PanelKind::Browser);
                 }
-                self.toggle_panel(PanelKind::Browser);
             }
             Message::ToggleSettings => self.toggle_panel(PanelKind::Settings),
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2490,7 +2490,7 @@ impl FlowrGui {
 
                 // Indent
                 if depth > 0 {
-                    row = row.push(Text::new(indent).size(theme::FONT_SM));
+                    row = row.push(Text::new(indent).size(theme::FONT_MD));
                 }
 
                 // Triangle toggle
@@ -2499,22 +2499,28 @@ impl FlowrGui {
                     row = row.push(
                         Button::new(
                             Text::new(indicator)
-                                .size(10.0)
+                                .size(12.0)
                                 .shaping(iced::widget::text::Shaping::Advanced),
                         )
                         .on_press(Message::BrowserToggleNode(child.id))
-                        .style(theme::ghost_button)
+                        .style(|theme: &iced::Theme, status| {
+                            let mut s = theme::ghost_button(theme, status);
+                            if matches!(status, iced::widget::button::Status::Hovered) {
+                                s.text_color = theme::lighten(theme::ACCENT, 0.3);
+                            }
+                            s
+                        })
                         .padding([1, 3]),
                     );
                 } else {
-                    row = row.push(Text::new("  ").size(10.0));
+                    row = row.push(Text::new("  ").size(12.0));
                 }
 
                 // Label button
                 row = row.push(
                     Button::new(
                         Text::new(format!("{bp_dot}{name_part}"))
-                            .size(theme::FONT_SM)
+                            .size(theme::FONT_MD)
                             .color(color),
                     )
                     .on_press(Message::DebugInspectLink(child.id.to_string()))
@@ -2548,7 +2554,7 @@ impl FlowrGui {
                         *items = std::mem::replace(items, Column::new()).push(
                             Button::new(
                                 Text::new(format!("{inp_indent}    {ibp}{iname}"))
-                                    .size(theme::FONT_SM)
+                                    .size(theme::FONT_MD)
                                     .color(theme::entity_colors::INPUT),
                             )
                             .on_press(Message::DebugInspectLink(spec))
@@ -2570,7 +2576,7 @@ impl FlowrGui {
                         *items = std::mem::replace(items, Column::new()).push(
                             Button::new(
                                 Text::new(format!("{out_indent}    {obp}output '{output_route}'"))
-                                    .size(theme::FONT_SM)
+                                    .size(theme::FONT_MD)
                                     .color(theme::entity_colors::OUTPUT),
                             )
                             .on_press(Message::DebugInspectLink(spec))
@@ -2597,7 +2603,7 @@ impl FlowrGui {
             for f in funcs {
                 let label = format!("#{} '{}'", f.id, f.name);
                 tree_items = tree_items.push(
-                    Button::new(Text::new(label).size(theme::FONT_SM))
+                    Button::new(Text::new(label).size(theme::FONT_MD))
                         .on_press(Message::DebugInspectLink(f.id.to_string()))
                         .style(theme::list_button)
                         .padding([2, 8])

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1223,7 +1223,9 @@ impl FlowrGui {
             | Message::ShowInspectPopup
             | Message::CloseInspectPopup
             | Message::InspectTabChanged(_)
-            | Message::InspectPopupSelect(_)) => {
+            | Message::InspectPopupSelect(_)
+            | Message::ToggleFlowBrowser
+            | Message::BrowserToggleNode(_)) => {
                 return self.process_debug_message(msg);
             }
             Message::CoordinatorDisconnected(reason) => {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1269,37 +1269,36 @@ impl FlowrGui {
         let left_element: Element<'_, Message> = if browser_open {
             self.flow_browser_panel()
         } else if self.debug_client_active {
-            // Vertical "Flow Browser" chip on the left edge
-            {
-                let label = Column::with_children(
-                    "\u{00AB} B r o w s e r"
-                        .chars()
-                        .map(|c| {
-                            Element::from(
-                                Text::new(c.to_string())
-                                    .size(theme::FONT_SM)
-                                    .color(iced::Color::WHITE)
-                                    .font(iced::Font {
-                                        weight: iced::font::Weight::Bold,
-                                        ..iced::Font::DEFAULT
-                                    }),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                )
-                .align_x(iced::alignment::Horizontal::Center)
-                .spacing(0);
+            let btn = Button::new(crate::icons::list().size(18.0))
+                .on_press(Message::ToggleFlowBrowser)
+                .style(theme::chip_button(theme::ACCENT))
+                .padding([6, 6]);
 
-                iced::widget::container(
-                    Button::new(label)
-                        .on_press(Message::ToggleFlowBrowser)
-                        .style(theme::chip_button(theme::ACCENT))
-                        .padding([8, 4]),
+            iced::widget::container(
+                iced::widget::tooltip(
+                    btn,
+                    Text::new("Flow Browser").size(theme::FONT_SM),
+                    iced::widget::tooltip::Position::Right,
                 )
-                .height(iced::Length::Fill)
-                .align_y(iced::alignment::Vertical::Center)
-                .into()
-            }
+                .style(|_: &iced::Theme| iced::widget::container::Style {
+                    background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                    text_color: Some(iced::Color::WHITE),
+                    border: iced::Border {
+                        radius: theme::RADIUS_SM.into(),
+                        width: 1.0,
+                        color: iced::Color {
+                            a: 0.3,
+                            ..theme::ACCENT
+                        },
+                    },
+                    ..Default::default()
+                })
+                .padding(6)
+                .gap(4),
+            )
+            .height(iced::Length::Fill)
+            .align_y(iced::alignment::Vertical::Center)
+            .into()
         } else {
             iced::widget::text("").into()
         };

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1268,23 +1268,36 @@ impl FlowrGui {
             self.flow_browser_panel()
         } else if self.debug_client_active {
             // Vertical "Flow Browser" chip on the left edge
-            iced::widget::container(
-                Button::new(
-                    Text::new("Flow Browser")
-                        .size(theme::FONT_SM)
-                        .color(iced::Color::WHITE)
-                        .font(iced::Font {
-                            weight: iced::font::Weight::Bold,
-                            ..iced::Font::DEFAULT
-                        }),
+            {
+                let label = Column::with_children(
+                    "\u{00AB} B r o w s e r"
+                        .chars()
+                        .map(|c| {
+                            Element::from(
+                                Text::new(c.to_string())
+                                    .size(theme::FONT_SM)
+                                    .color(iced::Color::WHITE)
+                                    .font(iced::Font {
+                                        weight: iced::font::Weight::Bold,
+                                        ..iced::Font::DEFAULT
+                                    }),
+                            )
+                        })
+                        .collect::<Vec<_>>(),
                 )
-                .on_press(Message::ToggleFlowBrowser)
-                .style(theme::chip_button(theme::ACCENT))
-                .padding([6, 4]),
-            )
-            .height(iced::Length::Fill)
-            .align_y(iced::alignment::Vertical::Center)
-            .into()
+                .align_x(iced::alignment::Horizontal::Center)
+                .spacing(0);
+
+                iced::widget::container(
+                    Button::new(label)
+                        .on_press(Message::ToggleFlowBrowser)
+                        .style(theme::chip_button(theme::ACCENT))
+                        .padding([8, 4]),
+                )
+                .height(iced::Length::Fill)
+                .align_y(iced::alignment::Vertical::Center)
+                .into()
+            }
         } else {
             iced::widget::text("").into()
         };

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -638,18 +638,6 @@ pub enum Message {
     ServiceSelected(String, String),
     /// Close the coordinator picker
     CloseCoordinatorPicker,
-    /// Show the inspect helper popup
-    #[cfg(feature = "debugger")]
-    ShowInspectPopup,
-    /// Close the inspect helper popup
-    #[cfg(feature = "debugger")]
-    CloseInspectPopup,
-    /// Inspect tab changed in popup
-    #[cfg(feature = "debugger")]
-    InspectTabChanged(InspectTab),
-    /// Item selected in inspect popup
-    #[cfg(feature = "debugger")]
-    InspectPopupSelect(String),
 }
 
 #[allow(clippy::ignored_unit_patterns)]
@@ -743,8 +731,8 @@ pub struct CachedFunction {
     pub route: String,
     /// Input info (index, name, `is_generic`)
     pub inputs: Vec<(usize, String, bool)>,
-    /// Output routes
-    pub outputs: Vec<String>,
+    /// Output connections: (`source_route`, `destination_id`, `destination_input_number`)
+    pub outputs: Vec<(String, usize, usize)>,
     /// Whether this is a flow (not a leaf function)
     pub is_flow: bool,
     /// Parent flow ID (for hierarchy)
@@ -790,53 +778,10 @@ const BP_TABS: [BpTab; 5] = [
 ];
 
 /// Tabs in the inspect popup
-#[cfg(feature = "debugger")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InspectTab {
-    /// Inspect by state (ready, waiting, etc.)
-    State,
-    /// Inspect a function
-    Function,
-    /// Inspect a flow
-    Flow,
-    /// Inspect an input
-    Input,
-    /// Inspect an output
-    Output,
-    /// Inspect by route
-    Route,
-}
-
-#[cfg(feature = "debugger")]
-impl std::fmt::Display for InspectTab {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::State => write!(f, "State"),
-            Self::Function => write!(f, "Function"),
-            Self::Flow => write!(f, "Flow"),
-            Self::Input => write!(f, "Input"),
-            Self::Output => write!(f, "Output"),
-            Self::Route => write!(f, "Route"),
-        }
-    }
-}
-
-#[cfg(feature = "debugger")]
-const INSPECT_TABS: [InspectTab; 6] = [
-    InspectTab::State,
-    InspectTab::Function,
-    InspectTab::Flow,
-    InspectTab::Input,
-    InspectTab::Output,
-    InspectTab::Route,
-];
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PanelKind {
     Settings,
     Metrics,
-    #[cfg(feature = "debugger")]
-    Inspect,
     #[cfg(feature = "debugger")]
     Breakpoints,
     #[cfg(feature = "debugger")]
@@ -889,8 +834,6 @@ struct FlowrGui {
     #[cfg(feature = "debugger")]
     #[cfg(feature = "debugger")]
     suppress_next_output: bool,
-    #[cfg(feature = "debugger")]
-    inspect_tab: InspectTab,
     #[cfg(feature = "debugger")]
     show_run_inputs: bool,
     #[cfg(feature = "debugger")]
@@ -950,8 +893,6 @@ impl FlowrGui {
             #[cfg(feature = "debugger")]
             #[cfg(feature = "debugger")]
             suppress_next_output: false,
-            #[cfg(feature = "debugger")]
-            inspect_tab: InspectTab::State,
             #[cfg(feature = "debugger")]
             show_run_inputs: false,
             #[cfg(feature = "debugger")]
@@ -1219,13 +1160,7 @@ impl FlowrGui {
             | Message::DebugFlowsReceived(_)
             | Message::DebugBreakpointListReceived(_)
             | Message::DebugInspectLink(_)
-            | Message::DebugToggleSection(_)
-            | Message::ShowInspectPopup
-            | Message::CloseInspectPopup
-            | Message::InspectTabChanged(_)
-            | Message::InspectPopupSelect(_)
-            | Message::ToggleFlowBrowser
-            | Message::BrowserToggleNode(_)) => {
+            | Message::DebugToggleSection(_)) => {
                 return self.process_debug_message(msg);
             }
             Message::CoordinatorDisconnected(reason) => {
@@ -1333,8 +1268,6 @@ impl FlowrGui {
                     let panel: Element<'_, Message> = match kind {
                         PanelKind::Settings => self.settings_panel(),
                         PanelKind::Metrics => self.metrics_panel(),
-                        #[cfg(feature = "debugger")]
-                        PanelKind::Inspect => self.inspect_panel(),
                         #[cfg(feature = "debugger")]
                         PanelKind::Breakpoints => self.bp_panel(),
                         #[cfg(feature = "debugger")]
@@ -1767,11 +1700,7 @@ impl FlowrGui {
             .style(theme::styled_button)
             .padding(sp);
         if can_cmd {
-            inspect_btn = inspect_btn.on_press(if self.debug_spec_text.is_empty() {
-                Message::ShowInspectPopup
-            } else {
-                Message::DebugInspect
-            });
+            inspect_btn = inspect_btn.on_press(Message::DebugInspect);
         }
 
         let mut funcs_btn = Button::new(Text::new("Functions"))
@@ -2010,7 +1939,7 @@ impl FlowrGui {
                             ibtn = ibtn.on_press(Message::BpTargetChanged(input_spec));
                             items = items.push(ibtn);
                         }
-                        for output_route in &f.outputs {
+                        for (output_route, _dest_id, _dest_io) in &f.outputs {
                             let out_spec = format!("{}{output_route}", f.id);
                             let om = bp_marker(&out_spec);
                             let out_label =
@@ -2055,7 +1984,7 @@ impl FlowrGui {
                 }
                 BpTab::Output => {
                     for f in &self.cached_functions {
-                        for output_route in &f.outputs {
+                        for (output_route, _dest_id, _dest_io) in &f.outputs {
                             let spec = format!("{}{output_route}", f.id);
                             let marker = bp_marker(&spec);
                             let label =
@@ -2105,173 +2034,6 @@ impl FlowrGui {
             .spacing(theme::SPACE_MD)
             .push(header)
             .push(type_row)
-            .push(list);
-
-        Container::new(panel_content)
-            .width(Length::Fixed(380.0))
-            .padding(theme::SPACE_LG)
-            .style(|_: &iced::Theme| iced::widget::container::Style {
-                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
-                border: iced::Border {
-                    radius: 0.0.into(),
-                    width: 0.0,
-                    color: iced::Color::TRANSPARENT,
-                },
-                ..Default::default()
-            })
-            .into()
-    }
-
-    #[cfg(feature = "debugger")]
-    #[allow(clippy::too_many_lines)]
-    fn inspect_panel(&self) -> Element<'_, Message> {
-        use iced::widget::scrollable::Scrollable;
-        use iced::widget::Container;
-        use iced::Length;
-
-        let tab_row = Row::new()
-            .spacing(4)
-            .align_y(iced::alignment::Vertical::Center);
-        let tab_row = INSPECT_TABS.iter().fold(tab_row, |row, &tab| {
-            let is_active = tab == self.inspect_tab;
-            let mut btn = Button::new(Text::new(tab.to_string()).size(theme::FONT_MD))
-                .padding(theme::BUTTON_PAD)
-                .style(if is_active {
-                    theme::pill_button_active
-                        as fn(
-                            &iced::Theme,
-                            iced::widget::button::Status,
-                        ) -> iced::widget::button::Style
-                } else {
-                    theme::pill_button
-                });
-            if !is_active {
-                btn = btn.on_press(Message::InspectTabChanged(tab));
-            }
-            row.push(btn)
-        });
-
-        let mut items = Column::new().spacing(2);
-
-        match self.inspect_tab {
-            InspectTab::State => {
-                for state_name in &["ready", "waiting", "running", "completed", "blocked"] {
-                    let btn = Button::new(Text::new(format!("  {state_name}")).size(13))
-                        .width(Length::Fill)
-                        .padding([3, 8])
-                        .style(theme::list_button)
-                        .on_press(Message::InspectPopupSelect((*state_name).to_string()));
-                    items = items.push(btn);
-                }
-            }
-            InspectTab::Function => {
-                for f in self.cached_functions.iter().filter(|f| !f.is_flow) {
-                    let btn = Button::new(
-                        Text::new(format!("#{} '{}' @ '{}'", f.id, f.name, f.route)).size(13),
-                    )
-                    .width(Length::Fill)
-                    .padding([3, 8])
-                    .style(theme::list_button)
-                    .on_press(Message::InspectPopupSelect(format!("{}", f.id)));
-                    items = items.push(btn);
-                }
-            }
-            InspectTab::Flow => {
-                for f in self.cached_functions.iter().filter(|f| f.is_flow) {
-                    let label = if f.name.is_empty() {
-                        format!("Flow #{}", f.id)
-                    } else {
-                        format!("Flow #{} '{}' @ {}", f.id, f.name, f.route)
-                    };
-                    let btn = Button::new(Text::new(label).size(13))
-                        .width(Length::Fill)
-                        .padding([3, 8])
-                        .style(theme::list_button)
-                        .on_press(Message::InspectPopupSelect(format!("{}", f.id)));
-                    items = items.push(btn);
-                }
-            }
-            InspectTab::Input => {
-                for f in &self.cached_functions {
-                    for (idx, input_name, _generic) in &f.inputs {
-                        let name_part = if input_name.is_empty() {
-                            String::new()
-                        } else {
-                            format!(" '{input_name}'")
-                        };
-                        let btn = Button::new(
-                            Text::new(format!("#{} '{}' input:{idx}{name_part}", f.id, f.name))
-                                .size(13),
-                        )
-                        .width(Length::Fill)
-                        .padding([3, 8])
-                        .style(theme::list_button)
-                        .on_press(Message::InspectPopupSelect(format!("{}:{idx}", f.id)));
-                        items = items.push(btn);
-                    }
-                }
-            }
-            InspectTab::Output => {
-                for f in &self.cached_functions {
-                    for output_route in &f.outputs {
-                        let btn = Button::new(
-                            Text::new(format!("#{} '{}' output:'{output_route}'", f.id, f.name))
-                                .size(13),
-                        )
-                        .width(Length::Fill)
-                        .padding([3, 8])
-                        .style(theme::list_button)
-                        .on_press(Message::InspectPopupSelect(format!(
-                            "{}{output_route}",
-                            f.id
-                        )));
-                        items = items.push(btn);
-                    }
-                }
-            }
-            InspectTab::Route => {
-                for f in &self.cached_functions {
-                    let btn = Button::new(
-                        Text::new(format!("{} (#{} '{}')", f.route, f.id, f.name)).size(13),
-                    )
-                    .width(Length::Fill)
-                    .padding([3, 8])
-                    .style(theme::list_button)
-                    .on_press(Message::InspectPopupSelect(f.route.clone()));
-                    items = items.push(btn);
-                }
-            }
-        }
-
-        let list = Scrollable::new(items)
-            .height(Length::Fill)
-            .width(Length::Fill);
-
-        let header = Row::new()
-            .push(Text::new("Inspect").size(theme::FONT_DEFAULT))
-            .push(Container::new(iced::widget::text("")).width(Length::Fill))
-            .push(
-                Button::new(
-                    Text::new("\u{00BB}")
-                        .size(20.0)
-                        .shaping(iced::widget::text::Shaping::Advanced),
-                )
-                .on_press(Message::CloseInspectPopup)
-                .style(theme::ghost_button)
-                .padding(theme::BUTTON_PAD_SM),
-            )
-            .align_y(iced::alignment::Vertical::Center)
-            .padding(iced::Padding {
-                top: 0.0,
-                right: 0.0,
-                bottom: theme::SPACE_SM,
-                left: 0.0,
-            });
-
-        let panel_content = Column::new()
-            .spacing(theme::SPACE_MD)
-            .push(header)
-            .push(tab_row)
             .push(list);
 
         Container::new(panel_content)
@@ -2570,10 +2332,24 @@ impl FlowrGui {
                         );
                     }
 
-                    // Outputs
-                    for output_route in &child.outputs {
+                    // Outputs (deduplicated by route)
+                    let mut seen_routes = std::collections::HashSet::new();
+                    for (output_route, _dest_id, _dest_input) in &child.outputs {
+                        if !seen_routes.insert(output_route.clone()) {
+                            continue;
+                        }
                         let out_indent = "  ".repeat(depth + 1);
-                        let spec = format!("{}{output_route}", child.id);
+                        let display_route = if output_route.is_empty() {
+                            "(default)".to_string()
+                        } else {
+                            format!("'{output_route}'")
+                        };
+                        let route = if output_route.is_empty() {
+                            "/"
+                        } else {
+                            output_route.as_str()
+                        };
+                        let spec = format!("{}{route}", child.id);
                         let obp = if bps.contains(&spec) {
                             "\u{1F534} "
                         } else {
@@ -2581,7 +2357,7 @@ impl FlowrGui {
                         };
                         *items = std::mem::replace(items, Column::new()).push(
                             Button::new(
-                                Text::new(format!("{out_indent}    {obp}output '{output_route}'"))
+                                Text::new(format!("{out_indent}    {obp}output {display_route}"))
                                     .size(theme::FONT_MD)
                                     .color(theme::entity_colors::OUTPUT),
                             )
@@ -3312,7 +3088,7 @@ impl FlowrGui {
                 }
                 self.cached_functions.sort_by_key(|f| f.id);
                 if let Some(action) = self.pending_action.take() {
-                    return self.process_debug_message(action);
+                    return self.update(action);
                 }
             }
             Message::DebugFlowsReceived(flows) => {
@@ -3378,43 +3154,7 @@ impl FlowrGui {
             Message::DebugToggleSection(section_id) => {
                 self.tab_set.debug_tab.toggle_section(section_id);
             }
-            Message::ShowInspectPopup => {
-                if !self.ensure_functions_cached(Message::ShowInspectPopup) {
-                    return iced::Task::none();
-                }
-                self.toggle_panel(PanelKind::Inspect);
-            }
-            Message::CloseInspectPopup | Message::CloseBpPopup => self.close_panel(),
-            Message::InspectTabChanged(tab) => self.inspect_tab = tab,
-            Message::InspectPopupSelect(spec) => {
-                self.close_panel();
-                if self.debug_waiting {
-                    self.debug_waiting = false;
-                    if spec.is_empty() {
-                        self.debug_separator("Inspect (overall flow state)");
-                        connection_manager::send_debug_command(
-                            flowcore::model::debug_command::DebugCommand::Inspect,
-                        );
-                    } else {
-                        let label = if spec.parse::<usize>().is_ok() {
-                            format!("Inspect #{spec}")
-                        } else if spec.starts_with('/') {
-                            format!("Inspect Route ({spec})")
-                        } else if spec.contains(':') {
-                            format!("Inspect Input ({spec})")
-                        } else if spec.contains('/') {
-                            format!("Inspect Output ({spec})")
-                        } else {
-                            format!("Inspect {spec}")
-                        };
-                        let params = Some(vec![spec]);
-                        if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
-                            self.debug_separator(&label);
-                            connection_manager::send_debug_command(cmd);
-                        }
-                    }
-                }
-            }
+            Message::CloseBpPopup => self.close_panel(),
             Message::ShowBpPopup => {
                 if !self.ensure_functions_cached(Message::ShowBpPopup) {
                     return iced::Task::none();
@@ -3857,8 +3597,6 @@ mod test {
             #[cfg(feature = "debugger")]
             suppress_next_output: false,
             #[cfg(feature = "debugger")]
-            inspect_tab: InspectTab::State,
-            #[cfg(feature = "debugger")]
             show_run_inputs: false,
             #[cfg(feature = "debugger")]
             run_target_id: None,
@@ -4068,7 +3806,7 @@ mod test {
         let mut gui = test_gui();
         gui.debug_client_active = true;
         gui.debug_waiting = true;
-        gui.active_panel = Some(PanelKind::Inspect);
+        gui.active_panel = Some(PanelKind::Breakpoints);
         let view = gui.view();
         let _ui = simulator(view);
     }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -744,6 +744,8 @@ pub struct CachedFunction {
     pub outputs: Vec<String>,
     /// Whether this is a flow (not a leaf function)
     pub is_flow: bool,
+    /// Parent flow ID (for hierarchy)
+    pub parent_id: Option<usize>,
 }
 
 /// Tabs in the breakpoint popup
@@ -2427,82 +2429,69 @@ impl FlowrGui {
                 left: 0.0,
             });
 
-        // Build tree from cached functions
-        let mut tree_items = Column::new().spacing(2);
-        let mut sorted: Vec<_> = self.cached_functions.iter().collect();
-        sorted.sort_by_key(|f| f.id);
+        // Build hierarchical tree using parent_id
+        let mut tree_items = Column::new().spacing(1);
+        let funcs = &self.cached_functions;
+        let bps = &self.active_breakpoints;
 
-        // Show flows first, then functions under them
-        for f in &sorted {
-            if !f.is_flow {
-                continue;
+        // Build tree nodes into a vec, then convert to Column
+        #[allow(clippy::items_after_statements)]
+        fn collect_nodes(
+            result: &mut Vec<(String, usize, iced::Color, usize)>,
+            funcs: &[CachedFunction],
+            parent: Option<usize>,
+            depth: usize,
+        ) {
+            let mut children: Vec<_> = funcs.iter().filter(|f| f.parent_id == parent).collect();
+            children.sort_by_key(|f| f.id);
+            for child in children {
+                let color = if child.is_flow {
+                    theme::entity_colors::FLOW
+                } else {
+                    theme::entity_colors::FUNCTION
+                };
+                let prefix = if child.is_flow { "flow" } else { "fn" };
+                let indent = "  ".repeat(depth);
+                let label = if child.name.is_empty() {
+                    format!("{indent}{prefix} #{}", child.id)
+                } else {
+                    format!("{indent}{prefix} #{} '{}'", child.id, child.name)
+                };
+                result.push((label, child.id, color, depth));
+                if child.is_flow {
+                    collect_nodes(result, funcs, Some(child.id), depth + 1);
+                }
             }
-            let bp_dot = if self.active_breakpoints.contains(&f.id.to_string()) {
+        }
+
+        let mut nodes = Vec::new();
+        let has_roots = funcs.iter().any(|f| f.is_flow && f.parent_id.is_none());
+        if has_roots {
+            collect_nodes(&mut nodes, funcs, None, 0);
+        } else {
+            for f in funcs {
+                let label = format!("#{} '{}'", f.id, f.name);
+                nodes.push((label, f.id, theme::entity_colors::FUNCTION, 0));
+            }
+        }
+
+        for (label, id, color, _depth) in &nodes {
+            let bp_dot = if bps.contains(&id.to_string()) {
                 "\u{1F534} "
             } else {
                 ""
             };
-            let label = if f.name.is_empty() {
-                format!("{bp_dot}Flow #{}", f.id)
-            } else {
-                format!("{bp_dot}Flow #{} '{}'", f.id, f.name)
-            };
             tree_items = tree_items.push(
                 Button::new(
-                    Text::new(label)
-                        .size(theme::FONT_MD)
-                        .color(theme::entity_colors::FLOW),
+                    Text::new(format!("{bp_dot}{label}"))
+                        .size(theme::FONT_SM)
+                        .color(*color),
                 )
-                .on_press(Message::DebugInspectLink(f.id.to_string()))
+                .on_press(Message::DebugInspectLink(id.to_string()))
                 .style(theme::list_button)
-                .padding([3, 8])
+                .padding([2, 8])
                 .width(Length::Fill),
             );
-
-            // Show functions under this flow (indented)
-            for func in &sorted {
-                if func.is_flow {
-                    continue;
-                }
-                // Simple: show all functions (proper parent tracking needs RunState)
-                let fbp_dot = if self.active_breakpoints.contains(&func.id.to_string()) {
-                    "\u{1F534} "
-                } else {
-                    ""
-                };
-                let flabel = format!("  {fbp_dot}#{} '{}'", func.id, func.name);
-                tree_items = tree_items.push(
-                    Button::new(
-                        Text::new(flabel)
-                            .size(theme::FONT_SM)
-                            .color(theme::entity_colors::FUNCTION),
-                    )
-                    .on_press(Message::DebugInspectLink(func.id.to_string()))
-                    .style(theme::list_button)
-                    .padding([2, 16])
-                    .width(Length::Fill),
-                );
-            }
-            break; // Only show root flow for now — proper hierarchy needs FlowInfo
-        }
-
-        // If no flows, just list all functions
-        if !sorted.iter().any(|f| f.is_flow) {
-            for f in &sorted {
-                let bp_dot = if self.active_breakpoints.contains(&f.id.to_string()) {
-                    "\u{1F534} "
-                } else {
-                    ""
-                };
-                let label = format!("{bp_dot}#{} '{}'", f.id, f.name);
-                tree_items = tree_items.push(
-                    Button::new(Text::new(label).size(theme::FONT_MD))
-                        .on_press(Message::DebugInspectLink(f.id.to_string()))
-                        .style(theme::list_button)
-                        .padding([3, 8])
-                        .width(Length::Fill),
-                );
-            }
         }
 
         let list = Scrollable::new(tree_items)

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1941,10 +1941,11 @@ impl FlowrGui {
             funcs: &[CachedFunction],
             collapsed: &std::collections::HashSet<usize>,
             bps: &std::collections::HashSet<String>,
-            can_bp: bool,
+            actions: (bool, bool),
             parent: Option<usize>,
             depth: usize,
         ) {
+            let (can_bp, can_run) = actions;
             let mut children: Vec<_> = funcs.iter().filter(|f| f.parent_id == parent).collect();
             children.sort_by_key(|f| f.id);
 
@@ -2049,18 +2050,18 @@ impl FlowrGui {
                     };
                     row = row.push(bp_tooltip(after_btn, after_tip));
 
-                    // Run button
-                    let mut run_btn = Button::new(
-                        Text::new("\u{25B6}")
-                            .size(10.0)
-                            .shaping(iced::widget::text::Shaping::Advanced),
-                    )
-                    .style(theme::ghost_button)
-                    .padding([1, 3]);
-                    if can_bp {
-                        run_btn = run_btn.on_press(Message::BrowserRunFunction(child.id));
+                    // Run button (only in initial/reset state)
+                    if can_run {
+                        let run_btn = Button::new(
+                            Text::new("\u{25B6}")
+                                .size(10.0)
+                                .shaping(iced::widget::text::Shaping::Advanced),
+                        )
+                        .style(theme::ghost_button)
+                        .padding([1, 3])
+                        .on_press(Message::BrowserRunFunction(child.id));
+                        row = row.push(bp_tooltip(run_btn, "Run this function"));
                     }
-                    row = row.push(bp_tooltip(run_btn, "Run this function"));
                 }
 
                 *items = std::mem::replace(items, Column::new()).push(Element::from(row));
@@ -2074,7 +2075,7 @@ impl FlowrGui {
                             funcs,
                             collapsed,
                             bps,
-                            can_bp,
+                            actions,
                             Some(child.id),
                             depth + 1,
                         );
@@ -2182,13 +2183,14 @@ impl FlowrGui {
 
         let has_roots = funcs.iter().any(|f| f.is_flow && f.parent_id.is_none());
         let can_bp = self.debug_waiting;
+        let can_run = self.debug_waiting && connection_manager::get_job_count() == 0;
         if has_roots {
             add_tree_nodes(
                 &mut tree_items,
                 funcs,
                 &self.browser_collapsed,
                 bps,
-                can_bp,
+                (can_bp, can_run),
                 None,
                 0,
             );

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -517,6 +517,9 @@ pub enum Message {
     /// Toggle flow browser panel
     #[cfg(feature = "debugger")]
     ToggleFlowBrowser,
+    /// Toggle fold/unfold in browser tree
+    #[cfg(feature = "debugger")]
+    BrowserToggleNode(usize),
     /// Toggle metrics panel
     ToggleMetrics,
     /// Metrics received from debug channel
@@ -862,6 +865,8 @@ struct FlowrGui {
     submitted: bool,
     show_modal: bool,
     active_panel: Option<PanelKind>,
+    #[cfg(feature = "debugger")]
+    browser_collapsed: std::collections::HashSet<usize>,
     last_metrics: Option<flowcore::model::metrics::Metrics>,
     modal_content: (String, String),
     pending_getline: bool,
@@ -921,6 +926,8 @@ impl FlowrGui {
             running: false,
             show_modal: false,
             active_panel: None,
+            #[cfg(feature = "debugger")]
+            browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,
             modal_content: (String::new(), String::new()),
             pending_getline: false,
@@ -1157,6 +1164,14 @@ impl FlowrGui {
                 self.last_metrics = Some(metrics);
             }
             Message::ToggleMetrics => self.toggle_panel(PanelKind::Metrics),
+            #[cfg(feature = "debugger")]
+            Message::BrowserToggleNode(id) => {
+                if self.browser_collapsed.contains(&id) {
+                    self.browser_collapsed.remove(&id);
+                } else {
+                    self.browser_collapsed.insert(id);
+                }
+            }
             #[cfg(feature = "debugger")]
             Message::ToggleFlowBrowser => {
                 if !self.ensure_functions_cached(Message::ToggleFlowBrowser) {
@@ -2433,85 +2448,162 @@ impl FlowrGui {
         let funcs = &self.cached_functions;
         let bps = &self.active_breakpoints;
 
-        // Build tree nodes into a vec, then convert to Column
+        // Build tree with fold/unfold triangles and outputs
         #[allow(clippy::items_after_statements)]
-        fn collect_nodes(
-            result: &mut Vec<(String, usize, iced::Color, usize)>,
+        fn add_tree_nodes(
+            items: &mut Column<'_, Message>,
             funcs: &[CachedFunction],
+            collapsed: &std::collections::HashSet<usize>,
+            bps: &std::collections::HashSet<String>,
             parent: Option<usize>,
             depth: usize,
         ) {
             let mut children: Vec<_> = funcs.iter().filter(|f| f.parent_id == parent).collect();
             children.sort_by_key(|f| f.id);
+
             for child in children {
-                let color = if child.is_flow {
-                    theme::entity_colors::FLOW
-                } else {
-                    theme::entity_colors::FUNCTION
-                };
-                let prefix = if child.is_flow { "flow" } else { "fn" };
                 let indent = "  ".repeat(depth);
-                let label = if child.name.is_empty() {
-                    format!("{indent}{prefix} #{}", child.id)
+                let is_collapsed = collapsed.contains(&child.id);
+                let has_children =
+                    child.is_flow || !child.inputs.is_empty() || !child.outputs.is_empty();
+
+                // Build the row: triangle + label
+                let (color, prefix) = if child.is_flow {
+                    (theme::entity_colors::FLOW, "flow")
                 } else {
-                    format!("{indent}{prefix} #{} '{}'", child.id, child.name)
+                    (theme::entity_colors::FUNCTION, "fn")
                 };
-                result.push((label, child.id, color, depth));
-                if child.is_flow {
-                    collect_nodes(result, funcs, Some(child.id), depth + 1);
+                let bp_dot = if bps.contains(&child.id.to_string()) {
+                    "\u{1F534} "
+                } else {
+                    ""
+                };
+                let name_part = if child.name.is_empty() {
+                    format!("{prefix} #{}", child.id)
+                } else {
+                    format!("{prefix} #{} '{}'", child.id, child.name)
+                };
+
+                let mut row = Row::new()
+                    .spacing(4)
+                    .align_y(iced::alignment::Vertical::Center);
+
+                // Indent
+                if depth > 0 {
+                    row = row.push(Text::new(indent).size(theme::FONT_SM));
+                }
+
+                // Triangle toggle
+                if has_children {
+                    let indicator = if is_collapsed { "\u{25B6}" } else { "\u{25BC}" };
+                    row = row.push(
+                        Button::new(
+                            Text::new(indicator)
+                                .size(10.0)
+                                .shaping(iced::widget::text::Shaping::Advanced),
+                        )
+                        .on_press(Message::BrowserToggleNode(child.id))
+                        .style(theme::ghost_button)
+                        .padding([1, 3]),
+                    );
+                } else {
+                    row = row.push(Text::new("  ").size(10.0));
+                }
+
+                // Label button
+                row = row.push(
+                    Button::new(
+                        Text::new(format!("{bp_dot}{name_part}"))
+                            .size(theme::FONT_SM)
+                            .color(color),
+                    )
+                    .on_press(Message::DebugInspectLink(child.id.to_string()))
+                    .style(theme::list_button)
+                    .padding([2, 4]),
+                );
+
+                *items = std::mem::replace(items, Column::new()).push(Element::from(row));
+
+                // Children (if not collapsed)
+                if !is_collapsed {
+                    // Sub-flows and functions
+                    if child.is_flow {
+                        add_tree_nodes(items, funcs, collapsed, bps, Some(child.id), depth + 1);
+                    }
+
+                    // Inputs
+                    for (idx, input_name, _generic) in &child.inputs {
+                        let iname = if input_name.is_empty() {
+                            format!("input:{idx}")
+                        } else {
+                            format!("input:{idx} '{input_name}'")
+                        };
+                        let inp_indent = "  ".repeat(depth + 1);
+                        let spec = format!("{}:{idx}", child.id);
+                        let ibp = if bps.contains(&spec) {
+                            "\u{1F534} "
+                        } else {
+                            ""
+                        };
+                        *items = std::mem::replace(items, Column::new()).push(
+                            Button::new(
+                                Text::new(format!("{inp_indent}    {ibp}{iname}"))
+                                    .size(theme::FONT_SM)
+                                    .color(theme::entity_colors::INPUT),
+                            )
+                            .on_press(Message::DebugInspectLink(spec))
+                            .style(theme::list_button)
+                            .padding([1, 8])
+                            .width(iced::Length::Fill),
+                        );
+                    }
+
+                    // Outputs
+                    for output_route in &child.outputs {
+                        let out_indent = "  ".repeat(depth + 1);
+                        let spec = format!("{}{output_route}", child.id);
+                        let obp = if bps.contains(&spec) {
+                            "\u{1F534} "
+                        } else {
+                            ""
+                        };
+                        *items = std::mem::replace(items, Column::new()).push(
+                            Button::new(
+                                Text::new(format!("{out_indent}    {obp}output '{output_route}'"))
+                                    .size(theme::FONT_SM)
+                                    .color(theme::entity_colors::OUTPUT),
+                            )
+                            .on_press(Message::DebugInspectLink(spec))
+                            .style(theme::list_button)
+                            .padding([1, 8])
+                            .width(iced::Length::Fill),
+                        );
+                    }
                 }
             }
         }
 
-        let mut nodes = Vec::new();
         let has_roots = funcs.iter().any(|f| f.is_flow && f.parent_id.is_none());
         if has_roots {
-            collect_nodes(&mut nodes, funcs, None, 0);
+            add_tree_nodes(
+                &mut tree_items,
+                funcs,
+                &self.browser_collapsed,
+                bps,
+                None,
+                0,
+            );
         } else {
             for f in funcs {
                 let label = format!("#{} '{}'", f.id, f.name);
-                nodes.push((label, f.id, theme::entity_colors::FUNCTION, 0));
+                tree_items = tree_items.push(
+                    Button::new(Text::new(label).size(theme::FONT_SM))
+                        .on_press(Message::DebugInspectLink(f.id.to_string()))
+                        .style(theme::list_button)
+                        .padding([2, 8])
+                        .width(Length::Fill),
+                );
             }
-        }
-
-        for (label, id, color, _depth) in &nodes {
-            let bp_dot = if bps.contains(&id.to_string()) {
-                "\u{1F534} "
-            } else {
-                ""
-            };
-            let btn = Button::new(
-                Text::new(format!("{bp_dot}{label}"))
-                    .size(theme::FONT_SM)
-                    .color(*color),
-            )
-            .on_press(Message::DebugInspectLink(id.to_string()))
-            .style(theme::list_button)
-            .padding([2, 8])
-            .width(Length::Fill);
-
-            tree_items = tree_items.push(
-                iced::widget::tooltip(
-                    btn,
-                    Text::new("Click to inspect").size(theme::FONT_SM),
-                    iced::widget::tooltip::Position::Right,
-                )
-                .style(|_: &iced::Theme| iced::widget::container::Style {
-                    background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
-                    text_color: Some(iced::Color::WHITE),
-                    border: iced::Border {
-                        radius: theme::RADIUS_SM.into(),
-                        width: 1.0,
-                        color: iced::Color {
-                            a: 0.3,
-                            ..theme::ACCENT
-                        },
-                    },
-                    ..Default::default()
-                })
-                .padding(6)
-                .gap(4),
-            );
         }
 
         let list = Scrollable::new(tree_items)
@@ -3728,6 +3820,8 @@ mod test {
             running: false,
             show_modal: false,
             active_panel: None,
+            #[cfg(feature = "debugger")]
+            browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,
             modal_content: (String::new(), String::new()),
             pending_getline: false,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2480,16 +2480,37 @@ impl FlowrGui {
             } else {
                 ""
             };
+            let btn = Button::new(
+                Text::new(format!("{bp_dot}{label}"))
+                    .size(theme::FONT_SM)
+                    .color(*color),
+            )
+            .on_press(Message::DebugInspectLink(id.to_string()))
+            .style(theme::list_button)
+            .padding([2, 8])
+            .width(Length::Fill);
+
             tree_items = tree_items.push(
-                Button::new(
-                    Text::new(format!("{bp_dot}{label}"))
-                        .size(theme::FONT_SM)
-                        .color(*color),
+                iced::widget::tooltip(
+                    btn,
+                    Text::new("Click to inspect").size(theme::FONT_SM),
+                    iced::widget::tooltip::Position::Right,
                 )
-                .on_press(Message::DebugInspectLink(id.to_string()))
-                .style(theme::list_button)
-                .padding([2, 8])
-                .width(Length::Fill),
+                .style(|_: &iced::Theme| iced::widget::container::Style {
+                    background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                    text_color: Some(iced::Color::WHITE),
+                    border: iced::Border {
+                        radius: theme::RADIUS_SM.into(),
+                        width: 1.0,
+                        color: iced::Color {
+                            a: 0.3,
+                            ..theme::ACCENT
+                        },
+                    },
+                    ..Default::default()
+                })
+                .padding(6)
+                .gap(4),
             );
         }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -520,6 +520,9 @@ pub enum Message {
     /// Toggle fold/unfold in browser tree
     #[cfg(feature = "debugger")]
     BrowserToggleNode(usize),
+    /// Run a specific function from browser tree
+    #[cfg(feature = "debugger")]
+    BrowserRunFunction(usize),
     /// Toggle metrics panel
     ToggleMetrics,
     /// Metrics received from debug channel
@@ -546,9 +549,6 @@ pub enum Message {
     /// User clicked Run/Reset in the debug controls
     #[cfg(feature = "debugger")]
     DebugReset,
-    /// User clicked Run Process — runs a specific process using the spec field
-    #[cfg(feature = "debugger")]
-    DebugRunProcess,
     /// User clicked Exit Debugger in the debug controls
     #[cfg(feature = "debugger")]
     DebugExit,
@@ -568,11 +568,6 @@ pub enum Message {
     #[cfg(feature = "debugger")]
     DebugStepCountChanged(String),
     /// The breakpoint/inspect spec text input changed
-    #[cfg(feature = "debugger")]
-    DebugSpecChanged(String),
-    /// User clicked Set Breakpoint
-    #[cfg(feature = "debugger")]
-    DebugSetBreakpoint,
     /// User clicked Delete All Breakpoints
     #[cfg(feature = "debugger")]
     DebugDeleteBreakpoints,
@@ -760,8 +755,6 @@ struct FlowrGui {
     #[cfg(feature = "debugger")]
     debug_waiting: bool,
     #[cfg(feature = "debugger")]
-    debug_spec_text: String,
-    #[cfg(feature = "debugger")]
     debug_step_count: String,
     #[cfg(feature = "debugger")]
     debug_client_active: bool,
@@ -813,8 +806,6 @@ impl FlowrGui {
             pending_getline: false,
             #[cfg(feature = "debugger")]
             debug_waiting: false,
-            #[cfg(feature = "debugger")]
-            debug_spec_text: String::new(),
             #[cfg(feature = "debugger")]
             debug_step_count: String::new(),
             #[cfg(feature = "debugger")]
@@ -1046,6 +1037,48 @@ impl FlowrGui {
                 }
             }
             #[cfg(feature = "debugger")]
+            Message::BrowserRunFunction(id) => {
+                if let Some(func) = self.cached_functions.iter().find(|f| f.id == id) {
+                    if func.inputs.is_empty() {
+                        self.debug_waiting = false;
+                        self.debug_separator(&format!("Run #{id} '{}'", func.name));
+                        connection_manager::send_debug_command(
+                            flowcore::model::debug_command::DebugCommand::RunReset(
+                                Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
+                                vec![],
+                            ),
+                        );
+                    } else {
+                        self.run_input_names = func
+                            .inputs
+                            .iter()
+                            .enumerate()
+                            .map(|(i, (_, name, _))| {
+                                if name.is_empty() {
+                                    format!("input_{i}")
+                                } else {
+                                    name.clone()
+                                }
+                            })
+                            .collect();
+                        self.run_input_types = func
+                            .inputs
+                            .iter()
+                            .map(|(_, _, generic)| {
+                                if *generic {
+                                    "Generic".to_string()
+                                } else {
+                                    "Value".to_string()
+                                }
+                            })
+                            .collect();
+                        self.run_input_values = vec![String::new(); func.inputs.len()];
+                        self.run_target_id = Some(id);
+                        self.show_run_inputs = true;
+                    }
+                }
+            }
+            #[cfg(feature = "debugger")]
             Message::ToggleFlowBrowser => {
                 if self.active_panel == Some(PanelKind::Browser) {
                     self.close_panel();
@@ -1065,15 +1098,12 @@ impl FlowrGui {
             | Message::DebugContinue
             | Message::DebugStep
             | Message::DebugReset
-            | Message::DebugRunProcess
             | Message::DebugExit
             | Message::DebugPause
             | Message::RunInputChanged(_, _)
             | Message::RunInputExecute
             | Message::RunInputCancel
             | Message::DebugStepCountChanged(_)
-            | Message::DebugSpecChanged(_)
-            | Message::DebugSetBreakpoint
             | Message::DebugDeleteBreakpoints
             | Message::DebugListBreakpoints
             | Message::DebugFunctions(_)
@@ -1562,21 +1592,15 @@ impl FlowrGui {
             .padding(theme::BUTTON_PAD)
             .width(35);
 
-        let has_run_target = !self.debug_spec_text.trim().is_empty();
-        let is_run = has_run_target || !jobs_started;
-        let mut reset_btn = Button::new(if is_run {
-            icon_btn("\u{25B6}", "Run")
-        } else {
+        let mut reset_btn = Button::new(if jobs_started {
             icon_btn("\u{27F3}", "Reset")
+        } else {
+            icon_btn("\u{25B6}", "Run")
         })
         .style(theme::styled_button)
         .padding(bp);
         if self.debug_client_active {
-            reset_btn = reset_btn.on_press(if has_run_target {
-                Message::DebugRunProcess
-            } else {
-                Message::DebugReset
-            });
+            reset_btn = reset_btn.on_press(Message::DebugReset);
         }
 
         let mut pause_btn = Button::new(icon_btn("\u{2389}", "Pause"))
@@ -1592,12 +1616,6 @@ impl FlowrGui {
         if can_cmd {
             exit_btn = exit_btn.on_press(Message::DebugExit);
         }
-
-        let spec_input = text_input("spec", &self.debug_spec_text)
-            .on_input(Message::DebugSpecChanged)
-            .on_submit(Message::DebugSetBreakpoint)
-            .style(theme::pill_input)
-            .width(100);
 
         let mut del_btn = Button::new(Text::new("Del All"))
             .style(theme::styled_button)
@@ -1666,15 +1684,7 @@ impl FlowrGui {
             .push(Self::tip(pause_btn, "Pause execution and enter debugger"))
             .push(Self::tip(
                 reset_btn,
-                if has_run_target {
-                    "Run a specific process (spec field has target)"
-                } else {
-                    "Reset flow state and re-run from start"
-                },
-            ))
-            .push(Self::tip(
-                spec_input,
-                "Enter spec: breakpoint (3, 3+, 1:0) or run target (ID, /route, name [args])",
+                "Reset flow state and re-run from start",
             ))
             .push(Self::tip(del_btn, "Delete all breakpoints"))
             .push(Self::tip(list_btn, "List active breakpoints"))
@@ -2018,7 +2028,7 @@ impl FlowrGui {
                         .padding([2, 4]),
                 );
 
-                // After-breakpoint indicator
+                // After-breakpoint indicator and run button (functions only)
                 if !child.is_flow {
                     let after_sym = if has_after { "\u{1F7E0}" } else { "\u{25CB}" };
                     let after_spec = format!("{}+", child.id);
@@ -2038,6 +2048,19 @@ impl FlowrGui {
                         "Set breakpoint after executing this function"
                     };
                     row = row.push(bp_tooltip(after_btn, after_tip));
+
+                    // Run button
+                    let mut run_btn = Button::new(
+                        Text::new("\u{25B6}")
+                            .size(10.0)
+                            .shaping(iced::widget::text::Shaping::Advanced),
+                    )
+                    .style(theme::ghost_button)
+                    .padding([1, 3]);
+                    if can_bp {
+                        run_btn = run_btn.on_press(Message::BrowserRunFunction(child.id));
+                    }
+                    row = row.push(bp_tooltip(run_btn, "Run this function"));
                 }
 
                 *items = std::mem::replace(items, Column::new()).push(Element::from(row));
@@ -2660,89 +2683,6 @@ impl FlowrGui {
                 self.debug_separator("Run / Reset");
                 connection_manager::send_debug_command(DebugCommand::RunReset(None, vec![]));
             }
-            Message::DebugRunProcess => {
-                if self.debug_spec_text.trim().is_empty() {
-                    return iced::Task::none();
-                }
-                if !self.ensure_functions_cached(Message::DebugRunProcess) {
-                    return iced::Task::none();
-                }
-                let parts: Vec<String> = self
-                    .debug_spec_text
-                    .split_whitespace()
-                    .map(String::from)
-                    .collect();
-                if let Some(target_str) = parts.first() {
-                    let target_id = if let Ok(id) = target_str.parse::<usize>() {
-                        Some(id)
-                    } else if target_str.starts_with('/') {
-                        self.cached_functions
-                            .iter()
-                            .find(|f| f.route == *target_str)
-                            .map(|f| f.id)
-                    } else {
-                        self.cached_functions
-                            .iter()
-                            .find(|f| f.name == *target_str)
-                            .map(|f| f.id)
-                    };
-                    if let Some(id) = target_id {
-                        if let Some(func) = self.cached_functions.iter().find(|f| f.id == id) {
-                            let inline_args: Vec<String> =
-                                parts.get(1..).unwrap_or_default().to_vec();
-                            self.run_input_names = func
-                                .inputs
-                                .iter()
-                                .enumerate()
-                                .map(|(i, (_, name, _))| {
-                                    if name.is_empty() {
-                                        format!("input_{i}")
-                                    } else {
-                                        name.clone()
-                                    }
-                                })
-                                .collect();
-                            self.run_input_types = func
-                                .inputs
-                                .iter()
-                                .map(|(_, _, generic)| {
-                                    if *generic {
-                                        "Generic".to_string()
-                                    } else {
-                                        "Value".to_string()
-                                    }
-                                })
-                                .collect();
-                            self.run_input_values = (0..func.inputs.len())
-                                .map(|i| inline_args.get(i).cloned().unwrap_or_default())
-                                .collect();
-                            self.run_target_id = Some(id);
-                            self.show_run_inputs = true;
-                        } else {
-                            let args: Vec<String> = parts.get(1..).unwrap_or_default().to_vec();
-                            self.debug_waiting = false;
-                            self.debug_spec_text.clear();
-                            self.debug_separator(&format!("Run process #{id}"));
-                            connection_manager::send_debug_command(DebugCommand::RunReset(
-                                Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
-                                args,
-                            ));
-                        }
-                    } else {
-                        self.debug_waiting = false;
-                        let target = if target_str.starts_with('/') {
-                            flowcore::model::debug_command::ProcessTarget::Route(target_str.clone())
-                        } else {
-                            flowcore::model::debug_command::ProcessTarget::Name(target_str.clone())
-                        };
-                        self.debug_separator(&format!("Run process: {target_str}"));
-                        connection_manager::send_debug_command(DebugCommand::RunReset(
-                            Some(target),
-                            vec![],
-                        ));
-                    }
-                }
-            }
             Message::RunInputChanged(index, value) => {
                 if let Some(v) = self.run_input_values.get_mut(index) {
                     *v = value;
@@ -2753,7 +2693,6 @@ impl FlowrGui {
                 if let Some(id) = self.run_target_id.take() {
                     let args = self.run_input_values.clone();
                     self.debug_waiting = false;
-                    self.debug_spec_text.clear();
                     self.debug_separator(&format!("Run process #{id}"));
                     connection_manager::send_debug_command(DebugCommand::RunReset(
                         Some(flowcore::model::debug_command::ProcessTarget::Id(id)),
@@ -2777,26 +2716,6 @@ impl FlowrGui {
                 connection_manager::send_debug_command(DebugCommand::ExitDebugger);
             }
             Message::DebugStepCountChanged(value) => self.debug_step_count = value,
-            Message::DebugSpecChanged(value) => self.debug_spec_text = value,
-            Message::DebugSetBreakpoint => {
-                self.debug_waiting = false;
-                let params = if self.debug_spec_text.is_empty() {
-                    None
-                } else {
-                    Some(vec![self.debug_spec_text.clone()])
-                };
-                let spec_label = if self.debug_spec_text.is_empty() {
-                    "no spec".to_string()
-                } else {
-                    self.debug_spec_text.clone()
-                };
-                self.debug_separator(&format!("Set Breakpoint ({spec_label})"));
-                if !self.debug_spec_text.is_empty() {
-                    self.active_breakpoints.insert(self.debug_spec_text.clone());
-                }
-                let spec = DebugClient::parse_breakpoint_spec(params);
-                connection_manager::send_debug_command(DebugCommand::Breakpoint(spec));
-            }
             Message::DebugDeleteBreakpoints => {
                 self.debug_waiting = false;
                 self.active_breakpoints.clear();
@@ -3285,8 +3204,6 @@ mod test {
             pending_getline: false,
             #[cfg(feature = "debugger")]
             debug_waiting: false,
-            #[cfg(feature = "debugger")]
-            debug_spec_text: String::new(),
             #[cfg(feature = "debugger")]
             debug_step_count: String::new(),
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -579,9 +579,6 @@ pub enum Message {
     /// User clicked List Breakpoints
     #[cfg(feature = "debugger")]
     DebugListBreakpoints,
-    /// User clicked Inspect State
-    #[cfg(feature = "debugger")]
-    DebugInspect,
     /// User clicked Functions list
     #[cfg(feature = "debugger")]
     DebugFunctions(bool),
@@ -1144,7 +1141,6 @@ impl FlowrGui {
             | Message::DebugSetBreakpoint
             | Message::DebugDeleteBreakpoints
             | Message::DebugListBreakpoints
-            | Message::DebugInspect
             | Message::DebugFunctions(_)
             | Message::DebugFlows
             | Message::DebugProcesses
@@ -1696,13 +1692,6 @@ impl FlowrGui {
             list_btn = list_btn.on_press(Message::DebugListBreakpoints);
         }
 
-        let mut inspect_btn = Button::new(Text::new("Inspect"))
-            .style(theme::styled_button)
-            .padding(sp);
-        if can_cmd {
-            inspect_btn = inspect_btn.on_press(Message::DebugInspect);
-        }
-
         let mut funcs_btn = Button::new(Text::new("Functions"))
             .style(theme::styled_button)
             .padding(sp);
@@ -1769,10 +1758,6 @@ impl FlowrGui {
             .push(Self::tip(bp_btn, "Open breakpoint picker"))
             .push(Self::tip(del_btn, "Delete all breakpoints"))
             .push(Self::tip(list_btn, "List active breakpoints"))
-            .push(Self::tip(
-                inspect_btn,
-                "Inspect state (use spec field for specific target)",
-            ))
             .push(Self::tip(funcs_btn, "List all functions"))
             .push(Self::tip(flows_btn, "List all flows"))
             .push(Self::tip(procs_btn, "Show flow/function hierarchy"))
@@ -2223,6 +2208,7 @@ impl FlowrGui {
             funcs: &[CachedFunction],
             collapsed: &std::collections::HashSet<usize>,
             bps: &std::collections::HashSet<String>,
+            can_bp: bool,
             parent: Option<usize>,
             depth: usize,
         ) {
@@ -2241,10 +2227,13 @@ impl FlowrGui {
                 } else {
                     (theme::entity_colors::FUNCTION, "fn")
                 };
-                let bp_dot = if bps.contains(&child.id.to_string()) {
-                    "\u{1F534} "
-                } else {
-                    ""
+                let has_before = bps.contains(&child.id.to_string());
+                let has_after = bps.contains(&format!("{}+", child.id));
+                let bp_symbol = match (has_before, has_after) {
+                    (true, true) => "\u{23FA}",
+                    (true, false) => "\u{1F534}",
+                    (false, true) => "\u{1F7E0}",
+                    (false, false) => "\u{25CB}",
                 };
                 let name_part = if child.name.is_empty() {
                     format!("{prefix} #{}", child.id)
@@ -2284,16 +2273,52 @@ impl FlowrGui {
                     row = row.push(Text::new("  ").size(12.0));
                 }
 
+                // Breakpoint indicator (clickable, cycles: none→before→after→both→none)
+                let mut bp_btn = Button::new(
+                    Text::new(bp_symbol)
+                        .size(10.0)
+                        .shaping(iced::widget::text::Shaping::Advanced),
+                )
+                .style(theme::ghost_button)
+                .padding([1, 2]);
+                if can_bp {
+                    bp_btn = bp_btn.on_press(Message::BpCycleFunction(child.id));
+                }
+                let bp_tooltip_text = match (has_before, has_after) {
+                    (true, true) => "BP: before+after (click to cycle)",
+                    (true, false) => "BP: before (click to cycle)",
+                    (false, true) => "BP: after (click to cycle)",
+                    (false, false) => "Click to set breakpoint",
+                };
+                row = row.push(
+                    iced::widget::tooltip(
+                        bp_btn,
+                        Text::new(bp_tooltip_text).size(theme::FONT_SM),
+                        iced::widget::tooltip::Position::Right,
+                    )
+                    .style(|_: &iced::Theme| iced::widget::container::Style {
+                        background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                        text_color: Some(iced::Color::WHITE),
+                        border: iced::Border {
+                            radius: theme::RADIUS_SM.into(),
+                            width: 1.0,
+                            color: iced::Color {
+                                a: 0.3,
+                                ..theme::ACCENT
+                            },
+                        },
+                        ..Default::default()
+                    })
+                    .padding(4)
+                    .gap(4),
+                );
+
                 // Label button
                 row = row.push(
-                    Button::new(
-                        Text::new(format!("{bp_dot}{name_part}"))
-                            .size(theme::FONT_MD)
-                            .color(color),
-                    )
-                    .on_press(Message::DebugInspectLink(child.id.to_string()))
-                    .style(theme::list_button)
-                    .padding([2, 4]),
+                    Button::new(Text::new(name_part).size(theme::FONT_MD).color(color))
+                        .on_press(Message::DebugInspectLink(child.id.to_string()))
+                        .style(theme::list_button)
+                        .padding([2, 4]),
                 );
 
                 *items = std::mem::replace(items, Column::new()).push(Element::from(row));
@@ -2302,7 +2327,15 @@ impl FlowrGui {
                 if !is_collapsed {
                     // Sub-flows and functions
                     if child.is_flow {
-                        add_tree_nodes(items, funcs, collapsed, bps, Some(child.id), depth + 1);
+                        add_tree_nodes(
+                            items,
+                            funcs,
+                            collapsed,
+                            bps,
+                            can_bp,
+                            Some(child.id),
+                            depth + 1,
+                        );
                     }
 
                     // Inputs
@@ -2314,22 +2347,34 @@ impl FlowrGui {
                         };
                         let inp_indent = "  ".repeat(depth + 1);
                         let spec = format!("{}:{idx}", child.id);
-                        let ibp = if bps.contains(&spec) {
-                            "\u{1F534} "
-                        } else {
-                            ""
-                        };
-                        *items = std::mem::replace(items, Column::new()).push(
-                            Button::new(
-                                Text::new(format!("{inp_indent}    {ibp}{iname}"))
-                                    .size(theme::FONT_MD)
-                                    .color(theme::entity_colors::INPUT),
-                            )
-                            .on_press(Message::DebugInspectLink(spec))
-                            .style(theme::list_button)
-                            .padding([1, 8])
-                            .width(iced::Length::Fill),
-                        );
+                        let has_bp = bps.contains(&spec);
+                        let bp_sym = if has_bp { "\u{1F534}" } else { "\u{25CB}" };
+                        let mut bp_btn = Button::new(
+                            Text::new(bp_sym)
+                                .size(10.0)
+                                .shaping(iced::widget::text::Shaping::Advanced),
+                        )
+                        .style(theme::ghost_button)
+                        .padding([1, 2]);
+                        if can_bp {
+                            bp_btn = bp_btn.on_press(Message::BpTargetChanged(spec.clone()));
+                        }
+                        let irow = Row::new()
+                            .spacing(4)
+                            .align_y(iced::alignment::Vertical::Center)
+                            .push(Text::new(format!("{inp_indent}    ")).size(theme::FONT_MD))
+                            .push(bp_btn)
+                            .push(
+                                Button::new(
+                                    Text::new(iname)
+                                        .size(theme::FONT_MD)
+                                        .color(theme::entity_colors::INPUT),
+                                )
+                                .on_press(Message::DebugInspectLink(spec))
+                                .style(theme::list_button)
+                                .padding([1, 4]),
+                            );
+                        *items = std::mem::replace(items, Column::new()).push(Element::from(irow));
                     }
 
                     // Outputs (deduplicated by route)
@@ -2350,34 +2395,48 @@ impl FlowrGui {
                             output_route.as_str()
                         };
                         let spec = format!("{}{route}", child.id);
-                        let obp = if bps.contains(&spec) {
-                            "\u{1F534} "
-                        } else {
-                            ""
-                        };
-                        *items = std::mem::replace(items, Column::new()).push(
-                            Button::new(
-                                Text::new(format!("{out_indent}    {obp}output {display_route}"))
-                                    .size(theme::FONT_MD)
-                                    .color(theme::entity_colors::OUTPUT),
-                            )
-                            .on_press(Message::DebugInspectLink(spec))
-                            .style(theme::list_button)
-                            .padding([1, 8])
-                            .width(iced::Length::Fill),
-                        );
+                        let has_bp = bps.contains(&spec);
+                        let bp_sym = if has_bp { "\u{1F534}" } else { "\u{25CB}" };
+                        let mut bp_btn = Button::new(
+                            Text::new(bp_sym)
+                                .size(10.0)
+                                .shaping(iced::widget::text::Shaping::Advanced),
+                        )
+                        .style(theme::ghost_button)
+                        .padding([1, 2]);
+                        if can_bp {
+                            bp_btn = bp_btn.on_press(Message::BpTargetChanged(spec.clone()));
+                        }
+                        let orow = Row::new()
+                            .spacing(4)
+                            .align_y(iced::alignment::Vertical::Center)
+                            .push(Text::new(format!("{out_indent}    ")).size(theme::FONT_MD))
+                            .push(bp_btn)
+                            .push(
+                                Button::new(
+                                    Text::new(format!("output {display_route}"))
+                                        .size(theme::FONT_MD)
+                                        .color(theme::entity_colors::OUTPUT),
+                                )
+                                .on_press(Message::DebugInspectLink(spec))
+                                .style(theme::list_button)
+                                .padding([1, 4]),
+                            );
+                        *items = std::mem::replace(items, Column::new()).push(Element::from(orow));
                     }
                 }
             }
         }
 
         let has_roots = funcs.iter().any(|f| f.is_flow && f.parent_id.is_none());
+        let can_bp = self.debug_waiting;
         if has_roots {
             add_tree_nodes(
                 &mut tree_items,
                 funcs,
                 &self.browser_collapsed,
                 bps,
+                can_bp,
                 None,
                 0,
             );
@@ -3022,25 +3081,6 @@ impl FlowrGui {
                 self.debug_separator("List Breakpoints");
                 connection_manager::send_debug_command(DebugCommand::List);
             }
-            Message::DebugInspect => {
-                self.debug_waiting = false;
-                let params = if self.debug_spec_text.is_empty() {
-                    None
-                } else {
-                    Some(vec![self.debug_spec_text.clone()])
-                };
-                if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
-                    let label = if self.debug_spec_text.is_empty() {
-                        "Inspect (overall flow state)".to_string()
-                    } else {
-                        format!("Inspect ({})", self.debug_spec_text)
-                    };
-                    self.debug_separator(&label);
-                    connection_manager::send_debug_command(cmd);
-                } else {
-                    self.debug_waiting = true;
-                }
-            }
             Message::DebugFunctions(display) => {
                 self.debug_waiting = false;
                 if display {
@@ -3144,6 +3184,9 @@ impl FlowrGui {
                     };
                     let params = Some(vec![spec.clone()]);
                     if let Some(cmd) = DebugClient::parse_inspect_spec(params) {
+                        if let DebugCommand::InspectOutput(pid, _) = &cmd {
+                            connection_manager::set_last_output_inspect_pid(*pid);
+                        }
                         self.debug_separator(&label);
                         connection_manager::send_debug_command(cmd);
                     } else {

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -156,7 +156,7 @@ fn chip_row<'a>(line: &crate::DebugEventLine, cache: &[crate::CachedFunction]) -
         let chip_color = chip_color_for(link.link_type);
         let label = line.text[link.start..link.end].to_lowercase();
         let spec = link.spec.clone();
-        let chip_btn = Button::new(
+        let mut chip_btn = Button::new(
             Text::new(label)
                 .size(crate::theme::FONT_MD)
                 .color(iced::Color::WHITE)
@@ -165,9 +165,11 @@ fn chip_row<'a>(line: &crate::DebugEventLine, cache: &[crate::CachedFunction]) -
                     ..iced::Font::DEFAULT
                 }),
         )
-        .on_press(Message::DebugInspectLink(spec.clone()))
         .style(crate::theme::chip_button(chip_color))
         .padding([3, 10]);
+        if !spec.is_empty() {
+            chip_btn = chip_btn.on_press(Message::DebugInspectLink(spec.clone()));
+        }
 
         if let Some(tip) = chip_tooltip(&spec, link.link_type, cache) {
             row = row.push(

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -174,12 +174,14 @@ impl DebugClient {
                 }
 
                 if spec.first()?.contains('/') {
-                    let sub_parts: Vec<&str> = spec.first()?.split('/').collect();
-                    if let Ok(source_process_id) = sub_parts.first()?.parse::<usize>() {
-                        return Some(BreakpointSpec::Output((
-                            source_process_id,
-                            format!("/{}", sub_parts.get(1)?),
-                        )));
+                    let full = spec.first()?;
+                    if let Some(slash_pos) = full.find('/') {
+                        if let Ok(source_process_id) = full[..slash_pos].parse::<usize>() {
+                            return Some(BreakpointSpec::Output((
+                                source_process_id,
+                                full[slash_pos..].to_string(),
+                            )));
+                        }
                     }
                 } else if spec.first()?.contains(':') {
                     let sub_parts: Vec<&str> = spec.first()?.split(':').collect();

--- a/flowr/src/lib/debug_gui_handler.rs
+++ b/flowr/src/lib/debug_gui_handler.rs
@@ -156,10 +156,17 @@ impl DebuggerHandler for DebugGuiHandler {
 
     fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
         let manifest = &state.get_submission().manifest;
-        let flows: Vec<(usize, String, String)> = manifest
+        let flows: Vec<(usize, String, String, Option<usize>)> = manifest
             .flows()
             .values()
-            .map(|fi| (fi.process_id, fi.name.clone(), fi.route.clone()))
+            .map(|fi| {
+                (
+                    fi.process_id,
+                    fi.name.clone(),
+                    fi.route.clone(),
+                    fi.parent_id,
+                )
+            })
             .collect();
         self.send_event(DebugServerMessage::FlowList(flows));
     }

--- a/flowr/src/lib/debug_server_message.rs
+++ b/flowr/src/lib/debug_server_message.rs
@@ -70,7 +70,7 @@ pub enum DebugServerMessage {
     #[cfg(feature = "metrics")]
     ExecutionMetrics(flowcore::model::metrics::Metrics),
     /// List of flows with names and routes
-    FlowList(Vec<(usize, String, String)>),
+    FlowList(Vec<(usize, String, String, Option<usize>)>),
     /// The list of active breakpoints
     BreakpointList(Vec<BreakpointSpec>),
     /// The run-time is resetting the status back to the initial state

--- a/flowr/src/lib/debug_zmq_handler.rs
+++ b/flowr/src/lib/debug_zmq_handler.rs
@@ -112,10 +112,17 @@ impl DebuggerHandler for DebugZmqHandler {
 
     fn flow_list(&mut self, _flow_ids: &[usize], state: &RunState) {
         let manifest = &state.get_submission().manifest;
-        let flows: Vec<(usize, String, String)> = manifest
+        let flows: Vec<(usize, String, String, Option<usize>)> = manifest
             .flows()
             .values()
-            .map(|fi| (fi.process_id, fi.name.clone(), fi.route.clone()))
+            .map(|fi| {
+                (
+                    fi.process_id,
+                    fi.name.clone(),
+                    fi.route.clone(),
+                    fi.parent_id,
+                )
+            })
             .collect();
         let _: flowcore::errors::Result<DebugCommand> = self
             .debug_server_connection

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -315,16 +315,17 @@ impl<'a> Debugger<'a> {
 
                         let mut output_connections = vec![];
 
+                        let normalized = if sub_route == "/" { "" } else { &sub_route };
                         for output_connection in function.get_output_connections() {
                             match &output_connection.source {
                                 Output(source_route) => {
-                                    if *source_route == sub_route {
+                                    if *source_route == normalized {
                                         output_connections.push(output_connection.clone());
                                     }
                                 }
                                 // add list of connections from an input to job if path "" is specified
                                 Input(_) => {
-                                    if sub_route.is_empty() {
+                                    if normalized.is_empty() {
                                         output_connections.push(output_connection.clone());
                                     }
                                 }


### PR DESCRIPTION
## Summary
- Add left-side Flow Browser panel with hierarchical tree view of flows, functions, inputs, outputs
- Clickable nodes inspect entities; separate before/after breakpoint indicators on functions
- Input/output breakpoint toggles with descriptive tooltips
- Remove Inspect button/panel and Set BP button/panel (replaced by browser tree)
- Remove DebugInspect, InspectTab, BpTab, BpCycleFunction and all related dead code (~700 lines removed)
- Unify output connection formatting via shared `format_output_connection()` helper
- Fix default output route "/" normalization in debugger
- Fix first-click lost on browser icon (pending action routing)

Closes #2793

## Test plan
- [ ] `make clippy` passes
- [ ] `make features` passes
- [ ] `make test` passes
- [ ] Launch flowrgui with `-d` and mandelbrot flow, verify Flow Browser opens/closes
- [ ] Click function/flow/input/output nodes to inspect
- [ ] Toggle breakpoints via before/after indicators on functions
- [ ] Toggle breakpoints on inputs and outputs
- [ ] Verify output inspection shows clickable chips
- [ ] Verify job inspection output connections match output inspection format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Flow Browser tree panel for hierarchical flow visualization in the debugger UI.
  * Enhanced output connection details now display destination function and input information.
  * Improved breakpoint management integrated into the Flow Browser panel.

* **Bug Fixes**
  * Fixed output route parsing to correctly handle multi-segment routes.
  * Corrected inspect link rendering for empty specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->