### PR TITLE
Function state diagram with live chips (#2787)

### DIFF
--- a/docs/design/flow-vocabulary.md
+++ b/docs/design/flow-vocabulary.md
@@ -20,7 +20,7 @@
   of each input queue.
 - **Full input**: An input with at least one value in its queue.
 - **Empty input**: An input with no values in its queue.
-- **Ready**: A function is ready when all its inputs have at least one value AND it is not blocked.
+- **Ready**: A function is ready when all its inputs have at least one value.
 
 ## Initializers
 
@@ -53,66 +53,31 @@
   same function).
 - **Send**: Delivering a value from a completed job's output to a destination input queue.
 
-## Blocking
-
-### Function blocking
-
-A function becomes **blocked** when it has all inputs ready (could run) but at least one of its cross-flow
-output destinations already has a value queued. Running the function would produce output that can't be
-delivered, so it is held back.
-
-- **Blocked function**: A function in the `blocked` set. It has a complete input set but cannot be scheduled.
-  It transitions from blocked to ready when all its output destinations have consumed their values (blocks
-  removed).
-- **Output block**: The condition that causes blocking — a cross-flow destination input already has a value.
-  Same-flow sends and loopbacks never create blocks.
-- **Block record**: An entry in the `blocks` set recording the blocked function (sender), the blocking
-  function (destination whose input is full), and which input is full.
-
-### Flow blocking
-
-When a function inside a sub-flow starts a job, external senders (functions in other flows) that send to
-that sub-flow are prevented from sending until the sub-flow goes idle. This prevents values from the parent
-flow arriving while the sub-flow is busy processing.
-
-- **flow_blocks**: A map of `flow_id → set of function_ids`. When a function starts a job, it registers in
-  flow_blocks for its flow. When the flow goes idle, `remove_blocks` is called for each registered function,
-  resolving the output blocks that were holding back external senders.
-
 ## Function State Transitions
 
-A function can be in one of five states: **Waiting**, **Ready**, **Blocked**, **Running**, **Completed**.
+A function can be in one of four states: **Waiting**, **Ready**, **Running**, **Completed**.
 
 ```text
 From      To         Trigger and conditions
 --------  ---------  --------------------------------------------------------
-Init      Ready      All inputs initialized AND no destination input full
-                     OR: no inputs AND no destination input full
-Init      Blocked    All inputs initialized BUT a destination input is full
+Init      Ready      All inputs initialized (or no inputs)
 Init      Waiting    At least one input is not full
 
-Waiting   Ready      A send fills the last empty input, no destination full
-Waiting   Blocked    A send fills the last empty input, but a destination full
+Waiting   Ready      A send fills the last empty input
 
 Ready     Running    Job dispatched for execution
 
-Running   Ready      Job done, all inputs still full, no destination full
+Running   Ready      Job done, all inputs still full (after re-applying
+                     Always initializers)
 Running   Waiting    Job done, at least one input empty
-Running   Blocked    Job done, all inputs full but a destination full
-
-Blocked   Ready      Output block removed (destination consumed its value)
-
-Any       Completed  Function indicates it will not run again (run_again=false)
+Running   Completed  Function indicates it will not run again (run_again=false)
 ```
-
-Notes:
-- Loopback sends (function to itself) never create blocks
-- Same-flow sends never create blocks
-- Only cross-flow sends can cause a function to become blocked
 
 ## Flow State Transitions
 
-A flow can be in one of two states: **Busy** or **Idle**.
+A flow can be in one of two states: **Busy** or **Idle**. These are tracked via a `busy_count`
+per flow — the number of functions in that flow (and descendant sub-flows) that have ready
+or running jobs.
 
 ```text
 From   To     Trigger and conditions
@@ -126,15 +91,16 @@ Idle   Busy   A job is created for a function in this flow
 Busy   Idle   Last busy function in the flow completes and no new jobs
               are created for functions in this flow
               On transition to idle:
-                1. External senders to this flow are unblocked
-                2. Always flow initializers are re-applied
+                1. Always flow initializers are re-applied
+                2. If new jobs are created, flow goes back to Busy
 ```
 
 Notes:
-- A flow with blocked functions but no busy functions is considered idle
 - The root flow (flow_id=0) going idle is normal between job batches
 - A sub-flow going idle signals the end of an iteration, triggering
-  parent flow unblocking and flow initializer re-application
+  flow initializer re-application
+- `busy_count` is incremented for a function AND all its ancestor flows
+  when a job is created, and decremented when a job completes
 
 ## Stale Values
 

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -106,6 +106,15 @@ pub fn set_flows_only(v: bool) {
     FLOWS_ONLY.store(v, Ordering::Relaxed);
 }
 
+/// Flag: extract states only from next `ProcessTree` (no debug output)
+#[cfg(feature = "debugger")]
+static STATES_ONLY: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "debugger")]
+pub fn set_states_only(v: bool) {
+    STATES_ONLY.store(v, Ordering::Relaxed);
+}
+
 /// Last output-inspect source process ID (set by GUI before sending `InspectOutput`)
 #[cfg(feature = "debugger")]
 static LAST_OUTPUT_INSPECT_PID: AtomicUsize = AtomicUsize::new(usize::MAX);
@@ -806,7 +815,9 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
             .text(")")
             .finish()],
         DebugServerMessage::ProcessTree(ref state) => {
-            if FLOWS_ONLY.swap(false, Ordering::Relaxed) {
+            if STATES_ONLY.swap(false, Ordering::Relaxed) {
+                vec![]
+            } else if FLOWS_ONLY.swap(false, Ordering::Relaxed) {
                 format_flows_only(state)
             } else {
                 format_tree_only(state)

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -1541,7 +1541,6 @@ fn format_inspect_by_state(
         "waiting" => Some(flowrlib::run_state::State::Waiting),
         "running" => Some(flowrlib::run_state::State::Running),
         "completed" => Some(flowrlib::run_state::State::Completed),
-        "blocked" => None,
         _ => {
             return vec![DebugEventLine::new(
                 format!("Unknown state '{state_name}'"),
@@ -1567,39 +1566,6 @@ fn format_inspect_by_state(
                     crate::LinkType::Function,
                     &states,
                 ));
-            }
-        }
-        if count == 0 {
-            lines.push(DebugEventLine::new("  (none)".into(), None));
-        }
-    } else {
-        let mut count = 0;
-        for func in &sorted {
-            let states = run_state.get_function_states(func.id());
-            if states.contains(&flowrlib::run_state::State::Waiting) {
-                if let Ok(blockers) = run_state.get_input_blockers(func.id()) {
-                    if !blockers.is_empty() {
-                        count += 1;
-                        let mut b = crate::DebugLineBuilder::new().text("  ");
-                        b = b.chip(
-                            &format!("function #{}", func.id()),
-                            &func.id().to_string(),
-                            crate::LinkType::Function,
-                        );
-                        b = b.text(" — blocked by: ");
-                        for (j, bid) in blockers.iter().enumerate() {
-                            if j > 0 {
-                                b = b.text(", ");
-                            }
-                            b = b.chip(
-                                &format!("function #{bid}"),
-                                &bid.to_string(),
-                                crate::LinkType::Function,
-                            );
-                        }
-                        lines.push(b.finish());
-                    }
-                }
             }
         }
         if count == 0 {

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -834,7 +834,7 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
                     let line = match spec {
                         BreakpointSpec::Numeric(id) => Some(
                             DebugLineBuilder::new()
-                                .text("  ")
+                                .text("  \u{1F534} before  ")
                                 .chip(
                                     &format!("function #{id}"),
                                     &id.to_string(),
@@ -844,41 +844,49 @@ fn format_debug_event(message: &DebugServerMessage) -> Vec<crate::DebugEventLine
                         ),
                         BreakpointSpec::Completed(id) => Some(
                             DebugLineBuilder::new()
-                                .text("  ")
+                                .text("  \u{1F7E0} after  ")
                                 .chip(
                                     &format!("function #{id}"),
                                     &id.to_string(),
                                     LinkType::Function,
                                 )
-                                .text(" (completion)")
                                 .finish(),
                         ),
                         BreakpointSpec::Input((id, num)) => Some(
                             DebugLineBuilder::new()
-                                .text("  ")
+                                .text("  \u{1F534} ")
+                                .chip(
+                                    &format!("input:{num}"),
+                                    &format!("{id}:{num}"),
+                                    LinkType::Input,
+                                )
+                                .text("  on  ")
                                 .chip(
                                     &format!("function #{id}"),
                                     &id.to_string(),
                                     LinkType::Function,
                                 )
-                                .text(&format!(" input:{num}"))
                                 .finish(),
                         ),
                         BreakpointSpec::Output((id, route)) => Some(
                             DebugLineBuilder::new()
-                                .text("  ")
+                                .text("  \u{1F534} ")
+                                .chip(
+                                    &format!("output '{route}'"),
+                                    &format!("{id}{route}"),
+                                    LinkType::Output,
+                                )
+                                .text("  on  ")
                                 .chip(
                                     &format!("function #{id}"),
                                     &id.to_string(),
                                     LinkType::Function,
                                 )
-                                .text(" ")
-                                .chip(route, route, LinkType::Route)
                                 .finish(),
                         ),
                         BreakpointSpec::Route(route) => Some(
                             DebugLineBuilder::new()
-                                .text("  ")
+                                .text("  \u{1F534} ")
                                 .chip(route, route, LinkType::Route)
                                 .finish(),
                         ),

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -543,9 +543,9 @@ pub enum Message {
     /// Toggle function state diagram panel
     #[cfg(feature = "debugger")]
     ToggleStateDiagram,
-    /// Hover info from state diagram canvas
+    /// Hover info from state diagram canvas (text, x, y) or None to clear
     #[cfg(feature = "debugger")]
-    DiagramHover(String),
+    DiagramHover(Option<(String, f32, f32)>),
     /// Metrics received from debug channel
     #[cfg(feature = "metrics")]
     DebugMetricsReceived(flowcore::model::metrics::Metrics),
@@ -777,7 +777,7 @@ struct FlowrGui {
     #[cfg(feature = "debugger")]
     states_refresh_pending: bool,
     #[cfg(feature = "debugger")]
-    diagram_hover_info: String,
+    diagram_hover_info: Option<(String, f32, f32)>,
     #[cfg(feature = "debugger")]
     browser_collapsed: std::collections::HashSet<usize>,
     last_metrics: Option<flowcore::model::metrics::Metrics>,
@@ -837,7 +837,7 @@ impl FlowrGui {
             #[cfg(feature = "debugger")]
             states_refresh_pending: false,
             #[cfg(feature = "debugger")]
-            diagram_hover_info: String::new(),
+            diagram_hover_info: None,
             #[cfg(feature = "debugger")]
             browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,
@@ -1101,7 +1101,7 @@ impl FlowrGui {
                 }
             }
             #[cfg(feature = "debugger")]
-            Message::DiagramHover(info) => self.diagram_hover_info = info,
+            Message::DiagramHover(data) => self.diagram_hover_info = data,
             #[cfg(feature = "debugger")]
             Message::DebugStatesReceived(states) => self.cached_states = states,
             #[cfg(feature = "debugger")]
@@ -1968,24 +1968,52 @@ impl FlowrGui {
         let canvas_height = state_diagram::canvas_height(&diagram_data);
         let canvas = state_diagram::StateDiagramCanvas { data: diagram_data };
 
-        let hover_text: Element<'_, Message> = if self.diagram_hover_info.is_empty() {
-            Text::new(" ").size(theme::FONT_SM).into()
+        let canvas_widget: Element<'_, Message> = iced::widget::canvas(canvas)
+            .width(Length::Fill)
+            .height(Length::Fixed(canvas_height))
+            .into();
+
+        let canvas_area: Element<'_, Message> = if let Some((ref tip_text, tip_x, tip_y)) =
+            self.diagram_hover_info
+        {
+            let tooltip_overlay: iced::widget::Container<'_, Message> = iced::widget::container(
+                iced::widget::container(
+                    Text::new(tip_text.clone())
+                        .size(theme::FONT_MD)
+                        .color(iced::Color::WHITE),
+                )
+                .padding(6)
+                .style(|_: &iced::Theme| iced::widget::container::Style {
+                    background: Some(iced::Background::Color(iced::Color {
+                        r: 0.1,
+                        g: 0.1,
+                        b: 0.15,
+                        a: 0.95,
+                    })),
+                    border: iced::Border {
+                        color: theme::ACCENT,
+                        width: 1.5,
+                        radius: 6.0.into(),
+                    },
+                    ..Default::default()
+                }),
+            )
+            .padding(iced::Padding {
+                top: (tip_y + 20.0).max(0.0),
+                left: (tip_x - 40.0).max(0.0),
+                right: 0.0,
+                bottom: 0.0,
+            });
+            let tip_el: Element<'_, Message> = tooltip_overlay.into();
+            iced::widget::stack![canvas_widget, tip_el].into()
         } else {
-            Text::new(&self.diagram_hover_info)
-                .size(theme::FONT_MD)
-                .color(iced::Color::WHITE)
-                .into()
+            canvas_widget
         };
 
         let panel_content = Column::new()
             .spacing(theme::SPACE_MD)
             .push(header)
-            .push(
-                iced::widget::canvas(canvas)
-                    .width(Length::Fill)
-                    .height(Length::Fixed(canvas_height)),
-            )
-            .push(hover_text);
+            .push(canvas_area);
 
         Container::new(panel_content)
             .width(Length::Fixed(380.0))
@@ -3596,7 +3624,7 @@ mod test {
             #[cfg(feature = "debugger")]
             states_refresh_pending: false,
             #[cfg(feature = "debugger")]
-            diagram_hover_info: String::new(),
+            diagram_hover_info: None,
             #[cfg(feature = "debugger")]
             browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1854,6 +1854,11 @@ impl FlowrGui {
         use iced::widget::{Container, Scrollable};
         use iced::Length;
 
+        let bold = iced::Font {
+            weight: iced::font::Weight::Bold,
+            ..iced::Font::DEFAULT
+        };
+
         let header = Row::new()
             .push(
                 Button::new(
@@ -1870,10 +1875,7 @@ impl FlowrGui {
                             Text::new("Function States")
                                 .size(theme::FONT_DEFAULT)
                                 .color(iced::Color::WHITE)
-                                .font(iced::Font {
-                                    weight: iced::font::Weight::Bold,
-                                    ..iced::Font::DEFAULT
-                                }),
+                                .font(bold),
                         ),
                 )
                 .on_press(Message::ToggleStateDiagram)
@@ -1936,14 +1938,11 @@ impl FlowrGui {
                         Text::new(id.to_string())
                             .size(theme::FONT_SM)
                             .color(iced::Color::WHITE)
-                            .font(iced::Font {
-                                weight: iced::font::Weight::Bold,
-                                ..iced::Font::DEFAULT
-                            }),
+                            .font(bold),
                     )
                     .on_press(Message::DebugInspectLink(id.to_string()))
                     .style(theme::chip_button(color))
-                    .padding([1, 5])
+                    .padding([2, 6])
                     .into(),
                 );
             }
@@ -1979,82 +1978,53 @@ impl FlowrGui {
                         ..iced::Color::WHITE
                     }
                 };
-                let mut col = Column::new().spacing(2).push(
+                let title = Button::new(
                     Row::new()
                         .spacing(6)
                         .push(
                             Text::new(label)
                                 .size(theme::FONT_DEFAULT)
                                 .color(text_color)
-                                .font(iced::Font {
-                                    weight: iced::font::Weight::Bold,
-                                    ..iced::Font::DEFAULT
-                                }),
+                                .font(bold),
                         )
                         .push(
                             Text::new(format!("({count})"))
                                 .size(theme::FONT_SM)
                                 .color(text_color),
                         ),
-                );
+                )
+                .style(theme::chip_button(bg))
+                .padding([6, 14])
+                .width(Length::Fill);
+                let mut col = Column::new().spacing(4).push(title);
                 if count > 0 {
                     col = col.push(fn_chips(ids, bg));
                 }
-                Container::new(col)
-                    .padding([6, 10])
-                    .width(Length::Fill)
-                    .style(move |_: &iced::Theme| iced::widget::container::Style {
-                        background: Some(iced::Background::Color(iced::Color { a: 0.25, ..bg })),
-                        border: iced::Border {
-                            radius: theme::RADIUS_SM.into(),
-                            width: 1.0,
-                            color: bg,
-                        },
-                        ..Default::default()
-                    })
-                    .into()
+                col.into()
             };
 
-        let fwd_arrow = |label: String| -> Element<'_, Message> {
+        let transition = |arrow: String,
+                          target: String,
+                          condition: String,
+                          color: iced::Color|
+         -> Element<'_, Message> {
             Row::new()
-                .spacing(4)
-                .align_y(iced::alignment::Vertical::Center)
-                .push(Text::new("    ").size(theme::FONT_SM))
-                .push(
-                    Text::new("\u{2193}")
-                        .size(16.0)
-                        .shaping(iced::widget::text::Shaping::Advanced)
-                        .color(theme::ACCENT),
-                )
-                .push(
-                    Text::new(label)
-                        .size(theme::FONT_SM)
-                        .color(theme::TEXT_SECONDARY),
-                )
-                .into()
-        };
-
-        let back_label = |from: String, to: String, label: String| -> Element<'_, Message> {
-            Row::new()
-                .spacing(4)
+                .spacing(6)
                 .align_y(iced::alignment::Vertical::Center)
                 .push(
-                    Text::new("\u{21B0}")
+                    Text::new(arrow)
                         .size(14.0)
                         .shaping(iced::widget::text::Shaping::Advanced)
-                        .color(theme::entity_colors::STATE_RUNNING),
+                        .color(color),
                 )
                 .push(
-                    Text::new(format!("{from} \u{2192} {to}"))
+                    Text::new(target)
                         .size(theme::FONT_SM)
-                        .color(theme::TEXT_SECONDARY)
-                        .font(iced::Font {
-                            weight: iced::font::Weight::Bold,
-                            ..iced::Font::DEFAULT
-                        }),
+                        .color(color)
+                        .font(bold),
                 )
                 .push(
-                    Text::new(label)
+                    Text::new(condition)
                         .size(theme::FONT_SM)
                         .color(theme::TEXT_SECONDARY),
                 )
@@ -2062,45 +2032,56 @@ impl FlowrGui {
         };
 
         let diagram = Column::new()
-            .spacing(4)
+            .spacing(8)
             .push(state_box(
                 "Waiting".into(),
                 &waiting_ids,
                 theme::entity_colors::STATE_WAITING,
             ))
-            .push(fwd_arrow("all inputs full".into()))
+            .push(transition(
+                "\u{2193}".into(),
+                "Ready".into(),
+                "all inputs full".into(),
+                theme::entity_colors::STATE_READY,
+            ))
             .push(state_box(
                 "Ready".into(),
                 &ready_ids,
                 theme::entity_colors::STATE_READY,
             ))
-            .push(fwd_arrow("job dispatched".into()))
+            .push(transition(
+                "\u{2193}".into(),
+                "Running".into(),
+                "job dispatched".into(),
+                theme::entity_colors::STATE_RUNNING,
+            ))
             .push(state_box(
                 "Running".into(),
                 &running_ids,
                 theme::entity_colors::STATE_RUNNING,
             ))
-            .push(fwd_arrow("run_again = false".into()))
+            .push(transition(
+                "\u{2193}".into(),
+                "Completed".into(),
+                "run_again = false".into(),
+                theme::entity_colors::STATE_COMPLETED,
+            ))
+            .push(transition(
+                "\u{21B0}".into(),
+                "Ready".into(),
+                "run_again, inputs full".into(),
+                theme::entity_colors::STATE_READY,
+            ))
+            .push(transition(
+                "\u{21B0}".into(),
+                "Waiting".into(),
+                "run_again, input(s) empty".into(),
+                theme::entity_colors::STATE_WAITING,
+            ))
             .push(state_box(
                 "Completed".into(),
                 &completed_ids,
                 theme::entity_colors::STATE_COMPLETED,
-            ))
-            .push(iced::widget::rule::horizontal(1))
-            .push(
-                Text::new("Back transitions:")
-                    .size(theme::FONT_MD)
-                    .color(theme::TEXT_SECONDARY),
-            )
-            .push(back_label(
-                "Running".into(),
-                "Ready".into(),
-                "inputs still full".into(),
-            ))
-            .push(back_label(
-                "Running".into(),
-                "Waiting".into(),
-                "input(s) empty".into(),
             ));
 
         let panel_content = Column::new()
@@ -2109,7 +2090,7 @@ impl FlowrGui {
             .push(Scrollable::new(diagram).height(Length::Fill));
 
         Container::new(panel_content)
-            .width(Length::Fixed(350.0))
+            .width(Length::Fixed(380.0))
             .height(Length::Fill)
             .padding(theme::SPACE_MD)
             .style(|_: &iced::Theme| iced::widget::container::Style {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -543,6 +543,9 @@ pub enum Message {
     /// Toggle function state diagram panel
     #[cfg(feature = "debugger")]
     ToggleStateDiagram,
+    /// Hover info from state diagram canvas
+    #[cfg(feature = "debugger")]
+    DiagramHover(String),
     /// Metrics received from debug channel
     #[cfg(feature = "metrics")]
     DebugMetricsReceived(flowcore::model::metrics::Metrics),
@@ -772,6 +775,10 @@ struct FlowrGui {
     #[cfg(feature = "debugger")]
     browser_open: bool,
     #[cfg(feature = "debugger")]
+    states_refresh_pending: bool,
+    #[cfg(feature = "debugger")]
+    diagram_hover_info: String,
+    #[cfg(feature = "debugger")]
     browser_collapsed: std::collections::HashSet<usize>,
     last_metrics: Option<flowcore::model::metrics::Metrics>,
     modal_content: (String, String),
@@ -827,6 +834,10 @@ impl FlowrGui {
             active_panel: None,
             #[cfg(feature = "debugger")]
             browser_open: false,
+            #[cfg(feature = "debugger")]
+            states_refresh_pending: false,
+            #[cfg(feature = "debugger")]
+            diagram_hover_info: String::new(),
             #[cfg(feature = "debugger")]
             browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,
@@ -1079,7 +1090,18 @@ impl FlowrGui {
             }
             Message::ToggleMetrics => self.toggle_panel(PanelKind::Metrics),
             #[cfg(feature = "debugger")]
-            Message::ToggleStateDiagram => self.toggle_panel(PanelKind::StateDiagram),
+            Message::ToggleStateDiagram => {
+                if self.active_panel == Some(PanelKind::StateDiagram) {
+                    self.close_panel();
+                } else {
+                    if !self.ensure_functions_cached(Message::ToggleStateDiagram) {
+                        return iced::Task::none();
+                    }
+                    self.open_panel(PanelKind::StateDiagram);
+                }
+            }
+            #[cfg(feature = "debugger")]
+            Message::DiagramHover(info) => self.diagram_hover_info = info,
             #[cfg(feature = "debugger")]
             Message::DebugStatesReceived(states) => self.cached_states = states,
             #[cfg(feature = "debugger")]
@@ -1862,6 +1884,7 @@ impl FlowrGui {
     }
 
     #[cfg(feature = "debugger")]
+    #[allow(clippy::too_many_lines)]
     fn state_diagram_panel(&self) -> Element<'_, Message> {
         use iced::widget::Container;
         use iced::Length;
@@ -1945,11 +1968,24 @@ impl FlowrGui {
         let canvas_height = state_diagram::canvas_height(&diagram_data);
         let canvas = state_diagram::StateDiagramCanvas { data: diagram_data };
 
-        let panel_content = Column::new().spacing(theme::SPACE_MD).push(header).push(
-            iced::widget::canvas(canvas)
-                .width(Length::Fill)
-                .height(Length::Fixed(canvas_height)),
-        );
+        let hover_text: Element<'_, Message> = if self.diagram_hover_info.is_empty() {
+            Text::new(" ").size(theme::FONT_SM).into()
+        } else {
+            Text::new(&self.diagram_hover_info)
+                .size(theme::FONT_MD)
+                .color(iced::Color::WHITE)
+                .into()
+        };
+
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_MD)
+            .push(header)
+            .push(
+                iced::widget::canvas(canvas)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(canvas_height)),
+            )
+            .push(hover_text);
 
         Container::new(panel_content)
             .width(Length::Fixed(380.0))
@@ -2986,7 +3022,18 @@ impl FlowrGui {
                 }
             }
             Message::DebugWaiting => {
-                self.debug_waiting = true;
+                if self.states_refresh_pending {
+                    self.states_refresh_pending = false;
+                } else {
+                    self.debug_waiting = true;
+                    if self.active_panel == Some(PanelKind::StateDiagram) {
+                        self.states_refresh_pending = true;
+                        connection_manager::set_states_only(true);
+                        connection_manager::send_debug_command(
+                            flowcore::model::debug_command::DebugCommand::ProcessList,
+                        );
+                    }
+                }
             }
             Message::DebugConnected => {
                 self.tab_set
@@ -3546,6 +3593,10 @@ mod test {
             active_panel: None,
             #[cfg(feature = "debugger")]
             browser_open: false,
+            #[cfg(feature = "debugger")]
+            states_refresh_pending: false,
+            #[cfg(feature = "debugger")]
+            diagram_hover_info: String::new(),
             #[cfg(feature = "debugger")]
             browser_collapsed: std::collections::HashSet::new(),
             last_metrics: None,

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -73,6 +73,19 @@ mod tabs;
 /// to get access to everything `error_chain` creates.
 mod errors;
 
+#[cfg(feature = "debugger")]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::min_ident_chars,
+    clippy::indexing_slicing,
+    clippy::manual_midpoint,
+    clippy::manual_div_ceil,
+    clippy::unnecessary_operation
+)]
+mod state_diagram;
+
 /// custom widget styling
 mod theme;
 
@@ -1849,15 +1862,9 @@ impl FlowrGui {
     }
 
     #[cfg(feature = "debugger")]
-    #[allow(clippy::too_many_lines)]
     fn state_diagram_panel(&self) -> Element<'_, Message> {
-        use iced::widget::{Container, Scrollable};
+        use iced::widget::Container;
         use iced::Length;
-
-        let bold = iced::Font {
-            weight: iced::font::Weight::Bold,
-            ..iced::Font::DEFAULT
-        };
 
         let header = Row::new()
             .push(
@@ -1875,7 +1882,10 @@ impl FlowrGui {
                             Text::new("Function States")
                                 .size(theme::FONT_DEFAULT)
                                 .color(iced::Color::WHITE)
-                                .font(bold),
+                                .font(iced::Font {
+                                    weight: iced::font::Weight::Bold,
+                                    ..iced::Font::DEFAULT
+                                }),
                         ),
                 )
                 .on_press(Message::ToggleStateDiagram)
@@ -1891,7 +1901,6 @@ impl FlowrGui {
                 left: 0.0,
             });
 
-        let max_chips = 30;
         let mut waiting_ids: Vec<usize> = Vec::new();
         let mut ready_ids: Vec<usize> = Vec::new();
         let mut running_ids: Vec<usize> = Vec::new();
@@ -1926,168 +1935,21 @@ impl FlowrGui {
         running_ids.sort_unstable();
         completed_ids.sort_unstable();
 
-        let fn_chips = |ids: &[usize], color: iced::Color| -> Element<'_, Message> {
-            if ids.is_empty() {
-                return iced::widget::text("").into();
-            }
-            let show = ids.len().min(max_chips);
-            let mut children: Vec<Element<'_, Message>> = Vec::new();
-            for &id in ids.iter().take(show) {
-                children.push(
-                    Button::new(
-                        Text::new(id.to_string())
-                            .size(theme::FONT_SM)
-                            .color(iced::Color::WHITE)
-                            .font(bold),
-                    )
-                    .on_press(Message::DebugInspectLink(id.to_string()))
-                    .style(theme::chip_button(color))
-                    .padding([2, 6])
-                    .into(),
-                );
-            }
-            if ids.len() > max_chips {
-                children.push(
-                    Text::new(format!("+{}", ids.len() - max_chips))
-                        .size(theme::FONT_SM)
-                        .color(theme::TEXT_SECONDARY)
-                        .into(),
-                );
-            }
-            Row::with_children(children).spacing(3).wrap().into()
+        let diagram_data = state_diagram::StateDiagramData {
+            waiting_ids,
+            ready_ids,
+            running_ids,
+            completed_ids,
+            cached_functions: self.cached_functions.clone(),
         };
+        let canvas_height = state_diagram::canvas_height(&diagram_data);
+        let canvas = state_diagram::StateDiagramCanvas { data: diagram_data };
 
-        let state_box =
-            |label: String, ids: &[usize], color: iced::Color| -> Element<'_, Message> {
-                let count = ids.len();
-                let bg = if count > 0 {
-                    color
-                } else {
-                    iced::Color {
-                        r: 0.3,
-                        g: 0.3,
-                        b: 0.35,
-                        a: 1.0,
-                    }
-                };
-                let text_color = if count > 0 {
-                    iced::Color::WHITE
-                } else {
-                    iced::Color {
-                        a: 0.5,
-                        ..iced::Color::WHITE
-                    }
-                };
-                let title = Button::new(
-                    Row::new()
-                        .spacing(6)
-                        .push(
-                            Text::new(label)
-                                .size(theme::FONT_DEFAULT)
-                                .color(text_color)
-                                .font(bold),
-                        )
-                        .push(
-                            Text::new(format!("({count})"))
-                                .size(theme::FONT_SM)
-                                .color(text_color),
-                        ),
-                )
-                .style(theme::chip_button(bg))
-                .padding([6, 14])
-                .width(Length::Fill);
-                let mut col = Column::new().spacing(4).push(title);
-                if count > 0 {
-                    col = col.push(fn_chips(ids, bg));
-                }
-                col.into()
-            };
-
-        let transition = |arrow: String,
-                          target: String,
-                          condition: String,
-                          color: iced::Color|
-         -> Element<'_, Message> {
-            Row::new()
-                .spacing(6)
-                .align_y(iced::alignment::Vertical::Center)
-                .push(
-                    Text::new(arrow)
-                        .size(14.0)
-                        .shaping(iced::widget::text::Shaping::Advanced)
-                        .color(color),
-                )
-                .push(
-                    Text::new(target)
-                        .size(theme::FONT_SM)
-                        .color(color)
-                        .font(bold),
-                )
-                .push(
-                    Text::new(condition)
-                        .size(theme::FONT_SM)
-                        .color(theme::TEXT_SECONDARY),
-                )
-                .into()
-        };
-
-        let diagram = Column::new()
-            .spacing(8)
-            .push(state_box(
-                "Waiting".into(),
-                &waiting_ids,
-                theme::entity_colors::STATE_WAITING,
-            ))
-            .push(transition(
-                "\u{2193}".into(),
-                "Ready".into(),
-                "all inputs full".into(),
-                theme::entity_colors::STATE_READY,
-            ))
-            .push(state_box(
-                "Ready".into(),
-                &ready_ids,
-                theme::entity_colors::STATE_READY,
-            ))
-            .push(transition(
-                "\u{2193}".into(),
-                "Running".into(),
-                "job dispatched".into(),
-                theme::entity_colors::STATE_RUNNING,
-            ))
-            .push(state_box(
-                "Running".into(),
-                &running_ids,
-                theme::entity_colors::STATE_RUNNING,
-            ))
-            .push(transition(
-                "\u{2193}".into(),
-                "Completed".into(),
-                "run_again = false".into(),
-                theme::entity_colors::STATE_COMPLETED,
-            ))
-            .push(transition(
-                "\u{21B0}".into(),
-                "Ready".into(),
-                "run_again, inputs full".into(),
-                theme::entity_colors::STATE_READY,
-            ))
-            .push(transition(
-                "\u{21B0}".into(),
-                "Waiting".into(),
-                "run_again, input(s) empty".into(),
-                theme::entity_colors::STATE_WAITING,
-            ))
-            .push(state_box(
-                "Completed".into(),
-                &completed_ids,
-                theme::entity_colors::STATE_COMPLETED,
-            ));
-
-        let panel_content = Column::new()
-            .spacing(theme::SPACE_MD)
-            .push(header)
-            .push(Scrollable::new(diagram).height(Length::Fill));
+        let panel_content = Column::new().spacing(theme::SPACE_MD).push(header).push(
+            iced::widget::canvas(canvas)
+                .width(Length::Fill)
+                .height(Length::Fixed(canvas_height)),
+        );
 
         Container::new(panel_content)
             .width(Length::Fixed(380.0))

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3125,12 +3125,6 @@ impl FlowrGui {
             }
             Message::DebugWaiting => {
                 self.debug_waiting = true;
-                if self.browser_open {
-                    self.suppress_next_output = true;
-                    connection_manager::send_debug_command(
-                        flowcore::model::debug_command::DebugCommand::ProcessList,
-                    );
-                }
             }
             Message::DebugConnected => {
                 self.tab_set
@@ -3222,13 +3216,11 @@ impl FlowrGui {
                 self.debug_waiting = false;
                 if display {
                     self.debug_separator("Functions List");
-                    connection_manager::send_debug_command(DebugCommand::InspectState(
-                        "all".to_string(),
-                    ));
-                } else {
-                    self.suppress_next_output = true;
-                    connection_manager::send_debug_command(DebugCommand::FunctionList);
                 }
+                if !display {
+                    self.suppress_next_output = true;
+                }
+                connection_manager::send_debug_command(DebugCommand::FunctionList);
             }
             Message::DebugFlows => {
                 self.debug_waiting = false;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -327,13 +327,7 @@ impl DebugEventLine {
         }
 
         // Match ALL occurrences of state keywords in square brackets
-        for keyword in &[
-            "[Ready]",
-            "[Waiting]",
-            "[Running]",
-            "[Completed]",
-            "[Blocked]",
-        ] {
+        for keyword in &["[Ready]", "[Waiting]", "[Running]", "[Completed]"] {
             let mut kw_from = 0;
             while let Some(pos) = text[kw_from..].find(keyword) {
                 let abs_pos = kw_from + pos;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3926,4 +3926,140 @@ mod test {
         let view = gui.view();
         let _ui = simulator(view);
     }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_functions_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugFunctions(true)));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_state_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugState));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_processes_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugProcesses));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_validate_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugValidate));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_list_breakpoints_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugListBreakpoints));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_flows_sets_waiting_false() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.debug_waiting = true;
+        drop(gui.update(Message::DebugFlows));
+        assert!(!gui.debug_waiting);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_waiting_does_not_auto_send() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.browser_open = true;
+        drop(gui.update(Message::DebugWaiting));
+        assert!(gui.debug_waiting);
+        assert!(!gui.suppress_next_output);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn view_renders_with_settings_panel() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.active_panel = Some(PanelKind::Settings);
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn view_renders_with_metrics_panel() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.active_panel = Some(PanelKind::Metrics);
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn view_renders_with_state_diagram_panel() {
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.active_panel = Some(PanelKind::StateDiagram);
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn browser_and_settings_independent() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.browser_open = true;
+        gui.active_panel = Some(PanelKind::Settings);
+        assert!(gui.browser_open);
+        assert_eq!(gui.active_panel, Some(PanelKind::Settings));
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn toggle_settings_does_not_close_browser() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.browser_open = true;
+        drop(gui.update(Message::ToggleSettings));
+        assert!(gui.browser_open);
+        assert_eq!(gui.active_panel, Some(PanelKind::Settings));
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn toggle_browser_does_not_close_settings() {
+        let mut gui = test_gui();
+        gui.debug_client_active = true;
+        gui.active_panel = Some(PanelKind::Settings);
+        gui.browser_open = true;
+        drop(gui.update(Message::ToggleFlowBrowser));
+        assert!(!gui.browser_open);
+        assert_eq!(gui.active_panel, Some(PanelKind::Settings));
+    }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -527,6 +527,9 @@ pub enum Message {
     BrowserRunFunction(usize),
     /// Toggle metrics panel
     ToggleMetrics,
+    /// Toggle function state diagram panel
+    #[cfg(feature = "debugger")]
+    ToggleStateDiagram,
     /// Metrics received from debug channel
     #[cfg(feature = "metrics")]
     DebugMetricsReceived(flowcore::model::metrics::Metrics),
@@ -727,6 +730,8 @@ pub struct CachedFunction {
 enum PanelKind {
     Settings,
     Metrics,
+    #[cfg(feature = "debugger")]
+    StateDiagram,
 }
 
 struct UiSettings {
@@ -1061,6 +1066,8 @@ impl FlowrGui {
             }
             Message::ToggleMetrics => self.toggle_panel(PanelKind::Metrics),
             #[cfg(feature = "debugger")]
+            Message::ToggleStateDiagram => self.toggle_panel(PanelKind::StateDiagram),
+            #[cfg(feature = "debugger")]
             Message::DebugStatesReceived(states) => self.cached_states = states,
             #[cfg(feature = "debugger")]
             Message::BrowserToggleNode(id) => {
@@ -1254,6 +1261,8 @@ impl FlowrGui {
             match kind {
                 PanelKind::Settings => self.settings_panel(),
                 PanelKind::Metrics => self.metrics_panel(),
+                #[cfg(feature = "debugger")]
+                PanelKind::StateDiagram => self.state_diagram_panel(),
             }
         } else {
             iced::widget::text("").into()
@@ -1724,6 +1733,17 @@ impl FlowrGui {
                 state_btn,
                 "Show runtime state (jobs, completed, busy)",
             ))
+            .push(Self::tip(
+                Button::new(
+                    Text::new("\u{2B21}")
+                        .size(16.0)
+                        .shaping(iced::widget::text::Shaping::Advanced),
+                )
+                .on_press(Message::ToggleStateDiagram)
+                .style(theme::styled_button)
+                .padding(sp),
+                "Function state transition diagram",
+            ))
             .push(Self::tip(validate_btn, "Validate flow state for deadlocks"))
             .push(iced::widget::container(iced::widget::text("")).width(iced::Length::Fill))
             .push(Self::tip(exit_btn, "Stop execution and exit debugger"));
@@ -1814,6 +1834,282 @@ impl FlowrGui {
 
         Container::new(panel_content)
             .width(Length::Fixed(300.0))
+            .height(Length::Fill)
+            .padding(theme::SPACE_MD)
+            .style(|_: &iced::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(theme::SURFACE_BUTTON)),
+                border: iced::Border {
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: iced::Color::TRANSPARENT,
+                },
+                ..Default::default()
+            })
+            .into()
+    }
+
+    #[cfg(feature = "debugger")]
+    #[allow(clippy::too_many_lines)]
+    fn state_diagram_panel(&self) -> Element<'_, Message> {
+        use iced::widget::{Container, Scrollable};
+        use iced::Length;
+
+        let header = Row::new()
+            .push(
+                Button::new(
+                    Row::new()
+                        .spacing(6)
+                        .align_y(iced::alignment::Vertical::Center)
+                        .push(
+                            Text::new("\u{2B21}")
+                                .size(16.0)
+                                .shaping(iced::widget::text::Shaping::Advanced)
+                                .color(iced::Color::WHITE),
+                        )
+                        .push(
+                            Text::new("Function States")
+                                .size(theme::FONT_DEFAULT)
+                                .color(iced::Color::WHITE)
+                                .font(iced::Font {
+                                    weight: iced::font::Weight::Bold,
+                                    ..iced::Font::DEFAULT
+                                }),
+                        ),
+                )
+                .on_press(Message::ToggleStateDiagram)
+                .style(theme::chip_button(theme::ACCENT))
+                .padding([4, 12]),
+            )
+            .push(Container::new(iced::widget::text("")).width(Length::Fill))
+            .align_y(iced::alignment::Vertical::Center)
+            .padding(iced::Padding {
+                top: 0.0,
+                right: 0.0,
+                bottom: theme::SPACE_SM,
+                left: 0.0,
+            });
+
+        let max_chips = 30;
+        let mut waiting_ids: Vec<usize> = Vec::new();
+        let mut ready_ids: Vec<usize> = Vec::new();
+        let mut running_ids: Vec<usize> = Vec::new();
+        let mut completed_ids: Vec<usize> = Vec::new();
+
+        for (&id, fn_states) in &self.cached_states {
+            for (letter, _) in fn_states {
+                match letter {
+                    'W' => waiting_ids.push(id),
+                    'R' => ready_ids.push(id),
+                    'X' => running_ids.push(id),
+                    'C' => completed_ids.push(id),
+                    _ => {}
+                }
+            }
+        }
+
+        if waiting_ids.is_empty()
+            && ready_ids.is_empty()
+            && running_ids.is_empty()
+            && completed_ids.is_empty()
+        {
+            for f in &self.cached_functions {
+                if !f.is_flow {
+                    waiting_ids.push(f.id);
+                }
+            }
+        }
+
+        waiting_ids.sort_unstable();
+        ready_ids.sort_unstable();
+        running_ids.sort_unstable();
+        completed_ids.sort_unstable();
+
+        let fn_chips = |ids: &[usize], color: iced::Color| -> Element<'_, Message> {
+            if ids.is_empty() {
+                return iced::widget::text("").into();
+            }
+            let show = ids.len().min(max_chips);
+            let mut children: Vec<Element<'_, Message>> = Vec::new();
+            for &id in ids.iter().take(show) {
+                children.push(
+                    Button::new(
+                        Text::new(id.to_string())
+                            .size(theme::FONT_SM)
+                            .color(iced::Color::WHITE)
+                            .font(iced::Font {
+                                weight: iced::font::Weight::Bold,
+                                ..iced::Font::DEFAULT
+                            }),
+                    )
+                    .on_press(Message::DebugInspectLink(id.to_string()))
+                    .style(theme::chip_button(color))
+                    .padding([1, 5])
+                    .into(),
+                );
+            }
+            if ids.len() > max_chips {
+                children.push(
+                    Text::new(format!("+{}", ids.len() - max_chips))
+                        .size(theme::FONT_SM)
+                        .color(theme::TEXT_SECONDARY)
+                        .into(),
+                );
+            }
+            Row::with_children(children).spacing(3).wrap().into()
+        };
+
+        let state_box =
+            |label: String, ids: &[usize], color: iced::Color| -> Element<'_, Message> {
+                let count = ids.len();
+                let bg = if count > 0 {
+                    color
+                } else {
+                    iced::Color {
+                        r: 0.3,
+                        g: 0.3,
+                        b: 0.35,
+                        a: 1.0,
+                    }
+                };
+                let text_color = if count > 0 {
+                    iced::Color::WHITE
+                } else {
+                    iced::Color {
+                        a: 0.5,
+                        ..iced::Color::WHITE
+                    }
+                };
+                let mut col = Column::new().spacing(2).push(
+                    Row::new()
+                        .spacing(6)
+                        .push(
+                            Text::new(label)
+                                .size(theme::FONT_DEFAULT)
+                                .color(text_color)
+                                .font(iced::Font {
+                                    weight: iced::font::Weight::Bold,
+                                    ..iced::Font::DEFAULT
+                                }),
+                        )
+                        .push(
+                            Text::new(format!("({count})"))
+                                .size(theme::FONT_SM)
+                                .color(text_color),
+                        ),
+                );
+                if count > 0 {
+                    col = col.push(fn_chips(ids, bg));
+                }
+                Container::new(col)
+                    .padding([6, 10])
+                    .width(Length::Fill)
+                    .style(move |_: &iced::Theme| iced::widget::container::Style {
+                        background: Some(iced::Background::Color(iced::Color { a: 0.25, ..bg })),
+                        border: iced::Border {
+                            radius: theme::RADIUS_SM.into(),
+                            width: 1.0,
+                            color: bg,
+                        },
+                        ..Default::default()
+                    })
+                    .into()
+            };
+
+        let fwd_arrow = |label: String| -> Element<'_, Message> {
+            Row::new()
+                .spacing(4)
+                .align_y(iced::alignment::Vertical::Center)
+                .push(Text::new("    ").size(theme::FONT_SM))
+                .push(
+                    Text::new("\u{2193}")
+                        .size(16.0)
+                        .shaping(iced::widget::text::Shaping::Advanced)
+                        .color(theme::ACCENT),
+                )
+                .push(
+                    Text::new(label)
+                        .size(theme::FONT_SM)
+                        .color(theme::TEXT_SECONDARY),
+                )
+                .into()
+        };
+
+        let back_label = |from: String, to: String, label: String| -> Element<'_, Message> {
+            Row::new()
+                .spacing(4)
+                .align_y(iced::alignment::Vertical::Center)
+                .push(
+                    Text::new("\u{21B0}")
+                        .size(14.0)
+                        .shaping(iced::widget::text::Shaping::Advanced)
+                        .color(theme::entity_colors::STATE_RUNNING),
+                )
+                .push(
+                    Text::new(format!("{from} \u{2192} {to}"))
+                        .size(theme::FONT_SM)
+                        .color(theme::TEXT_SECONDARY)
+                        .font(iced::Font {
+                            weight: iced::font::Weight::Bold,
+                            ..iced::Font::DEFAULT
+                        }),
+                )
+                .push(
+                    Text::new(label)
+                        .size(theme::FONT_SM)
+                        .color(theme::TEXT_SECONDARY),
+                )
+                .into()
+        };
+
+        let diagram = Column::new()
+            .spacing(4)
+            .push(state_box(
+                "Waiting".into(),
+                &waiting_ids,
+                theme::entity_colors::STATE_WAITING,
+            ))
+            .push(fwd_arrow("all inputs full".into()))
+            .push(state_box(
+                "Ready".into(),
+                &ready_ids,
+                theme::entity_colors::STATE_READY,
+            ))
+            .push(fwd_arrow("job dispatched".into()))
+            .push(state_box(
+                "Running".into(),
+                &running_ids,
+                theme::entity_colors::STATE_RUNNING,
+            ))
+            .push(fwd_arrow("run_again = false".into()))
+            .push(state_box(
+                "Completed".into(),
+                &completed_ids,
+                theme::entity_colors::STATE_COMPLETED,
+            ))
+            .push(iced::widget::rule::horizontal(1))
+            .push(
+                Text::new("Back transitions:")
+                    .size(theme::FONT_MD)
+                    .color(theme::TEXT_SECONDARY),
+            )
+            .push(back_label(
+                "Running".into(),
+                "Ready".into(),
+                "inputs still full".into(),
+            ))
+            .push(back_label(
+                "Running".into(),
+                "Waiting".into(),
+                "input(s) empty".into(),
+            ));
+
+        let panel_content = Column::new()
+            .spacing(theme::SPACE_MD)
+            .push(header)
+            .push(Scrollable::new(diagram).height(Length::Fill));
+
+        Container::new(panel_content)
+            .width(Length::Fixed(350.0))
             .height(Length::Fill)
             .padding(theme::SPACE_MD)
             .style(|_: &iced::Theme| iced::widget::container::Style {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1098,6 +1098,13 @@ impl FlowrGui {
                         return iced::Task::none();
                     }
                     self.open_panel(PanelKind::StateDiagram);
+                    if self.debug_waiting && !self.states_refresh_pending {
+                        self.states_refresh_pending = true;
+                        connection_manager::set_states_only(true);
+                        connection_manager::send_debug_command(
+                            flowcore::model::debug_command::DebugCommand::ProcessList,
+                        );
+                    }
                 }
             }
             #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/state_diagram.rs
+++ b/flowr/src/bin/flowrgui/state_diagram.rs
@@ -92,6 +92,7 @@ impl canvas::Program<Message> for StateDiagramCanvas {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Option<canvas::Action<Message>> {
+        state.chip_bounds = compute_all_chip_bounds(&self.data);
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if let Some(pos) = cursor.position_in(bounds) {
@@ -119,21 +120,26 @@ impl canvas::Program<Message> for StateDiagramCanvas {
                 if state.hovered == old {
                     None
                 } else {
-                    Some(canvas::Action::request_redraw())
+                    let info = state
+                        .hovered
+                        .and_then(|id| self.data.cached_functions.iter().find(|f| f.id == id))
+                        .map_or_else(String::new, |f| {
+                            format!("#{} '{}' @ {}", f.id, f.name, f.route)
+                        });
+                    Some(canvas::Action::publish(Message::DiagramHover(info)))
                 }
             }
             _ => None,
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     fn draw(
         &self,
         state: &Self::State,
         renderer: &Renderer,
         _theme: &Theme,
         bounds: Rectangle,
-        cursor: mouse::Cursor,
+        _cursor: mouse::Cursor,
     ) -> Vec<Geometry> {
         let mut frame = Frame::new(renderer, bounds.size());
         let d = &self.data;
@@ -186,19 +192,7 @@ impl canvas::Program<Message> for StateDiagramCanvas {
             );
         }
 
-        if let Some(pos) = cursor.position_in(bounds) {
-            if let Some(hovered_id) = state.hovered {
-                if let Some(func) = d.cached_functions.iter().find(|f| f.id == hovered_id) {
-                    draw_tooltip(&mut frame, pos, func, bounds);
-                }
-            }
-        }
-
-        // Store chip bounds for next update cycle (via interior mutability workaround)
-        // Note: we can't mutate state from draw(), so chip_bounds are computed but
-        // we rely on the initial empty state being populated after first mouse move
         let _ = chip_bounds;
-
         vec![frame.into_geometry()]
     }
 
@@ -244,6 +238,27 @@ fn build_boxes(d: &StateDiagramData) -> Vec<StateBox> {
         y,
     );
     vec![waiting, ready, running, completed]
+}
+
+fn compute_all_chip_bounds(data: &StateDiagramData) -> Vec<(Rectangle, usize)> {
+    let boxes = build_boxes(data);
+    let mut bounds = Vec::new();
+    let chips_per_row = ((BOX_W - CHIP_PAD * 2.0) / (CHIP_W + CHIP_GAP)) as usize;
+    for sb in &boxes {
+        let r = sb.rect();
+        let chip_start_y = r.y + 26.0;
+        for (i, &id) in sb.ids.iter().take(MAX_CHIPS).enumerate() {
+            let col = i % chips_per_row;
+            let row = i / chips_per_row;
+            let cx = r.x + CHIP_PAD + col as f32 * (CHIP_W + CHIP_GAP);
+            let cy = chip_start_y + row as f32 * (CHIP_H + CHIP_GAP);
+            bounds.push((
+                Rectangle::new(Point::new(cx, cy), Size::new(CHIP_W, CHIP_H)),
+                id,
+            ));
+        }
+    }
+    bounds
 }
 
 fn draw_state_box(
@@ -294,7 +309,7 @@ fn draw_state_box(
             sb.color
         };
 
-        let chip_path = rounded_rect(chip_rect.position(), chip_rect.size(), 4.0);
+        let chip_path = rounded_rect(chip_rect.position(), chip_rect.size(), CHIP_H / 2.0);
         frame.fill(&chip_path, chip_color);
 
         frame.fill_text(CanvasText {
@@ -324,7 +339,7 @@ fn draw_state_box(
                 a: 0.6,
                 ..Color::WHITE
             },
-            size: 10.0.into(),
+            size: 12.0.into(),
             ..CanvasText::default()
         });
     }
@@ -356,10 +371,10 @@ fn draw_forward_arrow(
         content: label.to_string(),
         position: Point::new(x + 12.0, (y1 + y2) / 2.0),
         color: Color {
-            a: 0.7,
+            a: 0.8,
             ..Color::WHITE
         },
-        size: 11.0.into(),
+        size: 14.0.into(),
         align_y: iced::alignment::Vertical::Center,
         ..CanvasText::default()
     });
@@ -401,50 +416,10 @@ fn draw_back_arrow(
         content: label.to_string(),
         position: Point::new(curve_x + 4.0, label_y),
         color: Color {
-            a: 0.7,
+            a: 0.8,
             ..Color::WHITE
         },
-        size: 10.0.into(),
-        align_y: iced::alignment::Vertical::Center,
-        ..CanvasText::default()
-    });
-}
-
-fn draw_tooltip(frame: &mut Frame, pos: Point, func: &CachedFunction, bounds: Rectangle) {
-    let text = format!("#{} '{}' @ {}", func.id, func.name, func.route);
-    let tip_w = text.len() as f32 * 6.5 + 16.0;
-    let tip_h = 22.0;
-    let mut tx = pos.x + 12.0;
-    let mut ty = pos.y - tip_h - 4.0;
-
-    if tx + tip_w > bounds.width {
-        tx = pos.x - tip_w - 4.0;
-    }
-    if ty < 0.0 {
-        ty = pos.y + 16.0;
-    }
-
-    let bg = Color {
-        r: 0.15,
-        g: 0.15,
-        b: 0.2,
-        a: 0.95,
-    };
-    let tip_rect = rounded_rect(Point::new(tx, ty), Size::new(tip_w, tip_h), 4.0);
-    frame.fill(&tip_rect, bg);
-    frame.stroke(
-        &tip_rect,
-        Stroke::default().with_width(1.0).with_color(Color {
-            a: 0.4,
-            ..crate::theme::ACCENT
-        }),
-    );
-
-    frame.fill_text(CanvasText {
-        content: text,
-        position: Point::new(tx + 8.0, ty + tip_h / 2.0),
-        color: Color::WHITE,
-        size: 11.0.into(),
+        size: 13.0.into(),
         align_y: iced::alignment::Vertical::Center,
         ..CanvasText::default()
     });

--- a/flowr/src/bin/flowrgui/state_diagram.rs
+++ b/flowr/src/bin/flowrgui/state_diagram.rs
@@ -64,22 +64,22 @@ impl StateBox {
     }
 }
 
-pub struct StateDiagramData {
-    pub waiting_ids: Vec<usize>,
-    pub ready_ids: Vec<usize>,
-    pub running_ids: Vec<usize>,
-    pub completed_ids: Vec<usize>,
-    pub cached_functions: Vec<CachedFunction>,
+pub(crate) struct StateDiagramData {
+    pub(crate) waiting_ids: Vec<usize>,
+    pub(crate) ready_ids: Vec<usize>,
+    pub(crate) running_ids: Vec<usize>,
+    pub(crate) completed_ids: Vec<usize>,
+    pub(crate) cached_functions: Vec<CachedFunction>,
 }
 
 #[derive(Default)]
-pub struct DiagramState {
+pub(crate) struct DiagramState {
     chip_bounds: Vec<(Rectangle, usize)>,
     hovered: Option<usize>,
 }
 
-pub struct StateDiagramCanvas {
-    pub data: StateDiagramData,
+pub(crate) struct StateDiagramCanvas {
+    pub(crate) data: StateDiagramData,
 }
 
 impl canvas::Program<Message> for StateDiagramCanvas {
@@ -456,7 +456,7 @@ fn rounded_rect(pos: Point, size: Size, radius: f32) -> Path {
     })
 }
 
-pub fn canvas_height(data: &StateDiagramData) -> f32 {
+pub(crate) fn canvas_height(data: &StateDiagramData) -> f32 {
     let boxes = build_boxes(data);
     if let Some(last) = boxes.last() {
         last.bottom() + 20.0

--- a/flowr/src/bin/flowrgui/state_diagram.rs
+++ b/flowr/src/bin/flowrgui/state_diagram.rs
@@ -1,0 +1,482 @@
+use iced::widget::canvas::{self, Event, Frame, Geometry, Path, Stroke, Text as CanvasText};
+use iced::{mouse, Color, Point, Rectangle, Renderer, Size, Theme};
+
+use crate::theme::entity_colors;
+use crate::{CachedFunction, Message};
+
+const BOX_W: f32 = 160.0;
+const BOX_H_MIN: f32 = 44.0;
+const BOX_RADIUS: f32 = 8.0;
+const CHIP_W: f32 = 28.0;
+const CHIP_H: f32 = 18.0;
+const CHIP_GAP: f32 = 4.0;
+const CHIP_PAD: f32 = 6.0;
+const ARROW_SIZE: f32 = 7.0;
+const GAP_Y: f32 = 50.0;
+const LEFT_X: f32 = 20.0;
+const MAX_CHIPS: usize = 30;
+
+struct StateBox {
+    label: &'static str,
+    color: Color,
+    ids: Vec<usize>,
+    y: f32,
+    height: f32,
+}
+
+impl StateBox {
+    fn new(label: &'static str, color: Color, ids: Vec<usize>, y: f32) -> Self {
+        let chip_rows = if ids.is_empty() {
+            0
+        } else {
+            let chips_per_row = ((BOX_W - CHIP_PAD * 2.0) / (CHIP_W + CHIP_GAP)) as usize;
+            let count = ids.len().min(MAX_CHIPS);
+            (count + chips_per_row - 1) / chips_per_row
+        };
+        let height = BOX_H_MIN + chip_rows as f32 * (CHIP_H + CHIP_GAP);
+        Self {
+            label,
+            color,
+            ids,
+            y,
+            height,
+        }
+    }
+
+    fn rect(&self) -> Rectangle {
+        Rectangle::new(Point::new(LEFT_X, self.y), Size::new(BOX_W, self.height))
+    }
+
+    fn bottom(&self) -> f32 {
+        self.y + self.height
+    }
+
+    fn center_x() -> f32 {
+        LEFT_X + BOX_W / 2.0
+    }
+
+    fn right() -> f32 {
+        LEFT_X + BOX_W
+    }
+
+    fn mid_right(&self) -> Point {
+        Point::new(Self::right(), self.y + self.height / 2.0)
+    }
+}
+
+pub struct StateDiagramData {
+    pub waiting_ids: Vec<usize>,
+    pub ready_ids: Vec<usize>,
+    pub running_ids: Vec<usize>,
+    pub completed_ids: Vec<usize>,
+    pub cached_functions: Vec<CachedFunction>,
+}
+
+#[derive(Default)]
+pub struct DiagramState {
+    chip_bounds: Vec<(Rectangle, usize)>,
+    hovered: Option<usize>,
+}
+
+pub struct StateDiagramCanvas {
+    pub data: StateDiagramData,
+}
+
+impl canvas::Program<Message> for StateDiagramCanvas {
+    type State = DiagramState;
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: &Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Option<canvas::Action<Message>> {
+        match event {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    for (rect, id) in &state.chip_bounds {
+                        if rect.contains(pos) {
+                            return Some(canvas::Action::publish(Message::DebugInspectLink(
+                                id.to_string(),
+                            )));
+                        }
+                    }
+                }
+                None
+            }
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let old = state.hovered;
+                state.hovered = None;
+                if let Some(pos) = cursor.position_in(bounds) {
+                    for (rect, id) in &state.chip_bounds {
+                        if rect.contains(pos) {
+                            state.hovered = Some(*id);
+                            break;
+                        }
+                    }
+                }
+                if state.hovered == old {
+                    None
+                } else {
+                    Some(canvas::Action::request_redraw())
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let mut frame = Frame::new(renderer, bounds.size());
+        let d = &self.data;
+
+        let boxes = build_boxes(d);
+        let mut chip_bounds: Vec<(Rectangle, usize)> = Vec::new();
+
+        for sb in &boxes {
+            draw_state_box(&mut frame, sb, &mut chip_bounds, state.hovered);
+        }
+
+        if boxes.len() == 4 {
+            draw_forward_arrow(
+                &mut frame,
+                &boxes[0],
+                &boxes[1],
+                "all inputs full",
+                crate::theme::ACCENT,
+            );
+            draw_forward_arrow(
+                &mut frame,
+                &boxes[1],
+                &boxes[2],
+                "job dispatched",
+                crate::theme::ACCENT,
+            );
+            draw_forward_arrow(
+                &mut frame,
+                &boxes[2],
+                &boxes[3],
+                "run_again = false",
+                crate::theme::ACCENT,
+            );
+
+            draw_back_arrow(
+                &mut frame,
+                &boxes[2],
+                &boxes[1],
+                "inputs full",
+                entity_colors::STATE_READY,
+                30.0,
+            );
+            draw_back_arrow(
+                &mut frame,
+                &boxes[2],
+                &boxes[0],
+                "inputs empty",
+                entity_colors::STATE_WAITING,
+                55.0,
+            );
+        }
+
+        if let Some(pos) = cursor.position_in(bounds) {
+            if let Some(hovered_id) = state.hovered {
+                if let Some(func) = d.cached_functions.iter().find(|f| f.id == hovered_id) {
+                    draw_tooltip(&mut frame, pos, func, bounds);
+                }
+            }
+        }
+
+        // Store chip bounds for next update cycle (via interior mutability workaround)
+        // Note: we can't mutate state from draw(), so chip_bounds are computed but
+        // we rely on the initial empty state being populated after first mouse move
+        let _ = chip_bounds;
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if let Some(pos) = cursor.position_in(bounds) {
+            for (rect, _) in &state.chip_bounds {
+                if rect.contains(pos) {
+                    return mouse::Interaction::Pointer;
+                }
+            }
+        }
+        mouse::Interaction::default()
+    }
+}
+
+fn build_boxes(d: &StateDiagramData) -> Vec<StateBox> {
+    let mut y = 10.0;
+    let waiting = StateBox::new(
+        "Waiting",
+        entity_colors::STATE_WAITING,
+        d.waiting_ids.clone(),
+        y,
+    );
+    y = waiting.bottom() + GAP_Y;
+    let ready = StateBox::new("Ready", entity_colors::STATE_READY, d.ready_ids.clone(), y);
+    y = ready.bottom() + GAP_Y;
+    let running = StateBox::new(
+        "Running",
+        entity_colors::STATE_RUNNING,
+        d.running_ids.clone(),
+        y,
+    );
+    y = running.bottom() + GAP_Y;
+    let completed = StateBox::new(
+        "Completed",
+        entity_colors::STATE_COMPLETED,
+        d.completed_ids.clone(),
+        y,
+    );
+    vec![waiting, ready, running, completed]
+}
+
+fn draw_state_box(
+    frame: &mut Frame,
+    sb: &StateBox,
+    chip_bounds: &mut Vec<(Rectangle, usize)>,
+    hovered: Option<usize>,
+) {
+    let r = sb.rect();
+    let bg = Color { a: 0.2, ..sb.color };
+    let border_color = sb.color;
+
+    let path = rounded_rect(r.position(), r.size(), BOX_RADIUS);
+    frame.fill(&path, bg);
+    frame.stroke(
+        &path,
+        Stroke::default().with_width(2.0).with_color(border_color),
+    );
+
+    let count = sb.ids.len();
+    frame.fill_text(CanvasText {
+        content: format!("{} ({})", sb.label, count),
+        position: Point::new(r.x + CHIP_PAD, r.y + 6.0),
+        color: Color::WHITE,
+        size: 14.0.into(),
+        ..CanvasText::default()
+    });
+
+    let chips_per_row = ((BOX_W - CHIP_PAD * 2.0) / (CHIP_W + CHIP_GAP)) as usize;
+    let chip_start_y = r.y + 26.0;
+
+    for (i, &id) in sb.ids.iter().take(MAX_CHIPS).enumerate() {
+        let col = i % chips_per_row;
+        let row = i / chips_per_row;
+        let cx = r.x + CHIP_PAD + col as f32 * (CHIP_W + CHIP_GAP);
+        let cy = chip_start_y + row as f32 * (CHIP_H + CHIP_GAP);
+        let chip_rect = Rectangle::new(Point::new(cx, cy), Size::new(CHIP_W, CHIP_H));
+
+        let is_hovered = hovered == Some(id);
+        let chip_color = if is_hovered {
+            Color {
+                r: (sb.color.r + 0.2).min(1.0),
+                g: (sb.color.g + 0.2).min(1.0),
+                b: (sb.color.b + 0.2).min(1.0),
+                a: 1.0,
+            }
+        } else {
+            sb.color
+        };
+
+        let chip_path = rounded_rect(chip_rect.position(), chip_rect.size(), 4.0);
+        frame.fill(&chip_path, chip_color);
+
+        frame.fill_text(CanvasText {
+            content: id.to_string(),
+            position: Point::new(cx + CHIP_W / 2.0, cy + CHIP_H / 2.0),
+            color: Color::WHITE,
+            size: 11.0.into(),
+            align_x: iced::alignment::Horizontal::Center.into(),
+            align_y: iced::alignment::Vertical::Center,
+            font: iced::Font {
+                weight: iced::font::Weight::Bold,
+                ..iced::Font::DEFAULT
+            },
+            ..CanvasText::default()
+        });
+
+        chip_bounds.push((chip_rect, id));
+    }
+
+    if sb.ids.len() > MAX_CHIPS {
+        let overflow = sb.ids.len() - MAX_CHIPS;
+        let oy = chip_start_y + (MAX_CHIPS / chips_per_row) as f32 * (CHIP_H + CHIP_GAP);
+        frame.fill_text(CanvasText {
+            content: format!("+{overflow}"),
+            position: Point::new(r.x + CHIP_PAD, oy),
+            color: Color {
+                a: 0.6,
+                ..Color::WHITE
+            },
+            size: 10.0.into(),
+            ..CanvasText::default()
+        });
+    }
+}
+
+fn draw_forward_arrow(
+    frame: &mut Frame,
+    from: &StateBox,
+    to: &StateBox,
+    label: &str,
+    color: Color,
+) {
+    let x = StateBox::center_x();
+    let y1 = from.bottom();
+    let y2 = to.y;
+
+    let path = Path::line(Point::new(x, y1), Point::new(x, y2 - ARROW_SIZE));
+    frame.stroke(&path, Stroke::default().with_width(2.0).with_color(color));
+
+    let arrow = Path::new(|b| {
+        b.move_to(Point::new(x - ARROW_SIZE, y2 - ARROW_SIZE * 1.5));
+        b.line_to(Point::new(x, y2));
+        b.line_to(Point::new(x + ARROW_SIZE, y2 - ARROW_SIZE * 1.5));
+        b.close();
+    });
+    frame.fill(&arrow, color);
+
+    frame.fill_text(CanvasText {
+        content: label.to_string(),
+        position: Point::new(x + 12.0, (y1 + y2) / 2.0),
+        color: Color {
+            a: 0.7,
+            ..Color::WHITE
+        },
+        size: 11.0.into(),
+        align_y: iced::alignment::Vertical::Center,
+        ..CanvasText::default()
+    });
+}
+
+fn draw_back_arrow(
+    frame: &mut Frame,
+    from: &StateBox,
+    to: &StateBox,
+    label: &str,
+    color: Color,
+    offset_x: f32,
+) {
+    let start = from.mid_right();
+    let end_y = to.y + to.height / 2.0;
+    let end = Point::new(StateBox::right(), end_y);
+    let curve_x = StateBox::right() + offset_x;
+
+    let path = Path::new(|b| {
+        b.move_to(start);
+        b.bezier_curve_to(
+            Point::new(curve_x, start.y),
+            Point::new(curve_x, end.y),
+            Point::new(end.x + ARROW_SIZE * 1.5, end.y),
+        );
+    });
+    frame.stroke(&path, Stroke::default().with_width(1.5).with_color(color));
+
+    let arrow = Path::new(|b| {
+        b.move_to(Point::new(end.x + ARROW_SIZE * 2.0, end.y - ARROW_SIZE));
+        b.line_to(end);
+        b.line_to(Point::new(end.x + ARROW_SIZE * 2.0, end.y + ARROW_SIZE));
+        b.close();
+    });
+    frame.fill(&arrow, color);
+
+    let label_y = (start.y + end.y) / 2.0;
+    frame.fill_text(CanvasText {
+        content: label.to_string(),
+        position: Point::new(curve_x + 4.0, label_y),
+        color: Color {
+            a: 0.7,
+            ..Color::WHITE
+        },
+        size: 10.0.into(),
+        align_y: iced::alignment::Vertical::Center,
+        ..CanvasText::default()
+    });
+}
+
+fn draw_tooltip(frame: &mut Frame, pos: Point, func: &CachedFunction, bounds: Rectangle) {
+    let text = format!("#{} '{}' @ {}", func.id, func.name, func.route);
+    let tip_w = text.len() as f32 * 6.5 + 16.0;
+    let tip_h = 22.0;
+    let mut tx = pos.x + 12.0;
+    let mut ty = pos.y - tip_h - 4.0;
+
+    if tx + tip_w > bounds.width {
+        tx = pos.x - tip_w - 4.0;
+    }
+    if ty < 0.0 {
+        ty = pos.y + 16.0;
+    }
+
+    let bg = Color {
+        r: 0.15,
+        g: 0.15,
+        b: 0.2,
+        a: 0.95,
+    };
+    let tip_rect = rounded_rect(Point::new(tx, ty), Size::new(tip_w, tip_h), 4.0);
+    frame.fill(&tip_rect, bg);
+    frame.stroke(
+        &tip_rect,
+        Stroke::default().with_width(1.0).with_color(Color {
+            a: 0.4,
+            ..crate::theme::ACCENT
+        }),
+    );
+
+    frame.fill_text(CanvasText {
+        content: text,
+        position: Point::new(tx + 8.0, ty + tip_h / 2.0),
+        color: Color::WHITE,
+        size: 11.0.into(),
+        align_y: iced::alignment::Vertical::Center,
+        ..CanvasText::default()
+    });
+}
+
+fn rounded_rect(pos: Point, size: Size, radius: f32) -> Path {
+    Path::new(|builder| {
+        let px = pos.x;
+        let py = pos.y;
+        let sw = size.width;
+        let sh = size.height;
+        let rd = radius;
+        builder.move_to(Point::new(px + rd, py));
+        builder.line_to(Point::new(px + sw - rd, py));
+        builder.quadratic_curve_to(Point::new(px + sw, py), Point::new(px + sw, py + rd));
+        builder.line_to(Point::new(px + sw, py + sh - rd));
+        builder.quadratic_curve_to(
+            Point::new(px + sw, py + sh),
+            Point::new(px + sw - rd, py + sh),
+        );
+        builder.line_to(Point::new(px + rd, py + sh));
+        builder.quadratic_curve_to(Point::new(px, py + sh), Point::new(px, py + sh - rd));
+        builder.line_to(Point::new(px, py + rd));
+        builder.quadratic_curve_to(Point::new(px, py), Point::new(px + rd, py));
+    })
+}
+
+pub fn canvas_height(data: &StateDiagramData) -> f32 {
+    let boxes = build_boxes(data);
+    if let Some(last) = boxes.last() {
+        last.bottom() + 20.0
+    } else {
+        500.0
+    }
+}

--- a/flowr/src/bin/flowrgui/state_diagram.rs
+++ b/flowr/src/bin/flowrgui/state_diagram.rs
@@ -119,14 +119,23 @@ impl canvas::Program<Message> for StateDiagramCanvas {
                 }
                 if state.hovered == old {
                     None
+                } else if let Some(pos) = cursor.position_in(bounds) {
+                    let data = state.hovered.and_then(|id| {
+                        self.data
+                            .cached_functions
+                            .iter()
+                            .find(|f| f.id == id)
+                            .map(|f| {
+                                (
+                                    format!("#{} '{}' @ {}", f.id, f.name, f.route),
+                                    pos.x,
+                                    pos.y,
+                                )
+                            })
+                    });
+                    Some(canvas::Action::publish(Message::DiagramHover(data)))
                 } else {
-                    let info = state
-                        .hovered
-                        .and_then(|id| self.data.cached_functions.iter().find(|f| f.id == id))
-                        .map_or_else(String::new, |f| {
-                            format!("#{} '{}' @ {}", f.id, f.name, f.route)
-                        });
-                    Some(canvas::Action::publish(Message::DiagramHover(info)))
+                    Some(canvas::Action::publish(Message::DiagramHover(None)))
                 }
             }
             _ => None,

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -46,7 +46,7 @@ const HELP_STRING: &str = "Debugger commands:
                                  - 'i <id>' inspects function by ID
                                  - 'i <id>:<input>' inspects an input
                                  - 'i <id>/<route>' inspects output connections
-                                 - 'i ready|waiting|running|completed|blocked' filters by state
+                                 - 'i ready|waiting|running|completed' filters by state
                                  - 'i /route/path' inspects function or flow at that route
 'l' | 'list'                  - List all breakpoints
 'm' | 'modify' [name]=[value] - Modify a debugger or runtime variable named 'name' to value 'value'
@@ -202,7 +202,7 @@ impl DebugClient {
     }
 
     /// Valid state keywords for inspect-by-state commands
-    pub const STATE_KEYWORDS: &[&str] = &["ready", "waiting", "running", "completed", "blocked"];
+    pub const STATE_KEYWORDS: &[&str] = &["ready", "waiting", "running", "completed"];
 
     /// Parse an inspect specification into a [`DebugCommand`]
     #[must_use]
@@ -686,15 +686,6 @@ mod test {
         assert_eq!(
             DebugClient::parse_inspect_spec(specs("ready")),
             Some(DebugCommand::InspectState("ready".into()))
-        );
-    }
-
-    #[test]
-    fn parse_inspect_spec_state_blocked() {
-        use crate::debug_command::DebugCommand;
-        assert_eq!(
-            DebugClient::parse_inspect_spec(specs("blocked")),
-            Some(DebugCommand::InspectState("blocked".into()))
         );
     }
 

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -820,11 +820,10 @@ impl<'a> Debugger<'a> {
             "waiting" => Some(State::Waiting),
             "running" => Some(State::Running),
             "completed" => Some(State::Completed),
-            "blocked" => None,
             _ => {
                 return format!(
-                "Unknown state '{state_name}'. Use: ready, waiting, running, completed, blocked"
-            )
+                    "Unknown state '{state_name}'. Use: ready, waiting, running, completed"
+                )
             }
         };
 
@@ -834,25 +833,7 @@ impl<'a> Debugger<'a> {
         sorted.sort_by_key(|f| f.id());
         let mut count = 0;
 
-        if state_name == "blocked" {
-            let _ = writeln!(response, "Blocked functions:");
-            for func in &sorted {
-                let states = state.get_function_states(func.id());
-                if states.contains(&State::Waiting) {
-                    if let Ok(blockers) = state.get_input_blockers(func.id()) {
-                        if !blockers.is_empty() {
-                            count += 1;
-                            let _ = writeln!(
-                                response,
-                                "  {} — blocked by: {:?}",
-                                Self::entity_long(func, false),
-                                blockers
-                            );
-                        }
-                    }
-                }
-            }
-        } else if let Some(ref target) = target_state {
+        if let Some(ref target) = target_state {
             let _ = writeln!(response, "Functions in '{state_name}' state:");
             for func in &sorted {
                 let states = state.get_function_states(func.id());
@@ -1606,13 +1587,6 @@ mod test {
         let state = RunState::new(test_submission(vec![test_function(0)]));
         let result = Debugger::inspect_by_state(&state, "bogus");
         assert!(result.contains("Unknown state"));
-    }
-
-    #[test]
-    fn test_inspect_by_state_blocked() {
-        let state = RunState::new(test_submission(vec![test_function(0)]));
-        let result = Debugger::inspect_by_state(&state, "blocked");
-        assert!(result.contains("Blocked functions:"));
     }
 
     #[test]

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -350,9 +350,8 @@ impl RunState {
     // If other functions were blocked trying to send to this one - we can now unblock them
     // as it has consumed its inputs, and they are free to be sent to again.
     //
-    // Then, take the output and send it to all destination IOs on different function it should be
-    // sent to, marking the source function as blocked because those others must consume the output
-    // if those other functions have all their inputs, then mark them accordingly.
+    // Then, take the output and send it to all destination IOs on different functions.
+    // If those other functions have all their inputs, then create jobs for them.
     #[allow(unused_variables, unused_assignments, unused_mut)]
     pub(crate) fn retire_a_job(
         &mut self,
@@ -1487,7 +1486,7 @@ mod test {
         */
         #[test]
         #[serial]
-        fn waiting_to_blocked_on_input() {
+        fn waiting_to_ready_via_output() {
             let f_a = super::test_function_a_to_b_not_init();
             let connection_to_f0 = OutputConnection::new(
                 Source::default(),


### PR DESCRIPTION
## Summary
- Add function state diagram panel showing Waiting → Ready → Running → Completed
- Each state box contains clickable function ID chips (up to 30, wrapping)
- Forward arrows with transition labels between states
- Back transitions: Running→Ready (inputs still full), Running→Waiting (input(s) empty)
- States refresh on debugger pause (step, breakpoint, end)
- Remove all Blocked state references from codebase (debugger, CLI, GUI, docs)
- Update flow-vocabulary.md: 4 function states, remove blocking section

Closes #2787

## Test plan
- [ ] `make clippy` passes
- [ ] `make features` passes
- [ ] `make test` passes
- [ ] Open state diagram (⬡ button), verify 4 states shown
- [ ] Step through a flow, watch function chips move between states
- [ ] Click a function chip to inspect it
- [ ] Verify no "blocked" references remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened "Ready" definition, simplified function state model (remove Blocked) and updated flow idle/initializer and sub-flow idle behavior notes.

* **Refactor**
  * Removed "Blocked" as a recognized function state; inspect/REPL/debug tooling no longer accept or emit "blocked".

* **New Features**
  * Added a Function States diagram panel with grouped state chips, hover tooltips, click-to-inspect and canvas interactions; debugger links adjusted.

* **Tests**
  * Added/extended debugger tests for the new panel and updated command behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->