### PR TITLE
Add per-function job counts to Metrics (#2806)

### DIFF
--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -16,12 +16,13 @@ pub struct Metrics {
     start_time: Instant,
     elapsed_time_seconds: u64,
     max_simultaneous_jobs: usize,
+    jobs_per_function: Vec<usize>,
 }
 
 impl Metrics {
     /// Create a new `Metrics` struct
     #[must_use]
-    pub fn new(num_functions: usize) -> Self {
+    pub fn new(num_functions: usize, num_processes: usize) -> Self {
         Metrics {
             num_functions,
             jobs_created: 0,
@@ -29,6 +30,7 @@ impl Metrics {
             start_time: Instant::now(),
             elapsed_time_seconds: 0,
             max_simultaneous_jobs: 0,
+            jobs_per_function: vec![0; num_processes],
         }
     }
 
@@ -39,11 +41,30 @@ impl Metrics {
         self.outputs_sent = 0;
         self.start_time = Instant::now();
         self.max_simultaneous_jobs = 0;
+        self.jobs_per_function.fill(0);
     }
 
     /// Set the number of jobs created in `Metrics` to the `jobs` value
     pub fn set_jobs_created(&mut self, jobs: usize) {
         self.jobs_created = jobs;
+    }
+
+    /// Set the per-function job counts from the run state
+    pub fn set_jobs_per_function(&mut self, counts: &[usize]) {
+        self.jobs_per_function = counts.to_vec();
+    }
+
+    /// Increment the job count for a specific function by `process_id`
+    pub fn increment_jobs_for_function(&mut self, process_id: usize) {
+        if let Some(count) = self.jobs_per_function.get_mut(process_id) {
+            *count += 1;
+        }
+    }
+
+    /// Get the per-function job counts
+    #[must_use]
+    pub fn jobs_per_function(&self) -> &[usize] {
+        &self.jobs_per_function
     }
 
     /// Increment the tracker for the number of output values sent between functions
@@ -76,7 +97,14 @@ impl fmt::Display for Metrics {
         writeln!(f, "Number of Jobs Created: {}", self.jobs_created)?;
         writeln!(f, "Values sent: {}", self.outputs_sent)?;
         writeln!(f, "Elapsed time(s): {:.*}", 1, self.elapsed_time_seconds)?;
-        write!(f, "Max Jobs in Parallel: {}", self.max_simultaneous_jobs)
+        writeln!(f, "Max Jobs in Parallel: {}", self.max_simultaneous_jobs)?;
+        write!(f, "Jobs per Function:")?;
+        for (id, &count) in self.jobs_per_function.iter().enumerate() {
+            if count > 0 {
+                write!(f, "  #{id}:{count}")?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -87,7 +115,7 @@ mod test {
 
     #[test]
     fn test_metrics_reset() {
-        let mut metrics = Metrics::new(10);
+        let mut metrics = Metrics::new(10, 10);
         metrics.jobs_created = 110;
         metrics.outputs_sent = 10;
         metrics.max_simultaneous_jobs = 4;
@@ -100,7 +128,7 @@ mod test {
 
     #[test]
     fn test_max_tracking() {
-        let mut metrics = Metrics::new(10);
+        let mut metrics = Metrics::new(10, 10);
         assert_eq!(metrics.max_simultaneous_jobs, 0);
 
         metrics.track_max_jobs(2);
@@ -112,7 +140,7 @@ mod test {
 
     #[test]
     fn test_metrics_display() {
-        let metrics = Metrics::new(10);
+        let metrics = Metrics::new(10, 10);
         println!("{metrics}");
     }
 }

--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -74,6 +74,8 @@ impl Metrics {
     pub fn increment_jobs_for_function(&mut self, process_id: usize) {
         if let Some(count) = self.jobs_per_function.get_mut(process_id) {
             *count += 1;
+        } else {
+            trace!("process_id {process_id} out of range for jobs_per_function");
         }
     }
 

--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -17,6 +17,7 @@ pub struct Metrics {
     elapsed_time_seconds: u64,
     max_simultaneous_jobs: usize,
     jobs_per_function: Vec<usize>,
+    function_names: Vec<(String, String)>,
 }
 
 impl Metrics {
@@ -31,7 +32,22 @@ impl Metrics {
             elapsed_time_seconds: 0,
             max_simultaneous_jobs: 0,
             jobs_per_function: vec![0; num_processes],
+            function_names: Vec::new(),
         }
+    }
+
+    /// Set function names (name, route) indexed by `process_id`
+    pub fn set_function_names(&mut self, names: Vec<(String, String)>) {
+        self.function_names = names;
+    }
+
+    /// Get function name and route by `process_id`
+    #[must_use]
+    pub fn function_name(&self, process_id: usize) -> Option<(&str, &str)> {
+        self.function_names
+            .get(process_id)
+            .filter(|(n, _)| !n.is_empty())
+            .map(|(n, r)| (n.as_str(), r.as_str()))
     }
 
     /// Reset the values of a `Metrics` struct back to their initial values

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -375,7 +375,7 @@ mod test {
         #[cfg(not(feature = "metrics"))]
         client.process_coordinator_message(CoordinatorMessage::FlowEnd);
         #[cfg(feature = "metrics")]
-        client.process_coordinator_message(CoordinatorMessage::FlowEnd(Metrics::new(1)));
+        client.process_coordinator_message(CoordinatorMessage::FlowEnd(Metrics::new(1, 1)));
 
         assert!(path.exists(), "Image file was not created");
     }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1885,7 +1885,7 @@ impl FlowrGui {
                 for &(id, count) in &non_zero {
                     let label = format!("{id:>id_width$}");
                     #[allow(clippy::cast_possible_truncation)]
-                    let portion = ((count * 100) / max_count).max(1) as u16;
+                    let portion = (count.saturating_mul(100) / max_count).max(1) as u16;
                     let bar = Container::new(Text::new("").size(1))
                         .width(Length::FillPortion(portion))
                         .height(Length::Fixed(14.0))

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1829,6 +1829,7 @@ impl FlowrGui {
         row
     }
 
+    #[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
     fn metrics_panel(&self) -> Element<'_, Message> {
         use iced::widget::Container;
         use iced::Length;
@@ -1858,7 +1859,88 @@ impl FlowrGui {
             let text = format!("{metrics}");
             let mut col = Column::new().spacing(theme::SPACE_SM);
             for line in text.lines() {
+                if line.starts_with("Jobs per Function:") {
+                    break;
+                }
                 col = col.push(Text::new(line.to_string()).size(theme::FONT_MD));
+            }
+
+            let counts = metrics.jobs_per_function();
+            let max_count = counts.iter().copied().max().unwrap_or(1).max(1);
+            let non_zero: Vec<(usize, usize)> = counts
+                .iter()
+                .enumerate()
+                .filter(|(_, &c)| c > 0)
+                .map(|(id, &c)| (id, c))
+                .collect();
+
+            if !non_zero.is_empty() {
+                col = col.push(
+                    Text::new("Jobs per Function:")
+                        .size(theme::FONT_MD)
+                        .color(theme::TEXT_SECONDARY),
+                );
+                let id_width = non_zero.last().map_or(1, |(id, _)| id.to_string().len());
+
+                for &(id, count) in &non_zero {
+                    let label = format!("{id:>id_width$}");
+                    #[allow(clippy::cast_possible_truncation)]
+                    let portion = ((count * 100) / max_count).max(1) as u16;
+                    let bar = Container::new(Text::new("").size(1))
+                        .width(Length::FillPortion(portion))
+                        .height(Length::Fixed(14.0))
+                        .style(move |_: &iced::Theme| iced::widget::container::Style {
+                            background: Some(iced::Background::Color(theme::ACCENT)),
+                            border: iced::Border {
+                                radius: 3.0.into(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        });
+                    let tip = metrics.function_name(id).map_or_else(
+                        || format!("#{id}"),
+                        |(name, route)| format!("'{name}' @ {route}"),
+                    );
+                    let label_widget = iced::widget::tooltip(
+                        Text::new(label)
+                            .size(theme::FONT_SM)
+                            .font(iced::Font::MONOSPACE)
+                            .color(theme::ACCENT),
+                        Text::new(tip).size(theme::FONT_MD),
+                        iced::widget::tooltip::Position::Left,
+                    )
+                    .style(|_: &iced::Theme| iced::widget::container::Style {
+                        background: Some(iced::Background::Color(theme::SURFACE_TOOLTIP)),
+                        text_color: Some(iced::Color::WHITE),
+                        border: iced::Border {
+                            radius: theme::RADIUS_SM.into(),
+                            width: 1.0,
+                            color: iced::Color {
+                                a: 0.3,
+                                ..theme::ACCENT
+                            },
+                        },
+                        ..Default::default()
+                    })
+                    .padding(4)
+                    .gap(4);
+                    let spacer_portion = (100 - portion).max(1);
+                    let row = Row::new()
+                        .spacing(4)
+                        .align_y(iced::alignment::Vertical::Center)
+                        .push(label_widget)
+                        .push(bar)
+                        .push(
+                            iced::widget::container(Text::new("").size(1))
+                                .width(Length::FillPortion(spacer_portion)),
+                        )
+                        .push(
+                            Text::new(count.to_string())
+                                .size(theme::FONT_SM)
+                                .color(theme::TEXT_SECONDARY),
+                        );
+                    col = col.push(row);
+                }
             }
             col
         } else {
@@ -1872,7 +1954,7 @@ impl FlowrGui {
         let panel_content = Column::new()
             .spacing(theme::SPACE_MD)
             .push(header)
-            .push(content);
+            .push(iced::widget::Scrollable::new(content).height(Length::Fill));
 
         Container::new(panel_content)
             .width(Length::Fixed(300.0))

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -88,7 +88,12 @@ impl<'a> Coordinator<'a> {
     ///
     /// Returns an error if the execution of the flow did not complete normally.
     ///
-    #[allow(unused_variables, unused_assignments, unused_mut)]
+    #[allow(
+        unused_variables,
+        unused_assignments,
+        unused_mut,
+        clippy::too_many_lines
+    )]
     pub fn execute_flow(&mut self, submission: Submission) -> Result<()> {
         self.dispatcher
             .set_results_timeout(submission.job_timeout)?;
@@ -96,6 +101,17 @@ impl<'a> Coordinator<'a> {
 
         #[cfg(feature = "metrics")]
         let mut metrics = Metrics::new(state.num_functions(), state.num_processes());
+        #[cfg(feature = "metrics")]
+        {
+            let num_proc = state.num_processes();
+            let mut names = vec![(String::new(), String::new()); num_proc];
+            for (id, func) in state.get_functions() {
+                if let Some(entry) = names.get_mut(*id) {
+                    *entry = (func.name().to_string(), func.route().to_string());
+                }
+            }
+            metrics.set_function_names(names);
+        }
 
         #[cfg(feature = "debugger")]
         if state.submission.debug_enabled {

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -95,7 +95,7 @@ impl<'a> Coordinator<'a> {
         let mut state = RunState::new(submission);
 
         #[cfg(feature = "metrics")]
-        let mut metrics = Metrics::new(state.num_functions());
+        let mut metrics = Metrics::new(state.num_functions(), state.num_processes());
 
         #[cfg(feature = "debugger")]
         if state.submission.debug_enabled {
@@ -177,6 +177,7 @@ impl<'a> Coordinator<'a> {
             if !restart {
                 metrics.stop_timer();
                 metrics.set_jobs_created(state.get_number_of_jobs_created());
+                metrics.set_jobs_per_function(state.jobs_per_function());
             }
 
             #[allow(clippy::collapsible_if)]

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -101,7 +101,7 @@ impl<'a> Coordinator<'a> {
 
         #[cfg(feature = "metrics")]
         let mut metrics = Metrics::new(state.num_functions(), state.num_processes());
-        #[cfg(feature = "metrics")]
+        #[cfg(all(feature = "metrics", feature = "debugger"))]
         {
             let num_proc = state.num_processes();
             let mut names = vec![(String::new(), String::new()); num_proc];

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -633,6 +633,8 @@ impl RunState {
                 #[cfg(feature = "metrics")]
                 if let Some(count) = self.jobs_per_function.get_mut(process_id) {
                     *count += 1;
+                } else {
+                    debug!("process_id {process_id} out of range for jobs_per_function");
                 }
                 *self.busy_count.entry(process_id).or_insert(0) += 1;
                 for ancestor in self.ancestors(parent_id) {

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -169,6 +169,9 @@ pub struct RunState {
     number_of_jobs_created: usize,
     /// Track how many busy entries exist per `process_id` (functions and ancestor flows)
     busy_count: HashMap<usize, usize>,
+    /// Per-function job creation count (index = `process_id`)
+    #[cfg(feature = "metrics")]
+    jobs_per_function: Vec<usize>,
     /// Index: parent flow ID → function IDs in that flow (avoids full-manifest scans)
     functions_by_flow: HashMap<usize, Vec<usize>>,
 }
@@ -186,6 +189,9 @@ impl RunState {
                 .push(*id);
         }
 
+        #[cfg(feature = "metrics")]
+        let num_processes =
+            submission.manifest.functions().len() + submission.manifest.flows().len();
         RunState {
             submission,
             ready_jobs: VecDeque::<Job>::new(),
@@ -193,6 +199,8 @@ impl RunState {
             completed: HashSet::<usize>::new(),
             number_of_jobs_created: 0,
             busy_count: HashMap::<usize, usize>::new(),
+            #[cfg(feature = "metrics")]
+            jobs_per_function: vec![0; num_processes],
             functions_by_flow,
         }
     }
@@ -622,6 +630,10 @@ impl RunState {
                 // avoid getting stuck in a loop generating jobs for a function - generate just one
                 let always_ready = function.is_always_ready();
                 self.ready_jobs.push_back(job);
+                #[cfg(feature = "metrics")]
+                if let Some(count) = self.jobs_per_function.get_mut(process_id) {
+                    *count += 1;
+                }
                 *self.busy_count.entry(process_id).or_insert(0) += 1;
                 for ancestor in self.ancestors(parent_id) {
                     *self.busy_count.entry(ancestor).or_insert(0) += 1;
@@ -644,6 +656,19 @@ impl RunState {
     #[must_use]
     pub fn num_functions(&self) -> usize {
         self.submission.manifest.functions().len()
+    }
+
+    /// Total number of processes (functions + flows) in the manifest
+    #[must_use]
+    pub fn num_processes(&self) -> usize {
+        self.submission.manifest.functions().len() + self.submission.manifest.flows().len()
+    }
+
+    /// Per-function job creation counts (index = `process_id`)
+    #[cfg(feature = "metrics")]
+    #[must_use]
+    pub fn jobs_per_function(&self) -> &[usize] {
+        &self.jobs_per_function
     }
 
     /// Return the ancestor flow ids starting from `parent_id` up to the root
@@ -1323,7 +1348,7 @@ mod test {
 
             let mut state = RunState::new(super::test_submission(vec![f_a]));
             #[cfg(feature = "metrics")]
-            let mut metrics = Metrics::new(1);
+            let mut metrics = Metrics::new(1, 1);
             #[cfg(feature = "debugger")]
             let mut server = super::DummyServer {};
             #[cfg(feature = "debugger")]
@@ -1373,7 +1398,7 @@ mod test {
 
             let mut state = RunState::new(super::test_submission(vec![f_a]));
             #[cfg(feature = "metrics")]
-            let mut metrics = Metrics::new(1);
+            let mut metrics = Metrics::new(1, 1);
             #[cfg(feature = "debugger")]
             let mut server = super::DummyServer {};
             #[cfg(feature = "debugger")]
@@ -1447,7 +1472,7 @@ mod test {
             );
             let mut state = RunState::new(super::test_submission(vec![f_a, f_b]));
             #[cfg(feature = "metrics")]
-            let mut metrics = Metrics::new(1);
+            let mut metrics = Metrics::new(1, 1);
             #[cfg(feature = "debugger")]
             let mut server = super::DummyServer {};
             #[cfg(feature = "debugger")]
@@ -1519,7 +1544,7 @@ mod test {
             );
             let mut state = RunState::new(super::test_submission(vec![f_a, f_b]));
             #[cfg(feature = "metrics")]
-            let mut metrics = Metrics::new(1);
+            let mut metrics = Metrics::new(1, 1);
             #[cfg(feature = "debugger")]
             let mut server = super::DummyServer {};
             #[cfg(feature = "debugger")]
@@ -1709,7 +1734,7 @@ mod test {
 
             let mut state = RunState::new(super::test_submission(vec![f_a]));
             #[cfg(feature = "metrics")]
-            let mut metrics = Metrics::new(1);
+            let mut metrics = Metrics::new(1, 1);
             #[cfg(feature = "debugger")]
             let mut server = super::DummyServer {};
             #[cfg(feature = "debugger")]


### PR DESCRIPTION
## Summary
- Add `jobs_per_function: Vec<usize>` to `Metrics` struct, indexed by `process_id`
- Track job creation counts per function in `RunState::create_jobs()`
- Transfer counts to Metrics at flow end via `set_jobs_per_function()`
- Display non-zero counts in Metrics Display output
- Add `num_processes()` to RunState for proper Vec sizing (functions + flows)

Closes #2806

## Test plan
- [ ] `make clippy` passes
- [ ] `make features` passes
- [ ] `make test` passes
- [ ] Run a flow, check metrics panel shows per-function job counts
- [ ] Verify counts match expected invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now record per-function job counts and display a “Jobs per Function” section.
  * GUI metrics panel shows per-function horizontal bars with tooltips linking to function names (or id fallback) and is scrollable.

* **Tests**
  * Unit tests updated to align with the enhanced metrics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->