### PR TITLE
Bump version to 1.1.0 — Debugger milestone complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flowc"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "colored",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "flowcore"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "curl",
  "error-chain",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "flowedit"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "flowmacro"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "flowcore",
  "proc-macro2",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "flowr"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1435,7 +1435,7 @@ version = "1.0.0"
 
 [[package]]
 name = "flowstdlib"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "error-chain",
  "flowcore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["flowc", "flowstdlib", "flowr", "flowcore", "flowmacro", "flo
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 license = "MIT"
 license-file = "LICENSE"

--- a/flowc/Cargo.toml
+++ b/flowc/Cargo.toml
@@ -30,7 +30,7 @@ debugger = ["flowcore/debugger"] # feature to add output for the debugger
 graph = ["svg"] # feature to enable SVG graph output with -g flag
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "1.0.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
+flowcore = {path = "../flowcore", version = "1.1.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
 svg = { version = "0.18", optional = true }
 clap = "~4"
 env_logger = "0.11.10"
@@ -47,7 +47,7 @@ colored = "3"
 toml = { version = "1.1.2" }
 
 [dev-dependencies]
-flowcore = {path = "../flowcore", version = "1.0.0", features = ["context"]}
+flowcore = {path = "../flowcore", version = "1.1.0", features = ["context"]}
 tempfile = "3"
 simpath = { version = "~2.5", features = ["urls"]}
 serial_test = "3.5.0"

--- a/flowedit/Cargo.toml
+++ b/flowedit/Cargo.toml
@@ -18,8 +18,8 @@ name = "flowedit"
 path = "src/main.rs"
 
 [dependencies]
-flowcore = { path = "../flowcore", version = "1.0.0", features = ["meta_provider", "context", "file_provider"] }
-flowrclib = { package = "flowc", path = "../flowc", version = "1.0.0" }
+flowcore = { path = "../flowcore", version = "1.1.0", features = ["meta_provider", "context", "file_provider"] }
+flowrclib = { package = "flowc", path = "../flowc", version = "1.1.0" }
 clap = "~4"
 iced = { version = "0.14.0", default-features = false, features = ["canvas", "tokio", "wgpu", "tiny-skia", "wayland", "x11"] }
 simpath = { version = "~2.5", features = ["urls"] }

--- a/flowmacro/Cargo.toml
+++ b/flowmacro/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "~2.0", features =["full"] } #Full is required for ItemFn in macro parsing
 quote = "~1.0"
-flowcore = {path = "../flowcore", version = "1.0.0" }
+flowcore = {path = "../flowcore", version = "1.1.0" }
 toml = "1.1.2"
 proc-macro2 = "1.0"
 

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -53,9 +53,9 @@ max_combination_size = 2
 skip_optional_dependencies = true
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "1.0.0", features = ["context", "file_provider", "http_provider",
+flowcore = {path = "../flowcore", version = "1.1.0", features = ["context", "file_provider", "http_provider",
         "context", "meta_provider"] }
-flowstdlib = {path = "../flowstdlib", version = "1.0.0", optional = true }
+flowstdlib = {path = "../flowstdlib", version = "1.1.0", optional = true }
 clap = "~4"
 log = "0.4.32"
 env_logger = "0.11.10"
@@ -91,4 +91,4 @@ portpicker = "0.1.1"
 iced_test = "0.14.0"
 # These two are needed for examples
 flowr-utilities = { path = "utilities" }
-flowstdlib = {path = "../flowstdlib", version = "1.0.0" }
+flowstdlib = {path = "../flowstdlib", version = "1.1.0" }

--- a/flowstdlib/Cargo.toml
+++ b/flowstdlib/Cargo.toml
@@ -2,7 +2,7 @@
 # Don't inherit from workspace as this is parsed by flowc for MetaData and it is not workspace inheritance aware
 name = "flowstdlib"
 description = "The standard library of functions and flows for 'flow' programs"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 # Inherit the other keys that are not parsed by flowc itself
 license.workspace = true
@@ -23,8 +23,8 @@ name = "flowstdlib"
 path = "src/lib.rs"
 
 [dependencies]
-flowmacro = {path = "../flowmacro", version = "1.0.0" }
-flowcore = {path = "../flowcore", version = "1.0.0" }
+flowmacro = {path = "../flowmacro", version = "1.1.0" }
+flowcore = {path = "../flowcore", version = "1.1.0" }
 simpath = { version = "2", features = ["urls"]}
 url = { version = "2.2", features = ["serde"] }
 serde_json = "1.0"
@@ -33,8 +33,8 @@ error-chain = "0.12.2"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3.5.0"
-flowcore = {path = "../flowcore", version = "1.0.0" }
-flowmacro = {path = "../flowmacro", version = "1.0.0" }
+flowcore = {path = "../flowcore", version = "1.1.0" }
+flowmacro = {path = "../flowmacro", version = "1.1.0" }
 serde_json = { version = "1.0", default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
Bump version from 1.0.0 to 1.1.0 across all workspace crates for the completed Debugger milestone.

All 51 issues in the [1.1.0 - Debugger milestone](https://github.com/andrewdavidmackenzie/flow/milestone/8) are closed.

### Files changed
- `Cargo.toml` (workspace root)
- `flowstdlib/Cargo.toml`
- `flowc/Cargo.toml`
- `flowr/Cargo.toml`
- `flowedit/Cargo.toml`
- `flowmacro/Cargo.toml`
- `Cargo.lock`

## Test plan
- [ ] `make clippy` passes
- [ ] `make features` passes
- [ ] `make test` passes
- [ ] Version shows 1.1.0 in all binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace version to 1.1.0
  * Synchronized all internal dependencies to version 1.1.0 across the workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->