### PR TITLE
Phase 2: Enable Windows release builds, add cargo-binstall metadata (#2810)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-26
             target: aarch64-apple-darwin
-          # Windows disabled until path/URL test fixes (#2815)
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          # - os: windows-11-arm
-          #   target: aarch64-pc-windows-msvc
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +61,12 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          echo "ZMQ and binaryen may need manual setup on Windows"
+          BINARYEN_VERSION="version_129"
+          curl -sL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-windows.tar.gz" -o binaryen.tar.gz
+          tar -xzf binaryen.tar.gz
+          cp binaryen-${BINARYEN_VERSION}/bin/* "$GITHUB_WORKSPACE/"
+          echo "$GITHUB_WORKSPACE" >> "$GITHUB_PATH"
+          rm -rf binaryen-${BINARYEN_VERSION} binaryen.tar.gz
 
       - name: Install WASM tools
         run: cargo install wasm-gc wasm-snip

--- a/flowc/Cargo.toml
+++ b/flowc/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 readme = "README.md"
 edition.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/flow-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [lints]
 workspace = true
 

--- a/flowedit/Cargo.toml
+++ b/flowedit/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 readme = "../README.md"
 edition.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/flow-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [lints]
 workspace = true
 

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 readme = "README.md"
 edition.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/flow-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Summary
- Enable Windows x86_64 in the release workflow (was disabled pending #2815)
- Add proper binaryen installation for Windows release builds
- Add `[package.metadata.binstall]` to flowc, flowr, and flowedit so `cargo binstall` can find pre-built binaries from GitHub releases

Stacked on #2816 (Windows CI fixes).

## Test plan
- [ ] CI passes on all platforms
- [ ] Verify release workflow builds Windows binaries (on next release)
- [ ] Test `cargo binstall flowc` after a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Windows build setup in the release workflow, replacing previous manual steps.
  * Added package metadata for binary installation configuration across the project's build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->