### PR TITLE
Use platform-standard data directories, bundle context definitions (#1622)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: test
         shell: bash
-        timeout-minutes: ${{ runner.os == 'Windows' && 25 || 15 }}
+        timeout-minutes: ${{ runner.os == 'Windows' && 25 || 20 }}
         run: cargo test --features "online_tests"
 
       - name: test-examples

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,19 @@ jobs:
           fi
           echo "Total binaries found: ${FOUND}"
 
+          # Bundle context definitions for runners
+          for runner in flowrcli flowrgui; do
+            CONTEXT_DIR="flowr/src/bin/${runner}/context"
+            if [ -d "${CONTEXT_DIR}" ]; then
+              mkdir -p "staging/runner/${runner}"
+              cp -r "${CONTEXT_DIR}"/* "staging/runner/${runner}/"
+              echo "Bundled context definitions for ${runner}"
+            fi
+          done
+
+          # Bundle install script
+          cp install.sh staging/ 2>/dev/null || true
+
           # Create archive
           cd staging
           if [[ "$TARGET" == *"windows"* ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1053,7 +1053,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1068,7 +1068,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1096,6 +1096,27 @@ dependencies = [
  "jwalk",
  "log",
  "walkdir",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1232,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1355,6 +1376,7 @@ name = "flowcore"
 version = "1.1.0"
 dependencies = [
  "curl",
+ "directories",
  "error-chain",
  "log",
  "mdns-sd",
@@ -3331,6 +3353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3871,6 +3899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,7 +4047,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4385,7 +4424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4539,7 +4578,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5569,7 +5608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/flowc/src/bin/flowc/main.rs
+++ b/flowc/src/bin/flowc/main.rs
@@ -91,11 +91,9 @@ fn get_lib_search_path(search_path_additions: &[String]) -> Simpath {
     }
 
     if lib_search_path.is_empty() {
-        let home = env::var("HOME")
-            .or_else(|_| env::var("USERPROFILE"))
-            .unwrap_or_else(|_| ".".to_string());
-        let default_path = std::path::PathBuf::from(home).join(".flow").join("lib");
-        lib_search_path.add(default_path.to_str().unwrap_or(".flow/lib"));
+        if let Some(default_path) = flowcore::dirs::lib_dir() {
+            lib_search_path.add(&default_path.to_string_lossy());
+        }
     }
 
     lib_search_path
@@ -282,7 +280,7 @@ fn get_matches() -> ArgMatches {
                 .number_of_values(1)
                 .value_name("OUTPUT_DIR")
                 .help("Specify a non-default directory for generated output. \
-                Default is $HOME/.flow/lib/{lib_name} for a library."),
+                Default is platform data dir + /flow/lib/{lib_name} for a library."),
         )
         .arg(
             Arg::new("verbosity")

--- a/flowc/src/bin/flowc/source_arg.rs
+++ b/flowc/src/bin/flowc/source_arg.rs
@@ -20,21 +20,32 @@ fn default_lib_compile_dir(source_url: &Url) -> Result<PathBuf> {
         .next_back()
         .ok_or("Could not get last path segment of source_url")?;
 
-    let home = env::var("HOME")
-        .or_else(|_| env::var("USERPROFILE"))
-        .map_err(|_| "Could not get HOME or USERPROFILE")?;
-
-    Ok(PathBuf::from(home).join(".flow").join("lib").join(lib_name))
+    flowcore::dirs::lib_dir()
+        .map(|d| d.join(lib_name))
+        .ok_or_else(|| "Could not determine flow data directory".into())
 }
 
 pub(crate) fn default_runner_dir(runner_name: &str) -> Result<PathBuf> {
-    let home = env::var("HOME")
-        .or_else(|_| env::var("USERPROFILE"))
-        .map_err(|_| "Could not get HOME or USERPROFILE")?;
-    Ok(PathBuf::from(home)
-        .join(".flow")
-        .join("runner")
-        .join(runner_name))
+    // Standard data directory location
+    if let Some(dir) = flowcore::dirs::runner_dir(runner_name) {
+        if dir.is_dir() {
+            return Ok(dir);
+        }
+    }
+
+    // Fallback: next to the binary (for portable installs)
+    if let Ok(exe_path) = env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            let system_dir = exe_dir.join("runner").join(runner_name);
+            if system_dir.is_dir() {
+                return Ok(system_dir);
+            }
+        }
+    }
+
+    // Return the standard path even if it doesn't exist yet (it may be created)
+    flowcore::dirs::runner_dir(runner_name)
+        .ok_or_else(|| "Could not determine flow data directory".into())
 }
 
 // Load a `RunnerSpec` from the context at `context_root`

--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -47,6 +47,7 @@ serde_yml = "0.0.13"
 curl = {version = "~0.4" }
 simpath = { version = "~2.5", features = ["urls"] }
 mdns-sd = { version = "0.20", default-features = false }
+directories = { version = "6.0.0", default-features = false }
 
 [lints]
 workspace = true

--- a/flowcore/src/dirs.rs
+++ b/flowcore/src/dirs.rs
@@ -1,0 +1,61 @@
+//! Platform-standard directory paths for flow data.
+//!
+//! Uses the `directories` crate to find the correct location per platform:
+//! - Linux: `~/.local/share/flow/`
+//! - macOS: `~/Library/Application Support/flow/`
+//! - Windows: `C:\Users\{user}\AppData\Roaming\flow\`
+//!
+//! Falls back to the legacy `~/.flow/` location if the standard path doesn't
+//! exist but the legacy one does, for backward compatibility.
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+fn project_dirs() -> Option<ProjectDirs> {
+    ProjectDirs::from("", "", "flow")
+}
+
+fn legacy_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(|h| PathBuf::from(h).join(".flow"))
+}
+
+/// Return the base data directory for flow.
+/// Prefers the standard platform directory, falls back to `~/.flow/` if it exists.
+#[must_use]
+pub fn data_dir() -> Option<PathBuf> {
+    let standard = project_dirs().map(|dirs| dirs.data_dir().to_path_buf());
+
+    // If the standard path exists, use it
+    if let Some(ref dir) = standard {
+        if dir.exists() {
+            return standard;
+        }
+    }
+
+    // If the legacy path exists, use it for backward compatibility
+    if let Some(legacy) = legacy_dir() {
+        if legacy.exists() {
+            return Some(legacy);
+        }
+    }
+
+    // Neither exists — return the standard path (it will be created on first use)
+    standard
+}
+
+/// Return the default library directory (`{data_dir}/lib/`).
+#[must_use]
+pub fn lib_dir() -> Option<PathBuf> {
+    data_dir().map(|d| d.join("lib"))
+}
+
+/// Return the default runner directory for a given runner name
+/// (`{data_dir}/runner/{runner_name}/`).
+#[must_use]
+pub fn runner_dir(runner_name: &str) -> Option<PathBuf> {
+    data_dir().map(|d| d.join("runner").join(runner_name))
+}

--- a/flowcore/src/lib.rs
+++ b/flowcore/src/lib.rs
@@ -103,6 +103,10 @@ pub type RunAgain = bool;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod content;
 
+/// Platform-standard directory paths for flow data
+#[cfg(not(target_arch = "wasm32"))]
+pub mod dirs;
+
 /// The `Implementation` trait used by functions to provide the code that runs on inputs
 ///
 /// A function's implementation must implement this trait with a single `run()` method that takes

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -26,25 +26,14 @@ pub(crate) struct EditorPrefs {
 /// and the default flowrcli context root.
 pub(crate) fn build_meta_provider() -> MetaProvider {
     let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
-    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        let default_lib = PathBuf::from(&home).join(".flow").join("lib");
+    if let Some(default_lib) = flowcore::dirs::lib_dir() {
         if default_lib.exists() {
             if let Some(path_str) = default_lib.to_str() {
                 lib_search_path.add_directory(path_str);
             }
         }
     }
-    let context_root = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_or_else(
-            |_| PathBuf::from("."),
-            |h| {
-                PathBuf::from(h)
-                    .join(".flow")
-                    .join("runner")
-                    .join("flowrcli")
-            },
-        );
+    let context_root = flowcore::dirs::runner_dir("flowrcli").unwrap_or_default();
     MetaProvider::new(lib_search_path, context_root)
 }
 
@@ -62,14 +51,10 @@ pub(crate) fn resolve_lib_paths() -> Vec<String> {
         }
     }
 
-    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        let default_lib = PathBuf::from(&home)
-            .join(".flow")
-            .join("lib")
-            .to_string_lossy()
-            .to_string();
-        if std::path::Path::new(&default_lib).is_dir() && !paths.contains(&default_lib) {
-            paths.push(default_lib);
+    if let Some(default_lib) = flowcore::dirs::lib_dir() {
+        let default_lib_str = default_lib.to_string_lossy().to_string();
+        if default_lib.is_dir() && !paths.contains(&default_lib_str) {
+            paths.push(default_lib_str);
         }
     }
 

--- a/flowedit/src/flow_edit.rs
+++ b/flowedit/src/flow_edit.rs
@@ -555,8 +555,7 @@ impl FlowEdit {
         let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
         lib_search_path.add_directory(parent_str);
 
-        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-            let default_lib = PathBuf::from(&home).join(".flow").join("lib");
+        if let Some(default_lib) = flowcore::dirs::lib_dir() {
             if default_lib.exists() {
                 if let Some(path_str) = default_lib.to_str() {
                     lib_search_path.add_directory(path_str);
@@ -564,17 +563,7 @@ impl FlowEdit {
             }
         }
 
-        let context_root = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .map_or_else(
-                |_| PathBuf::from("."),
-                |h| {
-                    PathBuf::from(h)
-                        .join(".flow")
-                        .join("runner")
-                        .join("flowrcli")
-                },
-            );
+        let context_root = flowcore::dirs::runner_dir("flowrcli").unwrap_or_default();
         let provider = MetaProvider::new(lib_search_path.clone(), context_root.clone());
         let arc_provider: Arc<dyn Provider> = Arc::new(provider);
 

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -71,15 +71,7 @@ pub(crate) fn load_library_catalogs(
     // Only scan ~/.flow/runner/flowrcli/ since flowedit only supports the flowrcli runner,
     // and the MetaProvider is configured with that context root.
     let ctx_provider = file_ops::build_meta_provider();
-    let runner_dir = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map(|h| {
-            std::path::PathBuf::from(h)
-                .join(".flow")
-                .join("runner")
-                .join("flowrcli")
-        })
-        .unwrap_or_default();
+    let runner_dir = flowcore::dirs::runner_dir("flowrcli").unwrap_or_default();
     if runner_dir.is_dir() {
         if let Ok(cats) = std::fs::read_dir(&runner_dir) {
             for cat_entry in cats.flatten() {

--- a/flowedit/src/main.rs
+++ b/flowedit/src/main.rs
@@ -126,8 +126,7 @@ pub(crate) fn setup_lib_search_path(lib_dirs: &[String]) {
         info!("'{addition}' added to the Library Search Path");
     }
     if lib_search_path.is_empty() {
-        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-            let default_lib = std::path::PathBuf::from(home).join(".flow").join("lib");
+        if let Some(default_lib) = flowcore::dirs::lib_dir() {
             let default_lib_str = default_lib.to_string_lossy();
             lib_search_path.add(&default_lib_str);
             std::env::set_var("FLOW_LIB_PATH", &*default_lib_str);

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -104,11 +104,9 @@ fn get_lib_search_path(search_path_additions: &[String]) -> Simpath {
     }
 
     if lib_search_path.is_empty() {
-        let home = env::var("HOME")
-            .or_else(|_| env::var("USERPROFILE"))
-            .unwrap_or_else(|_| ".".to_string());
-        let default_path = std::path::PathBuf::from(home).join(".flow").join("lib");
-        lib_search_path.add(default_path.to_str().unwrap_or(".flow/lib"));
+        if let Some(default_path) = flowcore::dirs::lib_dir() {
+            lib_search_path.add(&default_path.to_string_lossy());
+        }
     }
 
     lib_search_path

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3064,11 +3064,9 @@ impl FlowrGui {
         }
 
         if lib_search_path.is_empty() {
-            let home = env::var("HOME")
-                .or_else(|_| env::var("USERPROFILE"))
-                .unwrap_or_else(|_| ".".to_string());
-            let default_path = std::path::PathBuf::from(home).join(".flow").join("lib");
-            lib_search_path.add(default_path.to_str().unwrap_or(".flow/lib"));
+            if let Some(default_path) = flowcore::dirs::lib_dir() {
+                lib_search_path.add(&default_path.to_string_lossy());
+            }
         }
 
         lib_search_path

--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,30 @@
-#!/usr/bin/env sh
+#!/bin/bash
+# Install flow binaries and context definitions
+# Run this after extracting the release archive
 
-# Install cargo-binstall
-curl -L --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+set -e
 
-# binstall the flowc binary
-cargo binstall flowc
-echo "flowc binary installed by cargo"
+FLOW_DIR="${HOME}/.flow"
 
-# cargo binstall flowr crate's multiple binaries: flowrcli, flowrgui and flowrex
+echo "Installing flow context definitions to ${FLOW_DIR}/"
 
-# download the flowstdlib artifact and expand into $HOME/.flow/lib
-mkdir -p "$HOME"/.flow/lib
-curl -L --tlsv1.2 -sSf https://github.com/andrewdavidmackenzie/flow/releases/download/v0.135.0/flowstdlib-v0.135.0.tar.xz | tar -x --directory "$HOME"/.flow/lib
-echo "flowstdlib library installed in $HOME/.flow/lib"
+# Install flowrcli context definitions
+FLOWRCLI_DIR="${FLOW_DIR}/runner/flowrcli"
+if [ -d "runner/flowrcli" ]; then
+    mkdir -p "${FLOWRCLI_DIR}"
+    cp -r runner/flowrcli/* "${FLOWRCLI_DIR}/"
+    echo "  Installed flowrcli context definitions"
+fi
 
-# download the flowrcli context into $HOME/.flow/runner
-mkdir -p "$HOME"/.flow/runner
-curl -L --tlsv1.2 -sSf https://github.com/andrewdavidmackenzie/flow/releases/download/v0.135.0/flowrcli-v0.135.0.tar.xz | tar -x --directory "$HOME"/.flow/runner
-echo "flowrcli runner context installed in $HOME/.flow/runner"
+# Install flowrgui context definitions
+FLOWRGUI_DIR="${FLOW_DIR}/runner/flowrgui"
+if [ -d "runner/flowrgui" ]; then
+    mkdir -p "${FLOWRGUI_DIR}"
+    cp -r runner/flowrgui/* "${FLOWRGUI_DIR}/"
+    echo "  Installed flowrgui context definitions"
+fi
 
-# download the flowrgui context into $HOME/.flow/runner
-mkdir -p "$HOME"/.flow/runner
-curl -L --tlsv1.2 -sSf https://github.com/andrewdavidmackenzie/flow/releases/download/v0.135.0/flowrgui-v0.135.0.tar.xz | tar -x --directory "$HOME"/.flow/runner
-echo "flowrgui runner context installed in $HOME/.flow/runner"
+echo "Done. Context definitions installed to ${FLOW_DIR}/runner/"
+echo ""
+echo "To also install flowstdlib, download the flowstdlib tarball from the"
+echo "release and extract it to ${FLOW_DIR}/lib/"


### PR DESCRIPTION
## Summary
- Add `flowcore::dirs` module using the `directories` crate for platform-standard data paths
- Replace all hardcoded `~/.flow/` paths with `flowcore::dirs::lib_dir()` and `flowcore::dirs::runner_dir()`
- Falls back to legacy `~/.flow/` if it exists (backward compatible)
- Add `install.sh` script to release archives for installing context definitions
- Bundle runner context TOML files in release archives

## Platform paths
| Platform | Data directory |
|----------|---------------|
| Linux | `~/.local/share/flow/` |
| macOS | `~/Library/Application Support/flow/` |
| Windows | `C:\Users\{user}\AppData\Roaming\flow\` |
| Legacy (any) | `~/.flow/` (used if it exists and standard doesn't) |

Closes #1622

## Test plan
- [x] `make clippy` passes
- [x] `make test` passes locally (legacy `~/.flow/` fallback works)
- [ ] CI passes on all platforms
- [ ] After extracting a release archive, `./install.sh` copies context definitions to the right location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now uses system-standard directories instead of hardcoded paths for storing data and libraries.

* **Chores**
  * Revised installation process to local extraction workflow.
  * Enhanced release archives to include runner context definitions.
  * Adjusted test timeout settings for non-Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->