### PR TITLE
Bundle flowstdlib and compiled context definitions in release archives (#1634)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,18 +187,21 @@ jobs:
 
       - name: Compile flowstdlib to WASM (Linux x86_64 only)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          target/${{ matrix.target }}/release/flowc -d -g -O flowstdlib
+        run: target/${{ matrix.target }}/release/flowc -d -g -O flowstdlib
 
       - name: Upload flowstdlib tarball (Linux x86_64 only)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          cd $HOME/.flow/lib
-          tar -cJf "flowstdlib-${TAG}.tar.xz" flowstdlib
-          cd -
-          gh release upload "${TAG}" "$HOME/.flow/lib/flowstdlib-${TAG}.tar.xz" --clobber
+          mkdir -p flowstdlib-staging
+          cp -r $HOME/.flow/lib/flowstdlib flowstdlib-staging/
+          cp install-flowstdlib.sh flowstdlib-staging/
+          cd flowstdlib-staging
+          tar -cJf "flowstdlib-${TAG}.tar.xz" flowstdlib install-flowstdlib.sh
+          cd ..
+          gh release upload "${TAG}" "flowstdlib-staging/flowstdlib-${TAG}.tar.xz" --clobber
+          gh release upload "${TAG}" install-flowstdlib.sh --clobber
 
   build-and-publish-book:
     needs: [ build-and-bundle ]

--- a/install-flowstdlib.sh
+++ b/install-flowstdlib.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Install flowstdlib (compiled WASM standard library for flow)
+#
+# Usage:
+#   curl -sL https://raw.githubusercontent.com/andrewdavidmackenzie/flow/master/install-flowstdlib.sh | bash
+#
+# Or with a specific version:
+#   curl -sL https://raw.githubusercontent.com/andrewdavidmackenzie/flow/master/install-flowstdlib.sh | bash -s -- v1.1.0
+
+set -e
+
+REPO="andrewdavidmackenzie/flow"
+VERSION="${1:-latest}"
+
+# Determine platform-standard data directory
+case "$(uname -s)" in
+    Linux*)  FLOW_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/flow" ;;
+    Darwin*) FLOW_DIR="$HOME/Library/Application Support/flow" ;;
+    MINGW*|MSYS*|CYGWIN*) FLOW_DIR="$APPDATA/flow" ;;
+    *)       FLOW_DIR="$HOME/.flow" ;;
+esac
+
+# Fall back to legacy location if it exists
+if [ ! -d "$FLOW_DIR" ] && [ -d "$HOME/.flow" ]; then
+    FLOW_DIR="$HOME/.flow"
+fi
+
+# Resolve version tag
+if [ "$VERSION" = "latest" ]; then
+    TAG=$(curl -sI "https://github.com/${REPO}/releases/latest" | grep -i "^location:" | sed 's/.*tag\///' | tr -d '\r\n')
+    if [ -z "$TAG" ]; then
+        echo "Error: could not determine latest release tag"
+        exit 1
+    fi
+else
+    TAG="$VERSION"
+fi
+
+echo "Installing flowstdlib ${TAG} to ${FLOW_DIR}/lib/flowstdlib/"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+URL="https://github.com/${REPO}/releases/download/${TAG}/flowstdlib-${TAG}.tar.xz"
+echo "Downloading ${URL}..."
+curl -sL "$URL" -o "$TMPDIR/flowstdlib.tar.xz"
+
+cd "$TMPDIR"
+tar xJf flowstdlib.tar.xz
+
+if [ ! -d "flowstdlib" ]; then
+    echo "Error: flowstdlib/ not found in tarball"
+    exit 1
+fi
+
+DEST="${FLOW_DIR}/lib/flowstdlib"
+mkdir -p "${DEST}"
+cp -r flowstdlib/* "${DEST}/"
+
+echo "Done. flowstdlib installed to ${DEST}/"

--- a/install-flowstdlib.sh
+++ b/install-flowstdlib.sh
@@ -55,6 +55,6 @@ fi
 
 DEST="${FLOW_DIR}/lib/flowstdlib"
 mkdir -p "${DEST}"
-cp -r flowstdlib/* "${DEST}/"
+cp -a flowstdlib/. "${DEST}/"
 
 echo "Done. flowstdlib installed to ${DEST}/"

--- a/install.sh
+++ b/install.sh
@@ -21,14 +21,14 @@ echo "Installing flow data to ${FLOW_DIR}/"
 # Install flowrcli context definitions
 if [ -d "runner/flowrcli" ]; then
     mkdir -p "${FLOW_DIR}/runner/flowrcli"
-    cp -r runner/flowrcli/* "${FLOW_DIR}/runner/flowrcli/"
+    cp -a runner/flowrcli/. "${FLOW_DIR}/runner/flowrcli/"
     echo "  Installed flowrcli context definitions"
 fi
 
 # Install flowrgui context definitions
 if [ -d "runner/flowrgui" ]; then
     mkdir -p "${FLOW_DIR}/runner/flowrgui"
-    cp -r runner/flowrgui/* "${FLOW_DIR}/runner/flowrgui/"
+    cp -a runner/flowrgui/. "${FLOW_DIR}/runner/flowrgui/"
     echo "  Installed flowrgui context definitions"
 fi
 
@@ -36,7 +36,7 @@ fi
 # Looks for flowstdlib/ in the current directory (from the separate tarball)
 if [ -d "flowstdlib" ]; then
     mkdir -p "${FLOW_DIR}/lib/flowstdlib"
-    cp -r flowstdlib/* "${FLOW_DIR}/lib/flowstdlib/"
+    cp -a flowstdlib/. "${FLOW_DIR}/lib/flowstdlib/"
     echo "  Installed flowstdlib library"
 else
     echo "  flowstdlib/ not found — download the flowstdlib tarball from the"

--- a/install.sh
+++ b/install.sh
@@ -1,30 +1,47 @@
 #!/bin/bash
-# Install flow binaries and context definitions
+# Install flow data files (context definitions and flowstdlib)
 # Run this after extracting the release archive
 
 set -e
 
-FLOW_DIR="${HOME}/.flow"
+# Determine platform-standard data directory
+case "$(uname -s)" in
+    Linux*)  FLOW_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/flow" ;;
+    Darwin*) FLOW_DIR="$HOME/Library/Application Support/flow" ;;
+    *)       FLOW_DIR="$HOME/.flow" ;;
+esac
 
-echo "Installing flow context definitions to ${FLOW_DIR}/"
+# Fall back to legacy location if it exists
+if [ ! -d "$FLOW_DIR" ] && [ -d "$HOME/.flow" ]; then
+    FLOW_DIR="$HOME/.flow"
+fi
+
+echo "Installing flow data to ${FLOW_DIR}/"
 
 # Install flowrcli context definitions
-FLOWRCLI_DIR="${FLOW_DIR}/runner/flowrcli"
 if [ -d "runner/flowrcli" ]; then
-    mkdir -p "${FLOWRCLI_DIR}"
-    cp -r runner/flowrcli/* "${FLOWRCLI_DIR}/"
+    mkdir -p "${FLOW_DIR}/runner/flowrcli"
+    cp -r runner/flowrcli/* "${FLOW_DIR}/runner/flowrcli/"
     echo "  Installed flowrcli context definitions"
 fi
 
 # Install flowrgui context definitions
-FLOWRGUI_DIR="${FLOW_DIR}/runner/flowrgui"
 if [ -d "runner/flowrgui" ]; then
-    mkdir -p "${FLOWRGUI_DIR}"
-    cp -r runner/flowrgui/* "${FLOWRGUI_DIR}/"
+    mkdir -p "${FLOW_DIR}/runner/flowrgui"
+    cp -r runner/flowrgui/* "${FLOW_DIR}/runner/flowrgui/"
     echo "  Installed flowrgui context definitions"
 fi
 
-echo "Done. Context definitions installed to ${FLOW_DIR}/runner/"
+# Install flowstdlib (compiled WASM library)
+# Looks for flowstdlib/ in the current directory (from the separate tarball)
+if [ -d "flowstdlib" ]; then
+    mkdir -p "${FLOW_DIR}/lib/flowstdlib"
+    cp -r flowstdlib/* "${FLOW_DIR}/lib/flowstdlib/"
+    echo "  Installed flowstdlib library"
+else
+    echo "  flowstdlib/ not found — download the flowstdlib tarball from the"
+    echo "  release, extract it here, and re-run this script to install it."
+fi
+
 echo ""
-echo "To also install flowstdlib, download the flowstdlib tarball from the"
-echo "release and extract it to ${FLOW_DIR}/lib/"
+echo "Done. Flow data installed to ${FLOW_DIR}/"


### PR DESCRIPTION
## Summary
- Compile flowstdlib to WASM and runner context definitions on Linux x86_64 BEFORE creating the release archive, so the archive is self-contained
- Bundle compiled flowstdlib (`lib/flowstdlib/`) and runner context definitions (`runner/flowrcli/`, `runner/flowrgui/`) in the release tar.gz/zip
- Update `install.sh` to install flowstdlib and use platform-standard data directories
- Other platforms' archives include source context definitions (flowstdlib compilation is cross-platform — only needs to happen once)
- Standalone `flowstdlib-{TAG}.tar.xz` tarball still uploaded separately

After extracting a release archive, users run `./install.sh` to install everything to the correct data directory.

Closes #1634

## Test plan
- [ ] CI passes (no code changes, only workflow and script)
- [ ] On next release, verify Linux x86_64 archive contains `lib/flowstdlib/` and `runner/`
- [ ] `./install.sh` installs to correct platform directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release build workflow to streamline compilation and packaging of runtime components and libraries.
  * Updated installation script to automatically handle deployment of Flow data to platform-appropriate directories and include the standard library without requiring separate manual installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->