### PR TITLE
Improve error messages when definitions are missing (#2822)

### DIFF
--- a/flowcore/src/meta_provider.rs
+++ b/flowcore/src/meta_provider.rs
@@ -168,7 +168,7 @@ impl MetaProvider {
                  - Install the library with: curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flowstdlib.sh | bash\n\
                  - Set FLOW_LIB_PATH to the directory containing the library\n\
                  - Use the -L flag to add a library directory",
-                url,
+                lib_name,
                 self.lib_search_path
             ),
         }

--- a/flowcore/src/meta_provider.rs
+++ b/flowcore/src/meta_provider.rs
@@ -104,13 +104,15 @@ impl MetaProvider {
         let sub_dir = url.path().trim_start_matches('/');
         let context_function_path = self.context_root.join(dir).join(sub_dir);
         if !self.context_root.exists() {
-            bail!(
+            bail!(format!(
                 "Context function directory '{}' does not exist.\n\
                  Context definitions are needed to compile flows.\n\
-                 Run the install.sh script from a release archive to install them,\n\
-                 or compile the runner with: flowc flowr/src/bin/flowrcli",
+                 \n\
+                 Download a release archive from:\n\
+                   https://github.com/andrewdavidmackenzie/flow/releases/latest\n\
+                 Then run: ./install.sh",
                 self.context_root.display()
-            );
+            ));
         }
         Ok((
             Url::from_file_path(&context_function_path).map_err(|()| {
@@ -161,16 +163,22 @@ impl MetaProvider {
                     .extend(path_under_lib.split('/'));
                 Ok((lib_root_url, lib_reference))
             }
-            _ => bail!(
-                "Could not resolve library '{}' in search path: {}\n\
-                 \n\
-                 To fix this, either:\n\
-                 - Install the library with: curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flowstdlib.sh | bash\n\
-                 - Set FLOW_LIB_PATH to the directory containing the library\n\
-                 - Use the -L flag to add a library directory",
-                lib_name,
-                self.lib_search_path
-            ),
+            _ => {
+                let search_info = if self.lib_search_path.is_empty() {
+                    "FLOW_LIB_PATH is not set and no default library directory was found"
+                        .to_string()
+                } else {
+                    format!("searched: {}", self.lib_search_path)
+                };
+                bail!(format!(
+                    "Could not resolve library '{lib_name}' ({search_info})\n\
+                     \n\
+                     To fix this, either:\n\
+                     - Install the library with: curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flowstdlib.sh | bash\n\
+                     - Set FLOW_LIB_PATH to the directory containing the library\n\
+                     - Use the -L flag to add a library directory"
+                ))
+            }
         }
     }
 }

--- a/flowcore/src/meta_provider.rs
+++ b/flowcore/src/meta_provider.rs
@@ -103,9 +103,23 @@ impl MetaProvider {
             .chain_err(|| format!("context 'dir' could not be extracted from the url '{url}'"))?;
         let sub_dir = url.path().trim_start_matches('/');
         let context_function_path = self.context_root.join(dir).join(sub_dir);
+        if !self.context_root.exists() {
+            bail!(
+                "Context function directory '{}' does not exist.\n\
+                 Context definitions are needed to compile flows.\n\
+                 Run the install.sh script from a release archive to install them,\n\
+                 or compile the runner with: flowc flowr/src/bin/flowrcli",
+                self.context_root.display()
+            );
+        }
         Ok((
-            Url::from_file_path(context_function_path)
-                .map_err(|()| "Could not convert context function's path to a Url")?,
+            Url::from_file_path(&context_function_path).map_err(|()| {
+                format!(
+                    "Could not resolve context function at '{}'\n\
+                         Check that the runner context definitions are installed.",
+                    context_function_path.display()
+                )
+            })?,
             Some(Url::parse(&format!("context://{dir}/{sub_dir}"))?),
         ))
     }
@@ -148,7 +162,12 @@ impl MetaProvider {
                 Ok((lib_root_url, lib_reference))
             }
             _ => bail!(
-                "Could not resolve library Url '{}' using {}",
+                "Could not resolve library '{}' in search path: {}\n\
+                 \n\
+                 To fix this, either:\n\
+                 - Install the library with: curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flowstdlib.sh | bash\n\
+                 - Set FLOW_LIB_PATH to the directory containing the library\n\
+                 - Use the -L flag to add a library directory",
                 url,
                 self.lib_search_path
             ),

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -319,7 +319,11 @@ fn load_referenced_implementation(
         .locators
         .get(implementation_url)
         .ok_or(format!(
-            "Could not find ImplementationLocator for '{implementation_url}' in library"
+            "Could not find implementation for '{implementation_url}' in library '{}'.\n\
+             The library may need to be recompiled or reinstalled.\n\
+             For flowstdlib: curl -sL https://github.com/andrewdavidmackenzie/flow/releases/download/v{}/install-flowstdlib.sh | bash",
+            lib_manifest.metadata.name,
+            env!("CARGO_PKG_VERSION")
         ))?;
 
     // find the implementation we need from the locator
@@ -676,7 +680,7 @@ mod test {
         );
         let err_msg = result.expect_err("Expected an error").to_string();
         assert!(
-            err_msg.contains("Could not find ImplementationLocator"),
+            err_msg.contains("Could not find implementation for"),
             "Error should mention missing locator, got: {err_msg}"
         );
     }
@@ -785,7 +789,7 @@ mod test {
         );
         let err_msg = result.expect_err("Expected an error").to_string();
         assert!(
-            err_msg.contains("Could not find ImplementationLocator"),
+            err_msg.contains("Could not find implementation for"),
             "Error should mention missing locator, got: {err_msg}"
         );
     }


### PR DESCRIPTION
## Summary
When library, context, or implementation definitions can't be found at compile or runtime, the error messages now tell the user how to fix the problem:

- **Library not found**: suggests `install-flowstdlib.sh`, `FLOW_LIB_PATH`, or `-L` flag
- **Context directory missing**: suggests `install.sh` or `flowc flowr/src/bin/flowrcli`
- **Implementation not in library**: includes library name and versioned install URL

Example:
```
Could not resolve library 'lib://flowstdlib/math/add' in search path: ...

To fix this, either:
- Install the library with: curl -sL https://github.com/.../install-flowstdlib.sh | bash
- Set FLOW_LIB_PATH to the directory containing the library
- Use the -L flag to add a library directory
```

Closes #2822

## Test plan
- [x] `make clippy` passes
- [x] `make test` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for context resolution failures with clearer guidance on installing missing context definitions
  * Enhanced error messages for library resolution failures with concrete remediation steps (installation, path configuration, or library directory specification)
  * Provided more detailed error messages when library implementations cannot be found, including version information and remediation commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->