### PR TITLE
Add system installer for complete flow environment (#2811)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,7 @@ jobs:
           cd ..
           gh release upload "${TAG}" "flowstdlib-staging/flowstdlib-${TAG}.tar.xz" --clobber
           gh release upload "${TAG}" install-flowstdlib.sh --clobber
+          gh release upload "${TAG}" install-flow.sh --clobber
 
   build-and-publish-book:
     needs: [ build-and-bundle ]

--- a/README.md
+++ b/README.md
@@ -94,10 +94,23 @@ algorithms in a completely new way. This reminded me of when I got stuck trying 
 University. If you're trying to write a loop ...."you're thinking about it wrong".
 
 ## Installing
-You can install many of the crates from crates.io, but due to unresolved issues in packaging
-non-source files, a total working installation cannot yet be achieved using `cargo install`.
 
-The workaround in the meantime is to clone the repo and build all from source (see below).
+### Quick install (recommended)
+Install the complete flow environment with a single command:
+```bash
+curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flow.sh | bash
+```
+
+This installs all flow binaries (flowc, flowrcli, flowrgui, flowedit, flowrex, flowrdb),
+the standard library (flowstdlib), and runner context definitions.
+
+To install a specific version:
+```bash
+curl -sL https://github.com/andrewdavidmackenzie/flow/releases/download/v1.2.0/install-flow.sh | bash
+```
+
+### Building from source
+Alternatively, clone the repo and build from source (see below).
 
 ## Building `flow`
 For more details on how to build flow locally and contribute to it, please see

--- a/install-flow.sh
+++ b/install-flow.sh
@@ -7,7 +7,7 @@
 # Or with a specific version:
 #   curl -sL https://github.com/andrewdavidmackenzie/flow/releases/download/v1.2.0/install-flow.sh | bash
 
-set -e
+set -eo pipefail
 
 REPO="andrewdavidmackenzie/flow"
 VERSION="${1:-latest}"
@@ -27,10 +27,17 @@ case "$OS" in
         esac
         ;;
     Darwin*)
-        TARGET="aarch64-apple-darwin"
+        case "$ARCH" in
+            arm64|aarch64) TARGET="aarch64-apple-darwin" ;;
+            *) echo "Unsupported macOS architecture: $ARCH"; exit 1 ;;
+        esac
         ;;
     MINGW*|MSYS*|CYGWIN*)
-        TARGET="x86_64-pc-windows-msvc"
+        case "$ARCH" in
+            x86_64)        TARGET="x86_64-pc-windows-msvc" ;;
+            arm64|aarch64) TARGET="aarch64-pc-windows-msvc" ;;
+            *) echo "Unsupported Windows architecture: $ARCH"; exit 1 ;;
+        esac
         ;;
     *)
         echo "Unsupported OS: $OS"

--- a/install-flow.sh
+++ b/install-flow.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Install the complete flow development environment
+#
+# Usage:
+#   curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flow.sh | bash
+#
+# Or with a specific version:
+#   curl -sL https://github.com/andrewdavidmackenzie/flow/releases/download/v1.2.0/install-flow.sh | bash
+
+set -e
+
+REPO="andrewdavidmackenzie/flow"
+VERSION="${1:-latest}"
+INSTALL_DIR="${FLOW_INSTALL_DIR:-$HOME/.flow/bin}"
+
+# Detect platform
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+    Linux*)
+        case "$ARCH" in
+            x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+            aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+            armv7*)  TARGET="armv7-unknown-linux-gnueabihf" ;;
+            *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+        ;;
+    Darwin*)
+        TARGET="aarch64-apple-darwin"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        TARGET="x86_64-pc-windows-msvc"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Resolve version tag
+if [ "$VERSION" = "latest" ]; then
+    TAG=$(curl -sI "https://github.com/${REPO}/releases/latest" | grep -i "^location:" | sed 's/.*tag\///' | tr -d '\r\n')
+    if [ -z "$TAG" ]; then
+        echo "Error: could not determine latest release tag"
+        exit 1
+    fi
+else
+    TAG="$VERSION"
+fi
+
+echo "Installing flow ${TAG} for ${TARGET}"
+echo ""
+
+# Create temp directory
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Download and extract binaries
+ARCHIVE="flow-${TAG}-${TARGET}.tar.gz"
+if [[ "$TARGET" == *"windows"* ]]; then
+    ARCHIVE="flow-${TAG}-${TARGET}.zip"
+fi
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+echo "Downloading binaries: ${ARCHIVE}..."
+curl -sL "$URL" -o "$TMPDIR/$ARCHIVE"
+cd "$TMPDIR"
+if [[ "$ARCHIVE" == *.zip ]]; then
+    unzip -q "$ARCHIVE"
+else
+    tar xzf "$ARCHIVE"
+fi
+
+# Install binaries
+mkdir -p "$INSTALL_DIR"
+for bin in flowc flowrcli flowrgui flowrex flowrdb flowedit; do
+    if [ -f "$bin" ] || [ -f "$bin.exe" ]; then
+        cp "$bin"* "$INSTALL_DIR/"
+        echo "  Installed $bin"
+    fi
+done
+
+# Install context definitions
+if [ -f "install.sh" ]; then
+    bash install.sh
+fi
+
+# Install flowstdlib
+echo ""
+echo "Downloading flowstdlib..."
+STDLIBURL="https://github.com/${REPO}/releases/download/${TAG}/install-flowstdlib.sh"
+curl -sL "$STDLIBURL" | bash -s -- "$TAG"
+
+# Check PATH
+if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
+    echo ""
+    echo "⚠ Add the install directory to your PATH:"
+    SHELL_NAME=$(basename "$SHELL")
+    case "$SHELL_NAME" in
+        zsh)  echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
+        bash) echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
+        fish) echo "  fish_add_path $INSTALL_DIR" ;;
+        *)    echo "  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
+    esac
+fi
+
+echo ""
+echo "✓ Flow ${TAG} installed successfully!"
+echo ""
+echo "Verify your installation:"
+echo "  flowc --version"
+echo "  flowrcli --version"


### PR DESCRIPTION
## Summary
Add `install-flow.sh` — a single-command installer for the complete flow development environment:

```bash
curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/install-flow.sh | bash
```

The script:
- Detects platform (Linux/macOS/Windows) and architecture (x86_64/aarch64/armv7)
- Downloads the correct release archive
- Installs binaries to `~/.flow/bin/`
- Installs runner context definitions
- Downloads and installs flowstdlib
- Suggests PATH configuration for the user's shell

Also updates README with quick install instructions.

Closes #2811

## Test plan
- [ ] CI passes
- [ ] On next release, verify `curl ... | bash` installs a working environment
- [ ] Verify `flowc --version` and `flowrcli --version` work after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick installation method using a simple curl command, now the recommended way to install the Flow development environment.

* **Documentation**
  * Updated installation guide to emphasize the quick install approach as the primary method, with building from source as an alternative option. Installation now clearly includes all core binaries, standard library, and runner context definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->