### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flowc"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "colored",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "flowcore"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "curl",
  "directories",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "flowedit"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "flowmacro"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "flowcore",
  "proc-macro2",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "flowr"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1457,7 +1457,7 @@ version = "1.0.0"
 
 [[package]]
 name = "flowstdlib"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "error-chain",
  "flowcore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["flowc", "flowstdlib", "flowr", "flowcore", "flowmacro", "flo
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 license = "MIT"
 license-file = "LICENSE"

--- a/flowc/Cargo.toml
+++ b/flowc/Cargo.toml
@@ -43,7 +43,7 @@ debugger = ["flowcore/debugger"] # feature to add output for the debugger
 graph = ["svg"] # feature to enable SVG graph output with -g flag
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "1.1.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
+flowcore = {path = "../flowcore", version = "1.2.0", features = ["context", "file_provider", "http_provider", "meta_provider"]}
 svg = { version = "0.18", optional = true }
 clap = "~4"
 env_logger = "0.11.10"
@@ -60,7 +60,7 @@ colored = "3"
 toml = { version = "1.1.2" }
 
 [dev-dependencies]
-flowcore = {path = "../flowcore", version = "1.1.0", features = ["context"]}
+flowcore = {path = "../flowcore", version = "1.2.0", features = ["context"]}
 tempfile = "3"
 simpath = { version = "~2.5", features = ["urls"]}
 serial_test = "3.5.0"

--- a/flowedit/Cargo.toml
+++ b/flowedit/Cargo.toml
@@ -31,8 +31,8 @@ name = "flowedit"
 path = "src/main.rs"
 
 [dependencies]
-flowcore = { path = "../flowcore", version = "1.1.0", features = ["meta_provider", "context", "file_provider"] }
-flowrclib = { package = "flowc", path = "../flowc", version = "1.1.0" }
+flowcore = { path = "../flowcore", version = "1.2.0", features = ["meta_provider", "context", "file_provider"] }
+flowrclib = { package = "flowc", path = "../flowc", version = "1.2.0" }
 clap = "~4"
 iced = { version = "0.14.0", default-features = false, features = ["canvas", "tokio", "wgpu", "tiny-skia", "wayland", "x11"] }
 simpath = { version = "~2.5", features = ["urls"] }

--- a/flowmacro/Cargo.toml
+++ b/flowmacro/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "~2.0", features =["full"] } #Full is required for ItemFn in macro parsing
 quote = "~1.0"
-flowcore = {path = "../flowcore", version = "1.1.0" }
+flowcore = {path = "../flowcore", version = "1.2.0" }
 toml = "1.1.2"
 proc-macro2 = "1.0"
 

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -72,9 +72,9 @@ max_combination_size = 2
 skip_optional_dependencies = true
 
 [dependencies]
-flowcore = {path = "../flowcore", version = "1.1.0", features = ["context", "file_provider", "http_provider",
+flowcore = {path = "../flowcore", version = "1.2.0", features = ["context", "file_provider", "http_provider",
         "context", "meta_provider"] }
-flowstdlib = {path = "../flowstdlib", version = "1.1.0", optional = true }
+flowstdlib = {path = "../flowstdlib", version = "1.2.0", optional = true }
 clap = "~4"
 log = "0.4.32"
 env_logger = "0.11.10"
@@ -110,4 +110,4 @@ portpicker = "0.1.1"
 iced_test = "0.14.0"
 # These two are needed for examples
 flowr-utilities = { path = "utilities" }
-flowstdlib = {path = "../flowstdlib", version = "1.1.0" }
+flowstdlib = {path = "../flowstdlib", version = "1.2.0" }

--- a/flowstdlib/Cargo.toml
+++ b/flowstdlib/Cargo.toml
@@ -2,7 +2,7 @@
 # Don't inherit from workspace as this is parsed by flowc for MetaData and it is not workspace inheritance aware
 name = "flowstdlib"
 description = "The standard library of functions and flows for 'flow' programs"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 # Inherit the other keys that are not parsed by flowc itself
 license.workspace = true
@@ -23,8 +23,8 @@ name = "flowstdlib"
 path = "src/lib.rs"
 
 [dependencies]
-flowmacro = {path = "../flowmacro", version = "1.1.0" }
-flowcore = {path = "../flowcore", version = "1.1.0" }
+flowmacro = {path = "../flowmacro", version = "1.2.0" }
+flowcore = {path = "../flowcore", version = "1.2.0" }
 simpath = { version = "2", features = ["urls"]}
 url = { version = "2.2", features = ["serde"] }
 serde_json = "1.0"
@@ -33,8 +33,8 @@ error-chain = "0.12.2"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3.5.0"
-flowcore = {path = "../flowcore", version = "1.1.0" }
-flowmacro = {path = "../flowmacro", version = "1.1.0" }
+flowcore = {path = "../flowcore", version = "1.2.0" }
+flowmacro = {path = "../flowmacro", version = "1.2.0" }
 serde_json = { version = "1.0", default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
Version bump for the 1.2.0 Release Packaging milestone.

## What's in 1.2.0
- Windows CI and release support (x86_64 + ARM)
- Raspberry Pi armv7 cross-compilation
- cargo-packager config for native installers (.deb, .dmg, .msi)
- cargo-binstall metadata for pre-built binary discovery
- Platform-standard data directories via `directories` crate
- Context definitions and flowstdlib bundled in release archives
- Self-downloading install scripts (`install-flow.sh`, `install-flowstdlib.sh`)
- Unique per-binary icons
- Better error messages for missing definitions
- ZMQ socket linger fix
- Cross-platform path fixes throughout

## Test plan
- [ ] CI passes
- [ ] After merge, create GitHub release with tag `v1.2.0`
- [ ] Verify release artifacts and install scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.0 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->