### PR TITLE
Fix release workflow: add openssl to macOS deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install zmq binaryen
+        run: brew install zmq binaryen openssl
 
       - name: Install Windows dependencies
         if: runner.os == 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,9 +3342,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.117"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
openssl-sys build fails on macOS release builds. Add openssl to brew install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build dependencies in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->