### PR TITLE
Fix release build: empty OPENSSL_DIR breaks openssl-sys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,16 @@ jobs:
           cd ..
 
       - name: Build release binaries
-        run: cargo build --release --all-features --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [[ "${{ matrix.target }}" == "armv7-unknown-linux-gnueabihf" ]]; then
+            export OPENSSL_STATIC=1
+            export OPENSSL_DIR=/home/runner/openssl-armv7
+          fi
+          cargo build --release --all-features --target ${{ matrix.target }}
         env:
           CC_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
           CXX_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-g++
-          OPENSSL_STATIC: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '1' || '' }}
-          OPENSSL_DIR: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '/home/runner/openssl-armv7' || '' }}
 
       - name: Find and upload release binaries
         shell: bash


### PR DESCRIPTION
The `|| ''` fallback sets OPENSSL_DIR to an empty string instead of leaving it unset. openssl-sys interprets empty OPENSSL_DIR as "look in ./include" which doesn't exist, causing all non-armv7 release builds to fail.

Remove the `|| ''` so the env vars are unset for non-armv7 targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration for cross-compilation environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->