### PR TITLE
Improve first flow description and SVG initializer display (#2839)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,26 @@ curl -sL https://github.com/andrewdavidmackenzie/flow/releases/latest/download/i
 
 ## Your First Flow
 
-Here's a flow that generates the fibonacci sequence — two inputs feed into `add`,
-whose output loops back and also prints to stdout:
+Here's a flow that generates the fibonacci sequence:
 
 <div align="center">
-<img src="first.svg" alt="Fibonacci flow" width="500">
+<img src="first.svg" alt="Fibonacci flow" width="600">
 </div>
+
+This flow has two **functions** connected together:
+- `add` — a library function from `flowstdlib` that adds two numbers
+- `stdout` — a **context function** provided by the runner for printing to the terminal
+
+The `add` function has two inputs (`i1` and `i2`) with **initializers**: `i1` is
+set to `0` and `i2` to `1` at startup (shown as "once" — they're only set once).
+
+Three **connections** carry data between functions:
+- `add`'s output feeds back to its own `i2` input (the next value)
+- The previous `i2` value feeds back to `i1` (a **feedback connection**)
+- `add`'s output also flows to `stdout`, which prints each value
+
+The output of `add` includes the input values, enabling feedback of the
+previous value. The flow runs until integer overflow produces no output.
 
 ```bash
 flowc -r flowrcli flowr/examples/fibonacci    # compile and run

--- a/first.svg
+++ b/first.svg
@@ -1,4 +1,4 @@
-<svg height="270" viewBox="0 0 580 270" width="580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="270" viewBox="-80 -50 610 270" width="610" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>
 .node-subflow rect { cursor: pointer; }
 .node-subflow:hover rect { stroke-width: 3; }
@@ -74,16 +74,16 @@ next value
 </g>
 </g>
 <g>
-<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="10" text-anchor="middle" x="-10" y="115">
-0
+<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="11" text-anchor="middle" x="-20" y="115">
+0 (once)
 </text>
 <g>
 <path d="M 15 115 C 55 115, 10 115, 50 115" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="1.5"/>
 <path d="M 50 115 L 42.63151 118.11535 L 42.63151 111.88465 Z" fill="#4488CC" stroke="none"/>
 </g>
 <title>i1: 0</title>
-<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="10" text-anchor="middle" x="-10" y="135">
-1
+<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="11" text-anchor="middle" x="-20" y="135">
+1 (once)
 </text>
 <g>
 <path d="M 15 135 C 55 135, 10 135, 50 135" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="1.5"/>

--- a/flowc/src/lib/graph/renderer.rs
+++ b/flowc/src/lib/graph/renderer.rs
@@ -60,12 +60,22 @@ pub fn render_flow(flow: &FlowDefinition) -> String {
         }
     }
 
-    let (doc_width, doc_height) = compute_document_size(&layouts);
+    let has_initializers = flow
+        .process_refs
+        .iter()
+        .any(|pr| !pr.initializations.is_empty());
+    let (vb_x, vb_y, doc_width, doc_height) = compute_document_bounds(&layouts, has_initializers);
 
     let document = Document::new()
         .set(
             "viewBox",
-            format!("0 0 {} {}", doc_width.round(), doc_height.round()),
+            format!(
+                "{} {} {} {}",
+                vb_x.round(),
+                vb_y.round(),
+                doc_width.round(),
+                doc_height.round()
+            ),
         )
         .set("width", doc_width)
         .set("height", doc_height)
@@ -360,14 +370,20 @@ fn render_initializers(pr: &ProcessReference, layout: &NodeLayout) -> Group {
             value_str.clone()
         };
 
-        let label_x = px - 60.0;
+        let init_type = match initializer {
+            flowcore::model::input::InputInitializer::Always(_) => "always",
+            flowcore::model::input::InputInitializer::Once(_) => "once",
+        };
+        let label = format!("{truncated} ({init_type})");
+
+        let label_x = px - 70.0;
         let label_y = py;
 
         group = group.add(shapes::centered_text(
             label_x,
             label_y,
-            &truncated,
-            style::PORT_FONT_SIZE,
+            &label,
+            style::PORT_FONT_SIZE + 1.0,
             style::COLOR_INITIALIZER,
         ));
 
@@ -377,7 +393,7 @@ fn render_initializers(pr: &ProcessReference, layout: &NodeLayout) -> Group {
         };
 
         group = group.add(edge::bezier_edge(
-            label_x + 25.0,
+            label_x + 35.0,
             label_y,
             px,
             py,
@@ -391,17 +407,27 @@ fn render_initializers(pr: &ProcessReference, layout: &NodeLayout) -> Group {
     group
 }
 
-fn compute_document_size(layouts: &HashMap<String, NodeLayout>) -> (f32, f32) {
+fn compute_document_bounds(
+    layouts: &HashMap<String, NodeLayout>,
+    has_initializers: bool,
+) -> (f32, f32, f32, f32) {
+    let mut min_x: f32 = 0.0;
+    let mut min_y: f32 = 0.0;
     let mut max_x: f32 = 0.0;
     let mut max_y: f32 = 0.0;
 
     for layout in layouts.values() {
+        min_x = min_x.min(layout.x);
+        min_y = min_y.min(layout.y);
         max_x = max_x.max(layout.x + layout.width);
         max_y = max_y.max(layout.y + layout.height);
     }
 
-    (
-        max_x + style::GRID_ORIGIN_X * 2.0,
-        max_y + style::GRID_ORIGIN_Y * 2.0,
-    )
+    let left_pad = if has_initializers { 80.0 } else { 0.0 };
+    let origin_x = min_x - left_pad;
+    let origin_y = min_y - style::GRID_ORIGIN_Y;
+    let width = max_x - origin_x + style::GRID_ORIGIN_X;
+    let height = max_y - origin_y + style::GRID_ORIGIN_Y;
+
+    (origin_x, origin_y, width, height)
 }


### PR DESCRIPTION
## Summary
- Fix SVG renderer to show initializer labels (were clipped outside viewBox)
- Show initializer type: "0 (once)" instead of just "0"
- Rewrite README first flow section explaining functions, context functions, initializers, feedback connections

Closes #2839

## Test plan
- [x] `make clippy` passes
- [ ] CI passes
- [ ] SVG renders correctly on GitHub with initializers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)