### PR TITLE
Add --stdin-file option to flowrgui (#2845)

### DIFF
--- a/book/running/flowr.md
+++ b/book/running/flowr.md
@@ -72,6 +72,23 @@ Similar to `flowrcli` that interacts with the terminal and the file system for I
 for flows, but with a Graphical User Interface (GUI). It displays STDIO and STDERR on the UI, shows images written
 to visually and tracks writes to files during execution.
 
-Most (but not all) of the same command line options as `flowrcli` are supported, and help can be see using:
+Most (but not all) of the same command line options as `flowrcli` are supported, and help can be seen using:
 
 `flowrgui --help`
+
+#### `--stdin-file <FILE>`
+Read stdin lines from a file or named pipe instead of the GUI text input.
+Each line appears in the stdin tab as if typed by the user, and is consumed
+by `readline` context functions in the flow.
+
+This is useful for streaming data into a flow running in the GUI:
+
+```bash
+# Read from a file
+flowrgui --stdin-file test.stdin flowr/examples/running-average
+
+# Stream from a named pipe
+mkfifo /tmp/data_pipe
+./generate_data.sh > /tmp/data_pipe &
+flowrgui --stdin-file /tmp/data_pipe flowr/examples/weather-station
+```

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1425,6 +1425,7 @@ impl FlowrGui {
 
                     let (tx, mut rx) = tokio::sync::mpsc::channel::<Option<String>>(100);
 
+                    info!("stdin-file: reading from '{}'", path.display());
                     tokio::task::spawn_blocking(move || {
                         use std::io::BufRead;
                         let file = match std::fs::File::open(&path) {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -25,6 +25,7 @@ use core::str::FromStr;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::{env, process, thread};
 
 use clap::Command as ClapCommand;
@@ -753,6 +754,7 @@ enum PanelKind {
 struct UiSettings {
     auto_start: bool,
     auto_exit: bool,
+    stdin_file: Option<PathBuf>,
 }
 
 struct ImageReference {
@@ -1375,8 +1377,14 @@ impl FlowrGui {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        let coordinator_sub = connection_manager::subscribe(self.coordinator_settings.clone())
-            .map(Message::CoordinatorSent);
+        let mut subs = vec![
+            connection_manager::subscribe(self.coordinator_settings.clone())
+                .map(Message::CoordinatorSent),
+        ];
+
+        if let Some(ref path) = self.ui_settings.stdin_file {
+            subs.push(Self::stdin_file_subscription(path.clone()));
+        }
 
         #[cfg(feature = "debugger")]
         if self.debug_client_active {
@@ -1396,18 +1404,61 @@ impl FlowrGui {
                 }
             };
             if let Some(addr) = address {
-                return Subscription::batch([
-                    coordinator_sub,
-                    connection_manager::debug_client_subscribe(addr),
-                ]);
+                subs.push(connection_manager::debug_client_subscribe(addr));
             }
         }
 
-        coordinator_sub
+        Subscription::batch(subs)
     }
 }
 
 impl FlowrGui {
+    fn stdin_file_subscription(path: PathBuf) -> Subscription<Message> {
+        static STDIN_FILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+        STDIN_FILE_PATH.get_or_init(|| path);
+        Subscription::run(|| {
+            let path = STDIN_FILE_PATH.get().cloned().unwrap_or_default();
+            iced::stream::channel(
+                100,
+                move |mut sender: iced::futures::channel::mpsc::Sender<Message>| async move {
+                    use iced::futures::SinkExt;
+
+                    let (tx, mut rx) = tokio::sync::mpsc::channel::<Option<String>>(100);
+
+                    tokio::task::spawn_blocking(move || {
+                        use std::io::BufRead;
+                        let file = match std::fs::File::open(&path) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                info!("Could not open stdin file '{}': {e}", path.display());
+                                return;
+                            }
+                        };
+                        for line in std::io::BufReader::new(file).lines() {
+                            match line {
+                                Ok(l) => {
+                                    if tx.blocking_send(Some(l)).is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        let _ = tx.blocking_send(None);
+                    });
+
+                    while let Some(Some(line)) = rx.recv().await {
+                        if sender.send(Message::LineOfStdin(line)).await.is_err() {
+                            break;
+                        }
+                    }
+                    let _ = sender.send(Message::SendEof).await;
+                    std::future::pending::<()>().await;
+                },
+            )
+        })
+    }
+
     #[allow(clippy::unused_async)]
     async fn auto_submit() {
         info!("Auto submitting flow");
@@ -2882,6 +2933,7 @@ impl FlowrGui {
 
         let auto = matches.get_flag("auto");
         let mut auto_start = auto || matches.get_flag("auto-start");
+        let stdin_file = matches.get_one::<String>("stdin-file").map(PathBuf::from);
         #[cfg(feature = "debugger")]
         if debug_mode != DebugMode::Off
             && !matches!(coordinator_settings, CoordinatorSettings::ClientOnly)
@@ -2929,6 +2981,7 @@ impl FlowrGui {
             UiSettings {
                 auto_start,
                 auto_exit: auto,
+                stdin_file,
             },
         )
     }
@@ -2990,6 +3043,13 @@ impl FlowrGui {
                 .long("auto-start")
                 .action(clap::ArgAction::SetTrue)
                 .help("Run the flow automatically on start-up, but stay open for interaction."),
+        );
+
+        let app = app.arg(
+            Arg::new("stdin-file")
+                .long("stdin-file")
+                .value_name("FILE")
+                .help("Read stdin lines from a file or named pipe instead of the GUI input"),
         );
 
         let app = app
@@ -3704,6 +3764,7 @@ mod test {
             ui_settings: UiSettings {
                 auto_start: false,
                 auto_exit: false,
+                stdin_file: None,
             },
             coordinator_state: CoordinatorState::Disconnected("test".into()),
             tab_set: TabSet::new(),


### PR DESCRIPTION
## Summary
- Add `--stdin-file <FILE>` CLI option to flowrgui that reads stdin lines from a file or named pipe
- Lines are read asynchronously via an iced subscription using `spawn_blocking` + tokio channel
- Each line is emitted as `Message::LineOfStdin`, appearing in the GUI stdin tab as if typed by the user
- On EOF, `Message::SendEof` is emitted
- Works with named pipes for continuous streaming (e.g. weather station data generator)

## Usage
```bash
# Read from a file
flowrgui --stdin-file test.stdin flowr/examples/weather-station

# Stream from a named pipe
mkfifo /tmp/weather_pipe
./flowr/examples/weather-station/generate_data.sh > /tmp/weather_pipe &
flowrgui --stdin-file /tmp/weather_pipe flowr/examples/weather-station
```

## Test plan
- [x] `make clippy` clean
- [x] `make test` all pass
- [ ] Manual test: `flowrgui --stdin-file flowr/examples/weather-station/test.stdin flowr/examples/weather-station` — values appear in stdin tab
- [ ] Manual test: named pipe streaming with generate_data.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--stdin-file` command-line option to enable reading GUI input from a specified file or named pipe instead of only from standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->