### PR TITLE
Add job retry mechanism for lost remote executor jobs (#1563)

### DIFF
--- a/flowcore/src/model/job.rs
+++ b/flowcore/src/model/job.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Instant;
 
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
@@ -37,6 +38,36 @@ pub struct Job {
     pub result: Result<(Option<Value>, RunAgain)>,
     /// The destinations (other function's inputs) where any output should be sent
     pub connections: Vec<OutputConnection>,
+    /// When this job expires and should be considered lost (coordinator-local, not sent over wire)
+    #[serde(skip)]
+    pub ttl: Option<Instant>,
+    /// How many times this job has been attempted (coordinator-local, not sent over wire)
+    #[serde(skip)]
+    pub attempt: usize,
+}
+
+impl Job {
+    /// Create a new `Job` with default TTL and attempt count
+    #[must_use]
+    pub fn new(
+        process_id: usize,
+        parent_id: usize,
+        #[cfg(feature = "debugger")] function_name: String,
+        payload: Payload,
+        connections: Vec<OutputConnection>,
+    ) -> Self {
+        Self {
+            process_id,
+            parent_id,
+            #[cfg(feature = "debugger")]
+            function_name,
+            payload,
+            result: Ok((None, false)),
+            connections,
+            ttl: None,
+            attempt: 1,
+        }
+    }
 }
 
 impl fmt::Display for Job {
@@ -87,6 +118,8 @@ mod test {
                     .expect("Could not parse Url"),
             },
             result: Ok((None, false)),
+            ttl: None,
+            attempt: 1,
         };
         println!("Job: {job}");
     }
@@ -106,6 +139,8 @@ mod test {
                     .expect("Could not parse Url"),
             },
             result: Ok((Some(json!(42u64)), false)),
+            ttl: None,
+            attempt: 1,
         };
 
         assert_eq!(
@@ -137,6 +172,8 @@ mod test {
                     .expect("Could not parse Url"),
             },
             result: Ok((Some(json!(value)), false)),
+            ttl: None,
+            attempt: 1,
         };
 
         assert_eq!(

--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -16,6 +16,7 @@ pub struct Metrics {
     start_time: Instant,
     elapsed_time_seconds: u64,
     max_simultaneous_jobs: usize,
+    jobs_retried: usize,
     jobs_per_function: Vec<usize>,
     function_names: Vec<(String, String)>,
 }
@@ -31,6 +32,7 @@ impl Metrics {
             start_time: Instant::now(),
             elapsed_time_seconds: 0,
             max_simultaneous_jobs: 0,
+            jobs_retried: 0,
             jobs_per_function: vec![0; num_processes],
             function_names: Vec::new(),
         }
@@ -57,6 +59,7 @@ impl Metrics {
         self.outputs_sent = 0;
         self.start_time = Instant::now();
         self.max_simultaneous_jobs = 0;
+        self.jobs_retried = 0;
         self.jobs_per_function.fill(0);
     }
 
@@ -90,6 +93,11 @@ impl Metrics {
         self.outputs_sent += 1;
     }
 
+    /// Increment the count of jobs that were retried after expiring
+    pub fn increment_jobs_retried(&mut self) {
+        self.jobs_retried += 1;
+    }
+
     /// Keep track of the maximum jobs that are executing in parallel during a flows
     /// execution, as a measure of the maximum level of parallelism achieved
     pub fn track_max_jobs(&mut self, jobs_running: usize) {
@@ -116,6 +124,9 @@ impl fmt::Display for Metrics {
         writeln!(f, "Values sent: {}", self.outputs_sent)?;
         writeln!(f, "Elapsed time(s): {:.*}", 1, self.elapsed_time_seconds)?;
         writeln!(f, "Max Jobs in Parallel: {}", self.max_simultaneous_jobs)?;
+        if self.jobs_retried > 0 {
+            writeln!(f, "Jobs Retried: {}", self.jobs_retried)?;
+        }
         write!(f, "Jobs per Function:")?;
         for (id, &count) in self.jobs_per_function.iter().enumerate() {
             if count > 0 {

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -26,6 +26,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::{env, thread};
 
 use clap::{Arg, ArgMatches, Command};
@@ -380,10 +381,13 @@ fn client(
     let parallel_jobs_limit = matches
         .get_one::<usize>("jobs")
         .map(std::borrow::ToOwned::to_owned);
+    let job_timeout = matches
+        .get_one::<u64>("job-timeout")
+        .map(|secs| Duration::from_secs(*secs));
     let submission = Submission::new(
         flow_manifest,
         parallel_jobs_limit,
-        None, // No timeout waiting for job results
+        job_timeout,
         #[cfg(feature = "debugger")]
         debug_this_flow,
     );
@@ -471,6 +475,12 @@ fn get_matches() -> ArgMatches {
             .value_parser(clap::value_parser!(usize))
             .value_name("MAX_JOBS")
             .help("Set maximum number of jobs that can be running in parallel)"))
+        .arg(Arg::new("job-timeout")
+            .long("job-timeout")
+            .number_of_values(1)
+            .value_parser(clap::value_parser!(u64))
+            .value_name("SECONDS")
+            .help("Set timeout in seconds for job execution (lost jobs are retried)"))
         .arg(Arg::new("lib_dir")
             .short('L')
             .long("libdir")

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -478,7 +478,7 @@ fn get_matches() -> ArgMatches {
         .arg(Arg::new("job-timeout")
             .long("job-timeout")
             .number_of_values(1)
-            .value_parser(clap::value_parser!(u64))
+            .value_parser(clap::value_parser!(u64).range(1..))
             .value_name("SECONDS")
             .help("Set timeout in seconds for job execution (lost jobs are retried)"))
         .arg(Arg::new("lib_dir")

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3057,7 +3057,7 @@ impl FlowrGui {
             .arg(Arg::new("job-timeout")
                 .long("job-timeout")
                 .number_of_values(1)
-                .value_parser(clap::value_parser!(u64))
+                .value_parser(clap::value_parser!(u64).range(1..))
                 .value_name("SECONDS")
                 .help("Set timeout in seconds for job execution (lost jobs are retried)"))
             .arg(Arg::new("lib_dir")

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2925,6 +2925,9 @@ impl FlowrGui {
         let auto = matches.get_flag("auto");
         let mut auto_start = auto || matches.get_flag("auto-start");
         let stdin_file = matches.get_one::<String>("stdin-file").map(PathBuf::from);
+        let job_timeout_text = matches
+            .get_one::<u64>("job-timeout")
+            .map_or_else(String::new, std::string::ToString::to_string);
         #[cfg(feature = "debugger")]
         if debug_mode != DebugMode::Off
             && !matches!(coordinator_settings, CoordinatorSettings::ClientOnly)
@@ -2958,7 +2961,7 @@ impl FlowrGui {
                 flow_manifest_url,
                 flow_args,
                 max_jobs_text: parallel_jobs_limit.map_or(String::new(), |n| n.to_string()),
-                job_timeout_text: String::new(),
+                job_timeout_text,
                 debug_this_flow,
                 parallel_jobs_limit,
                 #[cfg(feature = "debugger")]
@@ -3051,6 +3054,12 @@ impl FlowrGui {
                 .value_parser(clap::value_parser!(usize))
                 .value_name("MAX_JOBS")
                 .help("Set maximum number of jobs that can be running in parallel)"))
+            .arg(Arg::new("job-timeout")
+                .long("job-timeout")
+                .number_of_values(1)
+                .value_parser(clap::value_parser!(u64))
+                .value_name("SECONDS")
+                .help("Set timeout in seconds for job execution (lost jobs are retried)"))
             .arg(Arg::new("lib_dir")
                 .short('L')
                 .long("libdir")

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -1,5 +1,6 @@
 #[cfg(all(not(feature = "debugger"), not(feature = "submission")))]
 use std::marker::PhantomData;
+use std::time::{Duration, Instant};
 
 use log::{debug, error, info, trace};
 use serde_json::Value;
@@ -34,6 +35,8 @@ pub struct Coordinator<'a> {
     submission_handler: &'a mut dyn SubmissionHandler,
     /// Dispatcher to dispatch jobs for execution
     dispatcher: Dispatcher,
+    /// Maximum time to wait for a job result before considering it lost
+    job_timeout: Option<Duration>,
     #[cfg(feature = "debugger")]
     /// A `Debugger` to communicate with debug clients
     debugger: Debugger<'a>,
@@ -42,6 +45,8 @@ pub struct Coordinator<'a> {
 }
 
 impl<'a> Coordinator<'a> {
+    const MAX_JOB_RETRIES: usize = 3;
+
     /// Create a new `coordinator` with `num_threads` local executor threads
     pub fn new(
         dispatcher: Dispatcher,
@@ -52,6 +57,7 @@ impl<'a> Coordinator<'a> {
             #[cfg(feature = "submission")]
             submission_handler: submitter,
             dispatcher,
+            job_timeout: None,
             #[cfg(feature = "debugger")]
             debugger: Debugger::new(debug_server),
             #[cfg(all(not(feature = "debugger"), not(feature = "submission")))]
@@ -95,6 +101,7 @@ impl<'a> Coordinator<'a> {
         clippy::too_many_lines
     )]
     pub fn execute_flow(&mut self, submission: Submission) -> Result<()> {
+        self.job_timeout = submission.job_timeout;
         self.dispatcher
             .set_results_timeout(submission.job_timeout)?;
         let mut state = RunState::new(submission);
@@ -261,6 +268,15 @@ impl<'a> Coordinator<'a> {
         let mut restart = false;
 
         if state.number_jobs_running() > 0 {
+            // Check for expired jobs and re-queue them
+            if self.job_timeout.is_some() {
+                state.requeue_expired_jobs(
+                    Self::MAX_JOB_RETRIES,
+                    #[cfg(feature = "metrics")]
+                    metrics,
+                )?;
+            }
+
             match self.get_result(state) {
                 Ok(Some(result)) => {
                     let job;
@@ -339,7 +355,7 @@ impl<'a> Coordinator<'a> {
     // Dispatch a job for execution
     fn dispatch_a_job(
         &mut self,
-        job: Job,
+        mut job: Job,
         state: &mut RunState,
         #[cfg(feature = "metrics")] metrics: &mut Metrics,
     ) -> Result<(bool, bool)> {
@@ -351,6 +367,7 @@ impl<'a> Coordinator<'a> {
 
         self.dispatcher.send_job_for_execution(&job.payload)?;
 
+        job.ttl = self.job_timeout.map(|d| Instant::now() + d);
         state.start_job(job);
 
         #[cfg(feature = "metrics")]

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -367,7 +367,7 @@ impl<'a> Coordinator<'a> {
 
         self.dispatcher.send_job_for_execution(&job.payload)?;
 
-        job.ttl = self.job_timeout.map(|d| Instant::now() + d);
+        job.ttl = self.job_timeout.and_then(|d| Instant::now().checked_add(d));
         state.start_job(job);
 
         #[cfg(feature = "metrics")]

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -1196,6 +1196,8 @@ mod test {
                 input_set: vec![json!(1)],
             },
             result: Ok((Some(json!(1)), true)),
+            ttl: None,
+            attempt: 1,
         }
     }
 

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -913,6 +913,8 @@ mod test {
                     .expect("Could not parse Url"),
             },
             result: Ok((None, false)),
+            ttl: None,
+            attempt: 1,
         };
 
         let job2 = Job {
@@ -928,6 +930,8 @@ mod test {
                     .expect("Could not parse Url"),
             },
             result: Ok((None, false)),
+            ttl: None,
+            attempt: 1,
         };
 
         let job3 = Job {
@@ -942,6 +946,8 @@ mod test {
                 implementation_url: Url::parse("file://fake/path").expect("Could not parse Url"),
             },
             result: Ok((None, false)),
+            ttl: None,
+            attempt: 1,
         };
 
         for job in [job1, job2, job3] {

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -365,10 +365,12 @@ impl RunState {
 
         for job_id in expired_ids {
             if let Some(mut job) = self.running_jobs.remove(&job_id) {
-                if job.attempt >= max_retries {
+                if job.attempt > max_retries {
                     return Err(format!(
-                        "Job #{} (function #{}) failed after {} attempts",
-                        job_id, job.process_id, job.attempt
+                        "Job #{} (function #{}) failed after {} retries",
+                        job_id,
+                        job.process_id,
+                        job.attempt - 1
                     )
                     .into());
                 }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1,8 +1,9 @@
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::time::Instant;
 
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -346,6 +347,46 @@ impl RunState {
         self.running_jobs.insert(job.payload.job_id, job);
     }
 
+    /// Check for running jobs that have exceeded their TTL.
+    /// Expired jobs are removed from `running_jobs` and re-queued with an incremented attempt count.
+    /// Returns `Err` if any job has exceeded `max_retries`.
+    pub(crate) fn requeue_expired_jobs(
+        &mut self,
+        max_retries: usize,
+        #[cfg(feature = "metrics")] metrics: &mut Metrics,
+    ) -> Result<()> {
+        let now = Instant::now();
+        let expired_ids: Vec<usize> = self
+            .running_jobs
+            .iter()
+            .filter(|(_, job)| job.ttl.is_some_and(|ttl| ttl < now))
+            .map(|(id, _)| *id)
+            .collect();
+
+        for job_id in expired_ids {
+            if let Some(mut job) = self.running_jobs.remove(&job_id) {
+                if job.attempt >= max_retries {
+                    return Err(format!(
+                        "Job #{} (function #{}) failed after {} attempts",
+                        job_id, job.process_id, job.attempt
+                    )
+                    .into());
+                }
+                warn!(
+                    "Job #{} (function #{}) expired after attempt {}, re-queuing",
+                    job_id, job.process_id, job.attempt
+                );
+                job.attempt += 1;
+                job.ttl = None;
+                #[cfg(feature = "metrics")]
+                metrics.increment_jobs_retried();
+                self.ready_jobs.push_back(job);
+            }
+        }
+
+        Ok(())
+    }
+
     /// get the number of jobs created to date in the flow's execution
     #[cfg(any(feature = "metrics", feature = "debugger"))]
     #[must_use]
@@ -613,19 +654,18 @@ impl RunState {
                 debug!(
                     "Job #{job_id} created for Function #{process_id}({parent_id}) with inputs: {input_set:?}"
                 );
-                let job = Job {
+                let job = Job::new(
                     process_id,
                     parent_id,
                     #[cfg(feature = "debugger")]
-                    function_name: function.name().to_string(),
-                    connections: function.get_output_connections().clone(),
-                    payload: Payload {
+                    function.name().to_string(),
+                    Payload {
                         job_id,
                         input_set,
                         implementation_url,
                     },
-                    result: Ok((None, false)),
-                };
+                    function.get_output_connections().clone(),
+                );
 
                 // avoid getting stuck in a loop generating jobs for a function - generate just one
                 let always_ready = function.is_always_ready();
@@ -1004,6 +1044,8 @@ mod test {
                 input_set: vec![json!(1)],
             },
             result: Ok((Some(json!(1)), true)),
+            ttl: None,
+            attempt: 1,
         }
     }
 
@@ -1322,6 +1364,8 @@ mod test {
                     input_set: vec![json!(1)],
                 },
                 result: Ok((None, true)),
+                ttl: None,
+                attempt: 1,
             }
         }
 


### PR DESCRIPTION
Closes #1563

## Summary
- Add TTL-based job retry: when a job's time-to-live expires, it's considered lost and re-queued with incremented attempt count
- Jobs exceeding 3 retries cause flow failure
- `ttl` and `attempt` fields on `Job` are coordinator-local (`#[serde(skip)]`) — not sent over the wire to executors
- Add `--job-timeout <SECONDS>` CLI option to both flowrcli and flowrgui
- flowrgui settings panel already had a job timeout text field, now also settable via CLI
- Add `jobs_retried` counter to `Metrics`

## How it works
1. When a job is dispatched, `ttl` is set to `Instant::now() + job_timeout`
2. Each time the coordinator retires a job result, it scans `running_jobs` for expired jobs
3. Expired jobs are removed from `running_jobs` and pushed back to `ready_jobs` with `attempt += 1`
4. If `attempt >= MAX_JOB_RETRIES (3)`, the flow fails with an error
5. Late results for already-retried jobs are ignored (job_id no longer in `running_jobs`)

## Test plan
- [x] `make clippy` clean
- [x] `make test` all pass
- [ ] Manual test: run with `--job-timeout 5` and verify normal execution completes without retry
- [ ] Integration test with remote executor and induced delay (future work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)