### PR TITLE
Use compiler type checks in flowedit

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,13 +105,7 @@ jobs:
       - name: build-flowstdlib
         run: |
           target/debug/flowc -d -g -O flowstdlib
-          echo "FLOW_LIB_DIR=$(target/debug/flowc --lib-dir 2>/dev/null || echo $HOME/.local/share/flow/lib)" >> "$GITHUB_ENV"
-
-      - name: find-flowstdlib
-        run: |
-          FLOWSTDLIB_DIR=$(find $HOME -type d -name flowstdlib -path "*/flow/lib/*" 2>/dev/null | head -1)
-          echo "Flowstdlib at: $FLOWSTDLIB_DIR"
-          echo "FLOWSTDLIB_DIR=$FLOWSTDLIB_DIR" >> "$GITHUB_ENV"
+          echo "FLOWSTDLIB_DIR=$(target/debug/flowc --print-lib-dir)/flowstdlib" >> "$GITHUB_ENV"
 
       - name: upload-flowstdlib
         uses: actions/upload-artifact@v4
@@ -127,8 +121,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-26, ubuntu-24.04, ubuntu-24.04-arm, windows-latest ]
-
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     steps:
       - name: Checkout
@@ -192,11 +184,9 @@ jobs:
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            FLOW_LIB="$APPDATA/flow/lib"
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            FLOW_LIB="$HOME/Library/Application Support/flow/lib"
+            FLOW_LIB=$(target/debug/flowc.exe --print-lib-dir)
           else
-            FLOW_LIB="$HOME/.local/share/flow/lib"
+            FLOW_LIB=$(target/debug/flowc --print-lib-dir)
           fi
           mkdir -p "$FLOW_LIB/flowstdlib"
           echo "FLOW_LIB_DIR=$FLOW_LIB" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,12 +209,9 @@ jobs:
         shell: bash
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          FLOW_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/flow"
-          if [ ! -d "$FLOW_DATA/lib/flowstdlib" ] && [ -d "$HOME/.flow/lib/flowstdlib" ]; then
-            FLOW_DATA="$HOME/.flow"
-          fi
+          FLOW_LIB=$(target/x86_64-unknown-linux-gnu/release/flowc --print-lib-dir)
           mkdir -p flowstdlib-staging
-          cp -r "$FLOW_DATA/lib/flowstdlib" flowstdlib-staging/
+          cp -r "$FLOW_LIB/flowstdlib" flowstdlib-staging/
           cp install-flowstdlib.sh flowstdlib-staging/
           cd flowstdlib-staging
           tar -cJf "flowstdlib-${TAG}.tar.xz" flowstdlib install-flowstdlib.sh

--- a/flowc/src/bin/flowc/main.rs
+++ b/flowc/src/bin/flowc/main.rs
@@ -21,7 +21,7 @@ use serde_derive::Deserialize;
 use simpath::Simpath;
 use url::Url;
 
-use errors::{Result, ResultExt};
+use errors::{bail, Result, ResultExt};
 use flowcore::meta_provider::MetaProvider;
 use flowcore::url_helper::url_from_string;
 use flowrclib::info;
@@ -145,7 +145,19 @@ fn compile_type(url: &Url) -> Result<CompileType> {
     a message to display to the user if all went OK
 */
 fn run() -> Result<()> {
-    let options = parse_args(&get_matches())?;
+    let matches = get_matches();
+
+    if matches.get_flag("print_lib_dir") {
+        match flowcore::dirs::lib_dir() {
+            Some(dir) => {
+                println!("{}", dir.display());
+                return Ok(());
+            }
+            None => bail!("Could not determine the default library directory"),
+        }
+    }
+
+    let options = parse_args(&matches)?;
     let mut lib_search_path = get_lib_search_path(&options.lib_dirs);
 
     let compile_type = compile_type(&options.source_url)?;
@@ -301,8 +313,15 @@ fn get_matches() -> ArgMatches {
                 .help("Read STDIN from the named file"),
         )
         .arg(
+            Arg::new("print_lib_dir")
+                .long("print-lib-dir")
+                .action(clap::ArgAction::SetTrue)
+                .help("Print the default library directory path and exit"),
+        )
+        .arg(
             Arg::new("source_url")
                 .num_args(1)
+                .required(false)
                 .help("path or url for the flow or library to compile")
         )
         .arg(
@@ -335,11 +354,11 @@ fn parse_args(matches: &ArgMatches) -> Result<Options> {
     let cwd_url = Url::from_directory_path(cwd)
         .map_err(|()| "Could not form a Url for the current working directory")?;
 
-    let source_url = url_from_string(
-        &cwd_url,
-        matches.get_one::<String>("source_url").map(String::as_str),
-    )
-    .chain_err(|| "Could not create a url for flow from the 'FLOW' command line parameter")?;
+    let source_str = matches
+        .get_one::<String>("source_url")
+        .ok_or("A flow or library source path is required")?;
+    let source_url = url_from_string(&cwd_url, Some(source_str.as_str()))
+        .chain_err(|| "Could not create a url for flow from the 'FLOW' command line parameter")?;
 
     let lib_dirs = if matches.contains_id("lib_dir") {
         matches

--- a/flowcore/src/dirs.rs
+++ b/flowcore/src/dirs.rs
@@ -3,10 +3,7 @@
 //! Uses the `directories` crate to find the correct location per platform:
 //! - Linux: `~/.local/share/flow/`
 //! - macOS: `~/Library/Application Support/flow/`
-//! - Windows: `C:\Users\{user}\AppData\Roaming\flow\`
-//!
-//! Falls back to the legacy `~/.flow/` location if the standard path doesn't
-//! exist but the legacy one does, for backward compatibility.
+//! - Windows: `C:\Users\{user}\AppData\Roaming\flow\data\`
 
 use std::path::PathBuf;
 
@@ -16,35 +13,10 @@ fn project_dirs() -> Option<ProjectDirs> {
     ProjectDirs::from("", "", "flow")
 }
 
-fn legacy_dir() -> Option<PathBuf> {
-    std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .ok()
-        .map(|h| PathBuf::from(h).join(".flow"))
-}
-
 /// Return the base data directory for flow.
-/// Prefers the standard platform directory, falls back to `~/.flow/` if it exists.
 #[must_use]
 pub fn data_dir() -> Option<PathBuf> {
-    let standard = project_dirs().map(|dirs| dirs.data_dir().to_path_buf());
-
-    // If the standard path exists, use it
-    if let Some(ref dir) = standard {
-        if dir.exists() {
-            return standard;
-        }
-    }
-
-    // If the legacy path exists, use it for backward compatibility
-    if let Some(legacy) = legacy_dir() {
-        if legacy.exists() {
-            return Some(legacy);
-        }
-    }
-
-    // Neither exists — return the standard path (it will be created on first use)
-    standard
+    project_dirs().map(|dirs| dirs.data_dir().to_path_buf())
 }
 
 /// Return the default library directory (`{data_dir}/lib/`).

--- a/flowedit/src/file_ops.rs
+++ b/flowedit/src/file_ops.rs
@@ -22,7 +22,7 @@ pub(crate) struct EditorPrefs {
     pub(crate) y: Option<f32>,
 }
 
-/// Build a `MetaProvider` with `FLOW_LIB_PATH` (plus `~/.flow/lib` default)
+/// Build a `MetaProvider` with `FLOW_LIB_PATH` (plus platform default lib dir)
 /// and the default flowrcli context root.
 pub(crate) fn build_meta_provider() -> MetaProvider {
     let mut lib_search_path = Simpath::new_with_separator("FLOW_LIB_PATH", ',');
@@ -38,7 +38,7 @@ pub(crate) fn build_meta_provider() -> MetaProvider {
 }
 
 /// Resolve the library search paths from the `FLOW_LIB_PATH` environment variable
-/// and the default `~/.flow/lib` directory.
+/// and the platform default library directory.
 pub(crate) fn resolve_lib_paths() -> Vec<String> {
     let mut paths = Vec::new();
 

--- a/flowedit/src/library_mgmt.rs
+++ b/flowedit/src/library_mgmt.rs
@@ -68,7 +68,7 @@ pub(crate) fn load_library_catalogs(
     }
 
     // Discover and parse context functions from the flowrcli runner directory.
-    // Only scan ~/.flow/runner/flowrcli/ since flowedit only supports the flowrcli runner,
+    // Only scan the flowrcli runner dir since flowedit only supports the flowrcli runner,
     // and the MetaProvider is configured with that context root.
     let ctx_provider = file_ops::build_meta_provider();
     let runner_dir = flowcore::dirs::runner_dir("flowrcli").unwrap_or_default();

--- a/flowedit/src/ui_test.rs
+++ b/flowedit/src/ui_test.rs
@@ -1482,10 +1482,8 @@ fn load_mandlebrot_app() -> (FlowEdit, window::Id, std::path::PathBuf) {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
 
-    // Ensure ~/.flow/lib is on FLOW_LIB_PATH so lib:// URLs resolve.
-    // Only adds if not already present — idempotent across concurrent calls.
-    if let Ok(home) = std::env::var("HOME") {
-        let default_lib = std::path::PathBuf::from(&home).join(".flow").join("lib");
+    // Ensure default lib dir is on FLOW_LIB_PATH so lib:// URLs resolve.
+    if let Some(default_lib) = flowcore::dirs::lib_dir() {
         if default_lib.exists() {
             let current = std::env::var("FLOW_LIB_PATH").unwrap_or_default();
             let default_str = default_lib.to_string_lossy();

--- a/flowedit/src/utils.rs
+++ b/flowedit/src/utils.rs
@@ -4,6 +4,7 @@ use iced::widget::canvas;
 use iced::{Point, Size};
 
 use flowcore::model::connection::Connection;
+use flowcore::model::datatype::DataType;
 use flowcore::model::io::IO;
 use flowcore::model::name::HasName;
 use flowcore::model::route::Route;
@@ -137,11 +138,8 @@ pub(crate) fn rounded_rect(
     builder.close();
 }
 
-/// Check if the types of two ports are compatible for a connection.
-///
-/// Returns true if:
-/// - Either port has no type info (unknown types are assumed compatible)
-/// - At least one type from the source port matches a type on the destination port
+/// Check if the types of two ports are compatible for a connection,
+/// using the same type compatibility logic as the compiler.
 pub(crate) fn check_port_type_compatibility(
     source_node: Option<&NodeLayout>,
     source_port: &str,
@@ -150,7 +148,7 @@ pub(crate) fn check_port_type_compatibility(
     target_port: &str,
     target_is_output: bool,
 ) -> bool {
-    let source_types = source_node.and_then(|n| {
+    let source_io = source_node.and_then(|n| {
         let ports = if source_is_output {
             n.outputs()
         } else {
@@ -159,7 +157,7 @@ pub(crate) fn check_port_type_compatibility(
         ports.iter().find(|p| p.name() == source_port)
     });
 
-    let target_types = {
+    let target_io = {
         let ports = if target_is_output {
             target_node.outputs()
         } else {
@@ -168,35 +166,14 @@ pub(crate) fn check_port_type_compatibility(
         ports.iter().find(|p| p.name() == target_port)
     };
 
-    match (source_types, target_types) {
+    match (source_io, target_io) {
         (Some(src), Some(tgt)) => {
-            log::info!(
-                "Type check: src port '{}' types {:?} → tgt port '{}' types {:?}",
-                src.name(),
-                src.datatypes(),
-                tgt.name(),
-                tgt.datatypes()
-            );
-            let src_untyped = src.datatypes().is_empty()
-                || src.datatypes().iter().all(|d| d.to_string().is_empty());
-            let tgt_untyped = tgt.datatypes().is_empty()
-                || tgt.datatypes().iter().all(|d| d.to_string().is_empty());
-            if src_untyped || tgt_untyped {
+            if src.datatypes().is_empty() || tgt.datatypes().is_empty() {
                 return true;
             }
-            src.datatypes()
-                .iter()
-                .any(|st| tgt.datatypes().iter().any(|tt| st == tt))
+            DataType::compatible_types(src.datatypes(), tgt.datatypes(), &Route::default()).is_ok()
         }
-        // Unknown port or no type info — allow
-        (src, tgt) => {
-            log::info!(
-                "Type check: src={}, tgt={} — allowing (unknown port)",
-                src.is_some(),
-                tgt.is_some()
-            );
-            true
-        }
+        _ => true,
     }
 }
 

--- a/flowedit/src/utils.rs
+++ b/flowedit/src/utils.rs
@@ -171,7 +171,12 @@ pub(crate) fn check_port_type_compatibility(
             if src.datatypes().is_empty() || tgt.datatypes().is_empty() {
                 return true;
             }
-            DataType::compatible_types(src.datatypes(), tgt.datatypes(), &Route::default()).is_ok()
+            let (from_types, to_types) = if source_is_output {
+                (src.datatypes(), tgt.datatypes())
+            } else {
+                (tgt.datatypes(), src.datatypes())
+            };
+            DataType::compatible_types(from_types, to_types, &Route::default()).is_ok()
         }
         _ => true,
     }
@@ -451,6 +456,41 @@ mod test {
             &nodes[1],
             "in",
             false
+        ));
+    }
+
+    #[test]
+    fn check_type_compat_reversed_direction() {
+        let data = [
+            test_node(
+                "a",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![IO::new_named(vec!["number".into()], Route::default(), "in")],
+                    vec![],
+                ))),
+            ),
+            test_node(
+                "b",
+                "",
+                Some(Process::FunctionProcess(function_with_io(
+                    vec![],
+                    vec![IO::new_named(
+                        vec!["number".into()],
+                        Route::default(),
+                        "out",
+                    )],
+                ))),
+            ),
+        ];
+        let nodes: Vec<_> = data.iter().map(as_layout).collect();
+        assert!(check_port_type_compatibility(
+            Some(&nodes[0]),
+            "in",
+            false,
+            &nodes[1],
+            "out",
+            true
         ));
     }
 }

--- a/install-flowstdlib.sh
+++ b/install-flowstdlib.sh
@@ -16,13 +16,12 @@ VERSION="${1:-latest}"
 case "$(uname -s)" in
     Linux*)  FLOW_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/flow" ;;
     Darwin*) FLOW_DIR="$HOME/Library/Application Support/flow" ;;
-    MINGW*|MSYS*|CYGWIN*) FLOW_DIR="$APPDATA/flow" ;;
-    *)       FLOW_DIR="$HOME/.flow" ;;
+    MINGW*|MSYS*|CYGWIN*) FLOW_DIR="$APPDATA/flow/data" ;;
 esac
 
-# Fall back to legacy location if it exists
-if [ ! -d "$FLOW_DIR" ] && [ -d "$HOME/.flow" ]; then
-    FLOW_DIR="$HOME/.flow"
+if [ -z "$FLOW_DIR" ]; then
+    echo "Error: unsupported platform"
+    exit 1
 fi
 
 # Resolve version tag

--- a/install.sh
+++ b/install.sh
@@ -8,12 +8,12 @@ set -e
 case "$(uname -s)" in
     Linux*)  FLOW_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/flow" ;;
     Darwin*) FLOW_DIR="$HOME/Library/Application Support/flow" ;;
-    *)       FLOW_DIR="$HOME/.flow" ;;
+    MINGW*|MSYS*|CYGWIN*) FLOW_DIR="$APPDATA/flow/data" ;;
 esac
 
-# Fall back to legacy location if it exists
-if [ ! -d "$FLOW_DIR" ] && [ -d "$HOME/.flow" ]; then
-    FLOW_DIR="$HOME/.flow"
+if [ -z "$FLOW_DIR" ]; then
+    echo "Error: unsupported platform"
+    exit 1
 fi
 
 echo "Installing flow data to ${FLOW_DIR}/"


### PR DESCRIPTION
## Summary
- Replace flowedit's custom `check_port_type_compatibility` logic with the compiler's `DataType::compatible_types()` from flowcore
- Fix argument order for reversed drag direction (input-to-output)
- Add `flowc --print-lib-dir` flag that prints the default library directory using the `directories` crate
- Fix Windows CI: replace hardcoded per-platform paths with `flowc --print-lib-dir`
- Remove `continue-on-error` for Windows so failures block PRs
- Remove legacy `~/.flow` fallback from `flowcore::dirs` — use only the `directories` crate
- Update install scripts and release workflow to remove legacy fallback

Fixes #2843

## Test plan
- [x] All type compatibility tests pass (4 tests including reversed direction)
- [x] `flowc --print-lib-dir` prints correct platform path
- [x] `make clippy` clean
- [x] `make test` passes
- [ ] Windows CI passes with correct flowstdlib path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port type compatibility validation, including compatibility when source/target direction is reversed.
* **New Features**
  * Added a `--print-lib-dir` CLI option to display the default library directory.
* **CI / Build**
  * Updated CI library directory discovery and simplified Windows error-handling behavior.
* **Release**
  * Adjusted how the release workflow stages and packages the Flowstdlib library.
* **Platform / Scripts**
  * Standardized default data/library directory resolution across platforms and tightened unsupported-platform handling.
* **Documentation & Tests**
  * Refreshed related user-facing comments and added coverage for reversed-direction compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->