### PR TITLE
Unify layout and appearance between SVG and flowedit

### DIFF
--- a/first.svg
+++ b/first.svg
@@ -59,8 +59,8 @@ context://stdio/stdout
 </g>
 <g class="edge">
 <g>
-<path d="M 230 135 C 260 200, 20 200, 50 145" fill="none" stroke="#808080" stroke-width="2"/>
-<path d="M 50 145 L 49.4049 150.97041 L 45.302475 148.73273 Z" fill="#808080" stroke="none"/>
+<path d="M 230 135 L 245 135 Q 255 135 255 145 L 255 185 Q 255 195 245 195 L 35 195 Q 25 195 25 185 L 25 155 Q 25 145 35 145 L 50 145" fill="none" stroke="#808080" stroke-width="2"/>
+<path d="M 50 145 L 44.473633 147.33652 L 44.473633 142.66348 Z" fill="#808080" stroke="none"/>
 </g>
 </g>
 <g class="edge">
@@ -75,8 +75,8 @@ next value
 </g>
 <g class="edge">
 <g>
-<path d="M 230 135 C 260 200, 20 200, 50 125" fill="none" stroke="#808080" stroke-width="2"/>
-<path d="M 50 125 L 50.116955 130.99886 L 45.778164 129.26334 Z" fill="#808080" stroke="none"/>
+<path d="M 230 135 L 245 135 Q 255 135 255 145 L 255 185 Q 255 195 245 195 L 35 195 Q 25 195 25 185 L 25 135 Q 25 125 35 125 L 50 125" fill="none" stroke="#808080" stroke-width="2"/>
+<path d="M 50 125 L 44.473633 127.33651 L 44.473633 122.66349 Z" fill="#808080" stroke="none"/>
 </g>
 </g>
 <g>

--- a/first.svg
+++ b/first.svg
@@ -2,66 +2,72 @@
 <style>
 .node-subflow rect { cursor: pointer; }
 .node-subflow:hover rect { stroke-width: 3; }
-.node-function:hover rect, .node-function:hover path { stroke-width: 3; }
+.node:hover rect { stroke-width: 3; }
 .port-label { pointer-events: none; }
 .edge path { transition: stroke-width 0.15s; }
 .edge:hover path { stroke-width: 3; }
 text { user-select: none; }
 </style>
 <g class="flow-graph">
-<g class="node-function">
-<rect fill="#FF7F50" height="120" rx="10" ry="10" stroke="#444444" stroke-width="1.5" width="180" x="50" y="50"/>
-<text dominant-baseline="central" fill="#222222" font-family="sans-serif" font-size="14" text-anchor="middle" x="140" y="65">
+<g class="node">
+<rect fill="#4D80E6" height="120" rx="10" ry="10" stroke="#444444" stroke-width="2" width="180" x="50" y="50"/>
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="16" text-anchor="middle" x="140" y="68">
 add
+</text>
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="12" text-anchor="middle" x="140" y="86">
+...flowstdlib/math/add
 </text>
 <title>add (lib://flowstdlib/math/add)</title>
 <g>
-<circle cx="50" cy="115" fill="#888888" r="5" stroke="#444444" stroke-width="1"/>
+<path d="M 50 120 A 5 5 0 0 0 50 130 Z" fill="#FFFFFF" stroke="#444444" stroke-width="1"/>
 <title>i1: number</title>
 </g>
-<text dominant-baseline="central" fill="#222222" font-family="sans-serif" font-size="10" text-anchor="start" x="58" y="115">
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="11" text-anchor="start" x="58" y="125">
 i1
 </text>
 <g>
-<circle cx="50" cy="135" fill="#888888" r="5" stroke="#444444" stroke-width="1"/>
+<path d="M 50 140 A 5 5 0 0 0 50 150 Z" fill="#FFFFFF" stroke="#444444" stroke-width="1"/>
 <title>i2: number</title>
 </g>
-<text dominant-baseline="central" fill="#222222" font-family="sans-serif" font-size="10" text-anchor="start" x="58" y="135">
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="11" text-anchor="start" x="58" y="145">
 i2
 </text>
 <g>
-<circle cx="230" cy="125" fill="#888888" r="5" stroke="#444444" stroke-width="1"/>
+<path d="M 230 130 A 5 5 0 0 1 230 140 Z" fill="#FFFFFF" stroke="#444444" stroke-width="1"/>
 <title>: number</title>
 </g>
-<text dominant-baseline="central" fill="#222222" font-family="sans-serif" font-size="10" text-anchor="end" x="222" y="125">
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="11" text-anchor="end" x="222" y="135">
 
 </text>
 </g>
-<g class="node-sink">
-<path d="M 390 50 L 480 86 L 480 170 L 300 170 L 300 86 Z" fill="#333333" stroke="#444444" stroke-width="1.5"/>
-<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="14" text-anchor="middle" x="390" y="65">
+<g class="node">
+<rect fill="#4DBF73" height="120" rx="10" ry="10" stroke="#444444" stroke-width="2" width="180" x="300" y="50"/>
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="16" text-anchor="middle" x="390" y="68">
 stdout
+</text>
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="12" text-anchor="middle" x="390" y="86">
+context://stdio/stdout
 </text>
 <title>stdout (context://stdio/stdout)</title>
 <g>
-<circle cx="300" cy="125" fill="#888888" r="5" stroke="#444444" stroke-width="1"/>
+<path d="M 300 130 A 5 5 0 0 0 300 140 Z" fill="#FFFFFF" stroke="#444444" stroke-width="1"/>
 <title>: generic</title>
 </g>
-<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="10" text-anchor="start" x="308" y="125">
+<text dominant-baseline="central" fill="#FFFFFF" font-family="sans-serif" font-size="11" text-anchor="start" x="308" y="135">
 
 </text>
 </g>
 <g class="edge">
 <g>
-<path d="M 230 125 C 260 200, 20 200, 50 135" fill="none" stroke="#555555" stroke-width="1.5"/>
-<path d="M 50 135 L 49.740784 142.9958 L 44.083565 140.38478 Z" fill="#555555" stroke="none"/>
+<path d="M 230 135 C 260 200, 20 200, 50 145" fill="none" stroke="#808080" stroke-width="2"/>
+<path d="M 50 145 L 49.4049 150.97041 L 45.302475 148.73273 Z" fill="#808080" stroke="none"/>
 </g>
 </g>
 <g class="edge">
 <g>
-<path d="M 230 125 C 270 125, 260 125, 300 125" fill="none" stroke="#555555" stroke-width="1.5"/>
-<path d="M 300 125 L 292.6315 128.11534 L 292.6315 121.88465 Z" fill="#555555" stroke="none"/>
-<text dominant-baseline="central" fill="#555555" font-family="sans-serif" font-size="10" text-anchor="middle" x="265" y="117">
+<path d="M 230 135 C 265 135, 265 135, 300 135" fill="none" stroke="#808080" stroke-width="2"/>
+<path d="M 300 135 L 294.47363 137.33652 L 294.47363 132.66348 Z" fill="#808080" stroke="none"/>
+<text dominant-baseline="central" fill="#808080" font-family="sans-serif" font-size="11" text-anchor="middle" x="265" y="127">
 next value
 </text>
 <title>add → stdout</title>
@@ -69,25 +75,25 @@ next value
 </g>
 <g class="edge">
 <g>
-<path d="M 230 125 C 260 200, 20 200, 50 115" fill="none" stroke="#555555" stroke-width="1.5"/>
-<path d="M 50 115 L 50.48536 122.98526 L 44.60988 120.91156 Z" fill="#555555" stroke="none"/>
+<path d="M 230 135 C 260 200, 20 200, 50 125" fill="none" stroke="#808080" stroke-width="2"/>
+<path d="M 50 125 L 50.116955 130.99886 L 45.778164 129.26334 Z" fill="#808080" stroke="none"/>
 </g>
 </g>
 <g>
-<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="11" text-anchor="middle" x="-20" y="115">
+<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="12" text-anchor="middle" x="-20" y="125">
 0 (once)
 </text>
 <g>
-<path d="M 15 115 C 55 115, 10 115, 50 115" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="1.5"/>
-<path d="M 50 115 L 42.63151 118.11535 L 42.63151 111.88465 Z" fill="#4488CC" stroke="none"/>
+<path d="M 15 125 C 45 125, 20 125, 50 125" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="2"/>
+<path d="M 50 125 L 44.473633 127.33651 L 44.473633 122.66349 Z" fill="#4488CC" stroke="none"/>
 </g>
 <title>i1: 0</title>
-<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="11" text-anchor="middle" x="-20" y="135">
+<text dominant-baseline="central" fill="#4488CC" font-family="sans-serif" font-size="12" text-anchor="middle" x="-20" y="145">
 1 (once)
 </text>
 <g>
-<path d="M 15 135 C 55 135, 10 135, 50 135" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="1.5"/>
-<path d="M 50 135 L 42.63151 138.11534 L 42.63151 131.88466 Z" fill="#4488CC" stroke="none"/>
+<path d="M 15 145 C 45 145, 20 145, 50 145" fill="none" stroke="#4488CC" stroke-dasharray="4 2" stroke-width="2"/>
+<path d="M 50 145 L 44.473633 147.33652 L 44.473633 142.66348 Z" fill="#4488CC" stroke="none"/>
 </g>
 <title>i2: 1</title>
 </g>

--- a/flowc/src/lib/graph/edge.rs
+++ b/flowc/src/lib/graph/edge.rs
@@ -42,7 +42,7 @@ pub fn bezier_edge(
         .add(arrow_head(to_x, to_y, ctrl_x2, to_y, color))
 }
 
-/// Render a loopback edge that curves below the node.
+/// Render a loopback edge that routes around the node: right, down, left, up.
 #[must_use]
 pub fn loopback_edge(
     out_x: f32,
@@ -52,12 +52,33 @@ pub fn loopback_edge(
     node_bottom: f32,
     color: &str,
 ) -> Group {
-    let loop_y = node_bottom + 30.0;
-    let ctrl_x1 = out_x + 30.0;
-    let ctrl_x2 = in_x - 30.0;
+    let margin = 25.0;
+    let r = 10.0;
+    let right_x = out_x + margin;
+    let left_x = in_x - margin;
+    let bottom_y = node_bottom + margin;
 
-    let path_data =
-        format!("M {out_x} {out_y} C {ctrl_x1} {loop_y}, {ctrl_x2} {loop_y}, {in_x} {in_y}");
+    // Path: right from output, round corner down, go under node, round corner up, into input
+    let path_data = format!(
+        "M {out_x} {out_y} \
+         L {} {out_y} \
+         Q {right_x} {out_y} {right_x} {} \
+         L {right_x} {} \
+         Q {right_x} {bottom_y} {} {bottom_y} \
+         L {} {bottom_y} \
+         Q {left_x} {bottom_y} {left_x} {} \
+         L {left_x} {} \
+         Q {left_x} {in_y} {} {in_y} \
+         L {in_x} {in_y}",
+        right_x - r,
+        out_y + r,
+        bottom_y - r,
+        right_x - r,
+        left_x + r,
+        bottom_y - r,
+        in_y + r,
+        left_x + r,
+    );
 
     let path = Path::new()
         .set("d", path_data)
@@ -67,7 +88,7 @@ pub fn loopback_edge(
 
     Group::new()
         .add(path)
-        .add(arrow_head(in_x, in_y, ctrl_x2, loop_y, color))
+        .add(arrow_head(in_x, in_y, left_x, in_y, color))
 }
 
 /// Arrow head pointing toward `(tip_x, tip_y)` from direction `(from_x, from_y)`.

--- a/flowc/src/lib/graph/edge.rs
+++ b/flowc/src/lib/graph/edge.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::cast_precision_loss)]
 
+use flowcore::graph::layout as shared;
 use svg::node::element::{Group, Path};
 
 use super::shapes;
@@ -17,8 +18,8 @@ pub fn bezier_edge(
     color: &str,
     dash: Option<&str>,
 ) -> Group {
-    let dx = (to_x - from_x).abs();
-    let offset = (dx / 3.0).max(40.0);
+    let dx = to_x - from_x;
+    let offset = shared::bezier_control_offset(dx);
 
     let ctrl_x1 = from_x + offset;
     let ctrl_x2 = to_x - offset;
@@ -30,7 +31,7 @@ pub fn bezier_edge(
         .set("d", path_data)
         .set("fill", "none")
         .set("stroke", color)
-        .set("stroke-width", 1.5);
+        .set("stroke-width", style::STROKE_WIDTH);
 
     if let Some(pattern) = dash {
         path = path.set("stroke-dasharray", pattern);
@@ -62,7 +63,7 @@ pub fn loopback_edge(
         .set("d", path_data)
         .set("fill", "none")
         .set("stroke", color)
-        .set("stroke-width", 1.5);
+        .set("stroke-width", style::STROKE_WIDTH);
 
     Group::new()
         .add(path)

--- a/flowc/src/lib/graph/layout.rs
+++ b/flowc/src/lib/graph/layout.rs
@@ -1,97 +1,22 @@
 //! Topological graph layout for flow diagrams.
 //!
-//! Computes node positions using BFS-based column assignment and vertical stacking.
-//! Adapted from flowedit's `node_layout.rs`.
+//! Thin wrapper around `flowcore::graph::layout` that converts flowcore model
+//! types into the generic inputs expected by the shared layout algorithm.
 
 #![allow(clippy::cast_precision_loss, clippy::implicit_hasher)]
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
+
+use flowcore::graph::layout as shared;
+pub use flowcore::graph::layout::PositionedNode;
 
 use flowcore::model::connection::Connection;
 use flowcore::model::process_reference::ProcessReference;
 
-use super::style;
-
-/// A positioned node with its dimensions and port info.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct NodeLayout {
-    /// Node identifier (alias or derived short name)
-    pub name: String,
-    /// X position
-    pub x: f32,
-    /// Y position
-    pub y: f32,
-    /// Width
-    pub width: f32,
-    /// Height
-    pub height: f32,
-    /// Input port names
-    pub inputs: Vec<String>,
-    /// Output port names
-    pub outputs: Vec<String>,
-}
-
-impl NodeLayout {
-    /// Y position of the nth input port
-    #[must_use]
-    pub fn input_port_y(&self, index: usize) -> f32 {
-        let count = self.inputs.len().max(1);
-        let ports_height = (count - 1) as f32 * style::PORT_SPACING;
-        let available = self.height - style::HEADER_HEIGHT;
-        let padding = ((available - ports_height) / 2.0).max(0.0);
-        self.y + style::HEADER_HEIGHT + padding + index as f32 * style::PORT_SPACING
-    }
-
-    /// Y position of the nth output port
-    #[must_use]
-    pub fn output_port_y(&self, index: usize) -> f32 {
-        let count = self.outputs.len().max(1);
-        let ports_height = (count - 1) as f32 * style::PORT_SPACING;
-        let available = self.height - style::HEADER_HEIGHT;
-        let padding = ((available - ports_height) / 2.0).max(0.0);
-        self.y + style::HEADER_HEIGHT + padding + index as f32 * style::PORT_SPACING
-    }
-
-    /// X position of input ports (left edge)
-    #[must_use]
-    pub fn input_port_x(&self) -> f32 {
-        self.x
-    }
-
-    /// X position of output ports (right edge)
-    #[must_use]
-    pub fn output_port_x(&self) -> f32 {
-        self.x + self.width
-    }
-}
-
-/// Extract a short name from a source path (e.g., `lib://flowstdlib/math/add` → `add`)
-fn derive_short_name(source: &str) -> String {
-    source.rsplit('/').next().unwrap_or(source).to_string()
-}
-
-/// Split a route like "sequence/number" into ("sequence", "number")
-pub(crate) fn split_route(route: &str) -> (String, String) {
-    let route = route.trim_start_matches('/');
-    if let Some(pos) = route.find('/') {
-        (route[..pos].to_string(), route[pos + 1..].to_string())
-    } else {
-        (route.to_string(), String::new())
-    }
-}
-
-/// Compute the required height for a node based on its port count.
-fn compute_node_height(input_count: usize, output_count: usize) -> f32 {
-    let max_ports = input_count.max(output_count).max(1);
-    let ports_height = (max_ports - 1) as f32 * style::PORT_SPACING;
-    (style::HEADER_HEIGHT + ports_height + style::NODE_PADDING * 2.0).max(style::NODE_HEIGHT)
-}
-
 /// Get the alias for a process reference.
 pub(crate) fn process_alias(p: &ProcessReference) -> String {
     if p.alias.is_empty() {
-        derive_short_name(&p.source)
+        shared::derive_short_name(&p.source)
     } else {
         p.alias.clone()
     }
@@ -99,101 +24,32 @@ pub(crate) fn process_alias(p: &ProcessReference) -> String {
 
 /// Compute topological layout for a set of processes and connections.
 ///
-/// Returns a map from alias to `NodeLayout` with computed positions.
+/// Converts flowcore model types into the generic format expected by
+/// `flowcore::graph::layout::compute_layout` and returns positioned nodes.
 #[must_use]
 pub fn compute_layout(
     process_refs: &[ProcessReference],
     connections: &[Connection],
     node_info: &HashMap<String, (Vec<String>, Vec<String>)>,
-) -> HashMap<String, NodeLayout> {
-    let aliases: Vec<String> = process_refs.iter().map(process_alias).collect();
-    let alias_set: HashSet<&str> = aliases.iter().map(String::as_str).collect();
+) -> HashMap<String, PositionedNode> {
+    let node_specs: Vec<(String, Vec<String>, Vec<String>)> = process_refs
+        .iter()
+        .map(|p| {
+            let alias = process_alias(p);
+            let (inputs, outputs) = node_info.get(&alias).cloned().unwrap_or_default();
+            (alias, inputs, outputs)
+        })
+        .collect();
 
-    let mut incoming: HashMap<String, Vec<String>> = HashMap::new();
-    let mut outgoing: HashMap<String, Vec<String>> = HashMap::new();
-    for alias in &aliases {
-        incoming.entry(alias.clone()).or_default();
-        outgoing.entry(alias.clone()).or_default();
-    }
+    let conn_pairs: Vec<(String, String)> = connections
+        .iter()
+        .flat_map(|conn| {
+            let from = conn.from().to_string();
+            conn.to()
+                .iter()
+                .map(move |to| (from.clone(), to.to_string()))
+        })
+        .collect();
 
-    for conn in connections {
-        let from_route = conn.from().to_string();
-        let (from_node, _) = split_route(&from_route);
-        if !alias_set.contains(from_node.as_str()) {
-            continue;
-        }
-        for to_route in conn.to() {
-            let to_str = to_route.to_string();
-            let (to_node, _) = split_route(&to_str);
-            if from_node != to_node && alias_set.contains(to_node.as_str()) {
-                outgoing
-                    .entry(from_node.clone())
-                    .or_default()
-                    .push(to_node.clone());
-                incoming.entry(to_node).or_default().push(from_node.clone());
-            }
-        }
-    }
-
-    // BFS column assignment (longest path from sources)
-    let mut depth: HashMap<String, usize> = HashMap::new();
-    let mut queue = VecDeque::new();
-    for alias in &aliases {
-        if incoming.get(alias).is_none_or(Vec::is_empty) {
-            depth.insert(alias.clone(), 0);
-            queue.push_back(alias.clone());
-        }
-    }
-
-    let max_depth = aliases.len().saturating_sub(1);
-    while let Some(node) = queue.pop_front() {
-        let node_depth = depth.get(&node).copied().unwrap_or(0);
-        if let Some(neighbors) = outgoing.get(&node) {
-            for neighbor in neighbors {
-                let new_depth = (node_depth + 1).min(max_depth);
-                let current = depth.get(neighbor).copied().unwrap_or(0);
-                if new_depth > current {
-                    depth.insert(neighbor.clone(), new_depth);
-                    queue.push_back(neighbor.clone());
-                }
-            }
-        }
-    }
-
-    for alias in &aliases {
-        depth.entry(alias.clone()).or_insert(0);
-    }
-
-    // Group by column
-    let mut columns: HashMap<usize, Vec<String>> = HashMap::new();
-    for alias in &aliases {
-        let col = depth.get(alias).copied().unwrap_or(0);
-        columns.entry(col).or_default().push(alias.clone());
-    }
-
-    // Compute positions and build NodeLayout
-    let mut layouts = HashMap::new();
-    for (col, col_nodes) in &columns {
-        let x = style::GRID_ORIGIN_X + *col as f32 * style::GRID_SPACING_X;
-        let mut y = style::GRID_ORIGIN_Y;
-        for alias in col_nodes {
-            let (inputs, outputs) = node_info.get(alias).cloned().unwrap_or_default();
-            let height = compute_node_height(inputs.len(), outputs.len());
-            layouts.insert(
-                alias.clone(),
-                NodeLayout {
-                    name: alias.clone(),
-                    x,
-                    y,
-                    width: style::NODE_WIDTH,
-                    height,
-                    inputs,
-                    outputs,
-                },
-            );
-            y += height + style::NODE_GAP_Y;
-        }
-    }
-
-    layouts
+    shared::compute_layout(&node_specs, &conn_pairs)
 }

--- a/flowc/src/lib/graph/renderer.rs
+++ b/flowc/src/lib/graph/renderer.rs
@@ -8,20 +8,20 @@ use std::collections::HashMap;
 use svg::node::element::{Group, Style};
 use svg::Document;
 
+use flowcore::graph::layout::split_route;
+use flowcore::graph::style::NodeCategory;
 use flowcore::model::connection::Connection;
 use flowcore::model::flow_definition::FlowDefinition;
 use flowcore::model::name::HasName;
 use flowcore::model::process::Process::{FlowProcess, FunctionProcess};
 use flowcore::model::process_reference::ProcessReference;
 
-use super::layout::{self, process_alias, split_route, NodeLayout};
+use super::layout::{self, process_alias, PositionedNode};
 use super::{edge, shapes, style};
 
 /// Information about a process needed for rendering.
 struct ProcessInfo {
-    is_subflow: bool,
-    is_impure: bool,
-    has_inputs: bool,
+    category: NodeCategory,
     /// (name, type) pairs
     inputs: Vec<(String, String)>,
     /// (name, type) pairs
@@ -39,7 +39,6 @@ pub fn render_flow(flow: &FlowDefinition) -> String {
 
     let mut svg_group = Group::new().set("class", "flow-graph");
 
-    // Render nodes
     for pr in &flow.process_refs {
         let alias = process_alias(pr);
         if let (Some(layout), Some(info)) = (layouts.get(&alias), process_info.get(&alias)) {
@@ -47,12 +46,10 @@ pub fn render_flow(flow: &FlowDefinition) -> String {
         }
     }
 
-    // Render connections
     for conn in &flow.connections {
         svg_group = svg_group.add(render_connection(conn, &layouts));
     }
 
-    // Render initializers
     for pr in &flow.process_refs {
         let alias = process_alias(pr);
         if let Some(layout) = layouts.get(&alias) {
@@ -91,7 +88,7 @@ fn css_styles() -> Style {
     Style::new(
         ".node-subflow rect { cursor: pointer; }
 .node-subflow:hover rect { stroke-width: 3; }
-.node-function:hover rect, .node-function:hover path { stroke-width: 3; }
+.node:hover rect { stroke-width: 3; }
 .port-label { pointer-events: none; }
 .edge path { transition: stroke-width 0.15s; }
 .edge:hover path { stroke-width: 3; }
@@ -120,44 +117,41 @@ fn collect_process_info(flow: &FlowDefinition) -> HashMap<String, ProcessInfo> {
 
     for pr in &flow.process_refs {
         let alias = process_alias(pr);
+        let process = flow.subprocesses.get(&alias);
+        let category = NodeCategory::classify(process, &pr.source);
 
-        if let Some(process) = flow.subprocesses.get(&alias) {
-            match process {
-                FlowProcess(sub_flow) => {
-                    let inputs: Vec<(String, String)> =
-                        sub_flow.inputs.iter().map(io_name_and_type).collect();
-                    let outputs: Vec<(String, String)> =
-                        sub_flow.outputs.iter().map(io_name_and_type).collect();
-                    info.insert(
-                        alias,
-                        ProcessInfo {
-                            is_subflow: true,
-                            is_impure: false,
-                            has_inputs: !inputs.is_empty(),
-                            inputs,
-                            outputs,
-                            source: pr.source.clone(),
-                        },
-                    );
-                }
-                FunctionProcess(func) => {
-                    let inputs: Vec<(String, String)> =
-                        func.inputs.iter().map(io_name_and_type).collect();
-                    let outputs: Vec<(String, String)> =
-                        func.outputs.iter().map(io_name_and_type).collect();
-                    info.insert(
-                        alias,
-                        ProcessInfo {
-                            is_subflow: false,
-                            is_impure: func.is_impure(),
-                            has_inputs: !inputs.is_empty(),
-                            inputs,
-                            outputs,
-                            source: pr.source.clone(),
-                        },
-                    );
-                }
+        match process {
+            Some(FlowProcess(sub_flow)) => {
+                let inputs: Vec<(String, String)> =
+                    sub_flow.inputs.iter().map(io_name_and_type).collect();
+                let outputs: Vec<(String, String)> =
+                    sub_flow.outputs.iter().map(io_name_and_type).collect();
+                info.insert(
+                    alias,
+                    ProcessInfo {
+                        category,
+                        inputs,
+                        outputs,
+                        source: pr.source.clone(),
+                    },
+                );
             }
+            Some(FunctionProcess(func)) => {
+                let inputs: Vec<(String, String)> =
+                    func.inputs.iter().map(io_name_and_type).collect();
+                let outputs: Vec<(String, String)> =
+                    func.outputs.iter().map(io_name_and_type).collect();
+                info.insert(
+                    alias,
+                    ProcessInfo {
+                        category,
+                        inputs,
+                        outputs,
+                        source: pr.source.clone(),
+                    },
+                );
+            }
+            None => {}
         }
     }
 
@@ -181,69 +175,56 @@ fn build_node_info(
         .collect()
 }
 
-fn render_node(layout: &NodeLayout, info: &ProcessInfo, alias: &str) -> Group {
+fn render_node(layout: &PositionedNode, info: &ProcessInfo, alias: &str) -> Group {
     let mut group = Group::new();
 
-    let (fill, text_color, css_class) = if info.is_subflow {
-        (style::COLOR_SUBFLOW, style::COLOR_TEXT, "node-subflow")
-    } else if info.is_impure && !info.has_inputs {
-        (style::COLOR_SOURCE, style::COLOR_TEXT, "node-source")
-    } else if info.is_impure {
-        (style::COLOR_SINK, style::COLOR_TEXT_LIGHT, "node-sink")
+    let fill = info.category.color_hex();
+    let css_class = if info.category == NodeCategory::Subflow {
+        "node node-subflow"
     } else {
-        (style::COLOR_FUNCTION, style::COLOR_TEXT, "node-function")
+        "node"
     };
 
     group = group.set("class", css_class);
 
-    // Node shape
-    if info.is_impure && !info.has_inputs {
-        group = group.add(shapes::inverted_house(
-            layout.x,
-            layout.y,
-            layout.width,
-            layout.height,
-            fill,
-            style::COLOR_BORDER,
-        ));
-    } else if info.is_impure && info.has_inputs {
-        group = group.add(shapes::house(
-            layout.x,
-            layout.y,
-            layout.width,
-            layout.height,
-            fill,
-            style::COLOR_BORDER,
-        ));
-    } else {
-        group = group.add(shapes::rounded_rect(
-            layout.x,
-            layout.y,
-            layout.width,
-            layout.height,
-            fill,
-            style::COLOR_BORDER,
-        ));
-    }
+    // All nodes use rounded rectangles
+    group = group.add(shapes::rounded_rect(
+        layout.x,
+        layout.y,
+        layout.width,
+        layout.height,
+        fill,
+        style::COLOR_BORDER,
+    ));
 
     // Node title
     group = group.add(shapes::centered_text(
         layout.x + layout.width / 2.0,
-        layout.y + style::HEADER_HEIGHT / 2.0,
+        layout.y + 18.0,
         alias,
-        style::FONT_SIZE,
-        text_color,
+        style::TITLE_FONT_SIZE,
+        style::COLOR_TEXT,
+    ));
+
+    // Source label (truncated)
+    let source_label = truncate_source(&info.source);
+    group = group.add(shapes::centered_text(
+        layout.x + layout.width / 2.0,
+        layout.y + 36.0,
+        &source_label,
+        style::SOURCE_FONT_SIZE,
+        style::COLOR_TEXT,
     ));
 
     // Tooltip
     group = group.add(shapes::tooltip(&format!("{} ({})", alias, info.source)));
 
-    // Input ports with type tooltips
+    // Input ports
     for (i, (port_name, port_type)) in info.inputs.iter().enumerate() {
         let px = layout.input_port_x();
         let py = layout.input_port_y(i);
         let mut port_group = Group::new();
-        port_group = port_group.add(shapes::port_circle(px, py));
+        port_group = port_group.add(shapes::input_port(px, py, style::COLOR_PORT));
         port_group = port_group.add(shapes::tooltip(&format!("{port_name}: {port_type}")));
         group = group.add(port_group);
         group = group.add(shapes::port_label(
@@ -251,16 +232,16 @@ fn render_node(layout: &NodeLayout, info: &ProcessInfo, alias: &str) -> Group {
             py,
             port_name,
             "start",
-            text_color,
+            style::COLOR_TEXT,
         ));
     }
 
-    // Output ports with type tooltips
+    // Output ports
     for (i, (port_name, port_type)) in info.outputs.iter().enumerate() {
         let px = layout.output_port_x();
         let py = layout.output_port_y(i);
         let mut port_group = Group::new();
-        port_group = port_group.add(shapes::port_circle(px, py));
+        port_group = port_group.add(shapes::output_port(px, py, style::COLOR_PORT));
         port_group = port_group.add(shapes::tooltip(&format!("{port_name}: {port_type}")));
         group = group.add(port_group);
         group = group.add(shapes::port_label(
@@ -268,11 +249,11 @@ fn render_node(layout: &NodeLayout, info: &ProcessInfo, alias: &str) -> Group {
             py,
             port_name,
             "end",
-            text_color,
+            style::COLOR_TEXT,
         ));
     }
 
-    if info.is_subflow {
+    if info.category == NodeCategory::Subflow {
         let href = format!("{alias}.svg");
         return Group::new().add(shapes::link(&href, group));
     }
@@ -280,7 +261,16 @@ fn render_node(layout: &NodeLayout, info: &ProcessInfo, alias: &str) -> Group {
     group
 }
 
-fn render_connection(conn: &Connection, layouts: &HashMap<String, NodeLayout>) -> Group {
+fn truncate_source(source: &str) -> String {
+    let max_len = 22;
+    if source.len() <= max_len {
+        source.to_string()
+    } else {
+        format!("...{}", &source[source.len() - max_len + 3..])
+    }
+}
+
+fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode>) -> Group {
     let mut group = Group::new().set("class", "edge");
 
     let from_route = conn.from().to_string();
@@ -319,7 +309,6 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, NodeLayout>) -
         let tooltip_text = format!("{from_route} → {to_str}");
 
         if from_node == to_node {
-            // Loopback
             group = group.add(edge::loopback_edge(
                 x1,
                 y1,
@@ -349,7 +338,7 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, NodeLayout>) -
     group
 }
 
-fn render_initializers(pr: &ProcessReference, layout: &NodeLayout) -> Group {
+fn render_initializers(pr: &ProcessReference, layout: &PositionedNode) -> Group {
     let mut group = Group::new();
 
     for (input_path, initializer) in &pr.initializations {
@@ -408,7 +397,7 @@ fn render_initializers(pr: &ProcessReference, layout: &NodeLayout) -> Group {
 }
 
 fn compute_document_bounds(
-    layouts: &HashMap<String, NodeLayout>,
+    layouts: &HashMap<String, PositionedNode>,
     has_initializers: bool,
 ) -> (f32, f32, f32, f32) {
     let mut min_x: f32 = 0.0;

--- a/flowc/src/lib/graph/shapes.rs
+++ b/flowc/src/lib/graph/shapes.rs
@@ -1,10 +1,10 @@
 //! SVG shape primitives for graph rendering.
 
-use svg::node::element::{Anchor, Circle, Group, Path, Rectangle, Text, Title};
+use svg::node::element::{Anchor, Group, Path, Rectangle, Text, Title};
 
 use super::style;
 
-/// Rounded rectangle node (for sub-flows and pure functions).
+/// Rounded rectangle node shape.
 #[must_use]
 pub fn rounded_rect(
     left: f32,
@@ -23,60 +23,37 @@ pub fn rounded_rect(
         .set("ry", style::CORNER_RADIUS)
         .set("fill", fill)
         .set("stroke", stroke)
-        .set("stroke-width", 1.5)
+        .set("stroke-width", style::STROKE_WIDTH)
 }
 
-/// House shape (pentagon pointing up) for sink nodes.
+/// Port semi-circle on the left edge (input port).
 #[must_use]
-pub fn house(left: f32, top: f32, width: f32, height: f32, fill: &str, stroke: &str) -> Path {
-    let mid_x = left + width / 2.0;
-    let roof_y = top + height * 0.3;
-    let bottom = top + height;
-    let right = left + width;
-
+pub fn input_port(center_x: f32, center_y: f32, fill: &str) -> Path {
+    let r = style::PORT_RADIUS;
+    let top_y = center_y - r;
+    let bot_y = center_y + r;
     Path::new()
         .set(
             "d",
-            format!("M {mid_x} {top} L {right} {roof_y} L {right} {bottom} L {left} {bottom} L {left} {roof_y} Z"),
+            format!("M {center_x} {top_y} A {r} {r} 0 0 0 {center_x} {bot_y} Z"),
         )
         .set("fill", fill)
-        .set("stroke", stroke)
-        .set("stroke-width", 1.5)
+        .set("stroke", style::COLOR_BORDER)
+        .set("stroke-width", 1)
 }
 
-/// Inverted house shape (pentagon pointing down) for source nodes.
+/// Port semi-circle on the right edge (output port).
 #[must_use]
-pub fn inverted_house(
-    left: f32,
-    top: f32,
-    width: f32,
-    height: f32,
-    fill: &str,
-    stroke: &str,
-) -> Path {
-    let mid_x = left + width / 2.0;
-    let body_y = top + height * 0.7;
-    let bottom = top + height;
-    let right = left + width;
-
+pub fn output_port(center_x: f32, center_y: f32, fill: &str) -> Path {
+    let r = style::PORT_RADIUS;
+    let top_y = center_y - r;
+    let bot_y = center_y + r;
     Path::new()
         .set(
             "d",
-            format!("M {left} {top} L {right} {top} L {right} {body_y} L {mid_x} {bottom} L {left} {body_y} Z"),
+            format!("M {center_x} {top_y} A {r} {r} 0 0 1 {center_x} {bot_y} Z"),
         )
         .set("fill", fill)
-        .set("stroke", stroke)
-        .set("stroke-width", 1.5)
-}
-
-/// Port circle (input or output).
-#[must_use]
-pub fn port_circle(center_x: f32, center_y: f32) -> Circle {
-    Circle::new()
-        .set("cx", center_x)
-        .set("cy", center_y)
-        .set("r", style::PORT_RADIUS)
-        .set("fill", style::COLOR_PORT)
         .set("stroke", style::COLOR_BORDER)
         .set("stroke-width", 1)
 }

--- a/flowc/src/lib/graph/style.rs
+++ b/flowc/src/lib/graph/style.rs
@@ -1,51 +1,6 @@
 //! Visual style constants for SVG graph rendering.
+//!
+//! Re-exports shared constants from `flowcore::graph::style` for use by
+//! the SVG renderer. All layout and style values are defined once in flowcore.
 
-/// Horizontal spacing between columns of nodes
-pub const GRID_SPACING_X: f32 = 250.0;
-/// X origin for the grid
-pub const GRID_ORIGIN_X: f32 = 50.0;
-/// Y origin for the grid
-pub const GRID_ORIGIN_Y: f32 = 50.0;
-/// Default node width
-pub const NODE_WIDTH: f32 = 180.0;
-/// Default node height
-pub const NODE_HEIGHT: f32 = 120.0;
-/// Vertical gap between nodes in the same column
-pub const NODE_GAP_Y: f32 = 30.0;
-/// Vertical spacing between ports on a node
-pub const PORT_SPACING: f32 = 20.0;
-/// Radius of port circles
-pub const PORT_RADIUS: f32 = 5.0;
-/// Corner radius for rounded rectangles
-pub const CORNER_RADIUS: f32 = 10.0;
-/// Header height (for node title)
-pub const HEADER_HEIGHT: f32 = 30.0;
-/// Font size for node labels
-pub const FONT_SIZE: f32 = 14.0;
-/// Font size for port labels
-pub const PORT_FONT_SIZE: f32 = 10.0;
-/// Arrow head size
-pub const ARROW_SIZE: f32 = 8.0;
-/// Padding inside nodes
-pub const NODE_PADDING: f32 = 10.0;
-
-/// Node fill colors by type
-pub const COLOR_SUBFLOW: &str = "#7FFFD4";
-/// Pure function fill
-pub const COLOR_FUNCTION: &str = "#FF7F50";
-/// Source (impure, no inputs) fill
-pub const COLOR_SOURCE: &str = "#FFFFFF";
-/// Sink (impure, has inputs) fill
-pub const COLOR_SINK: &str = "#333333";
-/// Node border color
-pub const COLOR_BORDER: &str = "#444444";
-/// Edge color
-pub const COLOR_EDGE: &str = "#555555";
-/// Initializer edge color
-pub const COLOR_INITIALIZER: &str = "#4488CC";
-/// Port circle fill
-pub const COLOR_PORT: &str = "#888888";
-/// Text color (dark)
-pub const COLOR_TEXT: &str = "#222222";
-/// Text color (light, for dark backgrounds)
-pub const COLOR_TEXT_LIGHT: &str = "#FFFFFF";
+pub use flowcore::graph::style::*;

--- a/flowcore/src/graph/layout.rs
+++ b/flowcore/src/graph/layout.rs
@@ -97,6 +97,96 @@ pub fn split_route(route: &str) -> (String, String) {
     }
 }
 
+/// Sort nodes within each column by the median index of their neighbors
+/// in adjacent columns, reducing edge crossings (Sugiyama barycenter heuristic).
+fn median_ordering(
+    columns: &mut HashMap<usize, Vec<String>>,
+    max_col: usize,
+    incoming: &HashMap<String, Vec<String>>,
+    outgoing: &HashMap<String, Vec<String>>,
+) {
+    for _pass in 0..3 {
+        // Forward pass: sort each column by median position of incoming neighbors
+        for col in 1..=max_col {
+            let prev_order: HashMap<String, usize> = columns
+                .get(&(col - 1))
+                .map(|nodes| {
+                    nodes
+                        .iter()
+                        .enumerate()
+                        .map(|(i, a)| (a.clone(), i))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if let Some(col_nodes) = columns.get_mut(&col) {
+                col_nodes.sort_by(|a, b| {
+                    let ma = median_neighbor_pos(a, incoming, &prev_order);
+                    let mb = median_neighbor_pos(b, incoming, &prev_order);
+                    ma.partial_cmp(&mb).unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+        }
+
+        // Backward pass: sort each column by median position of outgoing neighbors
+        for col in (0..max_col).rev() {
+            let next_order: HashMap<String, usize> = columns
+                .get(&(col + 1))
+                .map(|nodes| {
+                    nodes
+                        .iter()
+                        .enumerate()
+                        .map(|(i, a)| (a.clone(), i))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if let Some(col_nodes) = columns.get_mut(&col) {
+                col_nodes.sort_by(|a, b| {
+                    let ma = median_neighbor_pos(a, outgoing, &next_order);
+                    let mb = median_neighbor_pos(b, outgoing, &next_order);
+                    ma.partial_cmp(&mb).unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+        }
+    }
+}
+
+/// Compute the median position of a node's neighbors in an adjacent column.
+fn median_neighbor_pos(
+    node: &str,
+    adjacency: &HashMap<String, Vec<String>>,
+    order: &HashMap<String, usize>,
+) -> f32 {
+    let mut positions: Vec<usize> = adjacency
+        .get(node)
+        .map(|neighbors| {
+            neighbors
+                .iter()
+                .filter_map(|n| order.get(n).copied())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if positions.is_empty() {
+        return f32::MAX;
+    }
+
+    positions.sort_unstable();
+    let mid = positions.len() / 2;
+    if positions.len().is_multiple_of(2) {
+        let Some(&a) = positions.get(mid.wrapping_sub(1)) else {
+            return f32::MAX;
+        };
+        let Some(&b) = positions.get(mid) else {
+            return f32::MAX;
+        };
+        (a + b) as f32 / 2.0
+    } else {
+        positions.get(mid).map_or(f32::MAX, |&p| p as f32)
+    }
+}
+
 /// Compute topological layout for a set of nodes and connections.
 ///
 /// `node_specs` maps alias → (input names, output names).
@@ -178,6 +268,11 @@ pub fn compute_layout(
         .iter()
         .map(|(alias, inputs, outputs)| (alias.as_str(), (inputs.as_slice(), outputs.as_slice())))
         .collect();
+
+    // Median ordering: reduce edge crossings by sorting nodes within each column
+    // by the median position of their connected neighbors in adjacent columns.
+    let max_col = columns.keys().copied().max().unwrap_or(0);
+    median_ordering(&mut columns, max_col, &incoming, &outgoing);
 
     // Compute positions
     let mut layouts = HashMap::new();

--- a/flowcore/src/graph/layout.rs
+++ b/flowcore/src/graph/layout.rs
@@ -1,0 +1,421 @@
+//! Topological graph layout algorithm shared between flowc and flowedit.
+//!
+//! Computes node positions using BFS-based column assignment and vertical stacking.
+//! Framework-agnostic — works with simple node specs, not rendering types.
+
+#![allow(clippy::cast_precision_loss, clippy::implicit_hasher)]
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::style;
+
+/// A positioned node returned by [`compute_layout`].
+#[derive(Debug, Clone)]
+pub struct PositionedNode {
+    /// Node identifier (alias or derived short name)
+    pub alias: String,
+    /// X position
+    pub x: f32,
+    /// Y position
+    pub y: f32,
+    /// Width
+    pub width: f32,
+    /// Height
+    pub height: f32,
+    /// Column index (depth from source nodes)
+    pub column: usize,
+    /// Input port names
+    pub inputs: Vec<String>,
+    /// Output port names
+    pub outputs: Vec<String>,
+}
+
+impl PositionedNode {
+    /// Y position of the nth input port.
+    #[must_use]
+    pub fn input_port_y(&self, index: usize) -> f32 {
+        let count = self.inputs.len().max(1);
+        port_y(self.y, self.height, index, count)
+    }
+
+    /// Y position of the nth output port.
+    #[must_use]
+    pub fn output_port_y(&self, index: usize) -> f32 {
+        let count = self.outputs.len().max(1);
+        port_y(self.y, self.height, index, count)
+    }
+
+    /// X position of input ports (left edge).
+    #[must_use]
+    pub fn input_port_x(&self) -> f32 {
+        self.x
+    }
+
+    /// X position of output ports (right edge).
+    #[must_use]
+    pub fn output_port_x(&self) -> f32 {
+        self.x + self.width
+    }
+}
+
+/// Compute the Y position of a port given node geometry.
+fn port_y(node_y: f32, node_height: f32, index: usize, count: usize) -> f32 {
+    let ports_height = (count.saturating_sub(1)) as f32 * style::PORT_SPACING;
+    let available = node_height - style::HEADER_HEIGHT;
+    let padding = ((available - ports_height) / 2.0).max(0.0);
+    node_y + style::HEADER_HEIGHT + padding + index as f32 * style::PORT_SPACING
+}
+
+/// Compute the required height for a node based on its port count.
+#[must_use]
+pub fn compute_node_height(input_count: usize, output_count: usize) -> f32 {
+    let max_ports = input_count.max(output_count).max(1);
+    let ports_height = (max_ports - 1) as f32 * style::PORT_SPACING;
+    (style::HEADER_HEIGHT + ports_height + style::NODE_PADDING * 2.0).max(style::NODE_HEIGHT)
+}
+
+/// Compute the Bézier control point horizontal offset for a connection.
+#[must_use]
+pub fn bezier_control_offset(dx: f32) -> f32 {
+    dx.abs().max(60.0) * 0.5
+}
+
+/// Extract a short name from a source path (e.g., `lib://flowstdlib/math/add` → `add`).
+#[must_use]
+pub fn derive_short_name(source: &str) -> String {
+    source.rsplit('/').next().unwrap_or(source).to_string()
+}
+
+/// Split a route like `"sequence/number"` into `("sequence", "number")`.
+#[must_use]
+pub fn split_route(route: &str) -> (String, String) {
+    let route = route.trim_start_matches('/');
+    if let Some(pos) = route.find('/') {
+        (route[..pos].to_string(), route[pos + 1..].to_string())
+    } else {
+        (route.to_string(), String::new())
+    }
+}
+
+/// Compute topological layout for a set of nodes and connections.
+///
+/// `node_specs` maps alias → (input names, output names).
+/// `connections` is a list of `(from_route, to_route)` pairs where routes
+/// are in `"node/port"` format.
+///
+/// Returns a map from alias to [`PositionedNode`] with computed positions.
+#[must_use]
+pub fn compute_layout(
+    node_specs: &[(String, Vec<String>, Vec<String>)],
+    connections: &[(String, String)],
+) -> HashMap<String, PositionedNode> {
+    let aliases: Vec<String> = node_specs
+        .iter()
+        .map(|(alias, _, _)| alias.clone())
+        .collect();
+    let alias_set: HashSet<&str> = aliases.iter().map(String::as_str).collect();
+
+    let mut incoming: HashMap<String, Vec<String>> = HashMap::new();
+    let mut outgoing: HashMap<String, Vec<String>> = HashMap::new();
+    for alias in &aliases {
+        incoming.entry(alias.clone()).or_default();
+        outgoing.entry(alias.clone()).or_default();
+    }
+
+    for (from_route, to_route) in connections {
+        let (from_node, _) = split_route(from_route);
+        if !alias_set.contains(from_node.as_str()) {
+            continue;
+        }
+        let (to_node, _) = split_route(to_route);
+        if from_node != to_node && alias_set.contains(to_node.as_str()) {
+            outgoing
+                .entry(from_node.clone())
+                .or_default()
+                .push(to_node.clone());
+            incoming.entry(to_node).or_default().push(from_node.clone());
+        }
+    }
+
+    // BFS column assignment (longest path from sources)
+    let mut depth: HashMap<String, usize> = HashMap::new();
+    let mut queue = VecDeque::new();
+    for alias in &aliases {
+        if incoming.get(alias).is_none_or(Vec::is_empty) {
+            depth.insert(alias.clone(), 0);
+            queue.push_back(alias.clone());
+        }
+    }
+
+    let max_depth = aliases.len().saturating_sub(1);
+    while let Some(node) = queue.pop_front() {
+        let node_depth = depth.get(&node).copied().unwrap_or(0);
+        if let Some(neighbors) = outgoing.get(&node) {
+            for neighbor in neighbors {
+                let new_depth = (node_depth + 1).min(max_depth);
+                let current = depth.get(neighbor).copied().unwrap_or(0);
+                if new_depth > current {
+                    depth.insert(neighbor.clone(), new_depth);
+                    queue.push_back(neighbor.clone());
+                }
+            }
+        }
+    }
+
+    for alias in &aliases {
+        depth.entry(alias.clone()).or_insert(0);
+    }
+
+    // Group by column
+    let mut columns: HashMap<usize, Vec<String>> = HashMap::new();
+    for alias in &aliases {
+        let col = depth.get(alias).copied().unwrap_or(0);
+        columns.entry(col).or_default().push(alias.clone());
+    }
+
+    // Build a lookup for port info
+    let spec_map: HashMap<&str, (&[String], &[String])> = node_specs
+        .iter()
+        .map(|(alias, inputs, outputs)| (alias.as_str(), (inputs.as_slice(), outputs.as_slice())))
+        .collect();
+
+    // Compute positions
+    let mut layouts = HashMap::new();
+    for (col, col_nodes) in &columns {
+        let x = style::GRID_ORIGIN_X + *col as f32 * style::GRID_SPACING_X;
+        let mut y = style::GRID_ORIGIN_Y;
+        for alias in col_nodes {
+            let (inputs, outputs) = spec_map.get(alias.as_str()).copied().unwrap_or((&[], &[]));
+            let height = compute_node_height(inputs.len(), outputs.len());
+            layouts.insert(
+                alias.clone(),
+                PositionedNode {
+                    alias: alias.clone(),
+                    x,
+                    y,
+                    width: style::NODE_WIDTH,
+                    height,
+                    column: *col,
+                    inputs: inputs.to_vec(),
+                    outputs: outputs.to_vec(),
+                },
+            );
+            y += height + style::NODE_GAP_Y;
+        }
+    }
+
+    layouts
+}
+
+/// Compute waypoints for a backward edge (feedback connection) that routes
+/// below the graph to avoid crossing over nodes.
+///
+/// `edge_index` offsets multiple backward edges vertically to prevent overlap.
+#[must_use]
+pub fn backward_edge_waypoints(
+    from_x: f32,
+    from_y: f32,
+    to_x: f32,
+    to_y: f32,
+    graph_bottom: f32,
+    edge_index: usize,
+) -> Vec<(f32, f32)> {
+    let margin = 20.0;
+    let offset = graph_bottom + margin + edge_index as f32 * 15.0;
+    vec![
+        (from_x, from_y),
+        (from_x + 30.0, from_y),
+        (from_x + 30.0, offset),
+        (to_x - 30.0, offset),
+        (to_x - 30.0, to_y),
+        (to_x, to_y),
+    ]
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn split_route_with_port() {
+        let (node, port) = split_route("sequence/number");
+        assert_eq!(node, "sequence");
+        assert_eq!(port, "number");
+    }
+
+    #[test]
+    fn split_route_no_port() {
+        let (node, port) = split_route("value");
+        assert_eq!(node, "value");
+        assert_eq!(port, "");
+    }
+
+    #[test]
+    fn split_route_leading_slash() {
+        let (node, port) = split_route("/add/a");
+        assert_eq!(node, "add");
+        assert_eq!(port, "a");
+    }
+
+    #[test]
+    fn derive_short_name_lib_url() {
+        assert_eq!(derive_short_name("lib://flowstdlib/math/add"), "add");
+    }
+
+    #[test]
+    fn derive_short_name_plain() {
+        assert_eq!(derive_short_name("my_func"), "my_func");
+    }
+
+    #[test]
+    fn compute_height_single_port() {
+        let h = compute_node_height(1, 1);
+        assert!((h - style::NODE_HEIGHT).abs() < 0.01);
+    }
+
+    #[test]
+    fn compute_height_many_ports() {
+        let h = compute_node_height(8, 2);
+        assert!(h > style::NODE_HEIGHT);
+    }
+
+    #[test]
+    fn layout_chain() {
+        let specs = vec![
+            ("a".into(), vec![], vec!["out".into()]),
+            ("b".into(), vec!["in".into()], vec!["out".into()]),
+            ("c".into(), vec!["in".into()], vec![]),
+        ];
+        let conns = vec![
+            ("a/out".into(), "b/in".into()),
+            ("b/out".into(), "c/in".into()),
+        ];
+        let result = compute_layout(&specs, &conns);
+        assert_eq!(result.len(), 3);
+        assert!(result["a"].x < result["b"].x);
+        assert!(result["b"].x < result["c"].x);
+        assert_eq!(result["a"].column, 0);
+        assert_eq!(result["b"].column, 1);
+        assert_eq!(result["c"].column, 2);
+    }
+
+    #[test]
+    fn layout_diamond() {
+        let specs = vec![
+            ("src".into(), vec![], vec!["out".into()]),
+            ("left".into(), vec!["in".into()], vec!["out".into()]),
+            ("right".into(), vec!["in".into()], vec!["out".into()]),
+            ("sink".into(), vec!["a".into(), "b".into()], vec![]),
+        ];
+        let conns = vec![
+            ("src/out".into(), "left/in".into()),
+            ("src/out".into(), "right/in".into()),
+            ("left/out".into(), "sink/a".into()),
+            ("right/out".into(), "sink/b".into()),
+        ];
+        let result = compute_layout(&specs, &conns);
+        assert_eq!(result["src"].column, 0);
+        assert_eq!(result["left"].column, 1);
+        assert_eq!(result["right"].column, 1);
+        assert_eq!(result["sink"].column, 2);
+    }
+
+    #[test]
+    fn bezier_offset_small_dx() {
+        let offset = bezier_control_offset(20.0);
+        assert!((offset - 30.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn bezier_offset_large_dx() {
+        let offset = bezier_control_offset(200.0);
+        assert!((offset - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn backward_waypoints_go_below() {
+        let wp = backward_edge_waypoints(300.0, 100.0, 50.0, 80.0, 400.0, 0);
+        assert_eq!(wp.len(), 6);
+        for &(_, y) in &wp[2..4] {
+            assert!(y > 400.0);
+        }
+    }
+
+    #[test]
+    fn backward_waypoints_stack_vertically() {
+        let wp0 = backward_edge_waypoints(300.0, 100.0, 50.0, 80.0, 400.0, 0);
+        let wp1 = backward_edge_waypoints(300.0, 100.0, 50.0, 80.0, 400.0, 1);
+        assert!(wp1[2].1 > wp0[2].1);
+    }
+
+    #[test]
+    fn layout_isolated_nodes() {
+        let specs = vec![
+            ("a".into(), vec!["in".into()], vec!["out".into()]),
+            ("b".into(), vec!["in".into()], vec!["out".into()]),
+        ];
+        let conns: Vec<(String, String)> = vec![];
+        let result = compute_layout(&specs, &conns);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result["a"].column, 0);
+        assert_eq!(result["b"].column, 0);
+        assert!(result["b"].y > result["a"].y);
+    }
+
+    #[test]
+    fn layout_cycle_does_not_loop_forever() {
+        let specs = vec![
+            ("a".into(), vec!["in".into()], vec!["out".into()]),
+            ("b".into(), vec!["in".into()], vec!["out".into()]),
+        ];
+        let conns = vec![
+            ("a/out".into(), "b/in".into()),
+            ("b/out".into(), "a/in".into()),
+        ];
+        let result = compute_layout(&specs, &conns);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn port_y_positions_centered() {
+        let specs = vec![("n".into(), vec!["a".into(), "b".into(), "c".into()], vec![])];
+        let result = compute_layout(&specs, &[]);
+        let node = &result["n"];
+        let y0 = node.input_port_y(0);
+        let y1 = node.input_port_y(1);
+        let y2 = node.input_port_y(2);
+        assert!((y1 - y0 - style::PORT_SPACING).abs() < 0.01);
+        assert!((y2 - y1 - style::PORT_SPACING).abs() < 0.01);
+        assert!(y0 > node.y + style::HEADER_HEIGHT - 1.0);
+    }
+
+    #[test]
+    fn output_port_x_is_right_edge() {
+        let specs = vec![("n".into(), vec![], vec!["out".into()])];
+        let result = compute_layout(&specs, &[]);
+        let node = &result["n"];
+        assert!((node.output_port_x() - (node.x + node.width)).abs() < 0.01);
+    }
+
+    #[test]
+    fn input_port_x_is_left_edge() {
+        let specs = vec![("n".into(), vec!["in".into()], vec![])];
+        let result = compute_layout(&specs, &[]);
+        let node = &result["n"];
+        assert!((node.input_port_x() - node.x).abs() < 0.01);
+    }
+
+    #[test]
+    fn node_height_grows_with_ports() {
+        let h_few = compute_node_height(2, 1);
+        let h_many = compute_node_height(10, 1);
+        assert!(h_many > h_few);
+    }
+
+    #[test]
+    fn bezier_offset_negative_dx() {
+        let offset = bezier_control_offset(-200.0);
+        assert!((offset - 100.0).abs() < 0.01);
+    }
+}

--- a/flowcore/src/graph/mod.rs
+++ b/flowcore/src/graph/mod.rs
@@ -1,0 +1,4 @@
+//! Graph layout constants and algorithms shared between flowc and flowedit.
+
+pub mod layout;
+pub mod style;

--- a/flowcore/src/graph/style.rs
+++ b/flowcore/src/graph/style.rs
@@ -1,0 +1,265 @@
+//! Visual style constants shared between flowc SVG generation and flowedit.
+//!
+//! Colors are stored as hex strings so this module has no dependency on
+//! any rendering framework (iced, svg, etc.).
+
+#![allow(clippy::cast_precision_loss)]
+
+use crate::model::process::Process;
+
+// --- Layout geometry ---
+
+/// Horizontal spacing between columns of nodes
+pub const GRID_SPACING_X: f32 = 250.0;
+/// X origin for the grid
+pub const GRID_ORIGIN_X: f32 = 50.0;
+/// Y origin for the grid
+pub const GRID_ORIGIN_Y: f32 = 50.0;
+/// Default node width
+pub const NODE_WIDTH: f32 = 180.0;
+/// Default node height
+pub const NODE_HEIGHT: f32 = 120.0;
+/// Vertical gap between nodes in the same column
+pub const NODE_GAP_Y: f32 = 30.0;
+/// Padding inside nodes
+pub const NODE_PADDING: f32 = 10.0;
+
+// --- Port geometry ---
+
+/// Vertical spacing between ports on a node
+pub const PORT_SPACING: f32 = 20.0;
+/// Radius of port semi-circles
+pub const PORT_RADIUS: f32 = 5.0;
+
+// --- Node shape ---
+
+/// Corner radius for rounded rectangles
+pub const CORNER_RADIUS: f32 = 10.0;
+/// Header height (title + source label area)
+pub const HEADER_HEIGHT: f32 = 50.0;
+
+// --- Text sizes ---
+
+/// Font size for node title labels
+pub const TITLE_FONT_SIZE: f32 = 16.0;
+/// Font size for source path labels
+pub const SOURCE_FONT_SIZE: f32 = 12.0;
+/// Font size for port labels
+pub const PORT_FONT_SIZE: f32 = 11.0;
+
+// --- Edge geometry ---
+
+/// Arrow head size in pixels
+pub const ARROW_SIZE: f32 = 6.0;
+/// Edge stroke width
+pub const STROKE_WIDTH: f32 = 2.0;
+
+// --- Colors (hex strings) ---
+
+/// Node border color
+pub const COLOR_BORDER: &str = "#444444";
+/// Edge/connection color
+pub const COLOR_EDGE: &str = "#808080";
+/// Initializer edge color
+pub const COLOR_INITIALIZER: &str = "#4488CC";
+/// Port fill color (white)
+pub const COLOR_PORT: &str = "#FFFFFF";
+/// Text color on colored node backgrounds
+pub const COLOR_TEXT: &str = "#FFFFFF";
+/// Initializer port highlight color (yellow)
+pub const COLOR_INITIALIZER_PORT: &str = "#E6D94D";
+
+/// Classification of a node for visual styling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeCategory {
+    /// A subflow (contains other processes)
+    Subflow,
+    /// A library function (referenced via `lib://`)
+    Library,
+    /// A context function (referenced via `context://`)
+    Context,
+    /// A custom/local function
+    Custom,
+}
+
+impl NodeCategory {
+    /// Hex color for this node category.
+    #[must_use]
+    pub fn color_hex(&self) -> &'static str {
+        match self {
+            Self::Subflow => "#E69933",
+            Self::Library => "#4D80E6",
+            Self::Context => "#4DBF73",
+            Self::Custom => "#994DCC",
+        }
+    }
+
+    /// RGB color components (0.0–1.0) for this node category.
+    #[must_use]
+    pub fn color_rgb(&self) -> (f32, f32, f32) {
+        match self {
+            Self::Subflow => (0.9, 0.6, 0.2),
+            Self::Library => (0.3, 0.5, 0.9),
+            Self::Context => (0.3, 0.75, 0.45),
+            Self::Custom => (0.6, 0.3, 0.8),
+        }
+    }
+
+    /// Classify a process into a node category.
+    #[must_use]
+    pub fn classify(process: Option<&Process>, source: &str) -> Self {
+        match process {
+            Some(Process::FlowProcess(_)) => Self::Subflow,
+            Some(Process::FunctionProcess(f)) => {
+                if f.get_lib_reference().is_some() {
+                    Self::Library
+                } else if f.get_context_reference().is_some() {
+                    Self::Context
+                } else {
+                    Self::Custom
+                }
+            }
+            None => Self::classify_from_source(source),
+        }
+    }
+
+    fn classify_from_source(source: &str) -> Self {
+        if source.starts_with("lib://") {
+            Self::Library
+        } else if source.starts_with("context://") {
+            Self::Context
+        } else {
+            Self::Subflow
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::field_reassign_with_default,
+    clippy::indexing_slicing
+)]
+mod test {
+    use super::*;
+    use crate::model::flow_definition::FlowDefinition;
+    use crate::model::function_definition::FunctionDefinition;
+    use url::Url;
+
+    fn lib_function() -> FunctionDefinition {
+        let mut f = FunctionDefinition::default();
+        f.lib_reference = Some(Url::parse("lib://flowstdlib/math/add").expect("valid url"));
+        f
+    }
+
+    fn context_function() -> FunctionDefinition {
+        let mut f = FunctionDefinition::default();
+        f.context_reference = Some(Url::parse("context://stdio/stdout").expect("valid url"));
+        f
+    }
+
+    #[test]
+    fn classify_flow_process() {
+        let flow = Process::FlowProcess(FlowDefinition::default());
+        assert_eq!(
+            NodeCategory::classify(Some(&flow), ""),
+            NodeCategory::Subflow
+        );
+    }
+
+    #[test]
+    fn classify_library_function() {
+        let func = Process::FunctionProcess(lib_function());
+        assert_eq!(
+            NodeCategory::classify(Some(&func), ""),
+            NodeCategory::Library
+        );
+    }
+
+    #[test]
+    fn classify_context_function() {
+        let func = Process::FunctionProcess(context_function());
+        assert_eq!(
+            NodeCategory::classify(Some(&func), ""),
+            NodeCategory::Context
+        );
+    }
+
+    #[test]
+    fn classify_custom_function() {
+        let func = Process::FunctionProcess(FunctionDefinition::default());
+        assert_eq!(
+            NodeCategory::classify(Some(&func), ""),
+            NodeCategory::Custom
+        );
+    }
+
+    #[test]
+    fn classify_none_with_lib_source() {
+        assert_eq!(
+            NodeCategory::classify(None, "lib://flowstdlib/math/add"),
+            NodeCategory::Library
+        );
+    }
+
+    #[test]
+    fn classify_none_with_context_source() {
+        assert_eq!(
+            NodeCategory::classify(None, "context://stdio/stdout"),
+            NodeCategory::Context
+        );
+    }
+
+    #[test]
+    fn classify_none_with_unknown_source() {
+        assert_eq!(
+            NodeCategory::classify(None, "my_flow.toml"),
+            NodeCategory::Subflow
+        );
+    }
+
+    #[test]
+    fn all_categories_have_distinct_colors() {
+        let categories = [
+            NodeCategory::Subflow,
+            NodeCategory::Library,
+            NodeCategory::Context,
+            NodeCategory::Custom,
+        ];
+        for (i, a) in categories.iter().enumerate() {
+            for b in &categories[i + 1..] {
+                assert_ne!(a.color_hex(), b.color_hex());
+                assert_ne!(a.color_rgb(), b.color_rgb());
+            }
+        }
+    }
+
+    #[test]
+    fn color_hex_starts_with_hash() {
+        for cat in [
+            NodeCategory::Subflow,
+            NodeCategory::Library,
+            NodeCategory::Context,
+            NodeCategory::Custom,
+        ] {
+            assert!(cat.color_hex().starts_with('#'));
+            assert_eq!(cat.color_hex().len(), 7);
+        }
+    }
+
+    #[test]
+    fn color_rgb_in_range() {
+        for cat in [
+            NodeCategory::Subflow,
+            NodeCategory::Library,
+            NodeCategory::Context,
+            NodeCategory::Custom,
+        ] {
+            let (r, g, b) = cat.color_rgb();
+            assert!((0.0..=1.0).contains(&r));
+            assert!((0.0..=1.0).contains(&g));
+            assert!((0.0..=1.0).contains(&b));
+        }
+    }
+}

--- a/flowcore/src/lib.rs
+++ b/flowcore/src/lib.rs
@@ -99,6 +99,9 @@ pub const RUN_AGAIN: RunAgain = true;
 /// executed more times in the future.
 pub type RunAgain = bool;
 
+/// Graph layout constants and algorithms shared between flowc and flowedit
+pub mod graph;
+
 /// contains the file and http content provider implementations
 #[cfg(not(target_arch = "wasm32"))]
 pub mod content;

--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -205,14 +205,10 @@ struct ConnectingState {
     current_screen_pos: Point,
 }
 
-/// Corner radius for rounded rectangles
-pub(crate) const CORNER_RADIUS: f32 = 10.0;
-/// Title font size (minimum readable)
-pub(crate) const TITLE_FONT_SIZE: f32 = 16.0;
-/// Source label font size (minimum readable)
-pub(crate) const SOURCE_FONT_SIZE: f32 = 12.0;
-/// Port circle radius
-const PORT_RADIUS: f32 = 5.0;
+pub(crate) const CORNER_RADIUS: f32 = flowcore::graph::style::CORNER_RADIUS;
+pub(crate) const TITLE_FONT_SIZE: f32 = flowcore::graph::style::TITLE_FONT_SIZE;
+pub(crate) const SOURCE_FONT_SIZE: f32 = flowcore::graph::style::SOURCE_FONT_SIZE;
+const PORT_RADIUS: f32 = flowcore::graph::style::PORT_RADIUS;
 /// Maximum characters for source label before truncation
 const MAX_SOURCE_CHARS: usize = 22;
 

--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -462,6 +462,116 @@ fn loopback_waypoints(
     (box_right, box_bottom, box_left, mid_x)
 }
 
+/// Build the loopback path that routes around a node with rounded corners.
+#[allow(clippy::too_many_arguments)]
+fn loopback_path(
+    from_s: Point,
+    to_s: Point,
+    nx: f32,
+    ny: f32,
+    nw: f32,
+    nh: f32,
+    zoom: f32,
+    offset: Point,
+) -> Path {
+    let (box_right, box_bottom, box_left, _) = loopback_waypoints(nx, ny, nw, nh, zoom, offset);
+    let r = 10.0 * zoom;
+    Path::new(|builder| {
+        builder.move_to(from_s);
+        builder.line_to(Point::new(box_right - r, from_s.y));
+        builder.quadratic_curve_to(
+            Point::new(box_right, from_s.y),
+            Point::new(box_right, from_s.y + r),
+        );
+        builder.line_to(Point::new(box_right, box_bottom - r));
+        builder.quadratic_curve_to(
+            Point::new(box_right, box_bottom),
+            Point::new(box_right - r, box_bottom),
+        );
+        builder.line_to(Point::new(box_left + r, box_bottom));
+        builder.quadratic_curve_to(
+            Point::new(box_left, box_bottom),
+            Point::new(box_left, box_bottom - r),
+        );
+        builder.line_to(Point::new(box_left, to_s.y + r));
+        builder.quadratic_curve_to(
+            Point::new(box_left, to_s.y),
+            Point::new(box_left + r, to_s.y),
+        );
+        builder.line_to(to_s);
+    })
+}
+
+/// Sample points along a loopback path for hit-testing.
+#[allow(clippy::too_many_arguments)]
+fn loopback_sample_points(
+    from_s: Point,
+    to_s: Point,
+    box_right: f32,
+    box_bottom: f32,
+    box_left: f32,
+    zoom: f32,
+) -> Vec<Point> {
+    let mut pts = Vec::with_capacity(BEZIER_SAMPLES + 1);
+    let segments = BEZIER_SAMPLES / 8;
+    let r = 10.0 * zoom;
+
+    let lerp = |a: f32, b: f32, i: usize| a + (b - a) * (i as f32 / segments as f32);
+
+    for i in 0..=segments {
+        pts.push(Point::new(lerp(from_s.x, box_right - r, i), from_s.y));
+    }
+    for i in 0..=segments {
+        let t = i as f32 / segments as f32;
+        pts.push(quadratic_bezier_pt(
+            Point::new(box_right - r, from_s.y),
+            Point::new(box_right, from_s.y),
+            Point::new(box_right, from_s.y + r),
+            t,
+        ));
+    }
+    for i in 0..=segments {
+        pts.push(Point::new(box_right, lerp(from_s.y + r, box_bottom - r, i)));
+    }
+    for i in 0..=segments {
+        let t = i as f32 / segments as f32;
+        pts.push(quadratic_bezier_pt(
+            Point::new(box_right, box_bottom - r),
+            Point::new(box_right, box_bottom),
+            Point::new(box_right - r, box_bottom),
+            t,
+        ));
+    }
+    for i in 0..=segments {
+        pts.push(Point::new(lerp(box_right - r, box_left + r, i), box_bottom));
+    }
+    for i in 0..=segments {
+        let t = i as f32 / segments as f32;
+        pts.push(quadratic_bezier_pt(
+            Point::new(box_left + r, box_bottom),
+            Point::new(box_left, box_bottom),
+            Point::new(box_left, box_bottom - r),
+            t,
+        ));
+    }
+    for i in 0..=segments {
+        pts.push(Point::new(box_left, lerp(box_bottom - r, to_s.y + r, i)));
+    }
+    for i in 0..=segments {
+        let t = i as f32 / segments as f32;
+        pts.push(quadratic_bezier_pt(
+            Point::new(box_left, to_s.y + r),
+            Point::new(box_left, to_s.y),
+            Point::new(box_left + r, to_s.y),
+            t,
+        ));
+    }
+    for i in 0..=segments {
+        pts.push(Point::new(lerp(box_left + r, to_s.x, i), to_s.y));
+    }
+    pts
+}
+
 /// Draw a bezier curve connection between two world-space points, applying zoom and offset.
 /// `node_bounds` is `Some((x, y, width, height))` in world coords for self-connections,
 /// `None` for normal connections.
@@ -488,26 +598,7 @@ fn draw_bezier_connection(
         .with_color(conn_color);
 
     if let Some((nx, ny, nw, nh)) = node_bounds {
-        let (box_right, box_bottom, box_left, _mid_x) =
-            loopback_waypoints(nx, ny, nw, nh, zoom, offset);
-
-        let path = Path::new(|builder| {
-            builder.move_to(from_s);
-            // Go right past the box
-            builder.line_to(Point::new(box_right, from_s.y));
-            // Curve down to below the box
-            builder.quadratic_curve_to(
-                Point::new(box_right, box_bottom),
-                Point::new(box_right.midpoint(box_left), box_bottom),
-            );
-            // Curve up to left of the box
-            builder.quadratic_curve_to(
-                Point::new(box_left, box_bottom),
-                Point::new(box_left, to_s.y),
-            );
-            // Arrive at input
-            builder.line_to(to_s);
-        });
+        let path = loopback_path(from_s, to_s, nx, ny, nw, nh, zoom, offset);
         frame.stroke(&path, stroke);
     } else {
         // Normal connection: bezier curve from right to left
@@ -967,7 +1058,7 @@ impl FlowCanvas<'_> {
                         let Some(from_n) = from_node_ref else {
                             continue;
                         };
-                        let (box_right, box_bottom, box_left, mid_x) = loopback_waypoints(
+                        let (box_right, box_bottom, box_left, _mid_x) = loopback_waypoints(
                             from_n.x(),
                             from_n.y(),
                             from_n.width(),
@@ -976,42 +1067,7 @@ impl FlowCanvas<'_> {
                             offset,
                         );
 
-                        // Sample the path: from -> right -> curve down -> bottom -> curve up -> to
-                        let mut pts = Vec::with_capacity(BEZIER_SAMPLES + 1);
-                        let segments = BEZIER_SAMPLES / 5;
-                        // Segment 1: from -> right
-                        for i in 0..=segments {
-                            let t = i as f32 / segments as f32;
-                            pts.push(Point::new(from_s.x + (box_right - from_s.x) * t, from_s.y));
-                        }
-                        // Segment 2: curve right -> bottom
-                        for i in 0..=segments {
-                            let t = i as f32 / segments as f32;
-                            let p = quadratic_bezier_pt(
-                                Point::new(box_right, from_s.y),
-                                Point::new(box_right, box_bottom),
-                                Point::new(mid_x, box_bottom),
-                                t,
-                            );
-                            pts.push(p);
-                        }
-                        // Segment 3: curve bottom -> left
-                        for i in 0..=segments {
-                            let t = i as f32 / segments as f32;
-                            let p = quadratic_bezier_pt(
-                                Point::new(mid_x, box_bottom),
-                                Point::new(box_left, box_bottom),
-                                Point::new(box_left, to_s.y),
-                                t,
-                            );
-                            pts.push(p);
-                        }
-                        // Segment 4: left -> to
-                        for i in 0..=segments {
-                            let t = i as f32 / segments as f32;
-                            pts.push(Point::new(box_left + (to_s.x - box_left) * t, to_s.y));
-                        }
-                        pts
+                        loopback_sample_points(from_s, to_s, box_right, box_bottom, box_left, zoom)
                     } else {
                         // Use matching control points for flow I/O vs normal connections
                         let is_flow_io = from_node_str == "input" || to_node_str == "output";

--- a/flowedit/src/node_layout.rs
+++ b/flowedit/src/node_layout.rs
@@ -18,24 +18,14 @@ use flowcore::model::process::Process;
 use flowcore::model::process_reference::ProcessReference;
 
 use crate::flow_canvas::TITLE_FONT_SIZE;
-use crate::utils::{base_port_name, derive_short_name, format_value, split_route};
+use crate::utils::{base_port_name, derive_short_name, format_value};
 
-/// Default node width when no layout width is specified
-pub(crate) const DEFAULT_WIDTH: f32 = 180.0;
-/// Default node height when no layout height is specified
-pub(crate) const DEFAULT_HEIGHT: f32 = 120.0;
-/// Horizontal spacing between auto-laid-out nodes
-const GRID_SPACING_X: f32 = 250.0;
-/// Minimum vertical gap between auto-laid-out nodes
-const NODE_GAP_Y: f32 = 30.0;
-/// Starting X offset for auto-layout
-const GRID_ORIGIN_X: f32 = 50.0;
-/// Starting Y offset for auto-layout
-const GRID_ORIGIN_Y: f32 = 50.0;
-/// Port label font size
-pub(crate) const PORT_FONT_SIZE: f32 = 11.0;
-/// Vertical spacing between ports
-pub(crate) const PORT_SPACING: f32 = 20.0;
+use flowcore::graph::style;
+
+pub(crate) const DEFAULT_WIDTH: f32 = style::NODE_WIDTH;
+pub(crate) const DEFAULT_HEIGHT: f32 = style::NODE_HEIGHT;
+pub(crate) const PORT_FONT_SIZE: f32 = style::PORT_FONT_SIZE;
+pub(crate) const PORT_SPACING: f32 = style::PORT_SPACING;
 
 static EMPTY_IO: Vec<IO> = Vec::new();
 
@@ -85,10 +75,10 @@ impl<'a> NodeLayout<'a> {
 
     pub(crate) fn height(&self) -> f32 {
         let stored = self.process_ref.height.unwrap_or(DEFAULT_HEIGHT);
-        let header = 50.0;
         let bottom_pad = 25.0;
         let max_ports = self.inputs().len().max(self.outputs().len());
-        let min_for_ports = header + max_ports.saturating_sub(1) as f32 * PORT_SPACING + bottom_pad;
+        let min_for_ports =
+            style::HEADER_HEIGHT + max_ports.saturating_sub(1) as f32 * PORT_SPACING + bottom_pad;
         stored.max(min_for_ports)
     }
 
@@ -146,27 +136,8 @@ impl<'a> NodeLayout<'a> {
     }
 
     pub(crate) fn fill_color(&self) -> iced::Color {
-        match &self.process {
-            Some(Process::FlowProcess(_)) => iced::Color::from_rgb(0.9, 0.6, 0.2),
-            Some(Process::FunctionProcess(f)) => {
-                if f.get_lib_reference().is_some() {
-                    iced::Color::from_rgb(0.3, 0.5, 0.9)
-                } else if f.get_context_reference().is_some() {
-                    iced::Color::from_rgb(0.3, 0.75, 0.45)
-                } else {
-                    iced::Color::from_rgb(0.6, 0.3, 0.8)
-                }
-            }
-            None => {
-                if self.source().starts_with("lib://") {
-                    iced::Color::from_rgb(0.3, 0.5, 0.9)
-                } else if self.source().starts_with("context://") {
-                    iced::Color::from_rgb(0.3, 0.75, 0.45)
-                } else {
-                    iced::Color::from_rgb(0.9, 0.6, 0.2)
-                }
-            }
-        }
+        let (r, g, b) = style::NodeCategory::classify(self.process, self.source()).color_rgb();
+        iced::Color::from_rgb(r, g, b)
     }
 
     pub(crate) fn is_openable(&self) -> bool {
@@ -182,11 +153,10 @@ impl<'a> NodeLayout<'a> {
     }
 
     fn port_start_y(&self, port_count: usize) -> f32 {
-        let header_height = 50.0;
-        let available = self.height() - header_height;
+        let available = self.height() - style::HEADER_HEIGHT;
         let ports_height = (port_count.saturating_sub(1)) as f32 * PORT_SPACING;
         let padding = ((available - ports_height) / 2.0).max(0.0);
-        self.y() + header_height + padding
+        self.y() + style::HEADER_HEIGHT + padding
     }
 
     pub(crate) fn output_port_position(&self, port_index: usize) -> Point {
@@ -329,107 +299,40 @@ impl<'a> NodeLayout<'a> {
 
 /// Compute topology-based positions for nodes without saved layout.
 ///
-/// Assigns each node a column based on its depth from source nodes (nodes with no
-/// incoming connections). Nodes are spread vertically within each column.
+/// Delegates to the shared layout algorithm in `flowcore::graph::layout`.
 pub(crate) fn compute_topological_layout(
     process_refs: &[ProcessReference],
     connections: &[Connection],
-    node_heights: &HashMap<String, f32>,
+    _node_heights: &HashMap<String, f32>,
 ) -> HashMap<String, (f32, f32)> {
-    // Build alias list
-    let aliases: Vec<String> = process_refs
+    use flowcore::graph::layout as shared;
+
+    let node_specs: Vec<(String, Vec<String>, Vec<String>)> = process_refs
         .iter()
         .map(|p| {
-            if p.alias.is_empty() {
+            let alias = if p.alias.is_empty() {
                 derive_short_name(&p.source)
             } else {
                 p.alias.clone()
-            }
+            };
+            (alias, vec![], vec![])
         })
         .collect();
 
-    // Build adjacency: which nodes feed which
-    let mut incoming: HashMap<String, Vec<String>> = HashMap::new();
-    let mut outgoing: HashMap<String, Vec<String>> = HashMap::new();
-    for alias in &aliases {
-        incoming.entry(alias.clone()).or_default();
-        outgoing.entry(alias.clone()).or_default();
-    }
+    let conn_pairs: Vec<(String, String)> = connections
+        .iter()
+        .flat_map(|conn| {
+            let from = conn.from().to_string();
+            conn.to()
+                .iter()
+                .map(move |to| (from.clone(), to.to_string()))
+        })
+        .collect();
 
-    let alias_set: std::collections::HashSet<&str> = aliases.iter().map(String::as_str).collect();
-    for conn in connections {
-        let from_route = conn.from().to_string();
-        let (from_node, _) = split_route(&from_route);
-        if !alias_set.contains(from_node.as_str()) {
-            continue;
-        }
-        for to_route in conn.to() {
-            let to_str = to_route.to_string();
-            let (to_node, _) = split_route(&to_str);
-            if from_node != to_node && alias_set.contains(to_node.as_str()) {
-                outgoing
-                    .entry(from_node.clone())
-                    .or_default()
-                    .push(to_node.clone());
-                incoming.entry(to_node).or_default().push(from_node.clone());
-            }
-        }
-    }
-
-    // Assign column depth using BFS from source nodes (no incoming edges)
-    let mut depth: HashMap<String, usize> = HashMap::new();
-    let mut queue: std::collections::VecDeque<String> = std::collections::VecDeque::new();
-
-    for alias in &aliases {
-        if incoming.get(alias).is_none_or(std::vec::Vec::is_empty) {
-            depth.insert(alias.clone(), 0);
-            queue.push_back(alias.clone());
-        }
-    }
-
-    // BFS to assign max depth (longest path from any source).
-    // Cap depth to prevent infinite loops on cyclic flows (e.g., fibonacci feedback).
-    let max_depth = aliases.len().saturating_sub(1);
-    while let Some(node) = queue.pop_front() {
-        let node_depth = depth.get(&node).copied().unwrap_or(0);
-        if let Some(neighbors) = outgoing.get(&node) {
-            for neighbor in neighbors {
-                let new_depth = (node_depth + 1).min(max_depth);
-                let current = depth.get(neighbor).copied().unwrap_or(0);
-                if new_depth > current {
-                    depth.insert(neighbor.clone(), new_depth);
-                    queue.push_back(neighbor.clone());
-                }
-            }
-        }
-    }
-
-    // Assign any unvisited nodes depth 0
-    for alias in &aliases {
-        depth.entry(alias.clone()).or_insert(0);
-    }
-
-    // Group nodes by column
-    let mut columns: HashMap<usize, Vec<String>> = HashMap::new();
-    for alias in &aliases {
-        let col = depth.get(alias).copied().unwrap_or(0);
-        columns.entry(col).or_default().push(alias.clone());
-    }
-
-    // Compute positions: spread columns horizontally, stack nodes vertically
-    // using actual heights plus a gap
-    let mut positions = HashMap::new();
-    for (col, col_nodes) in &columns {
-        let x = GRID_ORIGIN_X + *col as f32 * GRID_SPACING_X;
-        let mut y = GRID_ORIGIN_Y;
-        for alias in col_nodes {
-            positions.insert(alias.clone(), (x, y));
-            let h = node_heights.get(alias).copied().unwrap_or(DEFAULT_HEIGHT);
-            y += h + NODE_GAP_Y;
-        }
-    }
-
-    positions
+    shared::compute_layout(&node_specs, &conn_pairs)
+        .into_iter()
+        .map(|(alias, node)| (alias, (node.x, node.y)))
+        .collect()
 }
 
 #[cfg(test)]

--- a/flowedit/src/utils.rs
+++ b/flowedit/src/utils.rs
@@ -23,23 +23,8 @@ pub(crate) fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
     }
 }
 
-/// Derive a short display name from a source URL.
-/// e.g., `"lib://flowstdlib/math/sequence"` → `"sequence"`
-/// e.g., `"context://stdio/stdout"` → `"stdout"`
-pub(crate) fn derive_short_name(source: &str) -> String {
-    source.rsplit('/').next().unwrap_or(source).to_string()
-}
-
-/// Split a route string like "sequence/number" into ("sequence", "number")
-/// or "add1" into ("add1", "")
-pub(crate) fn split_route(route: &str) -> (String, String) {
-    let route = route.trim_start_matches('/');
-    if let Some(pos) = route.find('/') {
-        (route[..pos].to_string(), route[pos + 1..].to_string())
-    } else {
-        (route.to_string(), String::new())
-    }
-}
+pub(crate) use flowcore::graph::layout::derive_short_name;
+pub(crate) use flowcore::graph::layout::split_route;
 
 /// Check whether a Connection references a node by alias in its from or to routes.
 pub(crate) fn connection_references_node(conn: &Connection, alias: &str) -> bool {


### PR DESCRIPTION
## Summary
- Extract shared graph layout algorithm, style constants, and node category classification into `flowcore::graph` module
- Both flowc (SVG generation) and flowedit will use the same layout logic and visual constants
- Includes `NodeCategory` enum for consistent color classification across renderers
- 30 unit tests covering layout, style, and edge routing

Part 1 of #2848 — subsequent commits will migrate flowc and flowedit to use the shared module.

## Test plan
- [x] 30 new unit tests in `flowcore::graph` (layout + style)
- [x] `make clippy` clean
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph visualization framework with automatic node layout and positioning.
  * Introduced visual styling system supporting multiple node categories with distinct colors.
  * Added edge routing capabilities including feedback loop handling and Bézier curve support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->