### PR TITLE
Remove misleading flowstdlib message from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Install flow data files (context definitions and flowstdlib)
-# Run this after extracting the release archive
+# Install flow context definitions (runner data files).
+# flowstdlib is installed separately via install-flowstdlib.sh.
 
 set -e
 
@@ -32,16 +32,5 @@ if [ -d "runner/flowrgui" ]; then
     echo "  Installed flowrgui context definitions"
 fi
 
-# Install flowstdlib (compiled WASM library)
-# Looks for flowstdlib/ in the current directory (from the separate tarball)
-if [ -d "flowstdlib" ]; then
-    mkdir -p "${FLOW_DIR}/lib/flowstdlib"
-    cp -a flowstdlib/. "${FLOW_DIR}/lib/flowstdlib/"
-    echo "  Installed flowstdlib library"
-else
-    echo "  flowstdlib/ not found — download the flowstdlib tarball from the"
-    echo "  release, extract it here, and re-run this script to install it."
-fi
-
 echo ""
-echo "Done. Flow data installed to ${FLOW_DIR}/"
+echo "Done. Context definitions installed to ${FLOW_DIR}/"


### PR DESCRIPTION
## Summary
- Remove flowstdlib installation section from `install.sh` — it's handled separately by `install-flowstdlib.sh`
- Fixes the misleading "flowstdlib not found" message that appeared when `install-flow.sh` called `install.sh` before downloading flowstdlib

Fixes #2840

## Test plan
- [x] `install.sh` no longer mentions flowstdlib
- [x] `install-flow.sh` still installs flowstdlib via `install-flowstdlib.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer top-of-script guidance for the installation flow.
* **Chores**
  * Updated the installer’s final output to show a more specific completion message for installed context definitions.
  * Removed an older, less specific success message and replaced it with a clearer destination path notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->