### PR TITLE
Add router correctness check for optimal route

### DIFF
--- a/flowr/examples/router/expected_contains.stdout
+++ b/flowr/examples/router/expected_contains.stdout
@@ -1,0 +1,1 @@
+BCACBBC

--- a/flowstdlib/src/charts/charts.md
+++ b/flowstdlib/src/charts/charts.md
@@ -6,7 +6,3 @@ Functions for generating chart and visualization images from data.
 [[process]]
 source = "lib://flowstdlib/charts/{function_name}"
 ```
-
-## List of Functions
-* [`histogram`](histogram/histogram.md) — generate a histogram image from binned data
-* [`time_series`](time_series/time_series.md) — generate a time series chart image

--- a/flowstdlib/src/charts/charts.md
+++ b/flowstdlib/src/charts/charts.md
@@ -1,3 +1,12 @@
 ## Charts (//flowstdlib/charts)
-
 Functions for generating chart and visualization images from data.
+
+### Include using
+```toml
+[[process]]
+source = "lib://flowstdlib/charts/{function_name}"
+```
+
+## List of Functions
+* [`histogram`](histogram/histogram.md) — generate a histogram image from binned data
+* [`time_series`](time_series/time_series.md) — generate a time series chart image

--- a/flowstdlib/src/data/avg/avg.md
+++ b/flowstdlib/src/data/avg/avg.md
@@ -1,4 +1,22 @@
 ## Stream Avg (//flowstdlib/data/avg)
-Compute the average of a null-terminated stream. Initialize `partial_sum`
-and `partial_count` to 0. On null, outputs average on `result` and count
-on `count`.
+Compute the running average of a null-terminated stream of numbers.
+
+Feed values one at a time. When a null is received, the final average
+is output on `result` and the count of values on `count`.
+
+### Inputs
+* `value` (number) — the next value in the stream (null to finish)
+* `partial_sum` (number) — accumulated sum (initialize to 0, feed back from output)
+* `partial_count` (number) — accumulated count (initialize to 0, feed back from output)
+
+### Outputs
+* `partial_sum` (number) — running sum (feed back to input)
+* `partial_count` (number) — running count (feed back to input)
+* `result` (number) — final average (emitted on null)
+* `count` (number) — total number of values (emitted on null)
+
+### Include using
+```toml
+[[process]]
+source = "lib://flowstdlib/data/avg"
+```

--- a/flowstdlib/src/data/max/max.md
+++ b/flowstdlib/src/data/max/max.md
@@ -1,3 +1,19 @@
 ## Stream Max (//flowstdlib/data/max)
-Track the maximum value in a null-terminated stream. Initialize `partial`
-to 0. On null, outputs final maximum on `result`.
+Track the maximum value in a null-terminated stream of numbers.
+
+Feed values one at a time. When a null is received, the final maximum
+is output on `result`.
+
+### Inputs
+* `value` (number) — the next value in the stream (null to finish)
+* `partial` (number) — current maximum (initialize to 0, feed back from output)
+
+### Outputs
+* `partial` (number) — running maximum (feed back to input)
+* `result` (number) — final maximum (emitted on null)
+
+### Include using
+```toml
+[[process]]
+source = "lib://flowstdlib/data/max"
+```

--- a/flowstdlib/src/data/min/min.md
+++ b/flowstdlib/src/data/min/min.md
@@ -1,3 +1,19 @@
 ## Stream Min (//flowstdlib/data/min)
-Track the minimum value in a null-terminated stream. Initialize `partial`
-to a large value (e.g. 255). On null, outputs final minimum on `result`.
+Track the minimum value in a null-terminated stream of numbers.
+
+Feed values one at a time. When a null is received, the final minimum
+is output on `result`.
+
+### Inputs
+* `value` (number) — the next value in the stream (null to finish)
+* `partial` (number) — current minimum (initialize to a large value, feed back from output)
+
+### Outputs
+* `partial` (number) — running minimum (feed back to input)
+* `result` (number) — final minimum (emitted on null)
+
+### Include using
+```toml
+[[process]]
+source = "lib://flowstdlib/data/min"
+```

--- a/flowstdlib/src/fmt/to_json/to_json.md
+++ b/flowstdlib/src/fmt/to_json/to_json.md
@@ -1,6 +1,24 @@
 ## ToJson (//flowstdlib/fmt/to_json)
-Convert a String to Json
- 
+Convert a String to a JSON value.
+
+Parses the input string as JSON. If parsing succeeds, outputs the
+parsed JSON value (number, array, object, boolean, null, etc.).
+If the string is not valid JSON, outputs it as a JSON string value.
+
+### Input
+* `string` — the string to parse as JSON
+
+### Output
+* The parsed JSON value
+
+### Supported conversions
+* `"42"` → number `42`
+* `"null"` → JSON null
+* `"[1,2,3]"` → array `[1,2,3]`
+* `"{\"key\":42}"` → object `{"key":42}`
+* `"\"hello\""` → string `"hello"`
+* Invalid JSON (e.g., `"-1.20,0.35"`) → returned as a JSON string
+
 ### Include using
 ```toml
 [[process]]

--- a/flowstdlib/src/fmt/to_string/to_string.md
+++ b/flowstdlib/src/fmt/to_string/to_string.md
@@ -1,14 +1,24 @@
 ## ToString (//flowstdlib/fmt/to_string)
-Convert an input type to a String
+Convert any JSON value to its string representation.
 
-Current types supported are:
- * null - A null will be printed as "null"
- * boolean - boolean JSON value
- * number - A JSON Number
- * string - a bit redundant, but it works
- * array - An JSON array of values that can be converted, they are converted one by one
- * object - a Map of names/objects that will also be printed out
- 
+Takes a generic input value and outputs its string form using JSON
+serialization. This is useful for converting numbers, arrays, objects,
+or other types into strings for display or further processing.
+
+### Input
+* Any JSON value (generic input — accepts all types)
+
+### Output
+* `string` — the string representation of the input value
+
+### Supported conversions
+* `null` → `"null"`
+* `true` / `false` → `"true"` / `"false"`
+* `42` → `"42"`
+* `"hello"` → `"\"hello\""`
+* `[1,2,3]` → `"[1,2,3]"`
+* `{"key": 42}` → `"{\"key\":42}"`
+
 ### Include using
 ```toml
 [[process]]


### PR DESCRIPTION
## Summary
- Add `expected_contains.stdout` for router with `BCACBBC` — verifies the optimal route is correct
- The route is deterministic; the distance (75 or 85) varies due to a race condition in the parallel tracker interaction
- The distance race condition is a separate issue that needs a deeper flow fix

Partially addresses #2874

## Test plan
- [x] `make clippy` clean
- [x] `make test` passes locally
- [x] Route `BCACBBC` is consistent across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded chart and data-process docs with clearer setup instructions, input/output details, and usage examples.
  * Added structured guidance for average, minimum, maximum, JSON conversion, and string conversion behaviors.
  * Included new “Include using” snippets to make it easier to reference these components.

* **Tests**
  * Updated an expected router output file to match the latest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->