### PR TITLE
Show output port path on feedback connection labels (#2878)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: install graphviz
-        run: sudo apt-get update && sudo apt-get -y install graphviz
       - name: install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
       - name: install link checker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build book
         run: |
-          sudo apt-get update && sudo apt-get -y install graphviz
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
           curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip > mdbook-linkcheck.zip
           mkdir -p $HOME/.cargo/bin

--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,19 @@ ifneq ($(DNF),)
 	@echo "To build OpenSSL you need perl installed"
 	@sudo dnf install perl
 	@sudo dnf install curl-devel elfutils-libelf-devel elfutils-devel openssl openssl-devel binutils-devel || true
-	@sudo dnf install zeromq zeromq-devel graphviz binaryen lcov || true
+	@sudo dnf install zeromq zeromq-devel binaryen lcov || true
 else ifneq ($(YUM),)
 	@echo "Installing dependencies using $(YUM)"
 	@echo "To build OpenSSL you need perl installed"
 	@sudo yum install perl
 	@sudo yum install curl-devel elfutils-libelf-devel elfutils-devel openssl openssl-devel binutils-devel || true
-	@sudo yum install zeromq zeromq-devel graphviz binaryen lcov || true
+	@sudo yum install zeromq zeromq-devel binaryen lcov || true
 else ifneq ($(APTGET),)
 	@echo "Installing dependencies using $(APTGET)"
 	@echo "To build OpenSSL you need perl installed"
 	@sudo apt-get install perl
 	@sudo apt-get -y install libcurl4-openssl-dev libelf-dev libdw-dev libssl-dev binutils-dev || true
-	@sudo apt-get -y install libzmq3-dev graphviz binaryen lcov || true
+	@sudo apt-get -y install libzmq3-dev binaryen lcov || true
 	@wget https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz
 	@tar -xvzf binaryen-version_116-x86_64-linux.tar.gz
 	@sudo cp binaryen-version_116/bin/* /bin/
@@ -60,7 +60,7 @@ else ifneq ($(APTGET),)
 	@rm binaryen-version_116-x86_64-linux.tar.gz
 else ifneq ($(BREW),)
 	@echo "Installing dependencies using $(BREW)"
-	@brew install --quiet zmq graphviz binaryen lcov
+	@brew install --quiet zmq binaryen lcov
 endif
 	@echo "Installing grcov using cargo"
 	@cargo install grcov
@@ -73,8 +73,6 @@ endif
 .PHONY: clean_examples
 clean_examples:
 	@find flowr/examples -name manifest.json | xargs rm -rf
-	@find flowr/examples -name \*.dot | xargs rm -rf
-	@find flowr/examples -name \*.dot.svg | xargs rm -rf
 	@find flowr/examples -name \*.svg -not -name test_\* | xargs rm -rf
 	@find flowr/examples -name \*.wasm | xargs rm -rf
 
@@ -193,11 +191,11 @@ build-book:
 .PHONE: copy-svgs
 copy-svgs:
 	@echo "copy-svgs<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-	@for i in $(shell find flowr/examples -name '*.dot.svg' -o -name '*.svg' | grep -v test_ ); do \
+	@for i in $(shell find flowr/examples -name '*.svg' | grep -v test_ ); do \
       mkdir -p target/html/$$(dirname $$i); \
       cp $$i target/html/$$i; \
     done
-	@for i in $(shell cd $$HOME/.flow/lib/flowstdlib && find . -name '*.dot.svg' -o -name '*.svg' | grep -v test_ ); do \
+	@for i in $(shell cd $$HOME/.flow/lib/flowstdlib && find . -name '*.svg' | grep -v test_ ); do \
       mkdir -p target/html/flowstdlib/src/$$(dirname $$i); \
       cp $$HOME/.flow/lib/flowstdlib/$$i target/html/flowstdlib/src/$$i; \
     done
@@ -220,7 +218,6 @@ trim-book:
 	@find target/html -name test.file | xargs rm -rf {}
 	@find target/html -name \*.rs | xargs rm -rf {}
 	@find target/html -name \*.dump | xargs rm -rf {}
-	@find target/html -name \*.dot | xargs rm -rf {}
 	@find target/html -name \*.wasm | xargs rm -rf {}
 	@find target/html -name \*.lock  | xargs rm -rf {}
 	@find target/html -name \*.profraw  | xargs rm -rf {}

--- a/book/describing/flow_libraries.md
+++ b/book/describing/flow_libraries.md
@@ -66,9 +66,8 @@ include:
 - `*.toml` - Flow and Function definition files copied into output directory corresponding to source directory
 - `*.wasm` - Function WASM implementation compiled from supplied function source and copied into output 
   directory corresponding to source directory
-- `*.dot` - 'dot' (graphvis) format graph descriptions of any flows in the library source
-- `*.dot.svg` - flow graphs rendered into SVG files from the corresponding 'dot' files. These can be referenced in 
-  doc files
+- `*.svg` - SVG flow graph files generated directly by the compiler for any flows in the library source. These can be
+  referenced in doc files
 
 ### Lib References
 References to flows or functions are described in more detail in the [process references](process_references.md)

--- a/book/developing/overview.md
+++ b/book/developing/overview.md
@@ -26,7 +26,7 @@ Once you have those, install the remaining dependencies with:
 make config
 ```
 
-This installs the wasm target, clippy, graphviz, mdbook, and other tools.
+This installs the wasm target, clippy, mdbook, and other tools.
 It works on macOS and Linux variants using `apt-get` or `yum`.
 
 ### Build and test

--- a/book/first_flow/debugging.md
+++ b/book/first_flow/debugging.md
@@ -17,7 +17,7 @@ USAGE:
 
 FLAGS:
     -d, --dump        Dump the flow to .dump files after loading it
-    -z, --graphs      Create .dot files for graph generation
+    -g, --graphs      Generate SVG graph files for flow visualization
     -h, --help        Prints help information
     -p, --provided    Provided function implementations should NOT be compiled from source
     -s, --skip        Skip execution of flow

--- a/book/running/flowc.md
+++ b/book/running/flowc.md
@@ -28,7 +28,7 @@ Options:
   -L, --libdir <LIB_DIR|BASE_URL>
           Add a directory or base Url to the Library Search path
   -t, --tables
-          Write flow and compiler tables to .dump and .dot files
+          Write flow and compiler tables to .dump files
   -g, --graphs
           Generate SVG graph files for flow visualization
   -m, --metrics
@@ -57,7 +57,7 @@ Options:
 *  `-C, --context_root <CONTEXT_DIRECTORY>` Set the directory to use as the root dir for context function definitions
 *  `-n, --native` Compile only native (not wasm) implementations when compiling a library
 *  `-L, --libdir <LIB_DIR|BASE_URL>` Add a directory or base Url to the Library Search path
-*  `-t, --tables` Write flow and compiler tables to .dump and .dot files
+*  `-t, --tables` Write flow and compiler tables to .dump files
 *  `-g, --graphs` Generate SVG graph files for flow visualization
 *  `-m, --metrics` Show flow execution metrics when execution ends
 *  `-w, --wasm` Use wasm library implementations (not any statically linked native implementations) when executing flow

--- a/flowc/src/lib/graph/edge.rs
+++ b/flowc/src/lib/graph/edge.rs
@@ -56,17 +56,22 @@ pub fn bezier_edge(
 
 /// Render a loopback edge that routes around the node: right, down, left, up.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn loopback_edge(
     out_x: f32,
     out_y: f32,
     in_x: f32,
     in_y: f32,
     node_bottom: f32,
+    loopback_index: usize,
+    label: Option<&str>,
+    tooltip_text: Option<&str>,
     color: &str,
 ) -> Group {
     let arrow_tip_x = in_x;
     let line_end_x = arrow_tip_x - style::ARROW_SIZE * 0.7;
-    let waypoints = connection::loopback_waypoints(out_x, out_y, line_end_x, in_y, node_bottom);
+    let waypoints =
+        connection::loopback_waypoints(out_x, out_y, line_end_x, in_y, node_bottom, loopback_index);
 
     let mut path_data = String::new();
     for (i, wp) in waypoints.iter().enumerate() {
@@ -92,9 +97,29 @@ pub fn loopback_edge(
         .set("stroke-width", style::STROKE_WIDTH);
 
     let arrow_from_x = arrow_tip_x - style::ARROW_SIZE;
-    Group::new()
-        .add(path)
-        .add(svg_arrow(arrow_tip_x, in_y, arrow_from_x, in_y, color))
+    let mut group =
+        Group::new()
+            .add(path)
+            .add(svg_arrow(arrow_tip_x, in_y, arrow_from_x, in_y, color));
+
+    if let Some(text) = label {
+        let label_x = f32::midpoint(in_x, out_x);
+        let bottom_y = node_bottom + 25.0 + loopback_index as f32 * 25.0;
+        let label_y = bottom_y + 12.0;
+        group = group.add(shapes::centered_text(
+            label_x,
+            label_y,
+            text,
+            style::PORT_FONT_SIZE,
+            color,
+        ));
+    }
+
+    if let Some(tip) = tooltip_text {
+        group = group.add(shapes::tooltip(tip));
+    }
+
+    group
 }
 
 /// Render an initializer edge — a bezier from the label to the port,

--- a/flowc/src/lib/graph/renderer.rs
+++ b/flowc/src/lib/graph/renderer.rs
@@ -46,14 +46,16 @@ pub fn render_flow(flow: &FlowDefinition) -> String {
         }
     }
 
+    let mut loopback_counts: HashMap<String, usize> = HashMap::new();
     for conn in &flow.connections {
-        svg_group = svg_group.add(render_connection(conn, &layouts));
+        svg_group = svg_group.add(render_connection(conn, &layouts, &mut loopback_counts));
     }
 
     for pr in &flow.process_refs {
         let alias = process_alias(pr);
         if let Some(layout) = layouts.get(&alias) {
-            svg_group = svg_group.add(render_initializers(pr, layout));
+            let node_loopbacks = loopback_counts.get(&alias).copied().unwrap_or(0);
+            svg_group = svg_group.add(render_initializers(pr, layout, node_loopbacks));
         }
     }
 
@@ -61,7 +63,9 @@ pub fn render_flow(flow: &FlowDefinition) -> String {
         .process_refs
         .iter()
         .any(|pr| !pr.initializations.is_empty());
-    let (vb_x, vb_y, doc_width, doc_height) = compute_document_bounds(&layouts, has_initializers);
+    let max_loopbacks = loopback_counts.values().copied().max().unwrap_or(0);
+    let (vb_x, vb_y, doc_width, doc_height) =
+        compute_document_bounds(&layouts, has_initializers, max_loopbacks);
 
     let document = Document::new()
         .set(
@@ -272,7 +276,11 @@ fn truncate_source(source: &str) -> String {
     }
 }
 
-fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode>) -> Group {
+fn render_connection(
+    conn: &Connection,
+    layouts: &HashMap<String, PositionedNode>,
+    loopback_counts: &mut HashMap<String, usize>,
+) -> Group {
     let mut group = Group::new().set("class", "edge");
 
     let from_route = conn.from().to_string();
@@ -288,7 +296,7 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode
         .position(|p| p == &from_port)
         .unwrap_or(0);
 
-    let x1 = from_layout.output_port_x();
+    let x1 = from_layout.output_port_x() + style::PORT_RADIUS;
     let y1 = from_layout.output_port_y(from_port_idx);
 
     for to_route in conn.to() {
@@ -305,18 +313,27 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode
             .position(|p| p == &to_port)
             .unwrap_or(0);
 
-        let x2 = to_layout.input_port_x();
+        let x2 = to_layout.input_port_x() - style::PORT_RADIUS;
         let y2 = to_layout.input_port_y(to_port_idx);
 
         let tooltip_text = format!("{from_route} → {to_str}");
 
+        let label = connection_label(&from_port, conn.name());
+        let label_opt = if label.is_empty() { None } else { Some(label) };
+
         if from_node == to_node {
+            let idx = loopback_counts.entry(from_node.clone()).or_insert(0);
+            let loopback_index = *idx;
+            *idx += 1;
             group = group.add(edge::loopback_edge(
                 x1,
                 y1,
                 x2,
                 y2,
                 from_layout.y + from_layout.height,
+                loopback_index,
+                label_opt.as_deref(),
+                Some(&tooltip_text),
                 style::COLOR_EDGE,
             ));
         } else {
@@ -325,15 +342,7 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode
                 y1,
                 x2,
                 y2,
-                {
-                    let label = connection_label(&from_port, conn.name());
-                    if label.is_empty() {
-                        None
-                    } else {
-                        Some(label)
-                    }
-                }
-                .as_deref(),
+                label_opt.as_deref(),
                 Some(&tooltip_text),
                 style::COLOR_EDGE,
                 None,
@@ -344,8 +353,15 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode
     group
 }
 
-fn render_initializers(pr: &ProcessReference, layout: &PositionedNode) -> Group {
+fn render_initializers(
+    pr: &ProcessReference,
+    layout: &PositionedNode,
+    node_loopbacks: usize,
+) -> Group {
     let mut group = Group::new();
+
+    #[allow(clippy::cast_precision_loss)]
+    let loopback_clearance = node_loopbacks as f32 * 25.0;
 
     for (input_path, initializer) in &pr.initializations {
         let port_name = input_path.rsplit('/').next().unwrap_or(input_path);
@@ -355,7 +371,7 @@ fn render_initializers(pr: &ProcessReference, layout: &PositionedNode) -> Group 
             .position(|p| p == port_name)
             .unwrap_or(0);
 
-        let px = layout.input_port_x();
+        let px = layout.input_port_x() - style::PORT_RADIUS;
         let py = layout.input_port_y(port_idx);
 
         let value_str = format!("{}", initializer.get_value());
@@ -371,8 +387,8 @@ fn render_initializers(pr: &ProcessReference, layout: &PositionedNode) -> Group 
         };
         let label = format!("{truncated} ({init_type})");
 
-        let init_offset_y = 20.0;
-        let label_x = px - 70.0;
+        let init_offset_y = 20.0 + loopback_clearance;
+        let label_x = px - 70.0 - loopback_clearance;
         let label_y = py - init_offset_y;
 
         let dash = match initializer {
@@ -406,6 +422,7 @@ fn render_initializers(pr: &ProcessReference, layout: &PositionedNode) -> Group 
 fn compute_document_bounds(
     layouts: &HashMap<String, PositionedNode>,
     has_initializers: bool,
+    max_loopbacks: usize,
 ) -> (f32, f32, f32, f32) {
     let mut min_x: f32 = 0.0;
     let mut min_y: f32 = 0.0;
@@ -419,11 +436,18 @@ fn compute_document_bounds(
         max_y = max_y.max(layout.y + layout.height);
     }
 
+    #[allow(clippy::cast_precision_loss)]
+    let loopback_extra = if max_loopbacks > 0 {
+        max_loopbacks as f32 * 25.0 + 25.0
+    } else {
+        0.0
+    };
+
     let left_pad = if has_initializers { 80.0 } else { 0.0 };
-    let origin_x = min_x - left_pad;
+    let origin_x = min_x - left_pad - loopback_extra;
     let origin_y = min_y - style::GRID_ORIGIN_Y;
-    let width = max_x - origin_x + style::GRID_ORIGIN_X;
-    let height = max_y - origin_y + style::GRID_ORIGIN_Y;
+    let width = max_x - origin_x + style::GRID_ORIGIN_X + loopback_extra;
+    let height = max_y - origin_y + style::GRID_ORIGIN_Y + loopback_extra;
 
     (origin_x, origin_y, width, height)
 }

--- a/flowc/src/lib/graph/renderer.rs
+++ b/flowc/src/lib/graph/renderer.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use svg::node::element::{Group, Style};
 use svg::Document;
 
-use flowcore::graph::layout::split_route;
+use flowcore::graph::layout::{connection_label, split_route};
 use flowcore::graph::style::NodeCategory;
 use flowcore::model::connection::Connection;
 use flowcore::model::flow_definition::FlowDefinition;
@@ -325,11 +325,15 @@ fn render_connection(conn: &Connection, layouts: &HashMap<String, PositionedNode
                 y1,
                 x2,
                 y2,
-                if conn.name().is_empty() {
-                    None
-                } else {
-                    Some(conn.name().as_str())
-                },
+                {
+                    let label = connection_label(&from_port, conn.name());
+                    if label.is_empty() {
+                        None
+                    } else {
+                        Some(label)
+                    }
+                }
+                .as_deref(),
                 Some(&tooltip_text),
                 style::COLOR_EDGE,
                 None,

--- a/flowcore/src/graph/connection.rs
+++ b/flowcore/src/graph/connection.rs
@@ -72,6 +72,8 @@ pub enum Waypoint {
 ///
 /// Coordinates are in world space. The path starts at the output port's
 /// semi-circle edge and ends at the input port's semi-circle edge.
+/// The `loopback_index` offsets successive loopbacks further from the node
+/// so multiple self-connections don't overlap.
 #[must_use]
 pub fn loopback_waypoints(
     out_x: f32,
@@ -79,11 +81,13 @@ pub fn loopback_waypoints(
     in_x: f32,
     in_y: f32,
     node_bottom: f32,
+    loopback_index: usize,
 ) -> Vec<Waypoint> {
     let r = LOOPBACK_CORNER;
-    let right_x = out_x + LOOPBACK_MARGIN;
-    let left_x = in_x - LOOPBACK_MARGIN;
-    let bottom_y = node_bottom + LOOPBACK_MARGIN;
+    let offset = LOOPBACK_MARGIN + loopback_index as f32 * LOOPBACK_MARGIN;
+    let right_x = out_x + offset;
+    let left_x = in_x - offset;
+    let bottom_y = node_bottom + offset;
 
     vec![
         Waypoint::Point(out_x, out_y),
@@ -146,7 +150,7 @@ mod test {
 
     #[test]
     fn loopback_stays_outside_node() {
-        let wp = loopback_waypoints(230.0, 135.0, 50.0, 145.0, 170.0);
+        let wp = loopback_waypoints(230.0, 135.0, 50.0, 145.0, 170.0, 0);
         for w in &wp {
             match w {
                 Waypoint::Point(_, y) | Waypoint::Corner(_, _, _, y) => {
@@ -158,7 +162,7 @@ mod test {
 
     #[test]
     fn loopback_starts_at_output_ends_at_input() {
-        let wp = loopback_waypoints(230.0, 135.0, 50.0, 145.0, 170.0);
+        let wp = loopback_waypoints(230.0, 135.0, 50.0, 145.0, 170.0, 0);
         let first = match wp.first() {
             Some(Waypoint::Point(x, y)) => (*x, *y),
             _ => panic!("first waypoint should be Point"),

--- a/flowcore/src/graph/layout.rs
+++ b/flowcore/src/graph/layout.rs
@@ -97,6 +97,17 @@ pub fn split_route(route: &str) -> (String, String) {
     }
 }
 
+/// Build a label for a connection from its output port name and connection name.
+#[must_use]
+pub fn connection_label(from_port: &str, conn_name: &str) -> String {
+    match (from_port, conn_name) {
+        ("", "") => String::new(),
+        ("", name) => name.to_string(),
+        (port, "") => format!("/{port}"),
+        (port, name) => format!("{name} /{port}"),
+    }
+}
+
 /// Sort nodes within each column by the median index of their neighbors
 /// in adjacent columns, reducing edge crossings (Sugiyama barycenter heuristic).
 fn median_ordering(
@@ -512,5 +523,25 @@ mod test {
     fn bezier_offset_negative_dx() {
         let offset = bezier_control_offset(-200.0);
         assert!((offset - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn connection_label_empty() {
+        assert_eq!(connection_label("", ""), "");
+    }
+
+    #[test]
+    fn connection_label_name_only() {
+        assert_eq!(connection_label("", "feedback-step"), "feedback-step");
+    }
+
+    #[test]
+    fn connection_label_subpath_only() {
+        assert_eq!(connection_label("right-lte", ""), "/right-lte");
+    }
+
+    #[test]
+    fn connection_label_both() {
+        assert_eq!(connection_label("i2", "feedback-step"), "feedback-step /i2");
     }
 }

--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -25,7 +25,8 @@ use flowcore::model::route::Route;
 
 use crate::node_layout::{NodeLayout, PORT_FONT_SIZE};
 use crate::utils::{
-    base_port_name, check_port_type_compatibility, rounded_rect, split_route, truncate_source,
+    base_port_name, check_port_type_compatibility, connection_label, rounded_rect, split_route,
+    truncate_source,
 };
 use crate::window_state::{FlowCanvasState, ZOOM_STEP};
 
@@ -2095,16 +2096,6 @@ impl canvas::Program<CanvasMessage> for FlowCanvas<'_> {
     }
 }
 
-/// Draw a single node as a rounded rectangle with title, source, and ports.
-fn connection_label(from_port: &str, conn_name: &str) -> String {
-    match (from_port, conn_name) {
-        ("", "") => String::new(),
-        ("", name) => name.to_string(),
-        (port, "") => format!("/{port}"),
-        (port, name) => format!("{name} /{port}"),
-    }
-}
-
 fn draw_node(frame: &mut Frame, node: &NodeLayout, zoom: f32, offset: Point) {
     let top_left = transform_point(Point::new(node.x(), node.y()), zoom, offset);
     let size = Size::new(node.width() * zoom, node.height() * zoom);
@@ -2543,25 +2534,5 @@ mod test {
         let (inp, outp) = compute_flow_io_positions(&[], &[], &[]);
         assert!(inp.is_empty());
         assert!(outp.is_empty());
-    }
-
-    #[test]
-    fn connection_label_empty() {
-        assert_eq!(connection_label("", ""), "");
-    }
-
-    #[test]
-    fn connection_label_name_only() {
-        assert_eq!(connection_label("", "feedback-step"), "feedback-step");
-    }
-
-    #[test]
-    fn connection_label_subpath_only() {
-        assert_eq!(connection_label("right-lte", ""), "/right-lte");
-    }
-
-    #[test]
-    fn connection_label_both() {
-        assert_eq!(connection_label("i2", "feedback-step"), "feedback-step /i2");
     }
 }

--- a/flowedit/src/utils.rs
+++ b/flowedit/src/utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn next_unique_io_name(prefix: &str, existing: &[IO]) -> String {
 }
 
 pub(crate) use flowcore::graph::layout::derive_short_name;
-pub(crate) use flowcore::graph::layout::split_route;
+pub(crate) use flowcore::graph::layout::{connection_label, split_route};
 
 /// Check whether a Connection references a node by alias in its from or to routes.
 pub(crate) fn connection_references_node(conn: &Connection, alias: &str) -> bool {

--- a/flowstdlib/README.md
+++ b/flowstdlib/README.md
@@ -20,7 +20,7 @@ NOTE: That flows are compiled down to a graph of functions at compile time, and 
 Libraries like `flowstdlib` are built using `flowc`, specifying the library root folder as the source url.
 
 This builds a directory tree (in `target/{lib_name}`) of all required files for a portable library, including:-
-* documentation files (.md MarkDown files, .dot graphs of flows, graphs rendered as .dot.svg SVG files)
+* documentation files (.md MarkDown files, SVG flow graphs generated directly by the compiler)
 * TOML definition files for flows and functions
 * Function implementations compiled to a .wasm WASM file
 * A `manifest.json` manifest of the libraries functions and where the implementations (.wasm files) can be found.

--- a/flowstdlib/src/control/index_f.md
+++ b/flowstdlib/src/control/index_f.md
@@ -11,6 +11,6 @@ source = "lib://flowstdlib/control/index_f"
 ```
 
 ### Flow Graph
-<a href="index_f.dot.svg" target="_blank"><img src="index_f.dot.svg"></a>
+<a href="index_f.svg" target="_blank"><img src="index_f.svg"></a>
 
 Click image to navigate flow hierarchy.

--- a/flowstdlib/src/math/range.md
+++ b/flowstdlib/src/math/range.md
@@ -7,6 +7,6 @@ Generate numbers within a range
 source = "lib://flowstdlib/math/range"
 ```
 ### Flow Graph
-<a href="range.dot.svg" target="_blank"><img src="range.dot.svg"></a>
+<a href="range.svg" target="_blank"><img src="range.svg"></a>
 
 Click image to navigate flow hierarchy.

--- a/flowstdlib/src/math/sequence.md
+++ b/flowstdlib/src/math/sequence.md
@@ -7,6 +7,6 @@ Generate a sequence of numbers
 source = "lib://flowstdlib/math/sequence"
 ```
 ### Flow Graph
-<a href="sequence.dot.svg" target="_blank"><img src="sequence.dot.svg"></a>
+<a href="sequence.svg" target="_blank"><img src="sequence.svg"></a>
 
 Click image to navigate flow hierarchy.

--- a/flowstdlib/src/matrix/multiply.md
+++ b/flowstdlib/src/matrix/multiply.md
@@ -41,6 +41,6 @@ source = "lib://flowstdlib/matrix/multiply"
 
 ### Flow Graph
 
-<a href="sequence.dot.svg" target="_blank"><img src="sequence.dot.svg"></a>
+<a href="sequence.svg" target="_blank"><img src="sequence.svg"></a>
 
 Click image to navigate flow hierarchy.


### PR DESCRIPTION
## Summary
- Show the output port path on SVG connection labels (e.g. `previous /i2`) matching flowedit behavior, by extracting a shared `connection_label()` function into flowcore
- Separate overlapping loopback edges so multiple self-connections are visually distinct
- Fix arrow tips to land at the outer edge of port semi-circles instead of overlapping them
- Push initializer labels clear of loopback paths when loopbacks are present
- Remove all graphviz/dot references from CI, Makefile, and docs (no longer needed since SVGs are generated directly)

Closes #2878

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt` applied
- [x] `make test` passes
- [ ] Visual inspection of fibonacci example SVG confirms separated loopback paths with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)