### PR TITLE
Add docs.rs feature annotations to library crates

### DIFF
--- a/flowc/Cargo.toml
+++ b/flowc/Cargo.toml
@@ -23,6 +23,9 @@ icons = ["assets/icons/flowc/icon.png", "assets/icons/flowc/icon.icns", "assets/
 [package.metadata.packager.deb]
 depends = ["libssl3"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/flowc/src/lib/lib.rs
+++ b/flowc/src/lib/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 #![deny(missing_docs)]
 #![warn(clippy::unwrap_used)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! The `flow` Compiler Library
 //!

--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -29,6 +29,9 @@ meta_provider = []
 file_provider = []
 http_provider = []
 
+[package.metadata.docs.rs]
+all-features = true
+
 [package.metadata.cargo-all-features]
 max_combination_size = 2
 skip_feature_sets = [["online_tests"]]

--- a/flowcore/src/lib.rs
+++ b/flowcore/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! `flowcore` defines core structs and traits used by other flow libraries and implementations
 
 use serde_json::Value;

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -67,6 +67,9 @@ submission = []
 # feature to include context functions, make sure flowcore is compiled with it if we plan to use it
 context = ["flowcore/context"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [package.metadata.cargo-all-features]
 max_combination_size = 2
 skip_optional_dependencies = true

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! `flowrlib` is the runtime library for flow execution. This can be used to produce a flow runner,
 //! such as the `flowr` command line runner.
 //!


### PR DESCRIPTION
## Summary
- Add `[package.metadata.docs.rs] all-features = true` to `flowcore`, `flowc`, and `flowr` Cargo.toml files so docs.rs builds with all features enabled
- Add `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to each crate's lib.rs so feature-gated items are automatically annotated with their required feature in the generated documentation

Closes #2277

## Test plan
- [x] `cargo fmt` — no changes
- [x] `make clippy` — clean
- [x] `make test` — all tests pass
- No functional changes — only affects documentation generation on docs.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved online documentation builds to include all available features.
  * Enabled richer auto-generated feature configuration in docs published on docs.rs for better visibility of supported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->