### PR TITLE
TLA+ Phase 4: external send gating

### DIFF
--- a/specs/ExternalGating.cfg
+++ b/specs/ExternalGating.cfg
@@ -2,5 +2,7 @@ SPECIFICATION Spec
 
 INVARIANTS
     TypeOK
+    CompletedNeverRuns
     InternalCountBound
     AncestorConsistency
+    BusyFlowBlocksExternalJob

--- a/specs/ExternalGating.cfg
+++ b/specs/ExternalGating.cfg
@@ -1,0 +1,6 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    InternalCountBound
+    AncestorConsistency

--- a/specs/ExternalGating.tla
+++ b/specs/ExternalGating.tla
@@ -4,20 +4,23 @@
  * while the destination flow is busy.
  *
  * Flow 10 contains p1 and p2.
- *   p1 has 1 input (Once-initialized), connects internally to p2 input 0.
- *   p2 has 1 input (no initializer), no outgoing connections.
+ *   p1 has 1 input (no initializer), no outgoing connections.
+ *   p2 has 1 input (Once-initialized), no outgoing connections.
  *
  * p3 is in root flow 0 with 1 input (Once-initialized), connects
  * externally to p1 input 0.
  *
- * At startup p1 and p3 both run.  When p1 retires it sends internally
- * to p2, making p2 runnable.  When p3 retires it sends externally to
- * p1.  If flow 10 is still busy (p2 running), the external value for
- * p1 must be queued without creating a job — CreateJob's gating guard
- * blocks because Parent[p1] = 10 is busy and intCount = 0.
+ * At startup p2 and p3 both run (they have Once-initialized inputs).
+ * p2 makes flow 10 busy.  When p3 retires it sends externally to p1.
+ * While flow 10 is busy (p2 running), the external value for p1 must
+ * be queued without creating a job — CreateJob's gating guard blocks
+ * because Parent[p1] = 10 is busy and CanRunOnInternal(p1) is false.
  *
- * Once flow 10 goes idle, CreateJob(p1) fires on the queued external
- * value.  This exercises the Phase 4 external send gating.
+ * Once p2 retires and flow 10 goes idle, CreateJob(p1) fires on the
+ * queued external value.
+ *
+ * BusyFlowBlocksExternalJob verifies this directly: whenever flow 10
+ * is busy and p1 has only external values, p1 must have no jobs.
  *)
 
 EXTENDS Integers, Sequences, FiniteSets, TLC
@@ -31,10 +34,9 @@ FR == INSTANCE FlowRuntimeBase WITH
     Procs <- {1, 2, 3},
     Flows <- {0, 10},
     InputsOf <- 1 :> {0} @@ 2 :> {0} @@ 3 :> {0},
-    Conns <- { [src |-> 1, dst |-> 2, dstInput |-> 0, internal |-> TRUE],
-               [src |-> 3, dst |-> 1, dstInput |-> 0, internal |-> FALSE] },
+    Conns <- { [src |-> 3, dst |-> 1, dstInput |-> 0, internal |-> FALSE] },
     Parent <- 1 :> 10 @@ 2 :> 10 @@ 3 :> 0 @@ 10 :> 0 @@ 0 :> NoParent,
-    InitOnce <- 1 :> (0 :> 1) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> 1),
+    InitOnce <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> 1) @@ 3 :> (0 :> 1),
     InitAlways <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
     NoParent <- NoParent,
     NoInit <- NoInit,
@@ -51,10 +53,13 @@ Next == FR!Next
 Spec == FR!Spec
 
 TypeOK == FR!TypeOK
+CompletedNeverRuns == FR!CompletedNeverRuns
 InternalCountBound == FR!InternalCountBound
 AncestorConsistency == FR!AncestorConsistency
-(* CompletedNeverRuns omitted: p1 runs twice (init + external from p3),
-   sending to p2 each time.  Two jobs for p2 can be queued, and
-   CompleteJob may fire on the first while the second is still ready. *)
+
+BusyFlowBlocksExternalJob ==
+    (FR!IsBusy(10) /\ Len(inputQ[1][0]) > 0 /\ intCount[1][0] = 0)
+    => (/\ \A j \in running : j.func # 1
+        /\ \A idx \in 1..Len(ready) : ready[idx].func # 1)
 
 =====================================================================

--- a/specs/ExternalGating.tla
+++ b/specs/ExternalGating.tla
@@ -1,0 +1,60 @@
+----------------------- MODULE ExternalGating -----------------------
+(*
+ * Scenario: External send gating — value crosses a flow boundary
+ * while the destination flow is busy.
+ *
+ * Flow 10 contains p1 and p2.
+ *   p1 has 1 input (Once-initialized), connects internally to p2 input 0.
+ *   p2 has 1 input (no initializer), no outgoing connections.
+ *
+ * p3 is in root flow 0 with 1 input (Once-initialized), connects
+ * externally to p1 input 0.
+ *
+ * At startup p1 and p3 both run.  When p1 retires it sends internally
+ * to p2, making p2 runnable.  When p3 retires it sends externally to
+ * p1.  If flow 10 is still busy (p2 running), the external value for
+ * p1 must be queued without creating a job — CreateJob's gating guard
+ * blocks because Parent[p1] = 10 is busy and intCount = 0.
+ *
+ * Once flow 10 goes idle, CreateJob(p1) fires on the queued external
+ * value.  This exercises the Phase 4 external send gating.
+ *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+NoParent == -1
+NoInit == -2
+
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+
+FR == INSTANCE FlowRuntimeBase WITH
+    Procs <- {1, 2, 3},
+    Flows <- {0, 10},
+    InputsOf <- 1 :> {0} @@ 2 :> {0} @@ 3 :> {0},
+    Conns <- { [src |-> 1, dst |-> 2, dstInput |-> 0, internal |-> TRUE],
+               [src |-> 3, dst |-> 1, dstInput |-> 0, internal |-> FALSE] },
+    Parent <- 1 :> 10 @@ 2 :> 10 @@ 3 :> 0 @@ 10 :> 0 @@ 0 :> NoParent,
+    InitOnce <- 1 :> (0 :> 1) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> 1),
+    InitAlways <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
+    NoParent <- NoParent,
+    NoInit <- NoInit,
+    inputQ <- inputQ,
+    intCount <- intCount,
+    busyCount <- busyCount,
+    ready <- ready,
+    running <- running,
+    done <- done,
+    jobCounter <- jobCounter
+
+Init == FR!Init
+Next == FR!Next
+Spec == FR!Spec
+
+TypeOK == FR!TypeOK
+InternalCountBound == FR!InternalCountBound
+AncestorConsistency == FR!AncestorConsistency
+(* CompletedNeverRuns omitted: p1 runs twice (init + external from p3),
+   sending to p2 each time.  Two jobs for p2 can be queued, and
+   CompleteJob may fire on the first while the second is still ready. *)
+
+=====================================================================

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -100,8 +100,29 @@ Init ==
 ---------------------------------------------------------------------------
 (* Actions *)
 
+(*
+ * External send gating (Phase 4)
+ *
+ * In the runtime, send_a_value gates job creation for external sends:
+ * if a value crosses a flow boundary (!connection.internal) and the
+ * destination's parent flow is already busy, the value is queued but
+ * no job is created.  The job is deferred until the parent flow goes
+ * idle (handled by unblock_flows / has_runnable_on_internal).
+ *
+ * Internal sends (!dest_flow_busy when connection.internal) bypass the
+ * gate — a function can always run on values produced within its own
+ * flow, even while the flow is busy.
+ *
+ * In TLA+, CreateJob is a standalone action that fires nondeterministically
+ * whenever its guard is satisfied.  Adding the gating guard here is
+ * equivalent to gating inline in RetireAndSend: after RetireAndSend
+ * queues values, CreateJob can only fire for a destination process if
+ * the parent flow is idle OR the process has internal values.
+ *)
 CreateJob(p) ==
     /\ CanRun(p)
+    /\ \/ ~IsBusy(Parent[p])
+       \/ \E i \in InputsOf[p] : intCount[p][i] > 0
     /\ LET inputs == [i \in InputsOf[p] |-> Head(inputQ[p][i])]
            toMark == {p} \union AncestorsOf(p)
        IN
@@ -176,8 +197,9 @@ CompleteJob(job) ==
 
 (*
  * When a flow becomes idle, the runtime first checks has_runnable_on_internal.
- * If any function can still run on internal data, CreateJob/CreateJobAfterIdle
- * handles that — those actions fire for any process where CanRun is true.
+ * If any function can still run on internal data, CreateJob handles that —
+ * its intCount guard allows firing for processes with internal values even
+ * while the parent flow is busy (matching the runtime's internal-send bypass).
  *
  * FlowGoesIdle fires only when NO function can run on internal data alone.
  * It clears all internal values, matching clear_flow_internal_inputs.
@@ -206,24 +228,6 @@ FlowGoesIdle(flow) ==
          ]]
     /\ UNCHANGED <<busyCount, ready, running, done, jobCounter>>
 
-CreateJobAfterIdle(p) ==
-    /\ CanRun(p)
-    /\ \/ ~IsBusy(Parent[p])
-       \/ \E i \in InputsOf[p] : intCount[p][i] > 0
-    /\ LET inputs == [i \in InputsOf[p] |-> Head(inputQ[p][i])]
-           toMark == {p} \union AncestorsOf(p)
-       IN
-       /\ inputQ' = [inputQ EXCEPT ![p] =
-            [i \in InputsOf[p] |-> Tail(inputQ[p][i])]]
-       /\ intCount' = [intCount EXCEPT ![p] =
-            [i \in InputsOf[p] |->
-              IF intCount[p][i] > 0 THEN intCount[p][i] - 1 ELSE 0]]
-       /\ jobCounter' = jobCounter + 1
-       /\ ready' = Append(ready,
-            [func |-> p, inputs |-> inputs, jobId |-> jobCounter + 1])
-       /\ busyCount' = IncrBusy(toMark)
-       /\ UNCHANGED <<running, done>>
-
 ---------------------------------------------------------------------------
 (* Specification *)
 
@@ -233,7 +237,6 @@ Next ==
     \/ \E job \in running : RetireAndSend(job)
     \/ \E job \in running : CompleteJob(job)
     \/ \E flow \in Flows : FlowGoesIdle(flow)
-    \/ \E p \in Procs : CreateJobAfterIdle(p)
 
 Spec == Init /\ [][Next]_vars
 

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -117,12 +117,13 @@ Init ==
  * whenever its guard is satisfied.  Adding the gating guard here is
  * equivalent to gating inline in RetireAndSend: after RetireAndSend
  * queues values, CreateJob can only fire for a destination process if
- * the parent flow is idle OR the process has internal values.
+ * the parent flow is idle OR the process can run entirely on internal
+ * values (CanRunOnInternal — all inputs have intCount > 0).
  *)
 CreateJob(p) ==
     /\ CanRun(p)
     /\ \/ ~IsBusy(Parent[p])
-       \/ \E i \in InputsOf[p] : intCount[p][i] > 0
+       \/ CanRunOnInternal(p)
     /\ LET inputs == [i \in InputsOf[p] |-> Head(inputQ[p][i])]
            toMark == {p} \union AncestorsOf(p)
        IN
@@ -198,8 +199,8 @@ CompleteJob(job) ==
 (*
  * When a flow becomes idle, the runtime first checks has_runnable_on_internal.
  * If any function can still run on internal data, CreateJob handles that —
- * its intCount guard allows firing for processes with internal values even
- * while the parent flow is busy (matching the runtime's internal-send bypass).
+ * its CanRunOnInternal guard allows firing for processes whose inputs are
+ * all internal, even while the parent flow is busy.
  *
  * FlowGoesIdle fires only when NO function can run on internal data alone.
  * It clears all internal values, matching clear_flow_internal_inputs.

--- a/specs/README.md
+++ b/specs/README.md
@@ -150,7 +150,10 @@ The trace shows you exactly which sequence of actions leads to the bug.
 ## Files
 
 - `FlowRuntimeBase.tla` — generic runtime semantics (CONSTANTS for topology)
-- `TwoFuncsOneFlow.tla` / `.cfg` — hand-written scenario (2 processes, 1 flow)
+- `TwoFuncsOneFlow.tla` / `.cfg` — scenario: 2 processes, 1 flow (internal send)
+- `InternalExternal.tla` / `.cfg` — scenario: mixed internal and external sends to same input
+- `MixedQueue.tla` / `.cfg` — scenario: internal self-feedback and external send with bounded execution
+- `ExternalGating.tla` / `.cfg` — scenario: external send gating across flow boundaries
 - `README.md` — this file
 
 ## Installing TLA+ Tools
@@ -177,7 +180,7 @@ as it explores states.
 ## Phases
 
 1. **Core state machine** — process states, input queues, job lifecycle ✅
-2. **Input queue ordering** — internal vs external values
-3. **Flow hierarchy** — busy/idle detection, ancestor tracking
-4. **External send gating** — cross-flow sends deferred when busy
+2. **Input queue ordering** — internal vs external values ✅
+3. **Flow hierarchy** — busy/idle detection, ancestor tracking ✅
+4. **External send gating** — cross-flow sends deferred when busy ✅
 5. **Initializer semantics** — Once/Always, function vs flow level


### PR DESCRIPTION
## Summary
- Add the runtime's `send_a_value` gating guard to `CreateJob`: a job is only created when the parent flow is idle OR the process has internal values, matching `run_state.rs:574-580`
- Remove `CreateJobAfterIdle` (now subsumed by the guarded `CreateJob`) and simplify `Next` to five disjuncts
- Add `ExternalGating` scenario exercising cross-flow send gating (p3 in flow 0 sends externally to p1 in busy flow 10)

Partially addresses #2872 (Phase 4)

## Design rationale

In the runtime, `send_a_value` gates job creation for external sends: if a value crosses a flow boundary and the destination's parent flow is busy, the value is queued without creating a job. Internal sends bypass this gate.

In TLA+, `CreateJob` is a standalone nondeterministic action. Adding the gating guard (`~IsBusy(Parent[p]) \/ intCount > 0`) achieves the same effect as inline gating in `RetireAndSend`: after values are queued, `CreateJob` only fires when the parent flow is idle or the process has internal data. This is equivalent because TLA+ explores all valid interleavings.

The `intCount > 0` disjunct models the runtime's internal-send bypass (`!connection.internal` makes `dest_flow_busy = false`), allowing functions to run on within-flow values even while the parent flow is busy.

## Test plan
- [x] `make clippy` clean
- [x] `make test` passes
- [x] TLC verifies all hand-written specs: TwoFuncsOneFlow, InternalExternal, MixedQueue, ExternalGating
- [x] All invariants hold: TypeOK, InternalCountBound, AncestorConsistency (+ CompletedNeverRuns where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new external-gating scenario to the specs, covering queued sends across a flow boundary and later delivery once the destination becomes idle.
  * Expanded the spec documentation to list the available runtime and scenario files more clearly.

* **Bug Fixes**
  * Updated job creation behavior so external sends wait when the parent flow is busy, while internal queued work can still proceed.
  * Removed the separate delayed job-creation path and folded that behavior into the main flow logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->