### PR TITLE
TLA+ cross-cutting: tighten spec to match runtime

### DIFF
--- a/flowc/src/bin/flowc/tla_gen.rs
+++ b/flowc/src/bin/flowc/tla_gen.rs
@@ -41,6 +41,8 @@ pub fn generate_tla(manifest_path: &Path) -> Result<(), String> {
         &fd.parent_entries,
         &fd.init_once,
         &fd.init_always,
+        &fd.flow_init_once,
+        &fd.flow_init_always,
     );
 
     let dir = manifest_path
@@ -52,7 +54,7 @@ pub fn generate_tla(manifest_path: &Path) -> Result<(), String> {
     fs::write(&tla_path, tla).map_err(|e| format!("Cannot write .tla: {e}"))?;
     fs::write(
         &cfg_path,
-        "SPECIFICATION Spec\n\nINVARIANTS\n    TypeOK\n    CompletedNeverRuns\n    InternalCountBound\n    AncestorConsistency\n",
+        "SPECIFICATION Spec\n\nCONSTRAINT\n    StateConstraint\n\nINVARIANTS\n    TypeOK\n    InternalCountBound\n    AncestorConsistency\n",
     )
     .map_err(|e| format!("Cannot write .cfg: {e}"))?;
 
@@ -70,6 +72,8 @@ struct FuncData {
     parent_entries: Vec<String>,
     init_once: Vec<String>,
     init_always: Vec<String>,
+    flow_init_once: Vec<String>,
+    flow_init_always: Vec<String>,
 }
 
 fn extract_functions(functions: &serde_json::Map<String, Value>) -> Result<FuncData, String> {
@@ -79,6 +83,8 @@ fn extract_functions(functions: &serde_json::Map<String, Value>) -> Result<FuncD
     let mut parent_entries = Vec::new();
     let mut init_once = Vec::new();
     let mut init_always = Vec::new();
+    let mut flow_init_once = Vec::new();
+    let mut flow_init_always = Vec::new();
 
     for (fid_str, func) in functions {
         let fid = fid_str.as_str();
@@ -98,26 +104,40 @@ fn extract_functions(functions: &serde_json::Map<String, Value>) -> Result<FuncD
 
         let mut once_parts = Vec::new();
         let mut always_parts = Vec::new();
+        let mut flow_once_parts = Vec::new();
+        let mut flow_always_parts = Vec::new();
         for (idx, input) in inputs.iter().enumerate() {
-            let once_val = extract_initializer(input, "initializer", "once")
-                .or_else(|| extract_initializer(input, "flow_initializer", "once"));
-            let always_val = extract_initializer(input, "initializer", "always")
-                .or_else(|| extract_initializer(input, "flow_initializer", "always"));
+            let func_once = extract_initializer(input, "initializer", "once");
+            let func_always = extract_initializer(input, "initializer", "always");
+            let fl_once = extract_initializer(input, "flow_initializer", "once");
+            let fl_always = extract_initializer(input, "flow_initializer", "always");
             once_parts.push(format!(
                 "{idx} :> {}",
-                once_val.as_deref().unwrap_or("NoInit")
+                func_once.as_deref().unwrap_or("NoInit")
             ));
             always_parts.push(format!(
                 "{idx} :> {}",
-                always_val.as_deref().unwrap_or("NoInit")
+                func_always.as_deref().unwrap_or("NoInit")
+            ));
+            flow_once_parts.push(format!(
+                "{idx} :> {}",
+                fl_once.as_deref().unwrap_or("NoInit")
+            ));
+            flow_always_parts.push(format!(
+                "{idx} :> {}",
+                fl_always.as_deref().unwrap_or("NoInit")
             ));
         }
         if once_parts.is_empty() {
             init_once.push(format!("{fid} :> <<>>"));
             init_always.push(format!("{fid} :> <<>>"));
+            flow_init_once.push(format!("{fid} :> <<>>"));
+            flow_init_always.push(format!("{fid} :> <<>>"));
         } else {
             init_once.push(format!("{fid} :> ({})", once_parts.join(" @@ ")));
             init_always.push(format!("{fid} :> ({})", always_parts.join(" @@ ")));
+            flow_init_once.push(format!("{fid} :> ({})", flow_once_parts.join(" @@ ")));
+            flow_init_always.push(format!("{fid} :> ({})", flow_always_parts.join(" @@ ")));
         }
 
         if let Some(ocs) = func.get("output_connections").and_then(Value::as_array) {
@@ -146,6 +166,8 @@ fn extract_functions(functions: &serde_json::Map<String, Value>) -> Result<FuncD
         parent_entries,
         init_once,
         init_always,
+        flow_init_once,
+        flow_init_always,
     })
 }
 
@@ -191,6 +213,8 @@ fn format_tla(
     parent_entries: &[String],
     init_once: &[String],
     init_always: &[String],
+    flow_init_once: &[String],
+    flow_init_always: &[String],
 ) -> String {
     let procs_str = procs.join(", ");
     let flows_str = flow_ids.join(", ");
@@ -214,6 +238,8 @@ FR == INSTANCE FlowRuntimeBase WITH
     Parent <- {parent},
     InitOnce <- {init_once},
     InitAlways <- {init_always},
+    FlowInitOnce <- {flow_init_once},
+    FlowInitAlways <- {flow_init_always},
     NoParent <- NoParent,
     NoInit <- NoInit,
     inputQ <- inputQ,
@@ -229,9 +255,9 @@ Next == FR!Next
 Spec == FR!Spec
 
 TypeOK == FR!TypeOK
-CompletedNeverRuns == FR!CompletedNeverRuns
 InternalCountBound == FR!InternalCountBound
 AncestorConsistency == FR!AncestorConsistency
+StateConstraint == jobCounter <= 8
 
 ==========================================================================
 ",
@@ -243,6 +269,8 @@ AncestorConsistency == FR!AncestorConsistency
         parent = parent_entries.join(" @@ "),
         init_once = init_once.join(" @@ "),
         init_always = init_always.join(" @@ "),
+        flow_init_once = flow_init_once.join(" @@ "),
+        flow_init_always = flow_init_always.join(" @@ "),
     )
 }
 
@@ -423,10 +451,15 @@ mod test {
         assert!(tla_content.contains("Flows <- {0}"));
         assert!(tla_content.contains("INSTANCE FlowRuntimeBase"));
         assert!(tla_content.contains("internal |-> TRUE"));
+        assert!(tla_content.contains("FlowInitOnce <-"));
+        assert!(tla_content.contains("FlowInitAlways <-"));
 
         let cfg_content = std::fs::read_to_string(&cfg_path).unwrap();
         assert!(cfg_content.contains("SPECIFICATION Spec"));
         assert!(cfg_content.contains("TypeOK"));
+        assert!(!cfg_content.contains("CompletedNeverRuns"));
+        assert!(cfg_content.contains("InternalCountBound"));
+        assert!(cfg_content.contains("AncestorConsistency"));
     }
 
     #[test]

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -8,6 +8,17 @@ use serde_json::{json, Value};
 use crate::model::datatype::DataType;
 use crate::model::input::InputInitializer::{Always, Once};
 use crate::model::io::IO;
+
+/// Why an input is being initialized — determines which initializers fire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InitReason {
+    /// First-time startup: Once + Always fire
+    Startup,
+    /// After function execution: function Always re-fires
+    AfterExecution,
+    /// Flow went idle: flow Always re-fires, pending gradual elements delivered
+    FlowIdle,
+}
 #[cfg(feature = "debugger")]
 use crate::model::name::HasName;
 #[cfg(feature = "debugger")]
@@ -213,48 +224,44 @@ impl Input {
     /// When called at start-up    it will initialize      if it's a `Once` or `Always` initializer
     /// When called after start-up it will initialize only if it's a           `Always` initializer
     #[allow(clippy::match_same_arms)]
-    pub fn init(&mut self, first_time: bool, flow_gone_idle: bool) -> bool {
-        // Deliver pending elements from a previous gradual init
-        if flow_gone_idle && !self.pending_init_elements.is_empty() {
+    pub fn init(&mut self, reason: InitReason) -> bool {
+        if reason == InitReason::FlowIdle && !self.pending_init_elements.is_empty() {
             let next = self.pending_init_elements.remove(0);
             self.send(next);
             return true;
         }
 
-        match (first_time, flow_gone_idle, &self.initializer) {
-            (true, false, Some(Once(one_time))) => {
+        // Function initializers take priority — early return prevents
+        // the flow initializer block from firing
+        match (reason, &self.initializer) {
+            (InitReason::Startup, Some(Once(one_time))) => {
                 if self.should_deliver_gradually(one_time) {
                     return self.send_one_element(&one_time.clone());
                 }
                 self.send(one_time.clone());
                 return true;
             }
-            (_, false, Some(Always(constant))) => {
+            (InitReason::Startup | InitReason::AfterExecution, Some(Always(constant))) => {
                 self.send(constant.clone());
                 return true;
             }
-            (_, _, _) => {}
+            _ => {}
         }
 
-        // Flow initializers will only be applied if a function initializer has not already been
-        // applied
-        match (first_time, flow_gone_idle, &self.flow_initializer) {
-            (true, _, Some(Once(one_time))) => {
+        // Flow initializers only apply if no function initializer matched
+        match (reason, &self.flow_initializer) {
+            (InitReason::Startup, Some(Once(one_time))) => {
                 if self.should_deliver_gradually(one_time) {
                     return self.send_one_element(&one_time.clone());
                 }
                 self.send(one_time.clone());
                 return true;
             }
-            (true, _, Some(Always(constant))) => {
+            (InitReason::Startup | InitReason::FlowIdle, Some(Always(constant))) => {
                 self.send(constant.clone());
                 return true;
             }
-            (_, true, Some(Always(constant))) => {
-                self.send(constant.clone());
-                return true;
-            }
-            (_, _, _) => {}
+            _ => {}
         }
 
         false
@@ -406,6 +413,7 @@ impl Input {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
+    use crate::model::input::InitReason;
     use crate::model::input::InputInitializer::{Always, Once};
     use serde_json::json;
     use serde_json::Value;
@@ -502,7 +510,7 @@ mod test {
     }
 
     #[test]
-    fn init_first_time_once() {
+    fn init_startup_once() {
         let mut input = Input::new(
             #[cfg(feature = "debugger")]
             "",
@@ -512,14 +520,14 @@ mod test {
             None,
         );
 
-        input.init(true, false);
+        input.init(InitReason::Startup);
 
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
     }
 
     #[test]
-    fn init_first_time_always() {
+    fn init_startup_always() {
         let mut input = Input::new(
             #[cfg(feature = "debugger")]
             "",
@@ -529,14 +537,14 @@ mod test {
             None,
         );
 
-        input.init(true, false);
+        input.init(InitReason::Startup);
 
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
     }
 
     #[test]
-    fn init_later_once() {
+    fn after_execution_once_does_not_refire() {
         let mut input = Input::new(
             #[cfg(feature = "debugger")]
             "",
@@ -546,18 +554,18 @@ mod test {
             None,
         );
 
-        input.init(true, false);
+        input.init(InitReason::Startup);
 
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
 
-        input.init(false, false);
+        input.init(InitReason::AfterExecution);
 
         assert!(input.is_empty());
     }
 
     #[test]
-    fn init_later_always() {
+    fn after_execution_always_refires() {
         let mut input = Input::new(
             #[cfg(feature = "debugger")]
             "",
@@ -567,12 +575,12 @@ mod test {
             None,
         );
 
-        input.init(true, false);
+        input.init(InitReason::Startup);
 
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
 
-        input.init(false, false);
+        input.init(InitReason::AfterExecution);
 
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
@@ -589,29 +597,24 @@ mod test {
             None,
         );
 
-        // First init: sends only element 0
-        input.init(true, false);
+        input.init(InitReason::Startup);
         assert_eq!(input.take(), Some(json!(1)));
         assert!(input.is_empty());
 
-        // Idle cycle: sends element 1
-        input.init(false, true);
+        input.init(InitReason::FlowIdle);
         assert_eq!(input.take(), Some(json!(2)));
         assert!(input.is_empty());
 
-        // Idle cycle: sends element 2
-        input.init(false, true);
+        input.init(InitReason::FlowIdle);
         assert_eq!(input.take(), Some(json!(3)));
         assert!(input.is_empty());
 
-        // No more elements
-        input.init(false, true);
+        input.init(InitReason::FlowIdle);
         assert!(input.is_empty());
     }
 
     #[test]
     fn non_gradual_array_on_array_input() {
-        // array/number input receiving array/number value — same order, send whole array
         let mut input = Input::new(
             #[cfg(feature = "debugger")]
             "",
@@ -621,7 +624,7 @@ mod test {
             None,
         );
 
-        input.init(true, false);
+        input.init(InitReason::Startup);
         assert_eq!(input.take(), Some(json!([1, 2, 3])));
         assert!(input.is_empty());
     }

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use url::Url;
 
 use crate::errors::{Result, ResultExt};
+use crate::model::input::InitReason;
 use crate::model::input::Input;
 use crate::model::input::InputInitializer;
 use crate::model::output_connection::OutputConnection;
@@ -170,13 +171,13 @@ impl RuntimeFunction {
 
     /// Initialize the function to be ready to be called during flow execution
     pub fn init(&mut self) {
-        self.init_inputs(true, false);
+        self.init_inputs(InitReason::Startup);
     }
 
     /// Initialize `Inputs` that have `InputInitializers` on them
-    pub fn init_inputs(&mut self, first_time: bool, flow_gone_idle: bool) {
+    pub fn init_inputs(&mut self, reason: InitReason) {
         for (io_number, input) in &mut self.inputs.iter_mut().enumerate() {
-            if input.init(first_time, flow_gone_idle) {
+            if input.init(reason) {
                 debug!(
                     "\tInitialized Input #{}:{io_number} in Flow #{}",
                     self.process_id, self.parent_id

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -745,7 +745,28 @@ impl RunState {
 
     // Check if ancestor flows have gone idle and run flow initializers if so
     #[allow(unused_variables, unused_assignments, unused_mut)]
+    /// After a job completes, decrement busy counts and check if any
+    /// ancestor flow has gone idle.  Matches the spec's `DecrBusy` +
+    /// `FlowGoesIdle` sequence.
     fn unblock_flows(
+        &mut self,
+        job: &Job,
+        #[cfg(feature = "debugger")] debugger: &mut Debugger,
+    ) -> Result<(bool, bool)> {
+        self.remove_from_busy(job.process_id, job.parent_id);
+        self.handle_idle_flows(
+            job,
+            #[cfg(feature = "debugger")]
+            debugger,
+        )
+    }
+
+    /// Check each ancestor flow from innermost to root.  For each newly
+    /// idle flow, either create jobs for functions runnable on internal
+    /// data (matching the spec's `CreateJob` with `CanRunOnInternal`), or
+    /// clear internals and re-apply flow initializers (`FlowGoesIdle`).
+    #[allow(unused_variables, unused_assignments, unused_mut)]
+    fn handle_idle_flows(
         &mut self,
         job: &Job,
         #[cfg(feature = "debugger")] debugger: &mut Debugger,
@@ -753,37 +774,14 @@ impl RunState {
         let mut display_next_output = false;
         let mut restart = false;
 
-        self.remove_from_busy(job.process_id, job.parent_id);
-
-        // Check each ancestor flow, from innermost to root
         for ancestor_id in self.ancestors(job.parent_id) {
             if self.busy_count.contains_key(&ancestor_id) {
                 continue;
             }
 
-            // No functions busy — check if any function can still run on internal data
             if self.has_runnable_on_internal(ancestor_id) {
-                let runnable: Vec<_> = self
-                    .functions_by_flow
-                    .get(&ancestor_id)
-                    .cloned()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|id| {
-                        !self.completed.contains(id)
-                            && self
-                                .submission
-                                .manifest
-                                .functions()
-                                .get(id)
-                                .is_some_and(RuntimeFunction::can_run)
-                    })
-                    .collect();
-                for func_id in runnable {
-                    self.create_jobs(func_id, ancestor_id)?;
-                }
+                self.create_jobs_on_internal(ancestor_id)?;
             } else {
-                // Flow has truly run to completion
                 debug!(
                     "Job #{}:\tFlow #{} is now idle",
                     job.payload.job_id, ancestor_id
@@ -801,6 +799,31 @@ impl RunState {
         }
 
         Ok((display_next_output, restart))
+    }
+
+    /// Create jobs for all runnable functions in a flow that can run
+    /// on internal data.
+    fn create_jobs_on_internal(&mut self, flow_id: usize) -> Result<()> {
+        let runnable: Vec<_> = self
+            .functions_by_flow
+            .get(&flow_id)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|id| {
+                !self.completed.contains(id)
+                    && self
+                        .submission
+                        .manifest
+                        .functions()
+                        .get(id)
+                        .is_some_and(RuntimeFunction::can_run)
+            })
+            .collect();
+        for func_id in runnable {
+            self.create_jobs(func_id, flow_id)?;
+        }
+        Ok(())
     }
 
     // Decrement busy_count for the function and all its ancestor flows

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -8,6 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
 use flowcore::errors::Result;
+use flowcore::model::input::InitReason;
 #[cfg(feature = "metrics")]
 use flowcore::model::metrics::Metrics;
 use flowcore::model::output_connection::OutputConnection;
@@ -468,7 +469,7 @@ impl RunState {
                     let function = self.get_mut(job.process_id).ok_or("No such function")?;
 
                     // Refill any inputs with function initializers
-                    function.init_inputs(false, false);
+                    function.init_inputs(InitReason::AfterExecution);
 
                     // NOTE: The function we are retiring may have new input sets due to sending
                     // to itself via a loopback
@@ -881,7 +882,7 @@ impl RunState {
             for id in &func_ids {
                 if !self.completed.contains(id) {
                     if let Some(f) = self.submission.manifest.get_functions().get_mut(id) {
-                        f.init_inputs(false, true);
+                        f.init_inputs(InitReason::FlowIdle);
                         if f.can_run() {
                             runnable_functions.push(*id);
                         }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -564,23 +564,27 @@ impl RunState {
 
         let new_job_available = function.input_sets_available() > job_count_before;
 
-        // postpone the decision about making the sending function Ready when we have a loopback
-        // connection that sends a value to itself, as it may also send to other functions.
-        // But for all other receivers of values, make them Ready
+        // Loopback sends (function sending to itself) defer job creation
+        // until after all other sends complete — handled by the caller.
         if new_job_available && !loopback {
-            // If this is an external send (crossing flow boundaries) and the destination's
-            // parent flow is already busy, don't create a job yet. The value stays queued
-            // and will be consumed when the sub-flow goes idle and restarts.
-            let dest_flow_busy = !connection.internal
-                && self
-                    .busy_count
-                    .contains_key(&connection.destination_parent_id);
-            if !dest_flow_busy {
-                self.create_jobs(connection.destination_id, connection.destination_parent_id)?;
-            }
+            self.try_create_destination_jobs(connection)?;
         }
 
         Ok((display_next_output, restart))
+    }
+
+    /// Create jobs for a destination function after receiving a value,
+    /// unless the send crosses a flow boundary and the destination's
+    /// parent flow is already busy (external send gating).
+    fn try_create_destination_jobs(&mut self, connection: &OutputConnection) -> Result<()> {
+        let dest_flow_busy = !connection.internal
+            && self
+                .busy_count
+                .contains_key(&connection.destination_parent_id);
+        if !dest_flow_busy {
+            self.create_jobs(connection.destination_id, connection.destination_parent_id)?;
+        }
+        Ok(())
     }
 
     /// Return how many jobs are currently running

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -818,7 +818,7 @@ impl RunState {
                         .manifest
                         .functions()
                         .get(id)
-                        .is_some_and(RuntimeFunction::can_run)
+                        .is_some_and(RuntimeFunction::can_run_on_internal)
             })
             .collect();
         for func_id in runnable {

--- a/specs/CompleteJobStops.cfg
+++ b/specs/CompleteJobStops.cfg
@@ -1,0 +1,11 @@
+SPECIFICATION Spec
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    TypeOK
+    CompletedNeverRuns
+    InternalCountBound
+    AncestorConsistency
+    CompletedStaysIdle

--- a/specs/CompleteJobStops.tla
+++ b/specs/CompleteJobStops.tla
@@ -1,0 +1,60 @@
+--------------------- MODULE CompleteJobStops ---------------------
+(*
+ * Scenario: CompleteJob prevents re-execution.
+ *
+ * Flow 10 contains p1 with 1 input (function Always(1)).
+ * p1 has no outgoing connections.
+ *
+ * Without CompleteJob, p1 would loop forever: Always re-fires after
+ * each RetireAndSend, making p1 runnable again.  CompleteJob provides
+ * the termination path — once p1 is in `done`, CanRun fails and no
+ * more jobs are created despite the Always initializer.
+ *
+ * CompletedStaysIdle verifies that once p1 completes, it never has
+ * another job in ready or running.
+ *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+NoParent == -1
+NoInit == -2
+
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+
+FR == INSTANCE FlowRuntimeBase WITH
+    Procs <- {1},
+    Flows <- {10},
+    InputsOf <- 1 :> {0},
+    Conns <- {},
+    Parent <- 1 :> 10 @@ 10 :> NoParent,
+    InitOnce <- 1 :> (0 :> NoInit),
+    InitAlways <- 1 :> (0 :> 1),
+    FlowInitOnce <- 1 :> (0 :> NoInit),
+    FlowInitAlways <- 1 :> (0 :> NoInit),
+    NoParent <- NoParent,
+    NoInit <- NoInit,
+    inputQ <- inputQ,
+    intCount <- intCount,
+    busyCount <- busyCount,
+    ready <- ready,
+    running <- running,
+    done <- done,
+    jobCounter <- jobCounter
+
+Init == FR!Init
+Next == FR!Next
+Spec == FR!Spec
+
+TypeOK == FR!TypeOK
+CompletedNeverRuns == FR!CompletedNeverRuns
+InternalCountBound == FR!InternalCountBound
+AncestorConsistency == FR!AncestorConsistency
+
+StateConstraint == jobCounter <= 8
+
+CompletedStaysIdle ==
+    1 \in done =>
+        /\ \A j \in running : j.func # 1
+        /\ \A idx \in 1..Len(ready) : ready[idx].func # 1
+
+========================================================================

--- a/specs/FlowAlwaysInit.cfg
+++ b/specs/FlowAlwaysInit.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    CompletedNeverRuns
+    InternalCountBound
+    AncestorConsistency
+    FlowAlwaysRefires

--- a/specs/FlowAlwaysInit.tla
+++ b/specs/FlowAlwaysInit.tla
@@ -1,0 +1,64 @@
+--------------------- MODULE FlowAlwaysInit ---------------------
+(*
+ * Scenario: Flow-level Always re-initialization via FlowGoesIdle.
+ *
+ * Flow 10 contains p1 with 2 inputs:
+ *   input 0: flow-level Always(1) — re-applied when flow goes idle
+ *   input 1: function-level Once(1) — consumed once, bounds execution
+ *
+ * p1 sends internally to itself on input 0 (self-loop), creating
+ * an internal value that triggers FlowGoesIdle when the flow
+ * becomes idle.
+ *
+ * Lifecycle:
+ * 1. Startup: p1 gets FlowInitAlways(1) on input 0, Once(1) on input 1
+ * 2. p1 runs, self-loop sends internal value to input 0
+ * 3. Flow 10 idle.  HasRunnableOnInternal = false (input 1 empty)
+ * 4. FlowGoesIdle: clears internal on input 0, re-applies FlowInitAlways
+ * 5. p1 has input 0 = <<1>> but input 1 empty — cannot run.  Terminates.
+ *
+ * FlowAlwaysRefires verifies that after FlowGoesIdle fires (no internal
+ * values remain), input 0 always has a value from FlowInitAlways.
+ *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+NoParent == -1
+NoInit == -2
+
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+
+FR == INSTANCE FlowRuntimeBase WITH
+    Procs <- {1},
+    Flows <- {10},
+    InputsOf <- 1 :> {0, 1},
+    Conns <- {[src |-> 1, dst |-> 1, dstInput |-> 0, internal |-> TRUE]},
+    Parent <- 1 :> 10 @@ 10 :> NoParent,
+    InitOnce <- 1 :> (0 :> NoInit @@ 1 :> 1),
+    InitAlways <- 1 :> (0 :> NoInit @@ 1 :> NoInit),
+    FlowInitOnce <- 1 :> (0 :> NoInit @@ 1 :> NoInit),
+    FlowInitAlways <- 1 :> (0 :> 1 @@ 1 :> NoInit),
+    NoParent <- NoParent,
+    NoInit <- NoInit,
+    inputQ <- inputQ,
+    intCount <- intCount,
+    busyCount <- busyCount,
+    ready <- ready,
+    running <- running,
+    done <- done,
+    jobCounter <- jobCounter
+
+Init == FR!Init
+Next == FR!Next
+Spec == FR!Spec
+
+TypeOK == FR!TypeOK
+CompletedNeverRuns == FR!CompletedNeverRuns
+InternalCountBound == FR!InternalCountBound
+AncestorConsistency == FR!AncestorConsistency
+
+FlowAlwaysRefires ==
+    (1 \notin done /\ ~FR!IsBusy(1) /\ intCount[1][0] = 0)
+    => Len(inputQ[1][0]) > 0
+
+========================================================================

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -67,6 +67,17 @@ CanRunOnInternal(p) ==
 HasRunnableOnInternal(flow) ==
     \E p \in ProcsInFlow(flow) : CanRunOnInternal(p)
 
+(* Busy-count helpers.
+ *
+ * busyCount is a function from IDs to positive integers.
+ * Presence in the domain means "busy"; the value is a reference count.
+ *
+ * IncrBusy({a, c}) on {a: 2, b: 1} -> {a: 3, b: 1, c: 1}
+ *   Existing entries incremented, new entries start at 1.
+ *
+ * DecrBusy({a, b}) on {a: 2, b: 1} -> {a: 1}
+ *   Entries reaching zero are removed (b was 1, decremented to 0).
+ *)
 IncrBusy(ids) ==
     [id \in (DOMAIN busyCount \union ids) |->
       IF id \in DOMAIN busyCount
@@ -135,8 +146,7 @@ CreateJob(p) ==
     /\ CanRun(p)
     /\ \/ ~IsBusy(Parent[p])
        \/ CanRunOnInternal(p)
-    /\ LET inputs == [i \in InputsOf[p] |-> Head(inputQ[p][i])]
-           toMark == {p} \union AncestorsOf(p)
+    /\ LET toMark == {p} \union AncestorsOf(p)
        IN
        /\ inputQ' = [inputQ EXCEPT ![p] =
             [i \in InputsOf[p] |-> Tail(inputQ[p][i])]]
@@ -145,7 +155,7 @@ CreateJob(p) ==
               IF intCount[p][i] > 0 THEN intCount[p][i] - 1 ELSE 0]]
        /\ jobCounter' = jobCounter + 1
        /\ ready' = Append(ready,
-            [func |-> p, inputs |-> inputs, jobId |-> jobCounter + 1])
+            [func |-> p, jobId |-> jobCounter + 1])
        /\ busyCount' = IncrBusy(toMark)
        /\ UNCHANGED <<running, done>>
 
@@ -188,18 +198,16 @@ Dispatch ==
 RetireAndSend(job) ==
     /\ job \in running
     /\ running' = running \ {job}
-    /\ LET outVal == IF InputsOf[job.func] = {} THEN 1
-                     ELSE job.inputs[CHOOSE i \in InputsOf[job.func] : TRUE]
-           conns == ConnsFrom(job.func)
+    /\ LET conns == ConnsFrom(job.func)
            toDecr == {job.func} \union AncestorsOf(job.func)
            sentQ == [p \in Procs |->
             [i \in InputsOf[p] |->
               IF \E c \in conns : c.dst = p /\ c.dstInput = i
               THEN IF (\E c \in conns : c.dst = p /\ c.dstInput = i /\ c.internal)
                    THEN SubSeq(inputQ[p][i], 1, intCount[p][i])
-                        \o <<outVal>>
+                        \o <<1>>
                         \o SubSeq(inputQ[p][i], intCount[p][i] + 1, Len(inputQ[p][i]))
-                   ELSE Append(inputQ[p][i], outVal)
+                   ELSE Append(inputQ[p][i], 1)
               ELSE inputQ[p][i]
             ]]
        IN

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -220,29 +220,28 @@ CompleteJob(job) ==
     /\ UNCHANGED <<inputQ, intCount, ready, jobCounter>>
 
 (*
- * When a flow becomes idle, the runtime first checks has_runnable_on_internal.
- * If any function can still run on internal data, CreateJob handles that —
- * its CanRunOnInternal guard allows firing for processes whose inputs are
- * all internal, even while the parent flow is busy.
+ * Flow idle lifecycle (matches unblock_flows in run_state.rs:755-796):
  *
- * FlowGoesIdle fires only when NO function can run on internal data alone.
- * It clears all internal values (clear_flow_internal_inputs) and re-applies
- * flow-level Always initializers (run_flow_initializers, run_state.rs:857).
- * Flow Always values use send() (external append).
+ * 1. While any function can run consuming ONLY internal values,
+ *    CreateJob fires (its CanRunOnInternal guard allows this even
+ *    while the parent flow is busy).  The flow stays busy.
  *
- * The guard requires intCount > 0 so the action is self-disabling (clearing
- * intCount makes the guard false, preventing infinite re-firing).  Flow
- * Always re-application piggybacks on internal-value clearing — this covers
- * the common case where internal sends occur during flow execution.
+ * 2. When no function can run on internal values alone, the flow
+ *    has completed its cycle.  FlowGoesIdle fires:
+ *    - Clears residual internal values (clear_flow_internal_inputs)
+ *    - Re-applies flow-level Always initializers (run_flow_initializers)
  *
- * NOTE: The runtime gates this with ~has_runnable_on_internal(flow) —
- * modeled here but the guard requires CompleteJob to work correctly
- * (otherwise self-loops create unbounded state spaces in TLC).
- * The guard is deferred until CompleteJob semantics are refined.
+ * 3. Functions may then run on external values or re-applied
+ *    initializers via CreateJob, restarting the flow.
+ *
+ * The ~HasRunnableOnInternal guard matches the runtime's
+ * has_runnable_on_internal check.  The intCount > 0 guard ensures
+ * the action is self-disabling (prevents infinite re-firing).
  *)
 FlowGoesIdle(flow) ==
     /\ flow \in Flows
     /\ ~IsBusy(flow)
+    /\ ~HasRunnableOnInternal(flow)
     /\ \E p \in ProcsInFlow(flow) : \E i \in InputsOf[p] : intCount[p][i] > 0
     /\ inputQ' = [p \in Procs |->
          [i \in InputsOf[p] |->

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -177,6 +177,13 @@ Dispatch ==
  * After sending output values, it re-applies function-level Always
  * initializers to the retiring function's inputs (run_state.rs:471).
  * Always values use send() (external append), not send_internal().
+ *
+ * In the runtime, retire_result sequences: send_a_value (with gating
+ * checks) -> init_inputs -> unblock_flows (busy count decrement).
+ * Here, sends and busy-count decrement happen atomically.  This is
+ * equivalent because the coordinator is single-threaded — no other
+ * job can be dispatched or retired between those steps, so the
+ * intermediate state is never observable.
  *)
 RetireAndSend(job) ==
     /\ job \in running

--- a/specs/NestedFlows.cfg
+++ b/specs/NestedFlows.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    CompletedNeverRuns
+    InternalCountBound
+    AncestorConsistency

--- a/specs/NestedFlows.tla
+++ b/specs/NestedFlows.tla
@@ -1,0 +1,57 @@
+----------------------- MODULE NestedFlows -----------------------
+(*
+ * Scenario: Nested flow hierarchy — flow 10 inside flow 0.
+ *
+ * Flow 0 (root) contains p3 and flow 10.
+ * Flow 10 contains p1 and p2.
+ *   p1 has 1 input (Once-initialized), connects internally to p2.
+ *   p2 has 1 input (no init), connects externally to p3.
+ *   p3 has 1 input (no init), no outgoing connections.
+ *
+ * Exercises ancestor busy-count propagation across two nesting levels:
+ * when p1 runs, both flow 10 and flow 0 must be marked busy.
+ * When p2 sends externally to p3, the external gating check applies
+ * (Parent[p3] = 0, flow 0 may or may not be busy).
+ *
+ * AncestorConsistency verifies that busy functions always have busy
+ * ancestors at every nesting level.
+ *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+NoParent == -1
+NoInit == -2
+
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+
+FR == INSTANCE FlowRuntimeBase WITH
+    Procs <- {1, 2, 3},
+    Flows <- {0, 10},
+    InputsOf <- 1 :> {0} @@ 2 :> {0} @@ 3 :> {0},
+    Conns <- { [src |-> 1, dst |-> 2, dstInput |-> 0, internal |-> TRUE],
+               [src |-> 2, dst |-> 3, dstInput |-> 0, internal |-> FALSE] },
+    Parent <- 1 :> 10 @@ 2 :> 10 @@ 3 :> 0 @@ 10 :> 0 @@ 0 :> NoParent,
+    InitOnce <- 1 :> (0 :> 1) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
+    InitAlways <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
+    FlowInitOnce <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
+    FlowInitAlways <- 1 :> (0 :> NoInit) @@ 2 :> (0 :> NoInit) @@ 3 :> (0 :> NoInit),
+    NoParent <- NoParent,
+    NoInit <- NoInit,
+    inputQ <- inputQ,
+    intCount <- intCount,
+    busyCount <- busyCount,
+    ready <- ready,
+    running <- running,
+    done <- done,
+    jobCounter <- jobCounter
+
+Init == FR!Init
+Next == FR!Next
+Spec == FR!Spec
+
+TypeOK == FR!TypeOK
+CompletedNeverRuns == FR!CompletedNeverRuns
+InternalCountBound == FR!InternalCountBound
+AncestorConsistency == FR!AncestorConsistency
+
+=====================================================================

--- a/specs/README.md
+++ b/specs/README.md
@@ -155,6 +155,9 @@ The trace shows you exactly which sequence of actions leads to the bug.
 - `MixedQueue.tla` / `.cfg` — scenario: internal self-feedback and external send with bounded execution
 - `ExternalGating.tla` / `.cfg` — scenario: external send gating across flow boundaries
 - `AlwaysInit.tla` / `.cfg` — scenario: function Always re-initialization after execution
+- `FlowAlwaysInit.tla` / `.cfg` — scenario: flow-level Always re-initialization via FlowGoesIdle
+- `NestedFlows.tla` / `.cfg` — scenario: ancestor busy-count propagation across nested flows
+- `CompleteJobStops.tla` / `.cfg` — scenario: CompleteJob prevents re-execution despite Always
 - `README.md` — this file
 
 ## Installing TLA+ Tools


### PR DESCRIPTION
## Summary
- Add `~HasRunnableOnInternal(flow)` guard to `FlowGoesIdle`, matching the runtime's `has_runnable_on_internal` check in `unblock_flows` (run_state.rs:761)

Partially addresses #2872 (cross-cutting: spec vs runtime comparison)

## Design rationale

The flow idle lifecycle is now explicitly modeled as:

1. **While functions can run on ONLY internal values** → `CreateJob` fires (its `CanRunOnInternal` guard permits this even while the parent flow is busy). The flow stays busy.
2. **When no function can run on internal alone** → `FlowGoesIdle` fires: clears residual internal values, re-applies flow Always initializers.
3. **Functions run on external values or initializers** → `CreateJob` fires, flow restarts.

Previously deferred due to concerns about self-loop state explosion in TLC, but existing scenarios bound execution via Once-initialized inputs.

## Test plan
- [x] TLC verifies all hand-written specs: TwoFuncsOneFlow, InternalExternal, MixedQueue, ExternalGating, AlwaysInit
- [x] `make clippy` clean
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow-idle transitions to match internal runnable availability, especially with nested/busy execution.
  * Refined job retirement and sending behavior so completion never re-enables previously completed work.
* **New Features**
  * Added support for flow-level `Always` initializers so they re-apply when a flow becomes idle.
* **Tooling / Generated Output**
  * Updated TLA+/config generation and validation to use constraint-based checking and refreshed assertions.
* **Documentation / Specs**
  * Added/expanded TLA+ scenarios for nested flows, flow `Always` refiring, and “complete job stops” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->