### PR TITLE
Add structured execution trace for TLA+ verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ flowr/**/*.tla
 flowr/**/*.cfg
 flowstdlib/**/*.tla
 flowstdlib/**/*.cfg
+flow_trace.json

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,11 @@ clean_examples:
 	@find flowr/examples -name \*.wasm | xargs rm -rf
 
 .PHONY: clean
-clean: clean_examples
+clean: clean_examples clean-traces
 	@echo "clean<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 	@cargo clean
 	@find . -name target -type d | xargs rm -rf
+	@find flowr/examples -name "flow_trace.json" -delete 2>/dev/null || true
 	@rm -rf $(HOME)/.flow/lib/flowstdlib
 
 .PHONY: build
@@ -103,7 +104,7 @@ features:
 	cargo build-all-features
 
 .PHONY: test
-test: build
+test: build check-binary-paths
 	@echo "test<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 ifneq ($(CODESIGN),)
 	@echo "Code signing tool \"codesign\" detected"
@@ -117,7 +118,7 @@ endif
 	cargo test --examples
 
 .PHONY: tla
-tla: build
+tla: build check-binary-paths
 	@echo "tla<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 	@echo "Generating TLA+ specs for flowr examples..."
 	@find flowr/examples -name "FlowRuntimeBase.tla" -delete 2>/dev/null || true
@@ -174,6 +175,57 @@ else
 	done; \
 	if [ $$FAIL -eq 1 ]; then echo "TLA+ verification failed"; exit 1; fi
 	@echo "All TLA+ specs verified."
+endif
+
+.PHONY: clean-traces
+clean-traces:
+	@find flowr/examples -name "flow_trace.json" -delete 2>/dev/null || true
+
+.PHONY: check-binary-paths
+check-binary-paths:
+	@for bin in flowrcli flowc flowrdb; do \
+		found=$$(which $$bin 2>/dev/null); \
+		expected="$(PWD)/target/debug/$$bin"; \
+		if [ "$$found" != "$$expected" ]; then \
+			echo "ERROR: $$bin resolves to '$$found' instead of '$$expected'"; \
+			echo "Ensure target/debug is first in PATH"; \
+			exit 1; \
+		fi; \
+	done
+
+.PHONY: trace
+trace: check-binary-paths clean-traces
+	@echo "trace<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+	cargo build -p flowr --features trace --bin flowrcli --bin flowr-tla-check
+	FLOW_TRACE=flow_trace.json cargo test --examples
+	@echo "Trace files:"
+	@find flowr/examples -name "flow_trace.json"
+
+.PHONY: tla-trace-check
+tla-trace-check: trace
+	@echo "tla-trace-check<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+ifeq ($(TLA2TOOLS),)
+	@echo "TLA+ Toolbox not found — skipping TLC trace verification"
+	@echo "Install with: brew install --cask tla+-toolbox"
+else
+	@TRACE_DIR=$$(mktemp -d); \
+	FAIL=0; COUNT=0; \
+	for trace in $$(find flowr/examples -name "flow_trace.json"); do \
+		name=$$(basename $$(dirname "$$trace")); \
+		printf "  %-30s" "$$name"; \
+		out="$$TRACE_DIR/$$name"; mkdir -p "$$out"; \
+		cp specs/FlowRuntimeBase.tla "$$out/"; \
+		target/debug/flowr-tla-check "$$trace" "$$out" 2>/dev/null || { echo "CONVERT FAILED"; FAIL=1; continue; }; \
+		if $(TLC_CMD) -metadir "$$TRACE_DIR/tlc-$$name" -config "$$out/TraceCheck.cfg" "$$out/TraceCheck.tla" > "$$out/tlc.log" 2>&1; then \
+			echo "OK"; COUNT=$$((COUNT+1)); \
+		else \
+			echo "TLC FAILED"; tail -5 "$$out/tlc.log"; FAIL=1; \
+		fi; \
+		rm -f "$$trace"; \
+	done; \
+	rm -rf "$$TRACE_DIR"; \
+	echo "$$COUNT examples verified against TLA+ spec."; \
+	if [ $$FAIL -eq 1 ]; then exit 1; fi
 endif
 
 .PHONY: coverage

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -408,6 +408,12 @@ impl Input {
     pub fn has_internal(&self) -> bool {
         self.internal_count > 0
     }
+
+    /// Return the number of internal values at the front of the queue
+    #[must_use]
+    pub fn internal_count(&self) -> usize {
+        self.internal_count
+    }
 }
 
 #[cfg(test)]

--- a/flowcore/src/model/mod.rs
+++ b/flowcore/src/model/mod.rs
@@ -44,5 +44,7 @@ pub mod process_reference;
 pub mod route;
 /// `submission`defines a struct for submitting flows for execution
 pub mod submission;
+/// Structured execution trace types for replay, debugging, and formal verification
+pub mod trace;
 /// Traits used for the validation of Model structs
 pub mod validation;

--- a/flowcore/src/model/trace.rs
+++ b/flowcore/src/model/trace.rs
@@ -1,0 +1,128 @@
+//! Structured execution trace types for replay, debugging, and formal verification.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_derive::{Deserialize, Serialize};
+
+/// Snapshot of runtime state variables at a point in execution
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceState {
+    /// Per-process, per-input queue contents (each value represented as 1)
+    pub input_q: BTreeMap<usize, BTreeMap<usize, Vec<i64>>>,
+    /// Per-process, per-input count of internal values at front of queue
+    pub int_count: BTreeMap<usize, BTreeMap<usize, usize>>,
+    /// Reference count of busy markers per process/flow ID
+    pub busy_count: BTreeMap<usize, usize>,
+    /// Queue of `[func_id, job_id]` pairs ready to run
+    pub ready: Vec<[usize; 2]>,
+    /// Set of `[func_id, job_id]` pairs currently running
+    pub running: Vec<[usize; 2]>,
+    /// Set of completed process IDs
+    pub done: BTreeSet<usize>,
+    /// Monotonically increasing job ID counter
+    pub job_counter: usize,
+}
+
+/// A single trace event: which action fired and the resulting state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceEvent {
+    /// Name of the action (e.g. "Init", "Dispatch")
+    pub action: String,
+    /// State snapshot after the action
+    pub state: TraceState,
+}
+
+/// A connection in the flow topology
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceConn {
+    /// Source process ID
+    pub src: usize,
+    /// Destination process ID
+    pub dst: usize,
+    /// Destination input index
+    pub dst_input: usize,
+    /// Whether this is an internal (within-flow) connection
+    pub internal: bool,
+}
+
+/// The static topology of a flow graph
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TraceTopology {
+    /// Set of all process (function) IDs
+    pub procs: BTreeSet<usize>,
+    /// Set of all flow (container) IDs
+    pub flows: BTreeSet<usize>,
+    /// Map from process ID to its set of input indices
+    pub inputs_of: BTreeMap<usize, BTreeSet<usize>>,
+    /// All connections in the flow graph
+    pub conns: Vec<TraceConn>,
+    /// Map from process/flow ID to parent flow ID (`None` for root)
+    pub parent: BTreeMap<usize, Option<usize>>,
+}
+
+/// A complete execution trace: topology plus sequence of state transitions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Trace {
+    /// The static flow topology
+    pub topology: TraceTopology,
+    /// Ordered sequence of trace events
+    pub events: Vec<TraceEvent>,
+}
+
+impl Trace {
+    /// Serialize the trace to pretty-printed JSON
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_default()
+    }
+
+    /// Deserialize a trace from JSON
+    ///
+    /// # Errors
+    /// Returns an error if the JSON is malformed.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_trace_roundtrips() {
+        let trace = Trace::default();
+        let json = trace.to_json();
+        let parsed = Trace::from_json(&json).unwrap();
+        assert!(parsed.events.is_empty());
+        assert!(parsed.topology.procs.is_empty());
+    }
+
+    #[test]
+    fn trace_with_events_roundtrips() {
+        let mut trace = Trace::default();
+        trace.topology.procs.insert(0);
+        trace.topology.procs.insert(1);
+        trace.topology.flows.insert(10);
+        trace.events.push(TraceEvent {
+            action: "Init".to_string(),
+            state: TraceState {
+                input_q: BTreeMap::new(),
+                int_count: BTreeMap::new(),
+                busy_count: BTreeMap::new(),
+                ready: vec![[0, 1]],
+                running: vec![],
+                done: BTreeSet::new(),
+                job_counter: 1,
+            },
+        });
+
+        let json = trace.to_json();
+        let parsed = Trace::from_json(&json).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+        assert_eq!(parsed.events[0].action, "Init");
+        assert_eq!(parsed.events[0].state.ready, vec![[0, 1]]);
+        assert_eq!(parsed.topology.procs.len(), 2);
+    }
+}

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -56,6 +56,11 @@ name = "flowrdb"
 path = "src/bin/flowrdb/main.rs"
 required-features = ["debugger"]
 
+[[bin]]
+name = "flowr-tla-check"
+path = "src/bin/flowr-tla-check/main.rs"
+required-features = ["trace"]
+
 [features]
 default = ["debugger", "metrics", "context", "submission", "flowstdlib"]
 # feature to add the debugger, requires flowcore crate to have feature enabled also, rustyline optional dependency too
@@ -64,6 +69,8 @@ debugger = ["flowcore/debugger", "rustyline"]
 metrics = []
 # feature to include ability to receive a submission of a flow
 submission = []
+# feature to emit structured trace events during execution
+trace = []
 # feature to include context functions, make sure flowcore is compiled with it if we plan to use it
 context = ["flowcore/context"]
 

--- a/flowr/src/bin/flowr-tla-check/main.rs
+++ b/flowr/src/bin/flowr-tla-check/main.rs
@@ -136,6 +136,7 @@ fn format_topology(topo: &TraceTopology) -> (String, String, String, String, Str
 fn generate_trace_tla(trace: &Trace) -> String {
     let topo = &trace.topology;
     let (procs, flows, inputs_of, conns, parent, init_stubs) = format_topology(topo);
+    let n = trace.events.len();
 
     let mut trace_states = String::new();
     for (i, event) in trace.events.iter().enumerate() {
@@ -146,18 +147,18 @@ fn generate_trace_tla(trace: &Trace) -> String {
         );
     }
 
-    let mut trace_next_parts = Vec::new();
-    for (i, pair) in trace.events.windows(2).enumerate() {
-        trace_next_parts.push(format!(
-            "    /\\ {} /\\ {}",
-            state_guard_tla(i, &pair[0].state),
-            state_prime_tla(i + 1, &pair[1].state, topo)
+    let mut trace_next_cases = Vec::new();
+    for i in 0..n - 1 {
+        trace_next_cases.push(format!(
+            "    \\/ /\\ traceIdx = {i}\n       /\\ traceIdx' = {next}\n{primed}",
+            next = i + 1,
+            primed = state_to_tla_primed(&trace.events[i + 1].state, topo)
         ));
     }
-    let trace_next = if trace_next_parts.is_empty() {
-        "FALSE".to_string()
+    let trace_next = if trace_next_cases.is_empty() {
+        "    FALSE".to_string()
     } else {
-        trace_next_parts.join("\n    \\/\n")
+        trace_next_cases.join("\n")
     };
 
     format!(
@@ -170,7 +171,7 @@ EXTENDS Integers, Sequences, FiniteSets, TLC
 NoParent == -1
 NoInit == -2
 
-VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter, traceIdx
 
 FR == INSTANCE FlowRuntimeBase WITH
     Procs <- {{{procs}}},
@@ -193,18 +194,18 @@ FR == INSTANCE FlowRuntimeBase WITH
     jobCounter <- jobCounter
 
 ---------------------------------------------------------------------------
-(* Trace states *)
+(* Trace states — used by TraceInit *)
 
 {trace_states}\
 ---------------------------------------------------------------------------
 (* Trace specification *)
 
-TraceInit == TraceState0
+TraceInit == TraceState0 /\\ traceIdx = 0
 
 TraceNext ==
 {trace_next}
 
-TraceSpec == TraceInit /\\ [][TraceNext]_<<inputQ, intCount, busyCount, ready, running, done, jobCounter>>
+TraceSpec == TraceInit /\\ [][TraceNext]_<<inputQ, intCount, busyCount, ready, running, done, jobCounter, traceIdx>>
 
 ---------------------------------------------------------------------------
 (* Invariants to check at each recorded state *)
@@ -214,26 +215,35 @@ InternalCountBound == FR!InternalCountBound
 AncestorConsistency == FR!AncestorConsistency
 
 ==========================================================================
-"
+",
     )
 }
 
 fn state_to_tla(state: &TraceState, topo: &TraceTopology) -> String {
+    format_state_lines(state, topo, false)
+}
+
+fn state_to_tla_primed(state: &TraceState, topo: &TraceTopology) -> String {
+    format_state_lines(state, topo, true)
+}
+
+fn format_state_lines(state: &TraceState, topo: &TraceTopology, primed: bool) -> String {
+    let p = if primed { "'" } else { "" };
     let mut lines = Vec::new();
 
     lines.push(format!(
-        "    /\\ inputQ = {}",
+        "       /\\ inputQ{p} = {}",
         format_input_queues(state, topo)
     ));
     lines.push(format!(
-        "    /\\ intCount = {}",
+        "       /\\ intCount{p} = {}",
         format_int_counts(state, topo)
     ));
-    lines.push(format_busy_count(state));
-    lines.push(format_ready(state));
-    lines.push(format_running(state));
-    lines.push(format_done(state));
-    lines.push(format!("    /\\ jobCounter = {}", state.job_counter));
+    lines.push(format_busy_count_with(state, p));
+    lines.push(format_ready_with(state, p));
+    lines.push(format_running_with(state, p));
+    lines.push(format_done_with(state, p));
+    lines.push(format!("       /\\ jobCounter{p} = {}", state.job_counter));
 
     lines.join("\n")
 }
@@ -305,72 +315,52 @@ fn format_int_counts(state: &TraceState, topo: &TraceTopology) -> String {
     parts.join(" @@ ")
 }
 
-fn format_busy_count(state: &TraceState) -> String {
+fn format_busy_count_with(state: &TraceState, prime: &str) -> String {
     if state.busy_count.is_empty() {
-        "    /\\ busyCount = [id \\in {} |-> 0]".to_string()
+        format!("       /\\ busyCount{prime} = [id \\in {{}} |-> 0]")
     } else {
         let bc: Vec<String> = state
             .busy_count
             .iter()
             .map(|(k, v)| format!("{k} :> {v}"))
             .collect();
-        format!("    /\\ busyCount = {}", bc.join(" @@ "))
+        format!("       /\\ busyCount{prime} = {}", bc.join(" @@ "))
     }
 }
 
-fn format_ready(state: &TraceState) -> String {
+fn format_ready_with(state: &TraceState, prime: &str) -> String {
     if state.ready.is_empty() {
-        "    /\\ ready = <<>>".to_string()
+        format!("       /\\ ready{prime} = <<>>")
     } else {
         let parts: Vec<String> = state
             .ready
             .iter()
             .map(|j| format!("[func |-> {}, jobId |-> {}]", j[0], j[1]))
             .collect();
-        format!("    /\\ ready = <<{}>>", parts.join(", "))
+        format!("       /\\ ready{prime} = <<{}>>", parts.join(", "))
     }
 }
 
-fn format_running(state: &TraceState) -> String {
+fn format_running_with(state: &TraceState, prime: &str) -> String {
     if state.running.is_empty() {
-        "    /\\ running = {}".to_string()
+        format!("       /\\ running{prime} = {{}}")
     } else {
         let parts: Vec<String> = state
             .running
             .iter()
             .map(|j| format!("[func |-> {}, jobId |-> {}]", j[0], j[1]))
             .collect();
-        format!("    /\\ running = {{{}}}", parts.join(", "))
+        format!("       /\\ running{prime} = {{{}}}", parts.join(", "))
     }
 }
 
-fn format_done(state: &TraceState) -> String {
+fn format_done_with(state: &TraceState, prime: &str) -> String {
     if state.done.is_empty() {
-        "    /\\ done = {}".to_string()
+        format!("       /\\ done{prime} = {{}}")
     } else {
         let parts: Vec<String> = state.done.iter().map(ToString::to_string).collect();
-        format!("    /\\ done = {{{}}}", parts.join(", "))
+        format!("       /\\ done{prime} = {{{}}}", parts.join(", "))
     }
-}
-
-fn state_guard_tla(idx: usize, state: &TraceState) -> String {
-    format!(
-        "jobCounter = {} /\\ Cardinality(done) = {} (* state {idx} *)",
-        state.job_counter,
-        state.done.len()
-    )
-}
-
-fn state_prime_tla(idx: usize, state: &TraceState, topo: &TraceTopology) -> String {
-    let tla = state_to_tla(state, topo);
-    tla.replace("inputQ =", "inputQ' =")
-        .replace("intCount =", "intCount' =")
-        .replace("busyCount =", "busyCount' =")
-        .replace("ready =", "ready' =")
-        .replace("running =", "running' =")
-        .replace("done =", "done' =")
-        .replace("jobCounter =", "jobCounter' =")
-        + &format!(" (* -> state {idx} *)")
 }
 
 fn generate_trace_cfg() -> String {

--- a/flowr/src/bin/flowr-tla-check/main.rs
+++ b/flowr/src/bin/flowr-tla-check/main.rs
@@ -1,0 +1,386 @@
+//! Reads a JSON execution trace and generates a TLA+ trace spec for TLC verification.
+//!
+//! Usage: flowr-tla-check <trace.json> [output-dir]
+//!
+//! Generates a `.tla` trace spec and `.cfg` file that TLC can check against
+//! `FlowRuntimeBase.tla` invariants.
+
+#![allow(clippy::indexing_slicing)]
+
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+
+use flowcore::model::trace::{Trace, TraceState, TraceTopology};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: flowr-tla-check <trace.json> [output-dir]");
+        std::process::exit(1);
+    }
+
+    let trace_path = args.get(1).expect("trace path argument required");
+    let output_dir = args.get(2).map_or(".", String::as_str);
+
+    let json = fs::read_to_string(trace_path).unwrap_or_else(|e| {
+        eprintln!("Cannot read {trace_path}: {e}");
+        std::process::exit(1);
+    });
+
+    let trace = Trace::from_json(&json).unwrap_or_else(|e| {
+        eprintln!("Cannot parse trace JSON: {e}");
+        std::process::exit(1);
+    });
+
+    if trace.events.is_empty() {
+        eprintln!("Trace has no events");
+        std::process::exit(1);
+    }
+
+    let tla = generate_trace_tla(&trace);
+    let cfg = generate_trace_cfg();
+
+    let tla_path = Path::new(output_dir).join("TraceCheck.tla");
+    let cfg_path = Path::new(output_dir).join("TraceCheck.cfg");
+
+    fs::write(&tla_path, &tla).unwrap_or_else(|e| {
+        eprintln!("Cannot write {}: {e}", tla_path.display());
+        std::process::exit(1);
+    });
+    fs::write(&cfg_path, &cfg).unwrap_or_else(|e| {
+        eprintln!("Cannot write {}: {e}", cfg_path.display());
+        std::process::exit(1);
+    });
+
+    eprintln!("Generated: {}", tla_path.display());
+    eprintln!("Generated: {}", cfg_path.display());
+    eprintln!(
+        "Trace has {} events across {} procs, {} flows",
+        trace.events.len(),
+        trace.topology.procs.len(),
+        trace.topology.flows.len()
+    );
+}
+
+fn format_topology(topo: &TraceTopology) -> (String, String, String, String, String, String) {
+    let procs = topo
+        .procs
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let flows = topo
+        .flows
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let inputs_of: Vec<String> = topo
+        .inputs_of
+        .iter()
+        .map(|(p, inputs)| {
+            let indices: Vec<String> = inputs.iter().map(ToString::to_string).collect();
+            format!("{p} :> {{{}}}", indices.join(", "))
+        })
+        .collect();
+
+    let conns: Vec<String> = topo
+        .conns
+        .iter()
+        .map(|c| {
+            format!(
+                "[src |-> {}, dst |-> {}, dstInput |-> {}, internal |-> {}]",
+                c.src,
+                c.dst,
+                c.dst_input,
+                if c.internal { "TRUE" } else { "FALSE" }
+            )
+        })
+        .collect();
+
+    let parent: Vec<String> = topo
+        .parent
+        .iter()
+        .map(|(id, pid)| match pid {
+            Some(p) => format!("{id} :> {p}"),
+            None => format!("{id} :> NoParent"),
+        })
+        .collect();
+
+    let init_stubs: Vec<String> = topo
+        .procs
+        .iter()
+        .map(|p| {
+            let inputs = topo.inputs_of.get(p).cloned().unwrap_or_default();
+            if inputs.is_empty() {
+                format!("{p} :> <<>>")
+            } else {
+                let parts: Vec<String> = inputs.iter().map(|i| format!("{i} :> NoInit")).collect();
+                format!("{p} :> ({})", parts.join(" @@ "))
+            }
+        })
+        .collect();
+
+    (
+        procs,
+        flows,
+        inputs_of.join(" @@ "),
+        conns.join(",\n                  "),
+        parent.join(" @@ "),
+        init_stubs.join(" @@ "),
+    )
+}
+
+fn generate_trace_tla(trace: &Trace) -> String {
+    let topo = &trace.topology;
+    let (procs, flows, inputs_of, conns, parent, init_stubs) = format_topology(topo);
+
+    let mut trace_states = String::new();
+    for (i, event) in trace.events.iter().enumerate() {
+        let _ = writeln!(
+            trace_states,
+            "TraceState{i} ==\n{}\n",
+            state_to_tla(&event.state, topo)
+        );
+    }
+
+    let mut trace_next_parts = Vec::new();
+    for (i, pair) in trace.events.windows(2).enumerate() {
+        trace_next_parts.push(format!(
+            "    /\\ {} /\\ {}",
+            state_guard_tla(i, &pair[0].state),
+            state_prime_tla(i + 1, &pair[1].state, topo)
+        ));
+    }
+    let trace_next = if trace_next_parts.is_empty() {
+        "FALSE".to_string()
+    } else {
+        trace_next_parts.join("\n    \\/\n")
+    };
+
+    format!(
+        "\
+--------------------------- MODULE TraceCheck ---------------------------
+(* Auto-generated trace spec for TLC verification. *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+NoParent == -1
+NoInit == -2
+
+VARIABLES inputQ, intCount, busyCount, ready, running, done, jobCounter
+
+FR == INSTANCE FlowRuntimeBase WITH
+    Procs <- {{{procs}}},
+    Flows <- {{{flows}}},
+    InputsOf <- {inputs_of},
+    Conns <- {{{conns}}},
+    Parent <- {parent},
+    InitOnce <- {init_stubs},
+    InitAlways <- {init_stubs},
+    FlowInitOnce <- {init_stubs},
+    FlowInitAlways <- {init_stubs},
+    NoParent <- NoParent,
+    NoInit <- NoInit,
+    inputQ <- inputQ,
+    intCount <- intCount,
+    busyCount <- busyCount,
+    ready <- ready,
+    running <- running,
+    done <- done,
+    jobCounter <- jobCounter
+
+---------------------------------------------------------------------------
+(* Trace states *)
+
+{trace_states}\
+---------------------------------------------------------------------------
+(* Trace specification *)
+
+TraceInit == TraceState0
+
+TraceNext ==
+{trace_next}
+
+TraceSpec == TraceInit /\\ [][TraceNext]_<<inputQ, intCount, busyCount, ready, running, done, jobCounter>>
+
+---------------------------------------------------------------------------
+(* Invariants to check at each recorded state *)
+
+TypeOK == FR!TypeOK
+InternalCountBound == FR!InternalCountBound
+AncestorConsistency == FR!AncestorConsistency
+
+==========================================================================
+"
+    )
+}
+
+fn state_to_tla(state: &TraceState, topo: &TraceTopology) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "    /\\ inputQ = {}",
+        format_input_queues(state, topo)
+    ));
+    lines.push(format!(
+        "    /\\ intCount = {}",
+        format_int_counts(state, topo)
+    ));
+    lines.push(format_busy_count(state));
+    lines.push(format_ready(state));
+    lines.push(format_running(state));
+    lines.push(format_done(state));
+    lines.push(format!("    /\\ jobCounter = {}", state.job_counter));
+
+    lines.join("\n")
+}
+
+fn format_input_queues(state: &TraceState, topo: &TraceTopology) -> String {
+    let parts: Vec<String> = topo
+        .procs
+        .iter()
+        .map(|p| {
+            let inputs = topo.inputs_of.get(p).cloned().unwrap_or_default();
+            if inputs.is_empty() {
+                format!("{p} :> <<>>")
+            } else {
+                let input_parts: Vec<String> = inputs
+                    .iter()
+                    .map(|i| {
+                        let q = state
+                            .input_q
+                            .get(p)
+                            .and_then(|m| m.get(i))
+                            .cloned()
+                            .unwrap_or_default();
+                        let seq = if q.is_empty() {
+                            "<<>>".to_string()
+                        } else {
+                            format!(
+                                "<<{}>>",
+                                q.iter()
+                                    .map(ToString::to_string)
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        };
+                        format!("{i} :> {seq}")
+                    })
+                    .collect();
+                format!("{p} :> ({})", input_parts.join(" @@ "))
+            }
+        })
+        .collect();
+    parts.join(" @@ ")
+}
+
+fn format_int_counts(state: &TraceState, topo: &TraceTopology) -> String {
+    let parts: Vec<String> = topo
+        .procs
+        .iter()
+        .map(|p| {
+            let inputs = topo.inputs_of.get(p).cloned().unwrap_or_default();
+            if inputs.is_empty() {
+                format!("{p} :> <<>>")
+            } else {
+                let input_parts: Vec<String> = inputs
+                    .iter()
+                    .map(|i| {
+                        let c = state
+                            .int_count
+                            .get(p)
+                            .and_then(|m| m.get(i))
+                            .copied()
+                            .unwrap_or(0);
+                        format!("{i} :> {c}")
+                    })
+                    .collect();
+                format!("{p} :> ({})", input_parts.join(" @@ "))
+            }
+        })
+        .collect();
+    parts.join(" @@ ")
+}
+
+fn format_busy_count(state: &TraceState) -> String {
+    if state.busy_count.is_empty() {
+        "    /\\ busyCount = [id \\in {} |-> 0]".to_string()
+    } else {
+        let bc: Vec<String> = state
+            .busy_count
+            .iter()
+            .map(|(k, v)| format!("{k} :> {v}"))
+            .collect();
+        format!("    /\\ busyCount = {}", bc.join(" @@ "))
+    }
+}
+
+fn format_ready(state: &TraceState) -> String {
+    if state.ready.is_empty() {
+        "    /\\ ready = <<>>".to_string()
+    } else {
+        let parts: Vec<String> = state
+            .ready
+            .iter()
+            .map(|j| format!("[func |-> {}, jobId |-> {}]", j[0], j[1]))
+            .collect();
+        format!("    /\\ ready = <<{}>>", parts.join(", "))
+    }
+}
+
+fn format_running(state: &TraceState) -> String {
+    if state.running.is_empty() {
+        "    /\\ running = {}".to_string()
+    } else {
+        let parts: Vec<String> = state
+            .running
+            .iter()
+            .map(|j| format!("[func |-> {}, jobId |-> {}]", j[0], j[1]))
+            .collect();
+        format!("    /\\ running = {{{}}}", parts.join(", "))
+    }
+}
+
+fn format_done(state: &TraceState) -> String {
+    if state.done.is_empty() {
+        "    /\\ done = {}".to_string()
+    } else {
+        let parts: Vec<String> = state.done.iter().map(ToString::to_string).collect();
+        format!("    /\\ done = {{{}}}", parts.join(", "))
+    }
+}
+
+fn state_guard_tla(idx: usize, state: &TraceState) -> String {
+    format!(
+        "jobCounter = {} /\\ Cardinality(done) = {} (* state {idx} *)",
+        state.job_counter,
+        state.done.len()
+    )
+}
+
+fn state_prime_tla(idx: usize, state: &TraceState, topo: &TraceTopology) -> String {
+    let tla = state_to_tla(state, topo);
+    tla.replace("inputQ =", "inputQ' =")
+        .replace("intCount =", "intCount' =")
+        .replace("busyCount =", "busyCount' =")
+        .replace("ready =", "ready' =")
+        .replace("running =", "running' =")
+        .replace("done =", "done' =")
+        .replace("jobCounter =", "jobCounter' =")
+        + &format!(" (* -> state {idx} *)")
+}
+
+fn generate_trace_cfg() -> String {
+    "\
+SPECIFICATION TraceSpec
+
+INVARIANTS
+    TypeOK
+    InternalCountBound
+    AncestorConsistency
+"
+    .to_string()
+}

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -224,6 +224,9 @@ impl<'a> Coordinator<'a> {
             }
         }
 
+        #[cfg(feature = "trace")]
+        state.write_trace()?;
+
         #[cfg(feature = "metrics")]
         metrics.stop_timer();
         #[cfg(feature = "metrics")]

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -93,7 +93,7 @@ mod checks;
 
 #[cfg(feature = "trace")]
 /// Structured execution trace capture for replay, debugging, and formal verification
-pub mod trace;
+pub(crate) mod trace;
 
 /// Shared test helper for setting up client-coordinator test connections
 pub mod test_helper;

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -91,5 +91,9 @@ mod wasm;
 #[cfg(debug_assertions)]
 mod checks;
 
+#[cfg(feature = "trace")]
+/// Structured execution trace capture for replay, debugging, and formal verification
+pub mod trace;
+
 /// Shared test helper for setting up client-coordinator test connections
 pub mod test_helper;

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -176,6 +176,9 @@ pub struct RunState {
     jobs_per_function: Vec<usize>,
     /// Index: parent flow ID → function IDs in that flow (avoids full-manifest scans)
     functions_by_flow: HashMap<usize, Vec<usize>>,
+    #[cfg(feature = "trace")]
+    #[serde(skip)]
+    trace: flowcore::model::trace::Trace,
 }
 
 impl RunState {
@@ -194,6 +197,8 @@ impl RunState {
         #[cfg(feature = "metrics")]
         let num_processes =
             submission.manifest.functions().len() + submission.manifest.flows().len();
+        #[cfg(feature = "trace")]
+        let trace = crate::trace::topology_from_submission(&submission);
         RunState {
             submission,
             ready_jobs: VecDeque::<Job>::new(),
@@ -204,6 +209,8 @@ impl RunState {
             #[cfg(feature = "metrics")]
             jobs_per_function: vec![0; num_processes],
             functions_by_flow,
+            #[cfg(feature = "trace")]
+            trace,
         }
     }
 
@@ -259,6 +266,9 @@ impl RunState {
             self.create_jobs(process_id, parent_id)?;
         }
 
+        #[cfg(feature = "trace")]
+        self.record_trace("Init");
+
         Ok(())
     }
 
@@ -300,7 +310,7 @@ impl RunState {
     }
 
     /// Get a Set (`job_id`) of the currently running jobs
-    #[cfg(any(feature = "debugger", debug_assertions))]
+    #[cfg(any(feature = "debugger", feature = "trace", debug_assertions))]
     #[must_use]
     pub fn get_running(&self) -> &HashMap<usize, Job> {
         &self.running_jobs
@@ -317,7 +327,7 @@ impl RunState {
         self.submission.manifest.get_functions().get_mut(&id)
     }
 
-    #[cfg(any(debug_assertions, feature = "debugger"))]
+    #[cfg(any(debug_assertions, feature = "debugger", feature = "trace"))]
     /// Return the busy count map (`process_id` -> count of busy entries)
     #[must_use]
     pub fn get_busy_count(&self) -> &HashMap<usize, usize> {
@@ -325,7 +335,7 @@ impl RunState {
     }
 
     /// Return the set of completed function IDs
-    #[cfg(feature = "debugger")]
+    #[cfg(any(feature = "debugger", feature = "trace"))]
     #[must_use]
     pub fn get_completed(&self) -> &HashSet<usize> {
         &self.completed
@@ -346,6 +356,8 @@ impl RunState {
     // Update the run_state to reflect that the job is now running
     pub(crate) fn start_job(&mut self, job: Job) {
         self.running_jobs.insert(job.payload.job_id, job);
+        #[cfg(feature = "trace")]
+        self.record_trace("Dispatch");
     }
 
     /// Check for running jobs that have exceeded their TTL.
@@ -391,7 +403,7 @@ impl RunState {
     }
 
     /// get the number of jobs created to date in the flow's execution
-    #[cfg(any(feature = "metrics", feature = "debugger"))]
+    #[cfg(any(feature = "metrics", feature = "debugger", feature = "trace"))]
     #[must_use]
     pub fn get_number_of_jobs_created(&self) -> usize {
         self.number_of_jobs_created
@@ -476,9 +488,13 @@ impl RunState {
                     if function.can_run() {
                         self.create_jobs(job.process_id, job.parent_id)?;
                     }
+                    #[cfg(feature = "trace")]
+                    self.record_trace("RetireAndSend");
                 } else {
                     // otherwise mark it as completed as it will never run again
                     self.mark_as_completed(job.process_id);
+                    #[cfg(feature = "trace")]
+                    self.record_trace("CompleteJob");
                 }
             }
             Err(e) => {
@@ -601,7 +617,7 @@ impl RunState {
     }
 
     /// Return the ready jobs queue
-    #[cfg(feature = "debugger")]
+    #[cfg(any(feature = "debugger", feature = "trace"))]
     #[must_use]
     pub fn get_ready_jobs(&self) -> &VecDeque<Job> {
         &self.ready_jobs
@@ -696,6 +712,8 @@ impl RunState {
                 for ancestor in self.ancestors(parent_id) {
                     *self.busy_count.entry(ancestor).or_insert(0) += 1;
                 }
+                #[cfg(feature = "trace")]
+                self.record_trace("CreateJob");
                 if always_ready {
                     return Ok(());
                 }
@@ -796,6 +814,8 @@ impl RunState {
 
                 self.clear_flow_internal_inputs(ancestor_id);
                 self.run_flow_initializers(ancestor_id)?;
+                #[cfg(feature = "trace")]
+                self.record_trace("FlowGoesIdle");
             }
         }
 
@@ -901,6 +921,29 @@ impl RunState {
     // Mark a function (via its ID) as having run to completion
     pub(crate) fn mark_as_completed(&mut self, function_id: usize) {
         self.completed.insert(function_id);
+    }
+
+    #[cfg(feature = "trace")]
+    fn record_trace(&mut self, action: &str) {
+        crate::trace::record_event(
+            &mut self.trace,
+            action,
+            &self.submission.manifest,
+            &self.busy_count,
+            &self.ready_jobs,
+            &self.running_jobs,
+            &self.completed,
+            self.number_of_jobs_created,
+        );
+    }
+
+    /// Extract the accumulated trace, replacing it with an empty trace
+    #[cfg(feature = "trace")]
+    pub fn take_trace(&mut self) -> flowcore::model::trace::Trace {
+        std::mem::replace(
+            &mut self.trace,
+            crate::trace::topology_from_submission(&self.submission),
+        )
     }
 }
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -238,6 +238,10 @@ impl RunState {
         self.completed.clear();
         self.number_of_jobs_created = 0;
         self.busy_count.clear();
+        #[cfg(feature = "trace")]
+        {
+            self.trace.events.clear();
+        }
     }
 
     /// The `ìnit()` function is responsible for initializing all functions, and it returns a
@@ -499,6 +503,8 @@ impl RunState {
             }
             Err(e) => {
                 error!("Error in Job #{}: {e}", job.payload.job_id);
+                #[cfg(feature = "trace")]
+                self.record_trace("JobError");
             }
         }
 
@@ -939,7 +945,8 @@ impl RunState {
 
     /// Extract the accumulated trace, replacing it with an empty trace
     #[cfg(feature = "trace")]
-    pub fn take_trace(&mut self) -> flowcore::model::trace::Trace {
+    #[allow(dead_code)]
+    pub(crate) fn take_trace(&mut self) -> flowcore::model::trace::Trace {
         std::mem::replace(
             &mut self.trace,
             crate::trace::topology_from_submission(&self.submission),

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -952,6 +952,18 @@ impl RunState {
             crate::trace::topology_from_submission(&self.submission),
         )
     }
+
+    /// Write the trace to the path specified by the `FLOW_TRACE` env var
+    #[cfg(feature = "trace")]
+    pub(crate) fn write_trace(&mut self) -> flowcore::errors::Result<()> {
+        if let Ok(trace_path) = std::env::var("FLOW_TRACE") {
+            let trace = self.take_trace();
+            let trace_json = trace.to_json();
+            std::fs::write(&trace_path, &trace_json)
+                .map_err(|e| format!("Could not write trace to {trace_path}: {e}"))?;
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for RunState {

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -239,9 +239,7 @@ impl RunState {
         self.number_of_jobs_created = 0;
         self.busy_count.clear();
         #[cfg(feature = "trace")]
-        {
-            self.trace.events.clear();
-        }
+        self.trace.events.clear();
     }
 
     /// The `ìnit()` function is responsible for initializing all functions, and it returns a

--- a/flowr/src/lib/trace.rs
+++ b/flowr/src/lib/trace.rs
@@ -1,0 +1,320 @@
+//! Runtime trace capture — builds `Trace` from live `RunState` transitions.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+
+use flowcore::model::flow_manifest::FlowManifest;
+use flowcore::model::submission::Submission;
+use flowcore::model::trace::{Trace, TraceConn, TraceEvent, TraceState, TraceTopology};
+
+use crate::job::Job;
+
+/// Extract the static topology from a submission (called once at construction)
+pub(crate) fn topology_from_submission(submission: &Submission) -> Trace {
+    let manifest = &submission.manifest;
+    let mut procs = BTreeSet::new();
+    let mut flows = BTreeSet::new();
+    let mut inputs_of = BTreeMap::new();
+    let mut conns = Vec::new();
+    let mut parent = BTreeMap::new();
+
+    for (id, function) in manifest.functions() {
+        procs.insert(*id);
+        let input_indices: BTreeSet<usize> = (0..function.inputs().len()).collect();
+        inputs_of.insert(*id, input_indices);
+        parent.insert(*id, Some(function.get_parent_id()));
+
+        for oc in function.get_output_connections() {
+            conns.push(TraceConn {
+                src: *id,
+                dst: oc.destination_id,
+                dst_input: oc.destination_io_number,
+                internal: oc.internal,
+            });
+        }
+    }
+
+    for (id, flow_info) in manifest.flows() {
+        flows.insert(*id);
+        parent.insert(*id, flow_info.parent_id);
+    }
+
+    Trace {
+        topology: TraceTopology {
+            procs,
+            flows,
+            inputs_of,
+            conns,
+            parent,
+        },
+        events: Vec::new(),
+    }
+}
+
+/// Snapshot the current runtime state and append a trace event.
+///
+/// Takes individual fields to avoid borrowing the entire `RunState`
+/// (which would conflict with the mutable borrow of the `trace` field).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_event(
+    trace: &mut Trace,
+    action: &str,
+    manifest: &FlowManifest,
+    busy_count: &HashMap<usize, usize>,
+    ready_jobs: &VecDeque<Job>,
+    running_jobs: &HashMap<usize, Job>,
+    completed: &HashSet<usize>,
+    number_of_jobs_created: usize,
+) {
+    let state = capture_state(
+        manifest,
+        busy_count,
+        ready_jobs,
+        running_jobs,
+        completed,
+        number_of_jobs_created,
+    );
+    trace.events.push(TraceEvent {
+        action: action.to_string(),
+        state,
+    });
+}
+
+fn capture_state(
+    manifest: &FlowManifest,
+    busy_count: &HashMap<usize, usize>,
+    ready_jobs: &VecDeque<Job>,
+    running_jobs: &HashMap<usize, Job>,
+    completed: &HashSet<usize>,
+    number_of_jobs_created: usize,
+) -> TraceState {
+    let mut input_q = BTreeMap::new();
+    let mut int_count = BTreeMap::new();
+
+    for (id, function) in manifest.functions() {
+        let mut q_map = BTreeMap::new();
+        let mut ic_map = BTreeMap::new();
+        for (idx, input) in function.inputs().iter().enumerate() {
+            q_map.insert(idx, vec![1i64; input.values_available()]);
+            ic_map.insert(idx, input.internal_count());
+        }
+        input_q.insert(*id, q_map);
+        int_count.insert(*id, ic_map);
+    }
+
+    let bc: BTreeMap<usize, usize> = busy_count.iter().map(|(&k, &v)| (k, v)).collect();
+
+    let ready: Vec<[usize; 2]> = ready_jobs
+        .iter()
+        .map(|j| [j.process_id, j.payload.job_id])
+        .collect();
+
+    let running: Vec<[usize; 2]> = running_jobs
+        .values()
+        .map(|j| [j.process_id, j.payload.job_id])
+        .collect();
+
+    let done: BTreeSet<usize> = completed.iter().copied().collect();
+
+    TraceState {
+        input_q,
+        int_count,
+        busy_count: bc,
+        ready,
+        running,
+        done,
+        job_counter: number_of_jobs_created,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod test {
+    use serde_json::json;
+
+    use flowcore::model::flow_manifest::{FlowInfo, FlowManifest};
+    use flowcore::model::input::Input;
+    use flowcore::model::input::InputInitializer::Once;
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowcore::model::submission::Submission;
+
+    use crate::run_state::RunState;
+
+    fn test_meta_data() -> MetaData {
+        MetaData {
+            name: "trace_test".into(),
+            version: "0.0.0".into(),
+            description: "a trace test".into(),
+            authors: vec!["test".into()],
+        }
+    }
+
+    fn test_manifest(functions: Vec<RuntimeFunction>) -> FlowManifest {
+        let mut manifest = FlowManifest::new(test_meta_data());
+        for function in functions {
+            manifest.add_function(function);
+        }
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![],
+            #[cfg(feature = "debugger")]
+            name: "root".to_string(),
+            #[cfg(feature = "debugger")]
+            route: "/".to_string(),
+        });
+        manifest
+    }
+
+    fn test_submission(functions: Vec<RuntimeFunction>) -> Submission {
+        Submission::new(
+            test_manifest(functions),
+            None,
+            None,
+            #[cfg(feature = "debugger")]
+            true,
+        )
+    }
+
+    fn func_a_sends_to_b() -> RuntimeFunction {
+        let conn = OutputConnection::new(
+            Source::default(),
+            1,
+            0,
+            0,
+            true,
+            "/fB".to_string(),
+            #[cfg(feature = "debugger")]
+            String::default(),
+        );
+        RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "fA",
+            #[cfg(feature = "debugger")]
+            "/fA",
+            "file://fake/test",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "",
+                0,
+                false,
+                Some(Once(json!(1))),
+                None,
+            )],
+            0,
+            0,
+            &[conn],
+            false,
+        )
+    }
+
+    fn func_b_no_init() -> RuntimeFunction {
+        RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "fB",
+            #[cfg(feature = "debugger")]
+            "/fB",
+            "file://fake/test",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "",
+                0,
+                false,
+                None,
+                None,
+            )],
+            1,
+            0,
+            &[],
+            false,
+        )
+    }
+
+    #[test]
+    fn topology_extracted_from_submission() {
+        let submission = test_submission(vec![func_a_sends_to_b(), func_b_no_init()]);
+        let trace = super::topology_from_submission(&submission);
+
+        assert!(trace.topology.procs.contains(&0));
+        assert!(trace.topology.procs.contains(&1));
+        assert!(trace.topology.flows.contains(&0));
+        assert_eq!(trace.topology.conns.len(), 1);
+        assert_eq!(trace.topology.conns[0].src, 0);
+        assert_eq!(trace.topology.conns[0].dst, 1);
+        assert!(trace.events.is_empty());
+    }
+
+    #[test]
+    fn init_records_trace_event() {
+        let mut state = RunState::new(test_submission(vec![func_a_sends_to_b(), func_b_no_init()]));
+        state.init().expect("init failed");
+
+        let trace = state.take_trace();
+        assert!(
+            trace.events.iter().any(|e| e.action == "Init"),
+            "Expected an Init event in trace"
+        );
+    }
+
+    #[test]
+    fn create_job_records_trace_event() {
+        let mut state = RunState::new(test_submission(vec![func_a_sends_to_b(), func_b_no_init()]));
+        state.init().expect("init failed");
+
+        let trace = state.take_trace();
+        assert!(
+            trace.events.iter().any(|e| e.action == "CreateJob"),
+            "Expected a CreateJob event in trace"
+        );
+    }
+
+    #[test]
+    fn dispatch_records_trace_event() {
+        let mut state = RunState::new(test_submission(vec![func_a_sends_to_b(), func_b_no_init()]));
+        state.init().expect("init failed");
+
+        let job = state.get_next_job().expect("expected a ready job");
+        state.start_job(job);
+
+        let trace = state.take_trace();
+        assert!(
+            trace.events.iter().any(|e| e.action == "Dispatch"),
+            "Expected a Dispatch event in trace"
+        );
+    }
+
+    #[test]
+    fn trace_serializes_to_valid_json() {
+        let mut state = RunState::new(test_submission(vec![func_a_sends_to_b(), func_b_no_init()]));
+        state.init().expect("init failed");
+
+        let trace = state.take_trace();
+        let json = trace.to_json();
+        assert!(!json.is_empty());
+
+        let parsed: flowcore::model::trace::Trace =
+            serde_json::from_str(&json).expect("trace JSON should be valid");
+        assert_eq!(parsed.events.len(), trace.events.len());
+    }
+
+    #[test]
+    fn init_state_has_correct_queue_lengths() {
+        let mut state = RunState::new(test_submission(vec![func_a_sends_to_b(), func_b_no_init()]));
+        state.init().expect("init failed");
+
+        let trace = state.take_trace();
+        let init_event = trace
+            .events
+            .iter()
+            .find(|e| e.action == "Init")
+            .expect("Init event");
+
+        // After init, func_a's input was consumed (job created), func_b has no values
+        let func_b_q = &init_event.state.input_q[&1][&0];
+        assert!(
+            func_b_q.is_empty(),
+            "func_b should have empty queue after init"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds generic trace capture to the runtime behind a `trace` feature flag, recording state snapshots at each transition (Init, CreateJob, Dispatch, RetireAndSend, CompleteJob, FlowGoesIdle)
- Shared trace types (`Trace`, `TraceState`, `TraceEvent`, `TraceTopology`, `TraceConn`) live in `flowcore::model::trace` so they can be reused by flowrgui, the editor, debugger, etc.
- New `flowr-tla-check` binary reads JSON traces and generates TLA+ trace specs for TLC invariant verification against `FlowRuntimeBase.tla`
- Zero overhead when `trace` feature is not enabled (not in default features)

## Test plan
- [x] `cargo fmt` — clean
- [x] `make clippy` — clean
- [x] `make test` — all tests pass (0 failures)
- [x] `cargo test -p flowr --lib --features trace -- trace::test` — 6 trace-specific tests pass
- [x] `cargo test -p flowcore -- model::trace::test` — 2 flowcore trace tests pass
- [ ] Manual: run a flow with trace enabled, verify `flowr-tla-check` generates valid TLA+

Closes #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional execution tracing that captures structured state snapshots and named execution events during runs.
  * Introduced a trace data model with JSON import/export to enable replay and inspection.
  * Added a `flowr-tla-check` command-line tool to convert saved traces into TLA+ artifacts for model checking.
  * Extended runtime trace capture and trace event recording when tracing is enabled.
* **Tests**
  * Added unit tests for trace JSON round-tripping and trace generation.
* **Chores**
  * Updated ignore rules to exclude generated trace output from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->