### PR TITLE
Join coordinator thread before exiting flowrcli

### DIFF
--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -239,7 +239,7 @@ fn client_and_coordinator(
     let coordinator_lib_search_path = lib_search_path.clone();
 
     info!("Starting coordinator in background thread");
-    thread::spawn(move || {
+    let coordinator_handle = thread::spawn(move || {
         let _ = coordinator(
             num_threads,
             coordinator_lib_search_path,
@@ -255,13 +255,17 @@ fn client_and_coordinator(
 
     let runtime_client_connection = ClientConnection::new(&coordinator_address)?;
 
-    client(
+    let result = client(
         matches,
         lib_search_path,
         &runtime_client_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
-    )
+    );
+
+    let _ = coordinator_handle.join();
+
+    result
 }
 
 /// Create a new `Coordinator`, preload any libraries in native format that we want to have before


### PR DESCRIPTION
## Summary

- Stores the coordinator thread's `JoinHandle` and joins it after the client function returns
- Ensures the coordinator completes all cleanup (e.g., writing trace files, flushing state) before the process exits

Closes #2892

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client/coordinator startup and shutdown handling so background work finishes cleanly before the app returns.
  * Reduced the risk of the app exiting before all coordinated tasks complete, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->