### PR TITLE
Test: re-enable debug tests on Windows (#2817)

### DIFF
--- a/flowr/examples/debug-help-string/main.rs
+++ b/flowr/examples/debug-help-string/main.rs
@@ -9,10 +9,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_help_string_example() {
         let example_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")

--- a/flowr/examples/debug-print-args/main.rs
+++ b/flowr/examples/debug-print-args/main.rs
@@ -15,10 +15,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_continue_and_exit() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -35,10 +31,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_step() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s");
@@ -58,10 +50,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_functions() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -78,10 +66,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i");
@@ -94,10 +78,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_list_empty() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("l");
@@ -109,10 +89,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_and_delete() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -126,10 +102,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_validate() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("v");
@@ -141,10 +113,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_step_n() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s 2");
@@ -160,10 +128,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_function() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -180,10 +144,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_input() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0:0");
@@ -195,10 +155,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_output() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0/");
@@ -210,10 +166,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_block() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0->1");
@@ -225,10 +177,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_output_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0/");
@@ -242,10 +190,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_input_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0:0");
@@ -259,10 +203,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_block_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0->1");
@@ -276,10 +216,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_modify() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("m max_parallel_jobs=2");
@@ -291,10 +227,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_reset() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -313,10 +245,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_delete_all() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -330,10 +258,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_completion_breakpoint() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 1+");
@@ -362,10 +286,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_processes() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("p");
@@ -381,10 +301,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_ready() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i ready");
@@ -400,10 +316,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_waiting() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i waiting");


### PR DESCRIPTION
## Summary
- Re-enables all debug integration tests on Windows (debug-help-string + debug-print-args) that were ignored due to #2817
- Tests whether the shared ServiceDaemon fix from PR #2900 resolved the mDNS contention that caused the debug handshake to fail

## Test plan
- [ ] Watch Windows CI — if debug tests pass, #2817 is fixed and this can be merged
- [ ] If they still fail/hang, close this PR and restore the ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)