### PR TITLE
Optimize Windows CI: Defender exclusion + rust-lld linker

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -135,10 +135,17 @@ jobs:
           echo "PATH=$GITHUB_WORKSPACE/target/debug:$PATH" >> "$GITHUB_ENV"
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> "$GITHUB_ENV"
 
-      - name: EnableIncrementalOnWindows
+      - name: OptimizeWindowsBuild
         if: runner.os == 'Windows'
         shell: bash
-        run: echo "CARGO_INCREMENTAL=1" >> "$GITHUB_ENV"
+        run: |
+          echo "CARGO_INCREMENTAL=1" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> "$GITHUB_ENV"
+
+      - name: DisableWindowsDefender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE"
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- Disable Windows Defender real-time scanning on the workspace directory
- Use `rust-lld` as the linker on Windows (faster than MSVC's `link.exe`)

These were tested in PR #2898 but abandoned because the test step appeared to hang. That hang was actually the coordinator join bug (fixed in PR #2900), not these changes.

## Previous results (PR #2898)

| Change | cargo-build | Savings |
|---|---|---|
| Baseline | 23m | — |
| Defender exclusion | 21.3m | -8% |
| Defender + rust-lld | 18.4m | -20% |

Fixes #2897

## Test plan
- [ ] Compare Windows `cargo-build` step time against baseline (~23m)
- [ ] Verify all Windows tests still pass (no hangs now that #2900 is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build and test workflow performance.
  * Enhanced Windows build configuration for more consistent compilation.
  * Reduced unnecessary workspace scanning during automated Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->