### PR TITLE
Fix flaky debug tests with handshake retry and graceful shutdown

### DIFF
--- a/flowr/examples/debug-help-string/main.rs
+++ b/flowr/examples/debug-help-string/main.rs
@@ -9,10 +9,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_help_string_example() {
         let example_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")

--- a/flowr/examples/debug-help-string/main.rs
+++ b/flowr/examples/debug-help-string/main.rs
@@ -9,6 +9,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_help_string_example() {
         let example_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")

--- a/flowr/examples/debug-print-args/main.rs
+++ b/flowr/examples/debug-print-args/main.rs
@@ -15,6 +15,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_continue_and_exit() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -31,6 +35,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_step() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s");
@@ -50,6 +58,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_functions() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -66,6 +78,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i");
@@ -78,6 +94,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_list_empty() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("l");
@@ -89,6 +109,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_breakpoint_and_delete() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -102,6 +126,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_validate() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("v");
@@ -113,6 +141,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_step_n() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s 2");
@@ -128,6 +160,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_function() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -144,6 +180,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_input() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0:0");
@@ -155,6 +195,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_output() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0/");
@@ -166,6 +210,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_block() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0->1");
@@ -177,6 +225,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_breakpoint_output_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0/");
@@ -190,6 +242,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_breakpoint_input_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0:0");
@@ -203,6 +259,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_breakpoint_block_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0->1");
@@ -216,6 +276,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_modify() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("m max_parallel_jobs=2");
@@ -227,6 +291,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_reset() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -245,6 +313,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_delete_all() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -258,6 +330,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_completion_breakpoint() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 1+");
@@ -286,6 +362,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_processes() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("p");
@@ -301,6 +381,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_ready() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i ready");
@@ -316,6 +400,10 @@ mod test {
 
     #[test]
     #[serial]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "mDNS unreliable on Windows CI (#2817)"
+    )]
     fn test_debug_inspect_waiting() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i waiting");

--- a/flowr/examples/debug-print-args/main.rs
+++ b/flowr/examples/debug-print-args/main.rs
@@ -15,10 +15,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_continue_and_exit() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -35,10 +31,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_step() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s");
@@ -58,10 +50,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_functions() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -78,10 +66,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i");
@@ -94,10 +78,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_list_empty() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("l");
@@ -109,10 +89,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_and_delete() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -126,10 +102,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_validate() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("v");
@@ -141,10 +113,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_step_n() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("s 2");
@@ -160,10 +128,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_function() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("f");
@@ -180,10 +144,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_input() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0:0");
@@ -195,10 +155,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_output() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0/");
@@ -210,10 +166,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_block() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i 0->1");
@@ -225,10 +177,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_output_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0/");
@@ -242,10 +190,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_input_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0:0");
@@ -259,10 +203,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_breakpoint_block_spec() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0->1");
@@ -276,10 +216,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_modify() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("m max_parallel_jobs=2");
@@ -291,10 +227,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_reset() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("c");
@@ -313,10 +245,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_delete_all() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 0");
@@ -330,10 +258,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_completion_breakpoint() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("b 1+");
@@ -362,10 +286,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_processes() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("p");
@@ -381,10 +301,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_ready() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i ready");
@@ -400,10 +316,6 @@ mod test {
 
     #[test]
     #[serial]
-    #[cfg_attr(
-        target_os = "windows",
-        ignore = "Debug handshake fails on Windows CI (#2817)"
-    )]
     fn test_debug_inspect_waiting() {
         let mut session = DebugSession::start(&example_dir(), &["test_arg1"]);
         session.send("i waiting");

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -657,7 +657,9 @@ impl DebugSession {
         }
     }
 
-    /// Close stdin, wait for flowrdb to exit, and return its stdout
+    /// Close stdin, wait for flowrdb to exit, and return its stdout.
+    /// Waits for the server to exit gracefully (so mDNS services are unregistered)
+    /// before falling back to kill.
     pub fn finish(mut self) -> String {
         drop(self.stdin.take());
 
@@ -671,8 +673,21 @@ impl DebugSession {
         }
 
         self.flowrdb.wait().expect("Could not wait for flowrdb");
-        self.server.kill().expect("Could not kill flowrcli");
-        self.server.wait().expect("Could not wait for flowrcli");
+
+        for _ in 0..20 {
+            if self
+                .server
+                .try_wait()
+                .expect("Could not check server")
+                .is_some()
+            {
+                return self.stdout_lines.join("");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+        let _ = self.server.kill();
+        let _ = self.server.wait();
+
         self.stdout_lines.join("")
     }
 }

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -580,55 +580,72 @@ impl DebugSession {
             .and_then(|s| s.trim().parse::<u16>().ok())
             .unwrap_or_else(|| panic!("Could not parse debug port from: {port_line}"));
 
-        let flowrdb = Command::new("flowrdb")
-            .args(["--address", &format!("localhost:{port}")])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("Could not spawn flowrdb");
+        let address = format!("localhost:{port}");
+        let max_attempts = 3;
+        let mut flowrdb = None;
+        let mut stdin = None;
+        let mut stdout_lines = Vec::new();
+        let mut stdout_reader = None;
 
-        let mut session = DebugSession {
-            server,
-            flowrdb,
-            stdin: None,
-            stdout_lines: Vec::new(),
-            stdout_reader: None,
-        };
-        session.stdin = session.flowrdb.stdin.take();
+        for attempt in 1..=max_attempts {
+            let mut child = Command::new("flowrdb")
+                .args(["--address", &address])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("Could not spawn flowrdb");
 
-        // Wait for the ZMQ handshake to complete by reading flowrdb stdout
-        // until we see "Entering Debugger" which confirms the connection
-        let stdout = session
-            .flowrdb
-            .stdout
-            .take()
-            .expect("Could not get flowrdb stdout");
-        let mut stdout_reader = BufReader::new(stdout);
-        let mut connected = false;
-        loop {
-            let mut line = String::new();
-            stdout_reader
-                .read_line(&mut line)
-                .expect("Could not read from flowrdb stdout");
-            if line.is_empty() {
+            let child_stdin = child.stdin.take();
+            let child_stdout = child.stdout.take().expect("Could not get flowrdb stdout");
+            let mut reader = BufReader::new(child_stdout);
+            let mut connected = false;
+            stdout_lines.clear();
+
+            loop {
+                let mut line = String::new();
+                reader
+                    .read_line(&mut line)
+                    .expect("Could not read from flowrdb stdout");
+                if line.is_empty() {
+                    break;
+                }
+                let ready = line.contains("Entering Debugger");
+                stdout_lines.push(line);
+                if ready {
+                    connected = true;
+                    break;
+                }
+            }
+
+            if connected {
+                flowrdb = Some(child);
+                stdin = child_stdin;
+                stdout_reader = Some(reader);
                 break;
             }
-            let ready = line.contains("Entering Debugger");
-            session.stdout_lines.push(line);
-            if ready {
-                connected = true;
-                break;
+
+            let _ = child.wait();
+            if attempt < max_attempts {
+                eprintln!("flowrdb handshake attempt {attempt}/{max_attempts} failed, retrying...");
+                std::thread::sleep(std::time::Duration::from_secs(2));
             }
         }
-        assert!(
-            connected,
-            "flowrdb exited before completing debug handshake. Output:\n{}",
-            session.stdout_lines.join("")
-        );
-        session.stdout_reader = Some(stdout_reader);
 
-        session
+        let flowrdb = flowrdb.unwrap_or_else(|| {
+            panic!(
+                "flowrdb failed to complete debug handshake after {max_attempts} attempts. Last output:\n{}",
+                stdout_lines.join("")
+            )
+        });
+
+        DebugSession {
+            server,
+            flowrdb,
+            stdin,
+            stdout_lines,
+            stdout_reader,
+        }
     }
 
     /// Send a debugger command (e.g. "s", "c", "h", "e")


### PR DESCRIPTION
## Summary
- `DebugSession::start_with_runner()` retries the flowrdb handshake up to 3 times (2s between attempts)
- `DebugSession::finish()` waits up to 10s for graceful server shutdown instead of SIGKILL, preventing stale mDNS entries from causing subsequent test hangs
- Windows debug tests remain ignored — mDNS is too unreliable there even with retries (#2817)

## Root Cause
flowrdb connects and sends `DebugClientStarting` before the coordinator has received the flow submission and called `debugger.start()`. The 10s receive timeout expires before the coordinator is ready. The retry gives subsequent attempts time to succeed once the coordinator catches up.

The graceful shutdown ensures mDNS services are properly unregistered between serial debug tests, preventing stale entries from causing the next test's `discover_service_on` to find a dead service.

## Test plan
- [x] `make test` passes locally (all 23 debug tests pass)
- [ ] CI passes on macOS, Linux x86, Linux ARM
- [ ] Windows debug tests correctly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)