### PR TITLE
Fix value interleaving in sub-flows with loopback connections (#2887)

### DIFF
--- a/book/describing/sub_flow_semantics.md
+++ b/book/describing/sub_flow_semantics.md
@@ -65,6 +65,11 @@ make sure the loop terminates cleanly — all internal loopback values should be
 or become irrelevant when the loop ends. Avoid producing internal values that feed
 downstream functions after the loop's termination condition is met.
 
+The runtime ensures that when a function with a loopback has a running job, external
+values on that input are not consumed until the loopback value arrives. This prevents
+values from different invocations being paired incorrectly when a sub-flow receives
+multiple sets of inputs concurrently.
+
 #### Flow initializers are external
 
 Input initializers set at the parent flow level (e.g., `input.start = {always = 0}`)

--- a/book/internals/flow_execution.md
+++ b/book/internals/flow_execution.md
@@ -226,6 +226,22 @@ destination input's queue, while external values go to the *back*. This ensures 
 internal pipeline values from the current execution are consumed before external values
 intended for the next invocation.
 
+#### Deferring External Value Consumption
+
+When a function has a running job and one of its inputs receives both internal connections
+(e.g. a loopback from itself or a sibling within the flow) and external connections (from
+the parent flow), the runtime defers creating a new job that would consume the external
+value. The running job may produce an internal (loopback) value that should be consumed
+first.
+
+Without this rule, concurrent job completion can cause value interleaving: if a function's
+running job hasn't retired yet (so its loopback value hasn't arrived), but another function
+in the same flow completes and makes the first function runnable using the queued external
+value, the wrong values get paired — leading to incorrect results.
+
+The deferral is lifted when the function's own job completes and its loopback value
+arrives, or when the flow goes idle and internal values are cleared.
+
 #### Clearing on Idle
 
 When a flow transitions to idle (run to completion):

--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -52,6 +52,8 @@ pub fn create_manifest(
         );
     }
 
+    manifest.mark_internal_inputs();
+
     emit_flow_hierarchy(flow, &mut manifest, None);
 
     manifest.set_lib_references(&tables.libs);

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -117,6 +117,27 @@ impl FlowManifest {
         self.functions.insert(function.id(), function);
     }
 
+    /// Scan all output connections and mark destination inputs that receive
+    /// internal connections. Must be called after all functions are added.
+    pub fn mark_internal_inputs(&mut self) {
+        let internal_targets: Vec<(usize, usize)> = self
+            .functions
+            .values()
+            .flat_map(|f| {
+                f.get_output_connections()
+                    .iter()
+                    .filter(|c| c.internal)
+                    .map(|c| (c.destination_id, c.destination_io_number))
+            })
+            .collect();
+
+        for (func_id, io_number) in internal_targets {
+            if let Some(func) = self.functions.get_mut(&func_id) {
+                func.set_input_receives_internal(io_number);
+            }
+        }
+    }
+
     /// Add flow hierarchy info to the manifest
     pub fn add_flow_info(&mut self, flow_info: FlowInfo) {
         self.flows.insert(flow_info.process_id, flow_info);

--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -76,6 +76,10 @@ pub struct Input {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     received: Vec<Value>,
 
+    // Whether this input has any internal connection (within same flow) that can send to it
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    receives_internal: bool,
+
     // How many values at the front of `received` are from internal connections
     #[serde(skip)]
     internal_count: usize,
@@ -144,6 +148,7 @@ impl Input {
             generic,
             initializer,
             flow_initializer,
+            receives_internal: false,
             received: Vec::new(),
             internal_count: 0,
             pending_init_elements: Vec::new(),
@@ -164,6 +169,7 @@ impl Input {
             generic,
             initializer,
             flow_initializer,
+            receives_internal: false,
             received: Vec::new(),
             internal_count: 0,
             pending_init_elements: Vec::new(),
@@ -199,6 +205,17 @@ impl Input {
     #[must_use]
     pub fn flow_initializer(&self) -> &Option<InputInitializer> {
         &self.flow_initializer
+    }
+
+    /// Whether this input can receive values from internal connections
+    #[must_use]
+    pub fn receives_internal(&self) -> bool {
+        self.receives_internal
+    }
+
+    /// Mark this input as receiving values from internal connections
+    pub fn set_receives_internal(&mut self) {
+        self.receives_internal = true;
     }
 
     /// Check if an initializer value should be delivered gradually (one element per idle cycle)
@@ -633,5 +650,48 @@ mod test {
         input.init(InitReason::Startup);
         assert_eq!(input.take(), Some(json!([1, 2, 3])));
         assert!(input.is_empty());
+    }
+
+    #[test]
+    fn receives_internal_default_false() {
+        let input = Input::new(
+            #[cfg(feature = "debugger")]
+            "",
+            0,
+            false,
+            None,
+            None,
+        );
+        assert!(!input.receives_internal());
+    }
+
+    #[test]
+    fn set_receives_internal() {
+        let mut input = Input::new(
+            #[cfg(feature = "debugger")]
+            "",
+            0,
+            false,
+            None,
+            None,
+        );
+        input.set_receives_internal();
+        assert!(input.receives_internal());
+    }
+
+    #[test]
+    fn internal_values_consumed_before_external() {
+        let mut input = Input::new(
+            #[cfg(feature = "debugger")]
+            "",
+            0,
+            false,
+            None,
+            None,
+        );
+        input.send(json!(1));
+        input.send_internal(json!(2));
+        assert_eq!(input.take(), Some(json!(2)));
+        assert_eq!(input.take(), Some(json!(1)));
     }
 }

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -218,6 +218,13 @@ impl RuntimeFunction {
         Ok(())
     }
 
+    /// Mark that the input at `io_number` receives internal connections
+    pub fn set_input_receives_internal(&mut self, io_number: usize) {
+        if let Some(input) = self.inputs.get_mut(io_number) {
+            input.set_receives_internal();
+        }
+    }
+
     /// Clear all internal values from all inputs of this function
     pub fn clear_internal_inputs(&mut self) {
         for input in &mut self.inputs {
@@ -301,6 +308,17 @@ impl RuntimeFunction {
     #[must_use]
     pub fn can_run(&self) -> bool {
         self.input_sets_available() > 0
+    }
+
+    /// Would creating a job consume an external value on an input that
+    /// receives internal connections? Used to gate job creation while the
+    /// parent flow is busy — external values should wait until the flow
+    /// goes idle so that internal (loopback) values arrive first.
+    #[must_use]
+    pub fn would_consume_external_on_internal_input(&self) -> bool {
+        self.inputs
+            .iter()
+            .any(|i| i.receives_internal() && i.internal_count() == 0 && i.values_available() > 0)
     }
 
     /// Can this function run using only internal values on all inputs?
@@ -701,5 +719,85 @@ mod test {
                 );
             }
         }
+    }
+
+    #[test]
+    fn would_consume_external_false_when_no_internal_inputs() {
+        let input = Input::new(
+            #[cfg(feature = "debugger")]
+            "i1",
+            0,
+            false,
+            None,
+            None,
+        );
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "test",
+            #[cfg(feature = "debugger")]
+            "/test",
+            "test",
+            vec![input],
+            0,
+            0,
+            &[],
+            false,
+        );
+        func.send(0, json!(1)).unwrap();
+        assert!(!func.would_consume_external_on_internal_input());
+    }
+
+    #[test]
+    fn would_consume_external_true_when_only_external_on_internal_input() {
+        let mut input = Input::new(
+            #[cfg(feature = "debugger")]
+            "i1",
+            0,
+            false,
+            None,
+            None,
+        );
+        input.set_receives_internal();
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "test",
+            #[cfg(feature = "debugger")]
+            "/test",
+            "test",
+            vec![input],
+            0,
+            0,
+            &[],
+            false,
+        );
+        func.send(0, json!(1)).unwrap();
+        assert!(func.would_consume_external_on_internal_input());
+    }
+
+    #[test]
+    fn would_consume_external_false_when_internal_value_present() {
+        let mut input = Input::new(
+            #[cfg(feature = "debugger")]
+            "i1",
+            0,
+            false,
+            None,
+            None,
+        );
+        input.set_receives_internal();
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "test",
+            #[cfg(feature = "debugger")]
+            "/test",
+            "test",
+            vec![input],
+            0,
+            0,
+            &[],
+            false,
+        );
+        func.send_internal(0, json!(1)).unwrap();
+        assert!(!func.would_consume_external_on_internal_input());
     }
 }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -679,6 +679,20 @@ impl RunState {
     // Create one or more new jobs for the function and mark it and ancestor flows as busy
     pub(crate) fn create_jobs(&mut self, process_id: usize, parent_id: usize) -> Result<()> {
         loop {
+            // Don't consume external values on inputs that receive internal
+            // connections while the function itself has a running job — the
+            // internal (loopback) value may not have arrived yet.
+            let function_busy = self.busy_count.contains_key(&process_id);
+            let would_consume_external = self
+                .submission
+                .manifest
+                .functions()
+                .get(&process_id)
+                .is_some_and(RuntimeFunction::would_consume_external_on_internal_input);
+            if function_busy && would_consume_external {
+                return Ok(());
+            }
+
             self.number_of_jobs_created = self
                 .number_of_jobs_created
                 .checked_add(1)

--- a/specs/FlowRuntimeBase.tla
+++ b/specs/FlowRuntimeBase.tla
@@ -67,6 +67,20 @@ CanRunOnInternal(p) ==
 HasRunnableOnInternal(flow) ==
     \E p \in ProcsInFlow(flow) : CanRunOnInternal(p)
 
+(* An input receives internal connections if any connection targets it
+   with internal=TRUE. Used to gate external value consumption. *)
+ReceivesInternal(p, i) ==
+    \E c \in Conns : c.dst = p /\ c.dstInput = i /\ c.internal
+
+(* A function would consume an external value on an input that receives
+   internal connections — the front value is external (intCount=0) but
+   the input has queued values and is marked as receiving internals. *)
+WouldConsumeExternalOnInternalInput(p) ==
+    \E i \in InputsOf[p] :
+        /\ ReceivesInternal(p, i)
+        /\ intCount[p][i] = 0
+        /\ Len(inputQ[p][i]) > 0
+
 (* Busy-count helpers.
  *
  * busyCount is a function from IDs to positive integers.
@@ -135,6 +149,14 @@ Init ==
  * gate — a function can always run on values produced within its own
  * flow, even while the flow is busy.
  *
+ * Loopback deferral (Phase 5 — fixes #2887)
+ *
+ * When a function itself is busy (has a running job) and would consume
+ * an external value on an input that also receives internal connections,
+ * defer job creation.  The running job may produce a loopback value
+ * that should be consumed first.  Without this guard, concurrent job
+ * retirement can cause values from different iterations to be paired.
+ *
  * In TLA+, CreateJob is a standalone action that fires nondeterministically
  * whenever its guard is satisfied.  Adding the gating guard here is
  * equivalent to gating inline in RetireAndSend: after RetireAndSend
@@ -146,6 +168,7 @@ CreateJob(p) ==
     /\ CanRun(p)
     /\ \/ ~IsBusy(Parent[p])
        \/ CanRunOnInternal(p)
+    /\ ~(IsBusy(p) /\ WouldConsumeExternalOnInternalInput(p))
     /\ LET toMark == {p} \union AncestorsOf(p)
        IN
        /\ inputQ' = [inputQ EXCEPT ![p] =

--- a/specs/README.md
+++ b/specs/README.md
@@ -188,3 +188,4 @@ as it explores states.
 3. **Flow hierarchy** — busy/idle detection, ancestor tracking ✅
 4. **External send gating** — cross-flow sends deferred when busy ✅
 5. **Initializer semantics** — Once/Always, function vs flow level ✅
+6. **Loopback deferral** — defer external consumption while function is busy with pending loopback ✅


### PR DESCRIPTION
## Summary
- Added `receives_internal` flag to `Input`, set at compile time by scanning internal output connections
- Gate in `create_jobs`: if a function has a running job AND would consume an external value on an input that receives internal connections, defer job creation until the loopback value arrives

## Root Cause
When a function with a loopback (e.g. `add` in the sequence sub-flow) had a running job, external values from the next iteration could be consumed before the loopback value arrived. This paired values from different iterations and produced wrong results.

Traced with diagnostic logging: Job #13 (compare_switch for trigger 2) retired before Job #12 (add for trigger 1), creating a new add job that consumed trigger 2's external step value instead of waiting for trigger 1's loopback step.

## Testing
- All `make test` passes
- Prime example: 50/50 runs pass (was failing ~10% before)
- New unit tests for `receives_internal`, `would_consume_external_on_internal_input`, and internal-before-external ordering

Fixes #2887

🤖 Generated with [Claude Code](https://claude.com/claude-code)