### PR TITLE
Defer debug client connection until FlowStart (#2766)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -990,7 +990,6 @@ impl FlowrGui {
                     self.submission_settings.debug_this_flow = true;
                     #[cfg(feature = "debugger")]
                     {
-                        self.debug_client_active = true;
                         self.debug_waiting = false;
                     }
                     return Task::perform(Self::submit(sender.clone(), settings), |result| {
@@ -1065,7 +1064,6 @@ impl FlowrGui {
                     #[cfg(feature = "debugger")]
                     {
                         self.selected_debug_address = Some(address);
-                        self.debug_client_active = true;
                         self.submission_settings.debug_this_flow = true;
                     }
                     self.show_coordinator_picker = false;
@@ -3443,6 +3441,10 @@ impl FlowrGui {
                 self.running = true;
                 self.submitted = false;
                 connection_manager::set_job_count(0);
+                #[cfg(feature = "debugger")]
+                if self.submission_settings.debug_this_flow && !self.debug_client_active {
+                    self.debug_client_active = true;
+                }
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::FlowEnd(metrics) => {


### PR DESCRIPTION
## Summary
- Don't set `debug_client_active = true` in `ServiceSelected` or `DebugSubmitFlow` handlers
- Instead, set it in the `FlowStart` handler — at that point the coordinator has received the submission and `debugger.start()` is listening on the debug socket

## Root Cause
In client mode (`-c -d`), the debug client subscription connected immediately when the user selected a debug server from the picker. But the coordinator hadn't received the flow submission yet, so `DebugZmqHandler::start()` hadn't been called. The `DebugClientStarting` handshake timed out after 5 seconds.

## Test plan
- [ ] All existing tests pass (`make test`)
- [ ] Manual test: start `flowrcli -s -d`, connect `flowrgui -c -d`, verify debug session works
- [ ] CI passes on all platforms

Fixes #2766

🤖 Generated with [Claude Code](https://claude.com/claude-code)