### PR TITLE
Two-socket architecture for concurrent blocking/non-blocking IO (#2918)

### DIFF
--- a/flowr/examples/concurrent-io/main.rs
+++ b/flowr/examples/concurrent-io/main.rs
@@ -1,0 +1,31 @@
+//! Test flow for concurrent IO — stdout should appear while readline is blocking
+fn main() {
+    utilities::run_example(file!(), "flowrgui", false, true);
+}
+
+#[cfg(test)]
+mod test {
+    use std::env;
+    use std::path::PathBuf;
+
+    #[ignore = "Blocked by #2918 — stdout cannot execute while readline is pending"]
+    #[test]
+    fn test_concurrent_io() {
+        let _ = env::set_current_dir(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("Could not cd into flow directory"),
+        );
+
+        // TODO: When #2918 is fixed, this test should:
+        // 1. Start the flow with delayed stdin (via FIFO or background thread)
+        // 2. Verify stdout output appears BEFORE stdin is provided
+        // 3. Then send stdin and verify stderr output appears
+        //
+        // Currently, stdout is blocked until readline completes because the
+        // coordinator serializes all context function communication through
+        // a single ZMQ socket.
+        super::main();
+        utilities::check_test_output(file!());
+    }
+}

--- a/flowr/examples/concurrent-io/root.toml
+++ b/flowr/examples/concurrent-io/root.toml
@@ -1,0 +1,28 @@
+flow = "concurrent-io"
+
+# get args, then:
+# - print args to stdout (fast, non-blocking)
+# - readline waits for user input
+# - print input to stderr when received
+#
+# If concurrent IO works, args should appear on stdout
+# while readline is still blocking.
+
+[[process]]
+source = "context://args/get"
+
+[[process]]
+source = "context://stdio/stdout"
+[[connection]]
+from = "get/string/0"
+to = "stdout"
+
+[[process]]
+source = "context://stdio/readline"
+input.prompt = {once = ""}
+
+[[process]]
+source = "context://stdio/stderr"
+[[connection]]
+from = "readline/string"
+to = "stderr"

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -51,46 +51,42 @@ impl CliRuntimeClient {
     ///
     /// Stdin is read on a separate background thread so the event loop can
     /// continue processing stdout and other messages while waiting for user input.
-    pub async fn event_loop(mut self, connection: ClientConnection) -> Result<()> {
+    pub async fn event_loop(
+        mut self,
+        connection: ClientConnection,
+        blocking_io_connection: ClientConnection,
+    ) -> Result<()> {
+        // Non-blocking bridge: handles stdout, stderr, file, image, args, protocol
         let (event_tx, mut event_rx) = mpsc::channel::<CoordinatorMessage>(32);
         let (response_tx, mut response_rx) = mpsc::channel::<ClientMessage>(32);
-
         let bridge =
             tokio::task::spawn_blocking(move || zmq_bridge(connection, event_tx, &mut response_rx));
 
+        // Blocking IO bridge: handles GetLine/GetStdin on a separate ZMQ socket
+        let (bio_event_tx, mut bio_event_rx) = mpsc::channel::<CoordinatorMessage>(4);
+        let (bio_response_tx, mut bio_response_rx) = mpsc::channel::<ClientMessage>(4);
+        let bio_bridge = tokio::task::spawn_blocking(move || {
+            zmq_bridge(blocking_io_connection, bio_event_tx, &mut bio_response_rx);
+        });
+
+        // Background stdin reader
         let (stdin_req_tx, mut stdin_req_rx) = mpsc::channel::<StdinRequest>(1);
         let (stdin_resp_tx, mut stdin_resp_rx) = mpsc::channel::<ClientMessage>(1);
-
         let stdin_thread = tokio::task::spawn_blocking(move || {
             stdin_reader(&mut stdin_req_rx, &stdin_resp_tx);
         });
 
         let result = loop {
             tokio::select! {
+                // Non-blocking bridge: coordinator messages (stdout, protocol, etc.)
                 event = event_rx.recv() => {
                     match event {
-                        Some(CoordinatorMessage::GetLine(prompt)) => {
-                            if stdin_req_tx.send(StdinRequest::ReadLine(prompt)).await.is_err() {
-                                let _ = response_tx.send(
-                                    ClientMessage::Error("Stdin reader closed".into())
-                                ).await;
-                            }
-                        }
-                        Some(CoordinatorMessage::GetStdin) => {
-                            if stdin_req_tx.send(StdinRequest::ReadAll).await.is_err() {
-                                let _ = response_tx.send(
-                                    ClientMessage::Error("Stdin reader closed".into())
-                                ).await;
-                            }
-                        }
                         Some(event) => {
                             let response = self.process_coordinator_message(event);
                             if let ClientMessage::ClientExiting(ref coordinator_result) = response {
                                 debug!("Client is exiting the event loop.");
                                 let exit_result = coordinator_result.clone();
-                                if let Err(e) = response_tx.send(response).await {
-                                    error!("Failed to send ClientExiting to bridge: {e}");
-                                }
+                                let _ = response_tx.send(response).await;
                                 break exit_result;
                             }
                             if let Err(e) = response_tx.send(response).await {
@@ -101,11 +97,27 @@ impl CliRuntimeClient {
                         None => break Err("ZMQ bridge closed unexpectedly".into()),
                     }
                 }
+                // Blocking IO bridge: GetLine/GetStdin from the coordinator
+                bio_event = bio_event_rx.recv() => {
+                    match bio_event {
+                        Some(CoordinatorMessage::GetLine(prompt)) => {
+                            let _ = stdin_req_tx.send(StdinRequest::ReadLine(prompt)).await;
+                        }
+                        Some(CoordinatorMessage::GetStdin) => {
+                            let _ = stdin_req_tx.send(StdinRequest::ReadAll).await;
+                        }
+                        Some(other) => {
+                            let response = self.process_coordinator_message(other);
+                            let _ = bio_response_tx.send(response).await;
+                        }
+                        None => {}
+                    }
+                }
+                // Stdin reader completed — send response to blocking IO bridge
                 stdin_response = stdin_resp_rx.recv() => {
                     if let Some(response) = stdin_response {
-                        if let Err(e) = response_tx.send(response).await {
-                            error!("Failed to send stdin response to bridge: {e}");
-                            break Err("Bridge channel closed".into());
+                        if let Err(e) = bio_response_tx.send(response).await {
+                            error!("Failed to send stdin response: {e}");
                         }
                     }
                 }
@@ -113,8 +125,10 @@ impl CliRuntimeClient {
         };
 
         drop(response_tx);
+        drop(bio_response_tx);
         drop(stdin_req_tx);
         let _ = bridge.await;
+        let _ = bio_bridge.await;
         let _ = stdin_thread.await;
 
         result

--- a/flowr/src/bin/flowrcli/cli/cli_submission_handler.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_submission_handler.rs
@@ -34,7 +34,7 @@ impl SubmissionHandler for CLISubmissionHandler {
     fn flow_execution_starting(&mut self) -> Result<()> {
         let _ = self
             .context_io
-            .send_and_receive(CoordinatorMessage::FlowStart)?;
+            .send_nonblocking(CoordinatorMessage::FlowStart)?;
         Ok(())
     }
 
@@ -46,7 +46,7 @@ impl SubmissionHandler for CLISubmissionHandler {
     #[cfg(feature = "metrics")]
     fn flow_execution_ended(&mut self, state: &RunState, metrics: Metrics) -> Result<()> {
         self.context_io
-            .send_and_receive(CoordinatorMessage::FlowEnd(metrics))?;
+            .send_nonblocking(CoordinatorMessage::FlowEnd(metrics))?;
         debug!("{state}");
         Ok(())
     }
@@ -54,7 +54,7 @@ impl SubmissionHandler for CLISubmissionHandler {
     #[cfg(not(feature = "metrics"))]
     fn flow_execution_ended(&mut self, state: &RunState) -> Result<()> {
         self.context_io
-            .send_and_receive(CoordinatorMessage::FlowEnd)?;
+            .send_nonblocking(CoordinatorMessage::FlowEnd)?;
         debug!("{}", state);
         Ok(())
     }
@@ -63,7 +63,7 @@ impl SubmissionHandler for CLISubmissionHandler {
         info!("Coordinator is waiting to receive a 'Submission'");
         // Tell the bridge thread to switch to ZMQ receive mode for the next submission
         self.context_io
-            .send_and_receive(CoordinatorMessage::Invalid)?;
+            .send_nonblocking(CoordinatorMessage::Invalid)?;
         match self.submission_rx.recv() {
             Ok(submission) => {
                 info!("Coordinator received a submission for execution");
@@ -77,7 +77,7 @@ impl SubmissionHandler for CLISubmissionHandler {
     fn coordinator_is_exiting(&mut self, result: Result<()>) -> Result<()> {
         debug!("Coordinator exiting");
         self.context_io
-            .send_and_receive(CoordinatorMessage::CoordinatorExiting(result))
+            .send_nonblocking(CoordinatorMessage::CoordinatorExiting(result))
             .map(|_| ())
     }
 }

--- a/flowr/src/bin/flowrcli/context/args/get.rs
+++ b/flowr/src/bin/flowrcli/context/args/get.rs
@@ -15,7 +15,7 @@ impl Implementation for Get {
     fn run(&self, mut _inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let response = self
             .context_io
-            .send_and_receive(CoordinatorMessage::GetArgs);
+            .send_nonblocking(CoordinatorMessage::GetArgs);
 
         match response {
             Ok(ClientMessage::Args(arg_vec)) => {
@@ -60,9 +60,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             Get {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )
@@ -71,8 +72,9 @@ mod test {
     #[test]
     fn gets_args_no_client() {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         let getter = Get {
-            context_io: ContextIO::new(tx),
+            context_io: ContextIO::new(dummy_tx, tx),
         };
         drop(rx);
         let (value, run_again) = getter.run(&[]).expect("_get() failed");

--- a/flowr/src/bin/flowrcli/context/file/file_read.rs
+++ b/flowr/src/bin/flowrcli/context/file/file_read.rs
@@ -14,7 +14,7 @@ impl Implementation for FileRead {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let path = inputs.first().ok_or("Could not get path")?;
 
-        let response = self.context_io.send_and_receive(CoordinatorMessage::Read(
+        let response = self.context_io.send_nonblocking(CoordinatorMessage::Read(
             path.as_str().unwrap_or("").to_string(),
         ));
 
@@ -48,9 +48,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             FileRead {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/file/file_write.rs
+++ b/flowr/src/bin/flowrcli/context/file/file_write.rs
@@ -23,7 +23,7 @@ impl Implementation for FileWrite {
             .map(|byte_value| byte_value.as_u64().unwrap_or(0) as u8)
             .collect();
 
-        self.context_io.send_and_receive(CoordinatorMessage::Write(
+        self.context_io.send_nonblocking(CoordinatorMessage::Write(
             filename.as_str().unwrap_or("").to_string(),
             bytes,
         ))?;
@@ -48,9 +48,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             FileWrite {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/image/image_buffer.rs
+++ b/flowr/src/bin/flowrcli/context/image/image_buffer.rs
@@ -71,7 +71,7 @@ impl Implementation for ImageBuffer {
             .ok_or("Could not get h")?;
 
         self.context_io
-            .send_and_receive(CoordinatorMessage::PixelWrite(
+            .send_nonblocking(CoordinatorMessage::PixelWrite(
                 (
                     u32::try_from(x).map_err(|_| "Integer overflow in 'x'")?,
                     u32::try_from(y).map_err(|_| "Integer overflow in 'y'")?,
@@ -108,9 +108,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             ImageBuffer {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/image/image_read.rs
+++ b/flowr/src/bin/flowrcli/context/image/image_read.rs
@@ -22,7 +22,7 @@ impl Implementation for ImageRead {
 
         let response = self
             .context_io
-            .send_and_receive(CoordinatorMessage::Read(filename.to_string()));
+            .send_nonblocking(CoordinatorMessage::Read(filename.to_string()));
 
         match response {
             Ok(ClientMessage::FileContents(_path, bytes)) => {

--- a/flowr/src/bin/flowrcli/context/image/image_write.rs
+++ b/flowr/src/bin/flowrcli/context/image/image_write.rs
@@ -52,7 +52,7 @@ impl Implementation for ImageWrite {
         };
 
         self.context_io
-            .send_and_receive(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
+            .send_nonblocking(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
 
         Ok((None, RUN_AGAIN))
     }

--- a/flowr/src/bin/flowrcli/context/mod.rs
+++ b/flowr/src/bin/flowrcli/context/mod.rs
@@ -25,45 +25,56 @@ pub struct ContextRequest {
     pub response_tx: Option<mpsc::Sender<ClientMessage>>,
 }
 
-/// Channel-based IO handle for context functions, replacing `Arc<Mutex<CoordinatorConnection>>`.
+/// Channel-based IO handle for context functions.
 ///
-/// Output functions (stdout, stderr, etc.) use `send_no_reply` for fire-and-forget.
-/// Input functions (readline, stdin, etc.) use `send_and_receive` to get a response.
+/// Uses two separate channels: one for blocking IO (readline, stdin) and one
+/// for non-blocking IO (stdout, stderr, file, image, args). Each channel has
+/// its own bridge thread and ZMQ socket, allowing non-blocking IO to proceed
+/// while blocking IO is waiting for user input.
 #[derive(Clone)]
 pub struct ContextIO {
-    tx: mpsc::Sender<ContextRequest>,
+    blocking_tx: mpsc::Sender<ContextRequest>,
+    nonblocking_tx: mpsc::Sender<ContextRequest>,
 }
 
 impl ContextIO {
-    /// Create a new `ContextIO` backed by the given channel sender.
-    pub fn new(tx: mpsc::Sender<ContextRequest>) -> Self {
-        ContextIO { tx }
+    /// Create a new `ContextIO` with separate channels for blocking and non-blocking IO.
+    pub fn new(
+        blocking_tx: mpsc::Sender<ContextRequest>,
+        nonblocking_tx: mpsc::Sender<ContextRequest>,
+    ) -> Self {
+        ContextIO {
+            blocking_tx,
+            nonblocking_tx,
+        }
     }
 
-    /// Send a message and wait for the client's response.
-    pub fn send_and_receive(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
-        let (response_tx, response_rx) = mpsc::channel();
-        self.tx
-            .send(ContextRequest {
-                message,
-                response_tx: Some(response_tx),
-            })
-            .map_err(|e| format!("Could not send to bridge: {e}"))?;
-        response_rx
-            .recv()
-            .map_err(|e| format!("Could not receive from bridge: {e}").into())
+    /// Send a message on the blocking channel and wait for the response.
+    /// Used by readline and stdin which may block indefinitely.
+    pub fn send_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        send_and_receive(&self.blocking_tx, message)
     }
 
-    /// Send a message without waiting for a response (fire-and-forget).
-    #[allow(dead_code)]
-    pub fn send_no_reply(&self, message: CoordinatorMessage) -> Result<()> {
-        self.tx
-            .send(ContextRequest {
-                message,
-                response_tx: None,
-            })
-            .map_err(|e| format!("Could not send to bridge: {e}").into())
+    /// Send a message on the non-blocking channel and wait for the response.
+    /// Used by stdout, stderr, file, image, args — these return quickly.
+    pub fn send_nonblocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        send_and_receive(&self.nonblocking_tx, message)
     }
+}
+
+fn send_and_receive(
+    tx: &mpsc::Sender<ContextRequest>,
+    message: CoordinatorMessage,
+) -> Result<ClientMessage> {
+    let (response_tx, response_rx) = mpsc::channel();
+    tx.send(ContextRequest {
+        message,
+        response_tx: Some(response_tx),
+    })
+    .map_err(|e| format!("Could not send to bridge: {e}"))?;
+    response_rx
+        .recv()
+        .map_err(|e| format!("Could not receive from bridge: {e}").into())
 }
 
 /// Return a `LibraryManifest` for the context functions

--- a/flowr/src/bin/flowrcli/context/stdio/readline.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/readline.rs
@@ -18,7 +18,7 @@ impl Implementation for Readline {
 
         let readline_response = self
             .context_io
-            .send_and_receive(CoordinatorMessage::GetLine(prompt));
+            .send_blocking(CoordinatorMessage::GetLine(prompt));
 
         match readline_response {
             Ok(ClientMessage::Line(contents)) => {
@@ -50,9 +50,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             Readline {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, dummy_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.rs
@@ -22,7 +22,7 @@ impl Implementation for Stderr {
             _ => CoordinatorMessage::Stderr(input.to_string()),
         };
 
-        self.context_io.send_and_receive(msg)?;
+        self.context_io.send_nonblocking(msg)?;
 
         Ok((None, RUN_AGAIN))
     }
@@ -46,9 +46,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             Stderr {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/stdio/stdin.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdin.rs
@@ -12,9 +12,7 @@ pub struct Stdin {
 
 impl Implementation for Stdin {
     fn run(&self, _inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let stdin_response = self
-            .context_io
-            .send_and_receive(CoordinatorMessage::GetStdin);
+        let stdin_response = self.context_io.send_blocking(CoordinatorMessage::GetStdin);
 
         match stdin_response {
             Ok(ClientMessage::Stdin(contents)) => {
@@ -53,9 +51,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             Stdin {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, dummy_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.rs
@@ -21,7 +21,7 @@ impl Implementation for Stdout {
             _ => CoordinatorMessage::Stdout(input.to_string()),
         };
 
-        self.context_io.send_and_receive(msg)?;
+        self.context_io.send_nonblocking(msg)?;
 
         Ok((None, RUN_AGAIN))
     }
@@ -45,9 +45,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (dummy_tx, _dummy_rx) = std::sync::mpsc::channel();
         (
             Stdout {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(dummy_tx, tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -526,6 +526,11 @@ fn blocking_io_bridge(
     use crate::cli::coordinator_message::ClientMessage;
     use flowrlib::connections::WAIT;
 
+    // Receive the initial Ack that starts the REQ/REP cycle
+    if connection.receive::<ClientMessage>(WAIT).is_err() {
+        return;
+    }
+
     while let Ok(request) = context_rx.recv() {
         if let Err(e) = connection.send(request.message) {
             error!("Blocking bridge: failed to send: {e}");
@@ -611,6 +616,9 @@ fn client(
 
     info!("Client sending submission to coordinator");
     client_connection.send(ClientMessage::ClientSubmission(Box::new(submission)))?;
+
+    // Start the blocking IO REQ/REP cycle with an initial Ack
+    blocking_io_client.send(ClientMessage::Ack)?;
 
     trace!("Entering client event loop");
     let rt = tokio::runtime::Runtime::new()

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -183,6 +183,8 @@ fn coordinator_only(
     let coordinator_port = pick_unused_port().chain_err(|| "No ports free")?;
     let coordinator_connection =
         CoordinatorConnection::new(COORDINATOR_SERVICE_NAME, coordinator_port)?;
+    let blocking_io_port = pick_unused_port().chain_err(|| "No ports free")?;
+    let blocking_io_connection = CoordinatorConnection::new("blocking-io", blocking_io_port)?;
     let mut fullnames = vec![register_service(
         &mdns,
         COORDINATOR_SERVICE_NAME,
@@ -209,6 +211,7 @@ fn coordinator_only(
         lib_search_path,
         native_flowstdlib,
         coordinator_connection,
+        blocking_io_connection,
         #[cfg(feature = "debugger")]
         debug_server_connection,
         true,
@@ -239,6 +242,8 @@ fn client_and_coordinator(
     let runtime_port = pick_unused_port().chain_err(|| "No ports free")?;
     let coordinator_connection =
         CoordinatorConnection::new(COORDINATOR_SERVICE_NAME, runtime_port)?;
+    let blocking_io_port = pick_unused_port().chain_err(|| "No ports free")?;
+    let blocking_io_connection = CoordinatorConnection::new("blocking-io", blocking_io_port)?;
 
     let mut fullnames = vec![register_service(
         &mdns,
@@ -269,6 +274,7 @@ fn client_and_coordinator(
             coordinator_lib_search_path,
             native_flowstdlib,
             coordinator_connection,
+            blocking_io_connection,
             #[cfg(feature = "debugger")]
             debug_connection,
             false,
@@ -279,11 +285,14 @@ fn client_and_coordinator(
 
     let coordinator_address = discover_service_on(&mdns, COORDINATOR_SERVICE_NAME)?;
     let runtime_client_connection = ClientConnection::new(&coordinator_address)?;
+    let blocking_io_address = format!("127.0.0.1:{blocking_io_port}");
+    let blocking_io_client = ClientConnection::new(&blocking_io_address)?;
 
     let result = client(
         matches,
         lib_search_path,
         runtime_client_connection,
+        blocking_io_client,
         #[cfg(feature = "debugger")]
         debug_this_flow,
     );
@@ -300,26 +309,34 @@ fn client_and_coordinator(
 }
 
 /// Create a new `Coordinator`, preload any libraries in native format that we want to have before
-/// loading a flow, and it's library references, then enter the `submission_loop()` accepting and
+/// loading a flow, and its library references, then enter the `submission_loop()` accepting and
 /// executing flows submitted for execution, executing each one using the `Coordinator`
+#[allow(clippy::too_many_arguments)]
 fn coordinator(
     mdns: &ServiceDaemon,
     num_threads: usize,
     lib_search_path: Simpath,
     native_flowstdlib: bool,
     coordinator_connection: CoordinatorConnection,
+    blocking_io_connection: CoordinatorConnection,
     #[cfg(feature = "debugger")] debug_connection: CoordinatorConnection,
     loop_forever: bool,
 ) -> Result<()> {
-    // Create channels for context functions and submission handler to communicate
-    // with the bridge thread that owns the ZMQ CoordinatorConnection.
-    let (context_tx, context_rx) = std::sync::mpsc::channel();
+    // Two channels: non-blocking IO (stdout, etc.) and blocking IO (readline, stdin).
+    // Each has its own bridge thread and ZMQ socket so they operate independently.
+    let (nonblocking_tx, nonblocking_rx) = std::sync::mpsc::channel();
+    let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
     let (submission_tx, submission_rx) = std::sync::mpsc::channel();
-    let context_io = context::ContextIO::new(context_tx);
+    let context_io = context::ContextIO::new(blocking_tx, nonblocking_tx);
 
-    // Spawn bridge thread that owns the ZMQ socket
-    let bridge_handle = thread::spawn(move || {
-        coordinator_bridge(coordinator_connection, context_rx, submission_tx);
+    // Non-blocking bridge: handles stdout, stderr, file, image, args, and protocol messages
+    let nonblocking_bridge = thread::spawn(move || {
+        coordinator_bridge(coordinator_connection, nonblocking_rx, submission_tx);
+    });
+
+    // Blocking bridge: handles readline and stdin (can block indefinitely)
+    let blocking_bridge = thread::spawn(move || {
+        blocking_io_bridge(blocking_io_connection, blocking_rx);
     });
 
     #[cfg(feature = "debugger")]
@@ -367,7 +384,7 @@ fn coordinator(
     )?;
     context_executor.start(
         &provider,
-        1,
+        2,
         &context_job_source_name,
         &results_sink,
         &control_socket,
@@ -396,7 +413,8 @@ fn coordinator(
         unregister_service(mdns, fullname);
     }
 
-    let _ = bridge_handle.join();
+    let _ = nonblocking_bridge.join();
+    let _ = blocking_bridge.join();
 
     result
 }
@@ -497,6 +515,42 @@ fn coordinator_bridge(
     }
 }
 
+/// Bridge thread for blocking IO (`readline`, `stdin`).
+/// Simpler than `coordinator_bridge` — no submission handling, just forwards
+/// requests and responses on its own ZMQ socket.
+#[allow(clippy::needless_pass_by_value)]
+fn blocking_io_bridge(
+    mut connection: CoordinatorConnection,
+    context_rx: std::sync::mpsc::Receiver<context::ContextRequest>,
+) {
+    use crate::cli::coordinator_message::ClientMessage;
+    use flowrlib::connections::WAIT;
+
+    while let Ok(request) = context_rx.recv() {
+        if let Err(e) = connection.send(request.message) {
+            error!("Blocking bridge: failed to send: {e}");
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+            }
+            continue;
+        }
+
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(response) => {
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(response);
+                }
+            }
+            Err(e) => {
+                error!("Blocking bridge: failed to receive: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+            }
+        }
+    }
+}
+
 /// Start only a client in the calling thread. Discover the remote Coordinator using service discovery
 fn client_only(
     matches: &ArgMatches,
@@ -505,11 +559,14 @@ fn client_only(
 ) -> Result<()> {
     let coordinator_address = discover_service(COORDINATOR_SERVICE_NAME)?;
     let client_connection = ClientConnection::new(&coordinator_address)?;
+    // In remote mode, blocking IO uses the same connection (no concurrency yet)
+    let blocking_io_client = ClientConnection::new(&coordinator_address)?;
 
     client(
         matches,
         lib_search_path,
         client_connection,
+        blocking_io_client,
         #[cfg(feature = "debugger")]
         debug_this_flow,
     )
@@ -520,6 +577,7 @@ fn client(
     matches: &ArgMatches,
     lib_search_path: Simpath,
     client_connection: ClientConnection,
+    blocking_io_client: ClientConnection,
     #[cfg(feature = "debugger")] debug_this_flow: bool,
 ) -> Result<()> {
     let override_args = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -557,7 +615,7 @@ fn client(
     trace!("Entering client event loop");
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| format!("Could not create tokio runtime: {e}"))?;
-    rt.block_on(client.event_loop(client_connection))
+    rt.block_on(client.event_loop(client_connection, blocking_io_client))
 }
 
 /// Determine the number of threads to use to execute flows


### PR DESCRIPTION
## Summary
- Adds a second `CoordinatorConnection` and bridge thread for blocking IO (readline, stdin)
- Non-blocking IO (stdout, stderr, file, image, args) uses the existing socket
- Context executor increased to 2 threads so readline and stdout can execute concurrently
- `ContextIO` routes messages: `send_blocking()` → blocking bridge, `send_nonblocking()` → non-blocking bridge
- Client event loop uses `tokio::select!` on both ZMQ bridges simultaneously

## Architecture
```
Context Executor Thread 1 (readline) → send_blocking() → Blocking Bridge → ZMQ socket B → Client
Context Executor Thread 2 (stdout)   → send_nonblocking() → Non-blocking Bridge → ZMQ socket A → Client
```

## Test flow
Includes `concurrent-io` test flow (currently ignored). Manual verification:
- `flowrgui --auto` with FIFO stdin: stdout is empty for 2+ seconds before stdin is provided (BUG)
- After this fix: stdout should appear immediately while readline is pending

## TODO
- [ ] flowrgui connection_manager needs same two-socket changes
- [ ] Un-ignore concurrent-io test after verification
- [ ] client_only mode needs blocking IO port discovery for remote use

Part of #2918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a concurrent I/O example demonstrating simultaneous output and interactive input.
  * Introduced a dedicated communication path for blocking input, allowing other output to continue while input is pending.

* **Bug Fixes**
  * Improved CLI responsiveness by separating blocking and non-blocking I/O operations.
  * Updated file, image, standard input, and standard output handling to avoid unnecessary waiting during execution.

* **Tests**
  * Added coverage for the concurrent I/O example; the interactive test remains disabled while an underlying terminal limitation is addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->