### PR TITLE
Fix concurrent blocking/non-blocking IO with two-socket architecture (#2918)

### DIFF
--- a/flowcore/src/services.rs
+++ b/flowcore/src/services.rs
@@ -14,6 +14,10 @@ pub const CONTROL_SERVICE_NAME: &str = "control";
 /// Use this to discover the coordinator service by name
 pub const COORDINATOR_SERVICE_NAME: &str = "runtime";
 
+/// Use this to discover the blocking IO service by name (separate socket for
+/// blocking context functions like readline and stdin)
+pub const BLOCKING_IO_SERVICE_NAME: &str = "blocking-io";
+
 /// Use this to discover the debug service by name
 #[cfg(feature = "debugger")]
 pub const DEBUG_SERVICE_NAME: &str = "debug";

--- a/flowr/examples/concurrent-io/main.rs
+++ b/flowr/examples/concurrent-io/main.rs
@@ -1,0 +1,73 @@
+//! Test flow for concurrent IO — stdout should appear while readline is blocking.
+//!
+//! This flow has two parallel paths from args:
+//! - Path 1: prints the first arg to stdout (fast, non-blocking)
+//! - Path 2: waits for readline input, then prints it to stderr
+//!
+//! The test verifies that stdout output appears BEFORE stdin input is provided.
+//! Currently this fails because the coordinator serializes context function
+//! communication through a single ZMQ socket.
+fn main() {
+    utilities::run_example(file!(), "flowrgui", false, true);
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::{BufRead, BufReader, Write};
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[ignore = "Blocked by #2918 — stdout blocked while readline is pending"]
+    #[test]
+    fn test_concurrent_stdout_while_readline_pending() {
+        let example_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples")
+            .join("concurrent-io");
+
+        utilities::compile_example(&example_dir, "flowrcli");
+
+        let mut child = Command::new("flowrcli")
+            .args(["--native", "manifest.json"])
+            .current_dir(
+                example_dir
+                    .canonicalize()
+                    .expect("Could not canonicalize path"),
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Could not spawn flowrcli");
+
+        let stdout = child.stdout.take().expect("Could not get stdout");
+
+        // Read stdout on a background thread with a channel to report results
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) > 0 {
+                let _ = tx.send(line);
+            }
+        });
+
+        // Wait up to 5 seconds for stdout — it should appear within ~1s
+        // because printing args is non-blocking and has no dependency on readline
+        let stdout_result = rx.recv_timeout(Duration::from_secs(5));
+
+        assert!(
+            stdout_result.is_ok(),
+            "Stdout should have received output while readline is pending, \
+             but it was blocked. This confirms the concurrent IO bug (#2918)."
+        );
+
+        // Send stdin to unblock readline and let the flow complete
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = writeln!(stdin, "test input");
+        }
+
+        let _ = child.wait();
+    }
+}

--- a/flowr/examples/concurrent-io/main.rs
+++ b/flowr/examples/concurrent-io/main.rs
@@ -19,7 +19,6 @@ mod test {
     use std::sync::mpsc;
     use std::time::Duration;
 
-    #[ignore = "Blocked by #2918 — stdout blocked while readline is pending"]
     #[test]
     fn test_concurrent_stdout_while_readline_pending() {
         let example_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -57,17 +56,19 @@ mod test {
         // because printing args is non-blocking and has no dependency on readline
         let stdout_result = rx.recv_timeout(Duration::from_secs(5));
 
-        assert!(
-            stdout_result.is_ok(),
-            "Stdout should have received output while readline is pending, \
-             but it was blocked. This confirms the concurrent IO bug (#2918)."
-        );
-
         // Send stdin to unblock readline and let the flow complete
         if let Some(mut stdin) = child.stdin.take() {
             let _ = writeln!(stdin, "test input");
         }
 
+        // Kill child — we only care whether stdout appeared in time
+        let _ = child.kill();
         let _ = child.wait();
+
+        assert!(
+            stdout_result.is_ok(),
+            "Stdout should have received output while readline is pending, \
+             but it was blocked. This confirms the concurrent IO bug (#2918)."
+        );
     }
 }

--- a/flowr/examples/concurrent-io/root.toml
+++ b/flowr/examples/concurrent-io/root.toml
@@ -1,0 +1,27 @@
+flow = "concurrent-io"
+
+# Two parallel paths from args:
+# Path 1: stdout prints the first arg (fast, non-blocking)
+# Path 2: readline waits for user input, then stderr prints it
+#
+# If concurrent IO works, path 1's stdout should complete
+# while path 2's readline is still blocking.
+
+[[process]]
+source = "context://args/get"
+
+[[process]]
+source = "context://stdio/stdout"
+[[connection]]
+from = "get/string/0"
+to = "stdout"
+
+[[process]]
+source = "context://stdio/readline"
+input.prompt = {once = ""}
+
+[[process]]
+source = "context://stdio/stderr"
+[[connection]]
+from = "readline/string"
+to = "stderr"

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -51,12 +51,31 @@ impl CliRuntimeClient {
     ///
     /// Stdin is read on a separate background thread so the event loop can
     /// continue processing stdout and other messages while waiting for user input.
-    pub async fn event_loop(mut self, connection: ClientConnection) -> Result<()> {
+    pub async fn event_loop(
+        mut self,
+        connection: ClientConnection,
+        blocking_io_connection: ClientConnection,
+    ) -> Result<()> {
         let (event_tx, mut event_rx) = mpsc::channel::<CoordinatorMessage>(32);
         let (response_tx, mut response_rx) = mpsc::channel::<ClientMessage>(32);
 
         let bridge =
             tokio::task::spawn_blocking(move || zmq_bridge(connection, event_tx, &mut response_rx));
+
+        // Blocking IO bridge: separate ZMQ bridge for GetLine/GetStdin
+        let (blocking_event_tx, mut blocking_event_rx) = mpsc::channel::<CoordinatorMessage>(1);
+        let (blocking_response_tx, mut blocking_response_rx) = mpsc::channel::<ClientMessage>(1);
+
+        // Set a receive timeout so the blocking IO bridge can detect when
+        // the coordinator shuts down and exit cleanly
+        let _ = blocking_io_connection.set_receive_timeout(2000);
+        let blocking_bridge = tokio::task::spawn_blocking(move || {
+            blocking_io_zmq_bridge(
+                blocking_io_connection,
+                blocking_event_tx,
+                &mut blocking_response_rx,
+            );
+        });
 
         let (stdin_req_tx, mut stdin_req_rx) = mpsc::channel::<StdinRequest>(1);
         let (stdin_resp_tx, mut stdin_resp_rx) = mpsc::channel::<ClientMessage>(1);
@@ -69,20 +88,6 @@ impl CliRuntimeClient {
             tokio::select! {
                 event = event_rx.recv() => {
                     match event {
-                        Some(CoordinatorMessage::GetLine(prompt)) => {
-                            if stdin_req_tx.send(StdinRequest::ReadLine(prompt)).await.is_err() {
-                                let _ = response_tx.send(
-                                    ClientMessage::Error("Stdin reader closed".into())
-                                ).await;
-                            }
-                        }
-                        Some(CoordinatorMessage::GetStdin) => {
-                            if stdin_req_tx.send(StdinRequest::ReadAll).await.is_err() {
-                                let _ = response_tx.send(
-                                    ClientMessage::Error("Stdin reader closed".into())
-                                ).await;
-                            }
-                        }
                         Some(event) => {
                             let response = self.process_coordinator_message(event);
                             if let ClientMessage::ClientExiting(ref coordinator_result) = response {
@@ -101,11 +106,36 @@ impl CliRuntimeClient {
                         None => break Err("ZMQ bridge closed unexpectedly".into()),
                     }
                 }
+                blocking_event = blocking_event_rx.recv() => {
+                    match blocking_event {
+                        Some(CoordinatorMessage::GetLine(prompt)) => {
+                            if stdin_req_tx.send(StdinRequest::ReadLine(prompt)).await.is_err() {
+                                let _ = blocking_response_tx.send(
+                                    ClientMessage::Error("Stdin reader closed".into())
+                                ).await;
+                            }
+                        }
+                        Some(CoordinatorMessage::GetStdin) => {
+                            if stdin_req_tx.send(StdinRequest::ReadAll).await.is_err() {
+                                let _ = blocking_response_tx.send(
+                                    ClientMessage::Error("Stdin reader closed".into())
+                                ).await;
+                            }
+                        }
+                        Some(other) => {
+                            debug!("Unexpected message on blocking IO bridge: {other}");
+                            let _ = blocking_response_tx.send(ClientMessage::Ack).await;
+                        }
+                        None => {
+                            debug!("Blocking IO bridge closed");
+                        }
+                    }
+                }
                 stdin_response = stdin_resp_rx.recv() => {
                     if let Some(response) = stdin_response {
-                        if let Err(e) = response_tx.send(response).await {
-                            error!("Failed to send stdin response to bridge: {e}");
-                            break Err("Bridge channel closed".into());
+                        if let Err(e) = blocking_response_tx.send(response).await {
+                            error!("Failed to send stdin response to blocking bridge: {e}");
+                            break Err("Blocking bridge channel closed".into());
                         }
                     }
                 }
@@ -113,8 +143,10 @@ impl CliRuntimeClient {
         };
 
         drop(response_tx);
+        drop(blocking_response_tx);
         drop(stdin_req_tx);
         let _ = bridge.await;
+        let _ = blocking_bridge.await;
         let _ = stdin_thread.await;
 
         result
@@ -308,6 +340,65 @@ fn stdin_reader(req_rx: &mut mpsc::Receiver<StdinRequest>, resp_tx: &mpsc::Sende
         };
         if resp_tx.blocking_send(response).is_err() {
             break;
+        }
+    }
+}
+
+/// Client-side ZMQ bridge for blocking IO (readline/stdin) on a separate socket.
+///
+/// Protocol (2 REQ/REP round-trips per blocking IO operation):
+/// 1. Send `Ack` to coordinator (initiate polling)
+/// 2. Receive `GetLine`/`GetStdin` from coordinator
+/// 3. Forward to event loop, wait for stdin result
+/// 4. Send `Line`/`Stdin` result to coordinator
+/// 5. Receive `Invalid` acknowledgement from coordinator
+/// 6. Loop
+#[allow(clippy::needless_pass_by_value)]
+fn blocking_io_zmq_bridge(
+    connection: ClientConnection,
+    event_tx: mpsc::Sender<CoordinatorMessage>,
+    response_rx: &mut mpsc::Receiver<ClientMessage>,
+) {
+    loop {
+        // Send Ack to poll the coordinator for a blocking IO request
+        if let Err(e) = connection.send(ClientMessage::Ack) {
+            debug!("Blocking IO bridge: send failed (shutdown expected): {e}");
+            break;
+        }
+
+        // Receive the blocking IO request (GetLine/GetStdin)
+        match connection.receive::<CoordinatorMessage>() {
+            Ok(event) => {
+                // Forward to event loop
+                if event_tx.blocking_send(event).is_err() {
+                    break;
+                }
+
+                // Wait for the response from the event loop (stdin reader)
+                match response_rx.blocking_recv() {
+                    Some(response) => {
+                        // Send the result back to the coordinator
+                        if let Err(e) = connection.send(response) {
+                            debug!("Blocking IO bridge: send failed: {e}");
+                            break;
+                        }
+
+                        // Receive the coordinator's acknowledgement
+                        match connection.receive::<CoordinatorMessage>() {
+                            Ok(_) => {} // Expected: Invalid or similar ack
+                            Err(e) => {
+                                debug!("Blocking IO bridge: recv ack failed: {e}");
+                                break;
+                            }
+                        }
+                    }
+                    None => break,
+                }
+            }
+            Err(_) => {
+                // Expected during shutdown — receive timeout or coordinator gone
+                break;
+            }
         }
     }
 }

--- a/flowr/src/bin/flowrcli/context/args/get.rs
+++ b/flowr/src/bin/flowrcli/context/args/get.rs
@@ -60,9 +60,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             Get {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )
@@ -71,8 +72,9 @@ mod test {
     #[test]
     fn gets_args_no_client() {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         let getter = Get {
-            context_io: ContextIO::new(tx),
+            context_io: ContextIO::new(tx, blocking_tx),
         };
         drop(rx);
         let (value, run_again) = getter.run(&[]).expect("_get() failed");

--- a/flowr/src/bin/flowrcli/context/file/file_read.rs
+++ b/flowr/src/bin/flowrcli/context/file/file_read.rs
@@ -48,9 +48,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             FileRead {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/file/file_write.rs
+++ b/flowr/src/bin/flowrcli/context/file/file_write.rs
@@ -48,9 +48,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             FileWrite {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/image/image_buffer.rs
+++ b/flowr/src/bin/flowrcli/context/image/image_buffer.rs
@@ -108,9 +108,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             ImageBuffer {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/mod.rs
+++ b/flowr/src/bin/flowrcli/context/mod.rs
@@ -27,20 +27,27 @@ pub struct ContextRequest {
 
 /// Channel-based IO handle for context functions, replacing `Arc<Mutex<CoordinatorConnection>>`.
 ///
-/// Output functions (stdout, stderr, etc.) use `send_no_reply` for fire-and-forget.
-/// Input functions (readline, stdin, etc.) use `send_and_receive` to get a response.
+/// Uses two channels: one for non-blocking IO (stdout, stderr, file, image, args)
+/// and one for blocking IO (readline, stdin). This allows blocking IO to be
+/// handled on a separate ZMQ socket so it doesn't block non-blocking IO.
 #[derive(Clone)]
 pub struct ContextIO {
+    /// Channel for non-blocking context function requests (stdout, stderr, etc.)
     tx: mpsc::Sender<ContextRequest>,
+    /// Channel for blocking context function requests (readline, stdin)
+    blocking_tx: mpsc::Sender<ContextRequest>,
 }
 
 impl ContextIO {
-    /// Create a new `ContextIO` backed by the given channel sender.
-    pub fn new(tx: mpsc::Sender<ContextRequest>) -> Self {
-        ContextIO { tx }
+    /// Create a new `ContextIO` backed by the given channel senders.
+    pub fn new(
+        tx: mpsc::Sender<ContextRequest>,
+        blocking_tx: mpsc::Sender<ContextRequest>,
+    ) -> Self {
+        ContextIO { tx, blocking_tx }
     }
 
-    /// Send a message and wait for the client's response.
+    /// Send a message on the non-blocking channel and wait for the client's response.
     pub fn send_and_receive(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
         let (response_tx, response_rx) = mpsc::channel();
         self.tx
@@ -52,6 +59,21 @@ impl ContextIO {
         response_rx
             .recv()
             .map_err(|e| format!("Could not receive from bridge: {e}").into())
+    }
+
+    /// Send a message on the blocking IO channel and wait for the client's response.
+    /// Used by context functions that may block for user input (readline, stdin).
+    pub fn send_and_receive_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        let (response_tx, response_rx) = mpsc::channel();
+        self.blocking_tx
+            .send(ContextRequest {
+                message,
+                response_tx: Some(response_tx),
+            })
+            .map_err(|e| format!("Could not send to blocking bridge: {e}"))?;
+        response_rx
+            .recv()
+            .map_err(|e| format!("Could not receive from blocking bridge: {e}").into())
     }
 
     /// Send a message without waiting for a response (fire-and-forget).
@@ -137,4 +159,123 @@ pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {
     );
 
     Ok(manifest)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod test {
+    use super::{ContextIO, ContextRequest};
+    use crate::cli::coordinator_message::{ClientMessage, CoordinatorMessage};
+
+    /// `send_and_receive` should deliver the request through the non-blocking channel.
+    #[test]
+    fn send_and_receive_uses_nonblocking_channel() {
+        let (tx, rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let context_io = ContextIO::new(tx, blocking_tx);
+
+        // Spawn because send_and_receive blocks waiting for the response
+        let handle =
+            std::thread::spawn(move || context_io.send_and_receive(CoordinatorMessage::GetArgs));
+
+        // The request must arrive on the non-blocking receiver
+        let req = rx.recv().expect("Expected request on non-blocking channel");
+        assert!(
+            matches!(req.message, CoordinatorMessage::GetArgs),
+            "Expected GetArgs on non-blocking channel"
+        );
+        // Nothing should arrive on the blocking receiver
+        assert!(
+            blocking_rx.try_recv().is_err(),
+            "Blocking channel should be empty"
+        );
+        // Respond so the thread can finish
+        req.response_tx.unwrap().send(ClientMessage::Ack).unwrap();
+        let result = handle.join().unwrap();
+        assert!(result.is_ok());
+    }
+
+    /// `send_and_receive_blocking` should deliver the request through the blocking channel.
+    #[test]
+    fn send_and_receive_blocking_uses_blocking_channel() {
+        let (tx, rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let context_io = ContextIO::new(tx, blocking_tx);
+
+        let handle = std::thread::spawn(move || {
+            context_io.send_and_receive_blocking(CoordinatorMessage::GetLine("prompt".into()))
+        });
+
+        // The request must arrive on the blocking receiver
+        let req = blocking_rx
+            .recv()
+            .expect("Expected request on blocking channel");
+        assert!(
+            matches!(req.message, CoordinatorMessage::GetLine(_)),
+            "Expected GetLine on blocking channel"
+        );
+        // Nothing should arrive on the non-blocking receiver
+        assert!(
+            rx.try_recv().is_err(),
+            "Non-blocking channel should be empty"
+        );
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Line("hello".into()))
+            .unwrap();
+        let result = handle
+            .join()
+            .unwrap()
+            .expect("send_and_receive_blocking failed");
+        assert!(matches!(result, ClientMessage::Line(_)));
+    }
+
+    /// When the non-blocking channel is disconnected, `send_and_receive` returns an error.
+    #[test]
+    fn send_and_receive_error_on_disconnected_channel() {
+        let (tx, rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let context_io = ContextIO::new(tx, blocking_tx);
+        drop(rx); // disconnect the receiver
+        let result = context_io.send_and_receive(CoordinatorMessage::GetArgs);
+        assert!(result.is_err());
+    }
+
+    /// When the blocking channel is disconnected, `send_and_receive_blocking` returns an error.
+    #[test]
+    fn send_and_receive_blocking_error_on_disconnected_channel() {
+        let (tx, _rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let context_io = ContextIO::new(tx, blocking_tx);
+        drop(blocking_rx); // disconnect the receiver
+        let result =
+            context_io.send_and_receive_blocking(CoordinatorMessage::GetLine(String::new()));
+        assert!(result.is_err());
+    }
+
+    /// `send_no_reply` delivers through the non-blocking channel without expecting a response.
+    #[test]
+    fn send_no_reply_uses_nonblocking_channel() {
+        let (tx, rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel::<ContextRequest>();
+        let context_io = ContextIO::new(tx, blocking_tx);
+
+        context_io
+            .send_no_reply(CoordinatorMessage::Stdout("hello".into()))
+            .expect("send_no_reply should succeed");
+
+        let req = rx.recv().expect("Expected request on non-blocking channel");
+        assert!(
+            matches!(req.message, CoordinatorMessage::Stdout(_)),
+            "Expected Stdout on non-blocking channel"
+        );
+        assert!(
+            req.response_tx.is_none(),
+            "send_no_reply should not set response_tx"
+        );
+        assert!(
+            blocking_rx.try_recv().is_err(),
+            "Blocking channel should be empty"
+        );
+    }
 }

--- a/flowr/src/bin/flowrcli/context/stdio/readline.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/readline.rs
@@ -18,7 +18,7 @@ impl Implementation for Readline {
 
         let readline_response = self
             .context_io
-            .send_and_receive(CoordinatorMessage::GetLine(prompt));
+            .send_and_receive_blocking(CoordinatorMessage::GetLine(prompt));
 
         match readline_response {
             Ok(ClientMessage::Line(contents)) => {
@@ -49,12 +49,13 @@ mod test {
         Readline,
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
-        let (tx, rx) = std::sync::mpsc::channel();
+        let (nonblocking_tx, _nonblocking_rx) = std::sync::mpsc::channel();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
         (
             Readline {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(nonblocking_tx, blocking_tx),
             },
-            rx,
+            blocking_rx,
         )
     }
 

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.rs
@@ -46,9 +46,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             Stderr {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/context/stdio/stdin.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdin.rs
@@ -14,7 +14,7 @@ impl Implementation for Stdin {
     fn run(&self, _inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let stdin_response = self
             .context_io
-            .send_and_receive(CoordinatorMessage::GetStdin);
+            .send_and_receive_blocking(CoordinatorMessage::GetStdin);
 
         match stdin_response {
             Ok(ClientMessage::Stdin(contents)) => {
@@ -52,12 +52,13 @@ mod test {
         Stdin,
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
-        let (tx, rx) = std::sync::mpsc::channel();
+        let (nonblocking_tx, _nonblocking_rx) = std::sync::mpsc::channel();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
         (
             Stdin {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(nonblocking_tx, blocking_tx),
             },
-            rx,
+            blocking_rx,
         )
     }
 

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.rs
@@ -45,9 +45,10 @@ mod test {
         std::sync::mpsc::Receiver<crate::context::ContextRequest>,
     ) {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
         (
             Stdout {
-                context_io: ContextIO::new(tx),
+                context_io: ContextIO::new(tx, blocking_tx),
             },
             rx,
         )

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -51,8 +51,8 @@ use flowrlib::coordinator::Coordinator;
 #[cfg(feature = "debugger")]
 use flowrlib::debug_zmq_handler::DebugZmqHandler;
 use flowrlib::discovery::{
-    create_service_daemon, discover_service, discover_service_on, register_service,
-    shutdown_service_daemon, unregister_service, ServiceDaemon,
+    create_service_daemon, discover_service, register_service, shutdown_service_daemon,
+    unregister_service, ServiceDaemon,
 };
 use flowrlib::dispatcher::Dispatcher;
 use flowrlib::executor::Executor;
@@ -60,7 +60,8 @@ use flowrlib::info as flowrlib_info;
 #[cfg(feature = "debugger")]
 use flowrlib::services::DEBUG_SERVICE_NAME;
 use flowrlib::services::{
-    CONTROL_SERVICE_NAME, COORDINATOR_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
+    BLOCKING_IO_SERVICE_NAME, CONTROL_SERVICE_NAME, COORDINATOR_SERVICE_NAME, JOB_SERVICE_NAME,
+    RESULTS_JOB_SERVICE_NAME,
 };
 
 /// Include the module that implements the context functions
@@ -189,6 +190,15 @@ fn coordinator_only(
         coordinator_port,
     )?];
 
+    let blocking_io_port = pick_unused_port().chain_err(|| "No ports free")?;
+    let blocking_io_connection =
+        CoordinatorConnection::new(BLOCKING_IO_SERVICE_NAME, blocking_io_port)?;
+    fullnames.push(register_service(
+        &mdns,
+        BLOCKING_IO_SERVICE_NAME,
+        blocking_io_port,
+    )?);
+
     #[cfg(feature = "debugger")]
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     #[cfg(feature = "debugger")]
@@ -209,6 +219,7 @@ fn coordinator_only(
         lib_search_path,
         native_flowstdlib,
         coordinator_connection,
+        blocking_io_connection,
         #[cfg(feature = "debugger")]
         debug_server_connection,
         true,
@@ -246,6 +257,15 @@ fn client_and_coordinator(
         runtime_port,
     )?];
 
+    let blocking_io_port = pick_unused_port().chain_err(|| "No ports free")?;
+    let blocking_io_connection =
+        CoordinatorConnection::new(BLOCKING_IO_SERVICE_NAME, blocking_io_port)?;
+    fullnames.push(register_service(
+        &mdns,
+        BLOCKING_IO_SERVICE_NAME,
+        blocking_io_port,
+    )?);
+
     #[cfg(feature = "debugger")]
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     #[cfg(feature = "debugger")]
@@ -269,6 +289,7 @@ fn client_and_coordinator(
             coordinator_lib_search_path,
             native_flowstdlib,
             coordinator_connection,
+            blocking_io_connection,
             #[cfg(feature = "debugger")]
             debug_connection,
             false,
@@ -277,13 +298,17 @@ fn client_and_coordinator(
         }
     });
 
-    let coordinator_address = discover_service_on(&mdns, COORDINATOR_SERVICE_NAME)?;
-    let runtime_client_connection = ClientConnection::new(&coordinator_address)?;
+    // Connect directly using the known ports — avoids mDNS race conditions
+    // when both coordinator and client are in the same process
+    let runtime_client_connection = ClientConnection::new(&format!("localhost:{runtime_port}"))?;
+    let blocking_io_client_connection =
+        ClientConnection::new(&format!("localhost:{blocking_io_port}"))?;
 
     let result = client(
         matches,
         lib_search_path,
         runtime_client_connection,
+        blocking_io_client_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
     );
@@ -302,24 +327,32 @@ fn client_and_coordinator(
 /// Create a new `Coordinator`, preload any libraries in native format that we want to have before
 /// loading a flow, and it's library references, then enter the `submission_loop()` accepting and
 /// executing flows submitted for execution, executing each one using the `Coordinator`
+#[allow(clippy::too_many_arguments)]
 fn coordinator(
     mdns: &ServiceDaemon,
     num_threads: usize,
     lib_search_path: Simpath,
     native_flowstdlib: bool,
     coordinator_connection: CoordinatorConnection,
+    blocking_io_connection: CoordinatorConnection,
     #[cfg(feature = "debugger")] debug_connection: CoordinatorConnection,
     loop_forever: bool,
 ) -> Result<()> {
     // Create channels for context functions and submission handler to communicate
     // with the bridge thread that owns the ZMQ CoordinatorConnection.
     let (context_tx, context_rx) = std::sync::mpsc::channel();
+    let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
     let (submission_tx, submission_rx) = std::sync::mpsc::channel();
-    let context_io = context::ContextIO::new(context_tx);
+    let context_io = context::ContextIO::new(context_tx, blocking_tx);
 
-    // Spawn bridge thread that owns the ZMQ socket
+    // Spawn bridge thread that owns the non-blocking ZMQ socket
     let bridge_handle = thread::spawn(move || {
         coordinator_bridge(coordinator_connection, context_rx, submission_tx);
+    });
+
+    // Spawn bridge thread that owns the blocking IO ZMQ socket
+    let blocking_bridge_handle = thread::spawn(move || {
+        blocking_io_bridge(blocking_io_connection, blocking_rx);
     });
 
     #[cfg(feature = "debugger")]
@@ -365,7 +398,10 @@ fn coordinator(
         context::get_manifest(context_io.clone())?,
         Url::parse("memory://")?,
     )?;
-    context_executor.start(
+    // Use start_spawning so blocking context functions (readline/stdin) don't
+    // prevent non-blocking ones (stdout/stderr) from executing concurrently.
+    // Each job is spawned on a separate thread within the executor.
+    context_executor.start_spawning(
         &provider,
         1,
         &context_job_source_name,
@@ -397,8 +433,110 @@ fn coordinator(
     }
 
     let _ = bridge_handle.join();
+    // The blocking IO bridge thread is not joined — it may be stuck waiting
+    // for a blocking IO request that never arrives (e.g. when no readline/stdin
+    // context function is used). It will exit when the process exits.
+    drop(blocking_bridge_handle);
 
     result
+}
+
+/// Bridge thread for blocking IO (readline/stdin) on a separate ZMQ socket.
+///
+/// Protocol:
+/// 1. Wait for a blocking IO request from a context function via `blocking_rx`
+/// 2. Wait for the client's `Ack` on ZMQ (client polls this socket)
+/// 3. Send the blocking IO request (GetLine/GetStdin) to the client
+/// 4. Wait for the client's response (Line/Stdin/etc.)
+/// 5. Forward the response to the context function
+#[allow(clippy::needless_pass_by_value)]
+fn blocking_io_bridge(
+    mut connection: CoordinatorConnection,
+    blocking_rx: std::sync::mpsc::Receiver<context::ContextRequest>,
+) {
+    use crate::cli::coordinator_message::{ClientMessage, CoordinatorMessage};
+    use flowrlib::connections::WAIT;
+    use log::debug;
+
+    debug!("[BLOCKING BRIDGE] started");
+
+    while let Ok(request) = blocking_rx.recv() {
+        debug!(
+            "[BLOCKING BRIDGE] received blocking request: {}",
+            request.message
+        );
+
+        // Wait for the client's Ack (client polls this socket)
+        debug!("[BLOCKING BRIDGE] waiting for client Ack on ZMQ...");
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(ClientMessage::Ack) => {
+                debug!("[BLOCKING BRIDGE] got client Ack");
+            }
+            Ok(ClientMessage::ClientExiting(_)) => {
+                debug!("[BLOCKING BRIDGE] client exited");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                }
+                return;
+            }
+            Ok(other) => {
+                debug!("[BLOCKING BRIDGE] unexpected message: {other}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!(
+                        "Unexpected message on blocking IO socket: {other}"
+                    )));
+                }
+                continue;
+            }
+            Err(e) => {
+                error!("Blocking bridge: error receiving Ack: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+                return;
+            }
+        }
+
+        // Send the blocking IO request to the client
+        debug!("[BLOCKING BRIDGE] sending blocking request on ZMQ...");
+        if let Err(e) = connection.send(request.message) {
+            error!("Blocking bridge: failed to send to client: {e}");
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+            }
+            continue;
+        }
+
+        // Wait for the client's response (this blocks while user types input)
+        debug!("[BLOCKING BRIDGE] waiting for blocking IO response on ZMQ...");
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(ClientMessage::ClientExiting(_)) => {
+                debug!("[BLOCKING BRIDGE] client exited during blocking IO");
+                let _ = connection.send(CoordinatorMessage::CoordinatorExiting(Ok(())));
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                }
+                return;
+            }
+            Ok(response) => {
+                debug!("[BLOCKING BRIDGE] got blocking IO response: {response}");
+                // Complete the REP cycle with an Ack
+                let _ = connection.send(CoordinatorMessage::Invalid);
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(response);
+                }
+            }
+            Err(e) => {
+                error!("Blocking bridge: failed to receive response: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+                return;
+            }
+        }
+    }
+
+    debug!("[BLOCKING BRIDGE] channel closed, exiting");
 }
 
 /// Bridge thread that owns the ZMQ `CoordinatorConnection` and serializes all
@@ -506,10 +644,14 @@ fn client_only(
     let coordinator_address = discover_service(COORDINATOR_SERVICE_NAME)?;
     let client_connection = ClientConnection::new(&coordinator_address)?;
 
+    let blocking_io_address = discover_service(BLOCKING_IO_SERVICE_NAME)?;
+    let blocking_io_connection = ClientConnection::new(&blocking_io_address)?;
+
     client(
         matches,
         lib_search_path,
         client_connection,
+        blocking_io_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
     )
@@ -520,6 +662,7 @@ fn client(
     matches: &ArgMatches,
     lib_search_path: Simpath,
     client_connection: ClientConnection,
+    blocking_io_connection: ClientConnection,
     #[cfg(feature = "debugger")] debug_this_flow: bool,
 ) -> Result<()> {
     let override_args = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -557,7 +700,7 @@ fn client(
     trace!("Entering client event loop");
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| format!("Could not create tokio runtime: {e}"))?;
-    rt.block_on(client.event_loop(client_connection))
+    rt.block_on(client.event_loop(client_connection, blocking_io_connection))
 }
 
 /// Determine the number of threads to use to execute flows

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -84,6 +84,48 @@ impl Executor {
         results_service: &str,
         control_service: &str,
     ) {
+        self.start_with_options(
+            provider,
+            number_of_executors,
+            job_service,
+            results_service,
+            control_service,
+            false,
+        );
+    }
+
+    /// Like [`start`](Self::start) but with `spawn_jobs = true`, each job is
+    /// executed on a spawned thread so one blocking job doesn't prevent the
+    /// executor thread from picking up the next job. This is used by the context
+    /// executor where blocking IO (readline/stdin) must not prevent non-blocking
+    /// IO (stdout/stderr) from executing concurrently.
+    pub fn start_spawning(
+        &mut self,
+        provider: &Arc<dyn Provider>,
+        number_of_executors: usize,
+        job_service: &str,
+        results_service: &str,
+        control_service: &str,
+    ) {
+        self.start_with_options(
+            provider,
+            number_of_executors,
+            job_service,
+            results_service,
+            control_service,
+            true,
+        );
+    }
+
+    fn start_with_options(
+        &mut self,
+        provider: &Arc<dyn Provider>,
+        number_of_executors: usize,
+        job_service: &str,
+        results_service: &str,
+        control_service: &str,
+        spawn_jobs: bool,
+    ) {
         let loaded_implementations =
             Arc::new(RwLock::new(HashMap::<Url, Arc<dyn Implementation>>::new()));
 
@@ -107,6 +149,7 @@ impl Executor {
                     job_source,
                     results_sink,
                     control_address,
+                    spawn_jobs,
                 ) {
                     error!("Execution loop error: {e}");
                 }
@@ -122,7 +165,7 @@ impl Executor {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 #[allow(clippy::needless_pass_by_value)]
 fn execution_loop(
     provider: &Arc<dyn Provider>,
@@ -133,6 +176,7 @@ fn execution_loop(
     job_service: String,
     results_service: String,
     control_address: String,
+    spawn_jobs: bool,
 ) -> Result<()> {
     let job_source = context
         .socket(zmq::PULL)
@@ -162,14 +206,37 @@ fn execution_loop(
 
     set_panic_hook();
 
+    // When spawning jobs, use a channel to relay results from spawned threads
+    // back to this thread (which owns the ZMQ results socket).
+    let spawn_result_tx = if spawn_jobs {
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        // Leak the receiver into a static — it will be polled in the loop below.
+        // This is safe because the execution_loop runs for the lifetime of the thread.
+        Some((tx, rx))
+    } else {
+        None
+    };
+
     let mut items: Vec<zmq::PollItem> = vec![
         job_source.as_poll_item(zmq::POLLIN),
         control_socket.as_poll_item(zmq::POLLIN),
     ];
 
     while process_jobs {
+        // When spawning jobs, drain results from spawned threads first
+        if let Some((_, ref rx)) = spawn_result_tx {
+            while let Ok(serialized_result) = rx.try_recv() {
+                results_sink
+                    .send(serialized_result.as_bytes(), 0)
+                    .map_err(|_| "Could not send result of Job from spawned thread")?;
+            }
+        }
+
         trace!("{name} waiting for a job to execute or a DONE signal");
-        match zmq::poll(&mut items, -1).map_err(|_| "Error while polling for Jobs to execute") {
+        let poll_timeout = if spawn_jobs { 100 } else { -1 };
+        match zmq::poll(&mut items, poll_timeout)
+            .map_err(|_| "Error while polling for Jobs to execute")
+        {
             Ok(_) => {
                 if items
                     .first()
@@ -184,16 +251,43 @@ fn execution_loop(
                         .map_err(|_| "Could not deserialize Message to Job")?;
 
                     trace!("Job #{}: Received by {}", payload.job_id, name);
-                    match execute_job(
-                        provider,
-                        &payload,
-                        &results_sink,
-                        name,
-                        &loaded_implementations.clone(),
-                        &loaded_lib_manifests.clone(),
-                    ) {
-                        Ok(keep_processing) => process_jobs = keep_processing,
-                        Err(e) => error!("{e}"),
+
+                    let is_blocking_io = spawn_jobs
+                        && (payload.implementation_url.as_str() == "context://stdio/readline"
+                            || payload.implementation_url.as_str() == "context://stdio/stdin");
+                    if is_blocking_io {
+                        // Spawn blocking IO jobs on a separate thread so this
+                        // executor can pick up the next job immediately.
+                        // Only readline and stdin are spawned — all other jobs
+                        // run synchronously to preserve output ordering.
+                        let sp = provider.clone();
+                        let sn = name.to_string();
+                        let si = loaded_implementations.clone();
+                        let sm = loaded_lib_manifests.clone();
+                        let stx = spawn_result_tx
+                            .as_ref()
+                            .map(|(tx, _)| tx.clone())
+                            .ok_or("spawn_result_tx missing")?;
+                        thread::spawn(move || {
+                            match execute_job_to_string(&sp, &payload, &sn, &si, &sm) {
+                                Ok(serialized) => {
+                                    let _ = stx.send(serialized);
+                                }
+                                Err(e) => error!("{e}"),
+                            }
+                        });
+                    } else {
+                        match execute_job(
+                            provider,
+                            &payload,
+                            &results_sink,
+                            name,
+                            &loaded_implementations.clone(),
+                            &loaded_lib_manifests.clone(),
+                        ) {
+                            Ok(keep_processing) => process_jobs = keep_processing,
+                            Err(e) => error!("{e}"),
+                        }
                     }
                 }
 
@@ -224,6 +318,30 @@ fn execution_loop(
     Ok(())
 }
 
+/// Execute a job and return the serialized result string (for spawned execution).
+/// Like `execute_job` but does not send the result over ZMQ directly.
+fn execute_job_to_string(
+    provider: &Arc<dyn Provider>,
+    payload: &Payload,
+    name: &str,
+    loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
+    loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+) -> Result<String> {
+    let implementation = get_or_load_implementation(
+        provider,
+        payload,
+        loaded_implementations,
+        loaded_lib_manifests,
+    )?;
+
+    trace!("Job #{}: Started executing on '{name}'", payload.job_id);
+    let result = implementation.run(&payload.input_set);
+    trace!("Job #{}: Finished executing on '{name}'", payload.job_id);
+
+    serde_json::to_string(&(payload.job_id, result))
+        .map_err(|e| format!("Could not serialize job result: {e}").into())
+}
+
 // Replace the standard panic hook with one that just outputs the file and line of any panic.
 fn set_panic_hook() {
     panic::set_hook(Box::new(|panic_info| {
@@ -237,6 +355,81 @@ fn set_panic_hook() {
     }));
 }
 
+/// Get (or load) the implementation for a job, releasing the lock before returning.
+/// This is critical: `run()` may block (e.g. readline waiting for user input) and
+/// holding the lock would prevent other executor threads from running concurrently.
+fn get_or_load_implementation(
+    provider: &Arc<dyn Provider>,
+    payload: &Payload,
+    loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
+    loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+) -> Result<Arc<dyn Implementation>> {
+    // First try a read lock to avoid contention
+    let needs_load = {
+        let implementations = loaded_implementations
+            .read()
+            .map_err(|_| "Could not gain read access to loaded implementations map")?;
+        implementations.get(&payload.implementation_url).is_none()
+    };
+
+    if needs_load {
+        trace!(
+            "Implementation '{}' is not loaded",
+            payload.implementation_url
+        );
+        let mut implementations = loaded_implementations
+            .write()
+            .map_err(|_| "Could not gain write access to loaded implementations map")?;
+        // Double-check after acquiring write lock (another thread may have loaded it)
+        if implementations.get(&payload.implementation_url).is_none() {
+            let impl_arc = match payload.implementation_url.scheme() {
+                "lib" => {
+                    let mut lib_root_url = payload.implementation_url.clone();
+                    lib_root_url.set_path("");
+                    load_referenced_implementation(
+                        provider,
+                        &lib_root_url,
+                        loaded_lib_manifests,
+                        &payload.implementation_url,
+                    )?
+                }
+                "context" => {
+                    let mut lib_root_url = payload.implementation_url.clone();
+                    let _ = lib_root_url.set_host(Some(""));
+                    lib_root_url.set_path("");
+                    load_referenced_implementation(
+                        provider,
+                        &lib_root_url,
+                        loaded_lib_manifests,
+                        &payload.implementation_url,
+                    )?
+                }
+                "file" => Arc::new(wasm::load(provider, &payload.implementation_url)?),
+                _ => bail!("Unsupported scheme on implementation_url"),
+            };
+            implementations.insert(payload.implementation_url.clone(), impl_arc);
+            trace!(
+                "Implementation '{}' added to executor",
+                payload.implementation_url
+            );
+        }
+        Ok(Arc::clone(
+            implementations
+                .get(&payload.implementation_url)
+                .ok_or("Could not find implementation")?,
+        ))
+    } else {
+        let implementations = loaded_implementations
+            .read()
+            .map_err(|_| "Could not gain read access to loaded implementations map")?;
+        Ok(Arc::clone(
+            implementations
+                .get(&payload.implementation_url)
+                .ok_or("Could not find implementation")?,
+        ))
+    }
+}
+
 // Return Ok(keep_processing) flag as true or false to keep processing
 fn execute_job(
     provider: &Arc<dyn Provider>,
@@ -246,50 +439,12 @@ fn execute_job(
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
 ) -> Result<bool> {
-    // TODO see if we can avoid write access until we know it's needed
-    let mut implementations = loaded_implementations
-        .write()
-        .map_err(|_| "Could not gain read access to loaded implementations map")?;
-    if implementations.get(&payload.implementation_url).is_none() {
-        trace!(
-            "Implementation '{}' is not loaded",
-            payload.implementation_url
-        );
-        let implementation = match payload.implementation_url.scheme() {
-            "lib" => {
-                let mut lib_root_url = payload.implementation_url.clone();
-                lib_root_url.set_path("");
-                load_referenced_implementation(
-                    provider,
-                    &lib_root_url,
-                    loaded_lib_manifests,
-                    &payload.implementation_url,
-                )?
-            }
-            "context" => {
-                let mut lib_root_url = payload.implementation_url.clone();
-                let _ = lib_root_url.set_host(Some(""));
-                lib_root_url.set_path("");
-                load_referenced_implementation(
-                    provider,
-                    &lib_root_url,
-                    loaded_lib_manifests,
-                    &payload.implementation_url,
-                )?
-            }
-            "file" => Arc::new(wasm::load(provider, &payload.implementation_url)?),
-            _ => bail!("Unsupported scheme on implementation_url"),
-        };
-        implementations.insert(payload.implementation_url.clone(), implementation);
-        trace!(
-            "Implementation '{}' added to executor",
-            payload.implementation_url
-        );
-    }
-
-    let implementation = implementations
-        .get(&payload.implementation_url)
-        .ok_or("Could not find implementation")?;
+    let implementation = get_or_load_implementation(
+        provider,
+        payload,
+        loaded_implementations,
+        loaded_lib_manifests,
+    )?;
 
     trace!("Job #{}: Started executing on '{name}'", payload.job_id);
     let result = implementation.run(&payload.input_set);
@@ -374,6 +529,8 @@ mod test {
     use std::collections::HashMap;
     use std::sync::{Arc, RwLock};
 
+    use portpicker::pick_unused_port;
+    use serial_test::serial;
     use url::Url;
 
     use flowcore::errors::Result;
@@ -974,5 +1131,306 @@ mod test {
             )
             .is_err());
         }
+    }
+
+    /// A trivial native implementation that returns its first input.
+    struct EchoImpl;
+
+    impl Implementation for EchoImpl {
+        fn run(
+            &self,
+            inputs: &[serde_json::Value],
+        ) -> flowcore::errors::Result<(Option<serde_json::Value>, bool)> {
+            Ok((inputs.first().cloned(), false))
+        }
+    }
+
+    /// Helper: pre-load a native implementation into the maps so tests can
+    /// call `get_or_load_implementation` / `execute_job_to_string` without
+    /// needing a real provider or manifest.
+    #[allow(clippy::type_complexity)]
+    fn preloaded_maps(
+        url: &Url,
+    ) -> (
+        Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
+        Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    ) {
+        let mut impls = HashMap::<Url, Arc<dyn Implementation>>::new();
+        impls.insert(url.clone(), Arc::new(EchoImpl));
+        (
+            Arc::new(RwLock::new(impls)),
+            Arc::new(RwLock::new(HashMap::new())),
+        )
+    }
+
+    #[test]
+    fn get_or_load_returns_cached_implementation() {
+        let url = Url::parse("context://test/echo").expect("bad url");
+        let (loaded_impls, loaded_manifests) = preloaded_maps(&url);
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+        let payload = Payload {
+            job_id: 1,
+            input_set: vec![],
+            implementation_url: url.clone(),
+        };
+
+        // First call — should find the pre-loaded implementation
+        let impl1 = super::get_or_load_implementation(
+            &provider,
+            &payload,
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("first get_or_load failed");
+
+        // Second call — should return the same Arc (no re-loading)
+        let impl2 = super::get_or_load_implementation(
+            &provider,
+            &payload,
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("second get_or_load failed");
+
+        assert!(Arc::ptr_eq(&impl1, &impl2), "should return cached Arc");
+    }
+
+    #[test]
+    fn execute_job_to_string_returns_serialized_result() {
+        let url = Url::parse("context://test/echo").expect("bad url");
+        let (loaded_impls, loaded_manifests) = preloaded_maps(&url);
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+        let payload = Payload {
+            job_id: 42,
+            input_set: vec![serde_json::json!("hello")],
+            implementation_url: url,
+        };
+
+        let serialized = super::execute_job_to_string(
+            &provider,
+            &payload,
+            "test",
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("execute_job_to_string failed");
+
+        // The serialized string should be a JSON tuple (job_id, Result)
+        let parsed: (usize, Result<(Option<serde_json::Value>, bool)>) =
+            serde_json::from_str(&serialized).expect("could not parse result JSON");
+        assert_eq!(parsed.0, 42, "job_id should match");
+        let (value, run_again) = parsed.1.expect("inner result should be Ok");
+        assert_eq!(value, Some(serde_json::json!("hello")));
+        assert!(!run_again);
+    }
+
+    #[test]
+    fn get_or_load_fails_for_unknown_implementation() {
+        let url = Url::parse("context://nonexistent/function").expect("bad url");
+        let loaded_impls = Arc::new(RwLock::new(HashMap::<Url, Arc<dyn Implementation>>::new()));
+        let loaded_manifests = Arc::new(RwLock::new(HashMap::<Url, (LibraryManifest, Url)>::new()));
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+        let payload = Payload {
+            job_id: 1,
+            input_set: vec![],
+            implementation_url: url,
+        };
+
+        let result = super::get_or_load_implementation(
+            &provider,
+            &payload,
+            &loaded_impls,
+            &loaded_manifests,
+        );
+        assert!(result.is_err(), "should fail for unknown implementation");
+    }
+
+    /// `get_or_load_implementation` loads from a pre-populated manifest when
+    /// the implementation is not yet cached, then caches it for later calls.
+    #[test]
+    fn get_or_load_loads_from_manifest_and_caches() {
+        let impl_url = Url::parse("context://test/echo").expect("bad url");
+        let lib_url = Url::parse("context://").expect("bad url");
+
+        // Build a manifest containing our EchoImpl at the impl_url
+        let mut manifest = LibraryManifest::new(lib_url.clone(), test_meta_data());
+        manifest.locators.insert(
+            impl_url.clone(),
+            flowcore::model::lib_manifest::ImplementationLocator::Native(Arc::new(EchoImpl)),
+        );
+        let resolved = Url::parse("memory://").expect("bad url");
+
+        // Pre-populate lib manifests but NOT the implementations map
+        let loaded_impls = Arc::new(RwLock::new(HashMap::<Url, Arc<dyn Implementation>>::new()));
+        let mut manifests_map = HashMap::new();
+        manifests_map.insert(lib_url, (manifest, resolved));
+        let loaded_manifests = Arc::new(RwLock::new(manifests_map));
+
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+        let payload = Payload {
+            job_id: 1,
+            input_set: vec![],
+            implementation_url: impl_url.clone(),
+        };
+
+        // First call: needs_load = true, loads from manifest
+        let impl1 = super::get_or_load_implementation(
+            &provider,
+            &payload,
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("first load from manifest failed");
+
+        // Verify it was cached
+        assert!(
+            loaded_impls.read().unwrap().contains_key(&impl_url),
+            "implementation should be cached after first load"
+        );
+
+        // Second call: needs_load = false, returns cached
+        let impl2 = super::get_or_load_implementation(
+            &provider,
+            &payload,
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("second load (cached) failed");
+
+        assert!(Arc::ptr_eq(&impl1, &impl2), "should return same cached Arc");
+    }
+
+    /// `execute_job` succeeds with a pre-loaded native implementation and sends
+    /// the result to the results sink.
+    #[test]
+    #[serial]
+    fn execute_job_native_succeeds() {
+        let url = Url::parse("context://test/echo").expect("bad url");
+        let (loaded_impls, loaded_manifests) = preloaded_maps(&url);
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+
+        let ports = (
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+        );
+        let context = zmq::Context::new();
+
+        // Bind a PULL socket to receive the result
+        let results_pull = context.socket(zmq::PULL).expect("PULL socket");
+        results_pull
+            .bind(&format!("tcp://*:{}", ports.2))
+            .expect("bind PULL");
+
+        // Create the PUSH socket that execute_job will use
+        let results_sink = context.socket(zmq::PUSH).expect("PUSH socket");
+        results_sink
+            .connect(&format!("tcp://127.0.0.1:{}", ports.2))
+            .expect("connect PUSH");
+
+        let payload = Payload {
+            job_id: 7,
+            input_set: vec![serde_json::json!(42)],
+            implementation_url: url,
+        };
+
+        let keep = super::execute_job(
+            &provider,
+            &payload,
+            &results_sink,
+            "test",
+            &loaded_impls,
+            &loaded_manifests,
+        )
+        .expect("execute_job should succeed");
+
+        assert!(keep, "execute_job should return true to keep processing");
+
+        // Verify the result arrived on the PULL socket
+        let msg = results_pull.recv_msg(0).expect("should receive result");
+        let msg_str = msg.as_str().expect("result should be str");
+        let parsed: (usize, Result<(Option<serde_json::Value>, bool)>) =
+            serde_json::from_str(msg_str).expect("should parse result");
+        assert_eq!(parsed.0, 7);
+        let (value, run_again) = parsed.1.expect("inner should be Ok");
+        assert_eq!(value, Some(serde_json::json!(42)));
+        assert!(!run_again);
+    }
+
+    /// `execute_job_to_string` fails gracefully when the implementation is missing.
+    #[test]
+    fn execute_job_to_string_fails_for_missing_impl() {
+        let url = Url::parse("context://missing/impl").expect("bad url");
+        let loaded_impls = Arc::new(RwLock::new(HashMap::<Url, Arc<dyn Implementation>>::new()));
+        let loaded_manifests = Arc::new(RwLock::new(HashMap::<Url, (LibraryManifest, Url)>::new()));
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+        let payload = Payload {
+            job_id: 1,
+            input_set: vec![],
+            implementation_url: url,
+        };
+
+        let result = super::execute_job_to_string(
+            &provider,
+            &payload,
+            "test",
+            &loaded_impls,
+            &loaded_manifests,
+        );
+        assert!(
+            result.is_err(),
+            "should fail when implementation is not loaded"
+        );
+    }
+
+    /// Verify `start_spawning` creates executor threads (they connect to ZMQ and
+    /// exit when DONE is sent on the control socket).
+    #[test]
+    #[serial]
+    fn start_spawning_creates_threads() {
+        let mut executor = Executor::new();
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+
+        let ports = (
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+        );
+
+        let context = zmq::Context::new();
+        // Bind sockets that the executor threads will connect to
+        let job_socket = context.socket(zmq::PUSH).expect("PUSH");
+        job_socket
+            .bind(&format!("tcp://*:{}", ports.0))
+            .expect("bind job");
+        let results_socket = context.socket(zmq::PULL).expect("PULL");
+        results_socket
+            .bind(&format!("tcp://*:{}", ports.2))
+            .expect("bind results");
+        let control_socket = context.socket(zmq::PUB).expect("PUB");
+        control_socket
+            .bind(&format!("tcp://*:{}", ports.3))
+            .expect("bind control");
+
+        executor.start_spawning(
+            &provider,
+            1,
+            &format!("tcp://127.0.0.1:{}", ports.0),
+            &format!("tcp://127.0.0.1:{}", ports.2),
+            &format!("tcp://127.0.0.1:{}", ports.3),
+        );
+
+        assert_eq!(executor.executors.len(), 1, "should have 1 executor thread");
+
+        // Give the thread time to connect, then send DONE
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        control_socket
+            .send("DONE".as_bytes(), 0)
+            .expect("send DONE");
+
+        // Wait for the thread to exit
+        executor.wait();
     }
 }


### PR DESCRIPTION
## Summary

Fixes the blocking IO problem (#1457/#2918): stdout cannot execute while readline is pending.

## Changes

### Two-socket architecture
- Added `BLOCKING_IO_SERVICE_NAME` for mDNS discovery of the blocking IO socket
- `ContextIO` now has two channels: `tx` (non-blocking) and `blocking_tx` (blocking IO)
- Coordinator creates two bridge threads: one for non-blocking IO, one for blocking IO
- Client creates two ZMQ bridge threads with separate `tokio::select!` handling
- Readline and stdin use `send_and_receive_blocking()` instead of `send_and_receive()`

### Executor concurrency
- Extracted `get_or_load_implementation()` with read-first locking to release the `RwLock` before calling `run()`
- Added `start_spawning()` which spawns each job on a separate thread within the executor
- Context executor uses `start_spawning()` so blocking readline doesn't prevent stdout from executing

### Graceful shutdown
- Blocking IO bridge threads use receive timeouts and debug-level logging for expected shutdown errors
- Coordinator's blocking bridge handle is dropped rather than joined

## Tests
- 12 new unit tests covering ContextIO channel routing, executor spawning, implementation caching, and job serialization
- `concurrent-io` example test verifies stdout appears while readline is pending (passes in ~0.14s)
- All existing tests pass (`make test`)

## Files modified (14)
- `flowcore/src/services.rs` — `BLOCKING_IO_SERVICE_NAME`
- `flowr/src/bin/flowrcli/context/mod.rs` — Two-channel `ContextIO` + 5 unit tests
- `flowr/src/bin/flowrcli/context/stdio/{readline,stdin}.rs` — `send_and_receive_blocking`
- `flowr/src/bin/flowrcli/main.rs` — Two coordinator connections, two bridge threads
- `flowr/src/bin/flowrcli/cli/cli_client.rs` — Two client ZMQ bridges
- `flowr/src/lib/executor.rs` — `start_spawning()`, `get_or_load_implementation()`, `execute_job_to_string()` + 7 unit tests
- 6 context function test files — Updated `ContextIO::new()` calls
- `flowr/examples/concurrent-io/main.rs` — Removed `#[ignore]`, cleaned up test

## Not included
- flowrgui changes (separate PR as noted in #2918)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated handling for blocking input operations such as `stdin` and `readline`.
  - Enabled other output and processing tasks to continue while input is waiting.
  - Added optional parallel job execution to improve responsiveness for concurrent workloads.

- **Bug Fixes**
  - Fixed an issue where pending input could prevent stdout output from becoming available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->