### PR TITLE
Port two-socket concurrent IO architecture to flowrgui (#2918)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use iced::futures::SinkExt;
 use iced::Subscription;
-use log::{error, info, trace};
+use log::{debug, error, info, trace};
 use portpicker::pick_unused_port;
 use tokio::sync::mpsc::Receiver;
 use url::Url;
@@ -31,9 +31,9 @@ use flowrlib::discovery::{
     create_service_daemon, discover_service, register_service, shutdown_service_daemon,
     unregister_service, ServiceDaemon,
 };
-use flowrlib::services::COORDINATOR_SERVICE_NAME;
 #[cfg(feature = "debugger")]
 use flowrlib::services::DEBUG_SERVICE_NAME;
+use flowrlib::services::{BLOCKING_IO_SERVICE_NAME, COORDINATOR_SERVICE_NAME};
 
 #[cfg(feature = "debugger")]
 use flowcore::model::debug_command::DebugCommand;
@@ -156,6 +156,7 @@ pub fn subscribe(coordinator_settings: CoordinatorSettings) -> Subscription<Coor
     Subscription::run(coordinator_stream)
 }
 
+#[allow(clippy::too_many_lines)]
 fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage> {
     let Some(settings) = COORDINATOR_SETTINGS.get().cloned() else {
         eprintln!("Error: Coordinator settings were not initialized before subscribing. This is a programming error.");
@@ -208,17 +209,65 @@ fn coordinator_stream() -> impl iced::futures::Stream<Item = CoordinatorMessage>
                     CoordinatorState::Discovered(address) => {
                         match ClientConnection::new(&address) {
                             Ok(connection) => {
+                                // Also discover and connect to the blocking IO socket
+                                let blocking_connection =
+                                    match discover_service(BLOCKING_IO_SERVICE_NAME) {
+                                        Ok(blocking_address) => {
+                                            match ClientConnection::new(&blocking_address) {
+                                                Ok(conn) => {
+                                                    // Set receive timeout for clean shutdown
+                                                    let _ = conn.set_receive_timeout(2000);
+                                                    conn
+                                                }
+                                                Err(e) => {
+                                                    let _ = app_sender
+                                                        .send(CoordinatorMessage::Disconnected(
+                                                            format!(
+                                                    "Could not connect to blocking IO: {e}"
+                                                ),
+                                                        ))
+                                                        .await;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            let _ = app_sender
+                                                .send(CoordinatorMessage::Disconnected(format!(
+                                                    "Could not discover blocking IO service: {e}"
+                                                )))
+                                                .await;
+                                            break;
+                                        }
+                                    };
+
                                 let (app_side_sender, app_receiver) =
                                     tokio::sync::mpsc::channel(100);
+                                let (blocking_response_sender, blocking_response_receiver) =
+                                    tokio::sync::mpsc::channel(10);
 
                                 if app_sender
-                                    .send(CoordinatorMessage::Connected(app_side_sender))
+                                    .send(CoordinatorMessage::Connected(
+                                        app_side_sender,
+                                        blocking_response_sender,
+                                    ))
                                     .await
                                     .is_err()
                                 {
                                     error!("Could not send Connected message to app");
                                     break;
                                 }
+
+                                // Spawn the blocking IO bridge with its own response channel
+                                let blocking_conn = Arc::new(Mutex::new(blocking_connection));
+                                let mut blocking_sender = app_sender.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    client_blocking_io_bridge(
+                                        blocking_conn,
+                                        &mut blocking_sender,
+                                        blocking_response_receiver,
+                                    );
+                                });
 
                                 state = CoordinatorState::Connected(
                                     app_receiver,
@@ -343,6 +392,15 @@ fn start_server(coordinator_settings: ServerSettings) -> Result<()> {
         runtime_port,
     )?];
 
+    let blocking_io_port = pick_unused_port().chain_err(|| "No ports free")?;
+    let blocking_io_connection =
+        CoordinatorConnection::new(BLOCKING_IO_SERVICE_NAME, blocking_io_port)?;
+    fullnames.push(register_service(
+        &mdns,
+        BLOCKING_IO_SERVICE_NAME,
+        blocking_io_port,
+    )?);
+
     #[cfg(feature = "debugger")]
     let debug_port = pick_unused_port().chain_err(|| "No ports free")?;
     #[cfg(feature = "debugger")]
@@ -364,6 +422,7 @@ fn start_server(coordinator_settings: ServerSettings) -> Result<()> {
             &coordinator_mdns,
             coordinator_settings,
             coordinator_connection,
+            blocking_io_connection,
             #[cfg(feature = "debugger")]
             debug_connection,
             true,
@@ -383,14 +442,31 @@ fn start_server(coordinator_settings: ServerSettings) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn coordinator(
     mdns: &ServiceDaemon,
     coordinator_settings: ServerSettings,
     coordinator_connection: CoordinatorConnection,
+    blocking_io_connection: CoordinatorConnection,
     #[cfg(feature = "debugger")] debug_connection: CoordinatorConnection,
     loop_forever: bool,
 ) -> Result<()> {
-    let connection = Arc::new(Mutex::new(coordinator_connection));
+    // Create channels for context functions and submission handler to communicate
+    // with the bridge thread that owns the ZMQ CoordinatorConnection.
+    let (context_tx, context_rx) = std::sync::mpsc::channel();
+    let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
+    let (submission_tx, submission_rx) = std::sync::mpsc::channel();
+    let context_io = context::ContextIO::new(context_tx, blocking_tx);
+
+    // Spawn bridge thread that owns the non-blocking ZMQ socket
+    let bridge_handle = thread::spawn(move || {
+        coordinator_bridge(coordinator_connection, context_rx, submission_tx);
+    });
+
+    // Spawn bridge thread that owns the blocking IO ZMQ socket
+    let blocking_bridge_handle = thread::spawn(move || {
+        blocking_io_bridge(blocking_io_connection, blocking_rx);
+    });
 
     #[cfg(feature = "debugger")]
     let mut debug_server = DebugZmqHandler {
@@ -416,15 +492,12 @@ fn coordinator(
         get_connect_addresses(ports);
 
     let mut executor = Executor::new();
-    // if the command line options request loading native implementation of available native libs
-    // if not, the native implementation is not loaded and later when a flow is loaded it's library
-    // references will be resolved and those libraries (WASM implementations) will be loaded at runtime
     #[cfg(feature = "flowstdlib")]
     if coordinator_settings.native_flowstdlib {
         executor.add_lib(
             flowstdlib::manifest::get()
                 .chain_err(|| "Could not get 'native' flowstdlib manifest")?,
-            Url::parse("memory://")?, // Statically linked library has no resolved Url
+            Url::parse("memory://")?,
         )?;
     }
     executor.start(
@@ -437,10 +510,12 @@ fn coordinator(
 
     let mut context_executor = Executor::new();
     context_executor.add_lib(
-        context::get_manifest(connection.clone())?,
-        Url::parse("memory://")?, // Statically linked library has no resolved Url
+        context::get_manifest(context_io.clone())?,
+        Url::parse("memory://")?,
     )?;
-    context_executor.start(
+    // Use start_spawning so blocking context functions (readline/stdin) don't
+    // prevent non-blocking ones (stdout/stderr) from executing concurrently.
+    context_executor.start_spawning(
         &provider,
         1,
         &context_job_source_name,
@@ -449,7 +524,7 @@ fn coordinator(
     );
 
     #[cfg(feature = "submission")]
-    let mut submitter = CLISubmissionHandler::new(connection);
+    let mut submitter = CLISubmissionHandler::new(context_io, submission_rx);
 
     let mut coordinator = Coordinator::new(
         dispatcher,
@@ -473,7 +548,233 @@ fn coordinator(
         unregister_service(mdns, fullname);
     }
 
+    let _ = bridge_handle.join();
+    // The blocking IO bridge thread is not joined — it may be stuck waiting
+    // for a blocking IO request that never arrives.
+    drop(blocking_bridge_handle);
+
     result
+}
+
+/// Client-side blocking IO bridge for the GUI. Runs as a `spawn_blocking` task.
+/// Polls the coordinator's blocking IO socket and forwards `GetLine`/`GetStdin`
+/// to the GUI. Receives responses from the GUI's blocking response channel.
+#[allow(clippy::needless_pass_by_value)]
+fn client_blocking_io_bridge(
+    connection: Arc<Mutex<ClientConnection>>,
+    app_sender: &mut iced::futures::channel::mpsc::Sender<CoordinatorMessage>,
+    mut response_rx: tokio::sync::mpsc::Receiver<ClientMessage>,
+) {
+    loop {
+        // Send Ack to poll the coordinator for a blocking IO request
+        if lock_and_send(&connection, ClientMessage::Ack).is_err() {
+            break;
+        }
+
+        // Receive the blocking IO request (GetLine/GetStdin)
+        match lock_and_receive(&connection) {
+            Ok(event) => {
+                // Forward to the GUI via app_sender
+                if app_sender.try_send(event).is_err() {
+                    break;
+                }
+
+                // Wait for the GUI's response
+                match response_rx.blocking_recv() {
+                    Some(response) => {
+                        // Send the result back to the coordinator
+                        if lock_and_send(&connection, response).is_err() {
+                            break;
+                        }
+
+                        // Receive the coordinator's acknowledgement
+                        if lock_and_receive(&connection).is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            Err(_) => {
+                // Expected during shutdown — receive timeout or coordinator gone
+                break;
+            }
+        }
+    }
+}
+
+/// Bridge thread for blocking IO (readline/stdin) on a separate ZMQ socket.
+///
+/// Protocol:
+/// 1. Wait for a blocking IO request from a context function via `blocking_rx`
+/// 2. Wait for the client's `Ack` on ZMQ (client polls this socket)
+/// 3. Send the blocking IO request (GetLine/GetStdin) to the client
+/// 4. Wait for the client's response (Line/Stdin/etc.)
+/// 5. Forward the response to the context function
+#[allow(clippy::needless_pass_by_value)]
+fn blocking_io_bridge(
+    mut connection: CoordinatorConnection,
+    blocking_rx: std::sync::mpsc::Receiver<context::ContextRequest>,
+) {
+    use crate::gui::client_message::ClientMessage;
+    use crate::gui::coordinator_message::CoordinatorMessage;
+    use flowrlib::connections::WAIT;
+
+    debug!("[BLOCKING BRIDGE] started");
+
+    while let Ok(request) = blocking_rx.recv() {
+        debug!(
+            "[BLOCKING BRIDGE] received blocking request: {}",
+            request.message
+        );
+
+        // Wait for the client's Ack (client polls this socket)
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(ClientMessage::Ack) => {}
+            Ok(ClientMessage::ClientExiting(_)) => {
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                }
+                return;
+            }
+            Ok(other) => {
+                debug!("[BLOCKING BRIDGE] unexpected message: {other:?}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!(
+                        "Unexpected message on blocking IO socket: {other:?}"
+                    )));
+                }
+                continue;
+            }
+            Err(e) => {
+                error!("Blocking bridge: error receiving Ack: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+                return;
+            }
+        }
+
+        // Send the blocking IO request to the client
+        if let Err(e) = connection.send(request.message) {
+            error!("Blocking bridge: failed to send to client: {e}");
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+            }
+            continue;
+        }
+
+        // Wait for the client's response (this blocks while user types input)
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(ClientMessage::ClientExiting(_)) => {
+                let _ = connection.send(CoordinatorMessage::CoordinatorExiting(Ok(())));
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                }
+                return;
+            }
+            Ok(response) => {
+                // Complete the REP cycle with an ack
+                let _ = connection.send(CoordinatorMessage::Invalid);
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(response);
+                }
+            }
+            Err(e) => {
+                error!("Blocking bridge: failed to receive response: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+                return;
+            }
+        }
+    }
+
+    debug!("[BLOCKING BRIDGE] channel closed, exiting");
+}
+
+/// Bridge thread that owns the ZMQ `CoordinatorConnection` and serializes all
+/// communication between context functions/submission handler and the client.
+#[allow(clippy::needless_pass_by_value)]
+fn coordinator_bridge(
+    mut connection: CoordinatorConnection,
+    context_rx: std::sync::mpsc::Receiver<context::ContextRequest>,
+    submission_tx: std::sync::mpsc::Sender<flowcore::model::submission::Submission>,
+) {
+    use crate::gui::client_message::ClientMessage;
+    use crate::gui::coordinator_message::CoordinatorMessage;
+    use flowrlib::connections::WAIT;
+
+    debug!("[BRIDGE] started");
+
+    while let Ok(request) = context_rx.recv() {
+        let is_exiting = matches!(request.message, CoordinatorMessage::CoordinatorExiting(_));
+        let wait_for_submission = matches!(request.message, CoordinatorMessage::Invalid);
+
+        if wait_for_submission {
+            debug!("[BRIDGE] waiting for submission on ZMQ...");
+            loop {
+                match connection.receive::<ClientMessage>(WAIT) {
+                    Ok(ClientMessage::ClientSubmission(submission)) => {
+                        if submission_tx.send(*submission).is_err() {
+                            return;
+                        }
+                        break;
+                    }
+                    Ok(ClientMessage::ClientExiting(_)) => {
+                        if let Some(response_tx) = request.response_tx {
+                            let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                        }
+                        return;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!("Bridge: error receiving submission: {e}");
+                        return;
+                    }
+                }
+            }
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Ack);
+            }
+            continue;
+        }
+
+        if is_exiting {
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Ack);
+            }
+            return;
+        }
+
+        if let Err(e) = connection.send(request.message) {
+            error!("Bridge: failed to send to client: {e}");
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+            }
+            continue;
+        }
+
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(ClientMessage::ClientExiting(_)) => {
+                let _ = connection.send(CoordinatorMessage::CoordinatorExiting(Ok(())));
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::ClientExiting(Ok(())));
+                }
+            }
+            Ok(response) => {
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(response);
+                }
+            }
+            Err(e) => {
+                error!("Bridge: failed to receive from client: {e}");
+                if let Some(response_tx) = request.response_tx {
+                    let _ = response_tx.send(ClientMessage::Error(format!("{e}")));
+                }
+            }
+        }
+    }
 }
 
 /// Global sender for debug commands from GUI to the debug client subscription

--- a/flowr/src/bin/flowrgui/context/args/get.rs
+++ b/flowr/src/bin/flowrgui/context/args/get.rs
@@ -1,30 +1,25 @@
-use std::sync::{Arc, Mutex};
-
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
 
+use crate::context::ContextIO;
 use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `get` function
 pub struct Get {
     /// It holds a reference to the runtime client in order to Get the Args
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for Get {
     fn run(&self, mut _inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let mut guard = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
+        let response = self
+            .context_io
+            .send_and_receive(CoordinatorMessage::GetArgs);
 
-        let sent = guard.send_and_receive_response(CoordinatorMessage::GetArgs);
-
-        match sent {
+        match response {
             Ok(ClientMessage::Args(arg_vec)) => {
                 let mut output_map = serde_json::Map::new();
 
@@ -53,31 +48,38 @@ impl Implementation for Get {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
-    use std::sync::{Arc, Mutex};
-
-    use portpicker::pick_unused_port;
     use serde_json::json;
-    use serial_test::serial;
 
     use flowcore::{Implementation, DONT_RUN_AGAIN};
 
-    use crate::gui::client_message::ClientMessage::Args;
-    use crate::gui::coordinator_message::CoordinatorMessage::GetArgs;
-    use crate::gui::test_helper::test::wait_for_then_send;
-    use flowrlib::connections::CoordinatorConnection;
+    use crate::context::ContextIO;
+    use crate::gui::client_message::ClientMessage;
+    use crate::gui::coordinator_message::CoordinatorMessage;
 
     use super::Get;
 
+    fn make_get() -> (
+        Get,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            Get {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn gets_args_no_client() {
-        let test_port = pick_unused_port().expect("No ports free");
-        let getter = &Get {
-            server_connection: Arc::new(Mutex::new(
-                CoordinatorConnection::new("foo", test_port)
-                    .expect("Could not create server connection"),
-            )),
-        } as &dyn Implementation;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        let getter = Get {
+            context_io: ContextIO::new(tx, blocking_tx),
+        };
+        drop(rx);
         let (value, run_again) = getter.run(&[]).expect("_get() failed");
 
         assert_eq!(run_again, DONT_RUN_AGAIN);
@@ -85,18 +87,24 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn gets_args() {
         let args: Vec<String> = ["flow_name", "arg1", "arg2"]
             .iter()
             .map(ToString::to_string)
             .collect();
 
-        let server_connection = wait_for_then_send(GetArgs, Args(args.clone()));
+        let (getter, rx) = make_get();
+        let args_clone = args.clone();
+        let handle = std::thread::spawn(move || getter.run(&[]));
 
-        let getter = &Get { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request");
+        assert!(matches!(req.message, CoordinatorMessage::GetArgs));
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Args(args_clone))
+            .unwrap();
 
-        let (value, run_again) = getter.run(&[]).expect("_get() failed");
+        let (value, run_again) = handle.join().unwrap().expect("_get() failed");
 
         assert_eq!(run_again, DONT_RUN_AGAIN);
 
@@ -110,18 +118,23 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn gets_args_num() {
         let args: Vec<String> = ["flow_name", "10"]
             .iter()
             .map(ToString::to_string)
             .collect();
 
-        let server_connection = wait_for_then_send(GetArgs, Args(args));
+        let (getter, rx) = make_get();
+        let args_clone = args.clone();
+        let handle = std::thread::spawn(move || getter.run(&[]));
 
-        let getter = &Get { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Args(args_clone))
+            .unwrap();
 
-        let (value, run_again) = getter.run(&[]).expect("_get() failed");
+        let (value, run_again) = handle.join().unwrap().expect("_get() failed");
 
         assert_eq!(run_again, DONT_RUN_AGAIN);
 
@@ -139,18 +152,23 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn gets_args_array_num() {
         let args: Vec<String> = ["flow_name", "[10,20]"]
             .iter()
             .map(ToString::to_string)
             .collect();
 
-        let server_connection = wait_for_then_send(GetArgs, Args(args));
+        let (getter, rx) = make_get();
+        let args_clone = args.clone();
+        let handle = std::thread::spawn(move || getter.run(&[]));
 
-        let getter = &Get { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Args(args_clone))
+            .unwrap();
 
-        let (value, run_again) = getter.run(&[]).expect("_get() failed");
+        let (value, run_again) = handle.join().unwrap().expect("_get() failed");
 
         assert_eq!(run_again, DONT_RUN_AGAIN);
 
@@ -168,18 +186,23 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn gets_args_array_array_num() {
         let args: Vec<String> = ["flow_name", "[[10,20],[30,40]]"]
             .iter()
             .map(ToString::to_string)
             .collect();
 
-        let server_connection = wait_for_then_send(GetArgs, Args(args));
+        let (getter, rx) = make_get();
+        let args_clone = args.clone();
+        let handle = std::thread::spawn(move || getter.run(&[]));
 
-        let getter = &Get { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Args(args_clone))
+            .unwrap();
 
-        let (value, run_again) = getter.run(&[]).expect("_get() failed");
+        let (value, run_again) = handle.join().unwrap().expect("_get() failed");
 
         assert_eq!(run_again, DONT_RUN_AGAIN);
 

--- a/flowr/src/bin/flowrgui/context/file/file_read.rs
+++ b/flowr/src/bin/flowrgui/context/file/file_read.rs
@@ -1,31 +1,24 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN, RUN_AGAIN};
 use serde_json::{json, Value};
 
+use crate::context::ContextIO;
 use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `file_read` function
 pub struct FileRead {
     /// It holds a reference to the runtime client in order to get file contents
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for FileRead {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let path = inputs.first().ok_or("Could not get filename")?;
 
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let response = server.send_and_receive_response::<CoordinatorMessage, ClientMessage>(
-            CoordinatorMessage::Read(path.as_str().unwrap_or("").to_string()),
-        );
+        let response = self.context_io.send_and_receive(CoordinatorMessage::Read(
+            path.as_str().unwrap_or("").to_string(),
+        ));
 
         match response {
             Ok(ClientMessage::FileContents(_path, bytes)) => {
@@ -46,16 +39,28 @@ impl Implementation for FileRead {
 mod test {
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
-    use serial_test::serial;
 
-    use crate::gui::client_message::ClientMessage::FileContents;
+    use crate::context::ContextIO;
+    use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::FileRead;
 
+    fn make_file_read() -> (
+        FileRead,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            FileRead {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn read_file() {
         let file_path = "test_read";
         let file_contents: Vec<u8> = "test text".as_bytes().to_vec();
@@ -63,17 +68,21 @@ mod test {
             String::from_utf8(file_contents.clone()).expect("Could not create Utf8 String");
 
         let inputs = [json!(file_path)];
-        let file_read_message = CoordinatorMessage::Read(file_path.to_string());
 
-        let server_connection = wait_for_then_send(
-            file_read_message,
-            FileContents(file_path.to_string(), file_contents),
-        );
+        let (reader, rx) = make_file_read();
+        let handle = std::thread::spawn(move || reader.run(&inputs));
 
-        let reader = &FileRead { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request");
+        assert!(matches!(req.message, CoordinatorMessage::Read(_)));
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::FileContents(
+                file_path.to_string(),
+                file_contents,
+            ))
+            .unwrap();
 
-        let (value, run_again) = reader.run(&inputs).expect("_file_write() failed");
-
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         match value {
             Some(Value::Object(map)) => {

--- a/flowr/src/bin/flowrgui/context/file/file_write.rs
+++ b/flowr/src/bin/flowrgui/context/file/file_write.rs
@@ -1,28 +1,20 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 use serde_json::Value;
 
-use crate::gui::client_message::ClientMessage;
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `file_write` function
 pub struct FileWrite {
     /// It holds a reference to the runtime client in order to get file contents
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for FileWrite {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let filename = inputs.first().ok_or("Could not get filename")?;
         let bytes = inputs.get(1).ok_or("Could not get filename")?;
-
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
 
         let byte_array = bytes.as_array().ok_or("Could not get bytes")?;
 
@@ -31,13 +23,13 @@ impl Implementation for FileWrite {
             .iter()
             .map(|byte_value| byte_value.as_u64().unwrap_or(0) as u8)
             .collect();
-        match server.send_and_receive_response::<CoordinatorMessage, ClientMessage>(
-            CoordinatorMessage::Write(filename.as_str().unwrap_or("").to_string(), bytes),
-        ) {
-            Ok(ClientMessage::Error(msg)) => Err(msg.into()),
-            Ok(_) => Ok((None, RUN_AGAIN)),
-            Err(e) => Err(e),
-        }
+
+        self.context_io.send_and_receive(CoordinatorMessage::Write(
+            filename.as_str().unwrap_or("").to_string(),
+            bytes,
+        ))?;
+
+        Ok((None, RUN_AGAIN))
     }
 }
 
@@ -46,29 +38,46 @@ impl Implementation for FileWrite {
 mod test {
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::json;
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::FileWrite;
 
+    fn make_file_write() -> (
+        FileWrite,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            FileWrite {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn write_file() {
         let file_path = std::path::Path::new("fake").join("write_test");
         let file_path = file_path.to_str().expect("Could not convert path");
         let file_contents = "test text".as_bytes().to_vec();
         let inputs = [json!(file_path), json!(file_contents)];
-        let file_write_message = CoordinatorMessage::Write(file_path.to_string(), file_contents);
 
-        let server_connection = wait_for_then_send(file_write_message, ClientMessage::Ack);
+        let (writer, rx) = make_file_write();
+        let handle = std::thread::spawn(move || writer.run(&inputs));
 
-        let writer = &FileWrite { server_connection } as &dyn Implementation;
+        let req = rx.recv().expect("No request received");
+        assert!(matches!(req.message, CoordinatorMessage::Write(..)));
+        if let Some(response_tx) = req.response_tx {
+            response_tx
+                .send(ClientMessage::Ack)
+                .expect("Could not send response");
+        }
 
-        let (value, run_again) = writer.run(&inputs).expect("_file_write() failed");
-
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }

--- a/flowr/src/bin/flowrgui/context/image/image_buffer.rs
+++ b/flowr/src/bin/flowrgui/context/image/image_buffer.rs
@@ -1,17 +1,14 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 use serde_json::Value;
 
-use crate::gui::client_message::ClientMessage;
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `image_buffer` function
 pub struct ImageBuffer {
     /// It holds a reference to the runtime client in order to send commands
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for ImageBuffer {
@@ -37,11 +34,6 @@ impl Implementation for ImageBuffer {
             .ok_or("Could not get filename")?
             .as_str()
             .ok_or("Could not get filename")?;
-
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
 
         #[allow(clippy::many_single_char_names)]
         let x = pixel
@@ -86,8 +78,8 @@ impl Implementation for ImageBuffer {
             .as_u64()
             .ok_or("Could not get h")?;
 
-        let _: Result<ClientMessage> =
-            server.send_and_receive_response(CoordinatorMessage::PixelWrite(
+        self.context_io
+            .send_and_receive(CoordinatorMessage::PixelWrite(
                 (
                     u32::try_from(x).map_err(|_| "Integer overflow in 'x'")?,
                     u32::try_from(y).map_err(|_| "Integer overflow in 'y'")?,
@@ -102,7 +94,7 @@ impl Implementation for ImageBuffer {
                     u32::try_from(h).map_err(|_| "Integer overflow in 'h'")?,
                 ),
                 filename.to_string(),
-            ));
+            ))?;
 
         Ok((None, RUN_AGAIN))
     }
@@ -113,48 +105,64 @@ impl Implementation for ImageBuffer {
 mod test {
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::json;
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::ImageBuffer;
 
+    fn make_image_buffer() -> (
+        ImageBuffer,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            ImageBuffer {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn invalid_parameters() {
         let pixel = (0, 0);
         let color = (1, 2, 3);
         let invalid_size = (1.2, 3.4); // invalid
-        let size = (1, 3);
-        let buffer_name = "image_buffer.png".into();
+        let buffer_name: String = "image_buffer.png".into();
         let inputs = [
             json!(pixel),
             json!(color),
             json!(invalid_size),
             json!(buffer_name),
         ];
-        let pixel = CoordinatorMessage::PixelWrite(pixel, color, size, buffer_name);
 
-        let server_connection = wait_for_then_send(pixel, ClientMessage::Ack);
-        let buffer = &ImageBuffer { server_connection } as &dyn Implementation;
+        let (buffer, _rx) = make_image_buffer();
         assert!(buffer.run(&inputs).is_err());
     }
 
     #[test]
-    #[serial]
     fn valid() {
         let pixel = (0, 0);
         let color = (1, 2, 3);
         let size = (1, 3);
-        let buffer_name = "image_buffer.png".into();
+        let buffer_name: String = "image_buffer.png".into();
         let inputs = [json!(pixel), json!(color), json!(size), json!(buffer_name)];
-        let pixel = CoordinatorMessage::PixelWrite(pixel, color, size, buffer_name);
 
-        let server_connection = wait_for_then_send(pixel, ClientMessage::Ack);
-        let buffer = &ImageBuffer { server_connection } as &dyn Implementation;
-        let (value, run_again) = buffer.run(&inputs).expect("run() failed");
+        let (buffer, rx) = make_image_buffer();
+        let handle = std::thread::spawn(move || buffer.run(&inputs));
+
+        let req = rx.recv().expect("No request received");
+        assert!(matches!(req.message, CoordinatorMessage::PixelWrite(..)));
+        if let Some(response_tx) = req.response_tx {
+            response_tx
+                .send(ClientMessage::Ack)
+                .expect("Could not send response");
+        }
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }

--- a/flowr/src/bin/flowrgui/context/image/image_read.rs
+++ b/flowr/src/bin/flowrgui/context/image/image_read.rs
@@ -1,18 +1,16 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
 use image::ImageReader;
 use serde_json::{json, Value};
 use std::io::Cursor;
 
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `image_read` function
 pub struct ImageRead {
     /// It holds a reference to the runtime client in order to read files
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for ImageRead {
@@ -23,13 +21,9 @@ impl Implementation for ImageRead {
             .as_str()
             .ok_or("Could not get filename as string")?;
 
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let response =
-            server.send_and_receive_response(CoordinatorMessage::Read(filename.to_string()));
+        let response = self
+            .context_io
+            .send_and_receive(CoordinatorMessage::Read(filename.to_string()));
 
         match response {
             Ok(crate::gui::client_message::ClientMessage::FileContents(_path, bytes)) => {

--- a/flowr/src/bin/flowrgui/context/image/image_write.rs
+++ b/flowr/src/bin/flowrgui/context/image/image_write.rs
@@ -1,16 +1,14 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 use serde_json::Value;
 
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `image_write` function
 pub struct ImageWrite {
     /// It holds a reference to the runtime client in order to send commands
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 fn to_u8(v: &Value) -> u8 {
@@ -54,13 +52,8 @@ impl Implementation for ImageWrite {
             flat.chunks(width).map(<[u8]>::to_vec).collect()
         };
 
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let _: Result<crate::gui::client_message::ClientMessage> = server
-            .send_and_receive_response(CoordinatorMessage::ImageWrite(grid, filename.to_string()));
+        self.context_io
+            .send_and_receive(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
 
         Ok((None, RUN_AGAIN))
     }

--- a/flowr/src/bin/flowrgui/context/mod.rs
+++ b/flowr/src/bin/flowrgui/context/mod.rs
@@ -1,6 +1,7 @@
-//! Module of context functions for Cli Flowr Runner
+//! Module of context functions for Gui Flowr Runner
 
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
+use std::sync::Arc;
 
 use flowcore::errors::{Result, ResultExt};
 use flowcore::model::lib_manifest::ImplementationLocator::Native;
@@ -8,21 +9,81 @@ use flowcore::model::lib_manifest::LibraryManifest;
 use flowcore::model::metadata::MetaData;
 use url::Url;
 
-use crate::CoordinatorConnection;
+use crate::gui::client_message::ClientMessage;
+use crate::gui::coordinator_message::CoordinatorMessage;
 
 mod args;
 mod file;
 mod image;
 mod stdio;
 
+/// A request sent from a context function to the ZMQ bridge thread.
+pub struct ContextRequest {
+    /// The message to send to the client
+    pub message: CoordinatorMessage,
+    /// If `Some`, the bridge sends the client's response back on this channel.
+    /// If `None`, the message is fire-and-forget (no response expected).
+    pub response_tx: Option<mpsc::Sender<ClientMessage>>,
+}
+
+/// Channel-based IO handle for context functions.
+///
+/// Uses two channels: one for non-blocking IO (stdout, stderr, file, image, args)
+/// and one for blocking IO (readline, stdin). This allows blocking IO to be
+/// handled on a separate ZMQ socket so it doesn't block non-blocking IO.
+#[derive(Clone)]
+pub struct ContextIO {
+    /// Channel for non-blocking context function requests (stdout, stderr, etc.)
+    tx: mpsc::Sender<ContextRequest>,
+    /// Channel for blocking context function requests (readline, stdin)
+    blocking_tx: mpsc::Sender<ContextRequest>,
+}
+
+impl ContextIO {
+    /// Create a new `ContextIO` backed by the given channel senders.
+    pub fn new(
+        tx: mpsc::Sender<ContextRequest>,
+        blocking_tx: mpsc::Sender<ContextRequest>,
+    ) -> Self {
+        ContextIO { tx, blocking_tx }
+    }
+
+    /// Send a message on the non-blocking channel and wait for the client's response.
+    pub fn send_and_receive(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        let (response_tx, response_rx) = mpsc::channel();
+        self.tx
+            .send(ContextRequest {
+                message,
+                response_tx: Some(response_tx),
+            })
+            .map_err(|e| format!("Could not send to bridge: {e}"))?;
+        response_rx
+            .recv()
+            .map_err(|e| format!("Could not receive from bridge: {e}").into())
+    }
+
+    /// Send a message on the blocking IO channel and wait for the client's response.
+    /// Used by context functions that may block for user input (readline, stdin).
+    pub fn send_and_receive_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        let (response_tx, response_rx) = mpsc::channel();
+        self.blocking_tx
+            .send(ContextRequest {
+                message,
+                response_tx: Some(response_tx),
+            })
+            .map_err(|e| format!("Could not send to blocking bridge: {e}"))?;
+        response_rx
+            .recv()
+            .map_err(|e| format!("Could not receive from blocking bridge: {e}").into())
+    }
+}
+
 /// Return a `LibraryManifest` for the context functions
-pub fn get_manifest(
-    server_connection: Arc<Mutex<CoordinatorConnection>>,
-) -> Result<LibraryManifest> {
+pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {
     let metadata = MetaData {
         name: "context".into(),
         version: "0.1.0".into(),
-        description: "context functions for Flowr Cli Runner".into(),
+        description: "context functions for Gui Flowr Runner".into(),
         authors: vec!["Andrew Mackenzie".to_string()],
     };
     let lib_url = Url::parse("context://")?;
@@ -31,60 +92,60 @@ pub fn get_manifest(
     manifest.locators.insert(
         Url::parse("context://args/get")?,
         Native(Arc::new(args::get::Get {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://file/file_write").chain_err(|| "Could not parse url")?,
         Native(Arc::new(file::file_write::FileWrite {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://file/file_read").chain_err(|| "Could not parse url")?,
         Native(Arc::new(file::file_read::FileRead {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://image/image_buffer").chain_err(|| "Could not parse url")?,
         Native(Arc::new(image::image_buffer::ImageBuffer {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://image/image_read").chain_err(|| "Could not parse url")?,
         Native(Arc::new(image::image_read::ImageRead {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://image/image_write").chain_err(|| "Could not parse url")?,
         Native(Arc::new(image::image_write::ImageWrite {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://stdio/readline").chain_err(|| "Could not parse url")?,
         Native(Arc::new(stdio::readline::Readline {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://stdio/stdin").chain_err(|| "Could not parse url")?,
         Native(Arc::new(stdio::stdin::Stdin {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://stdio/stdout").chain_err(|| "Could not parse url")?,
         Native(Arc::new(stdio::stdout::Stdout {
-            server_connection: server_connection.clone(),
+            context_io: context_io.clone(),
         })),
     );
     manifest.locators.insert(
         Url::parse("context://stdio/stderr").chain_err(|| "Could not parse url")?,
-        Native(Arc::new(stdio::stderr::Stderr { server_connection })),
+        Native(Arc::new(stdio::stderr::Stderr { context_io })),
     );
 
     Ok(manifest)

--- a/flowr/src/bin/flowrgui/context/stdio/readline.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/readline.rs
@@ -1,33 +1,27 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN, RUN_AGAIN};
 use serde_json::Value;
 
+use crate::context::ContextIO;
 use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `readline` function
 pub struct Readline {
     /// It holds a reference to the runtime client in order to read input
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for Readline {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
         let prompt = match inputs.first() {
             Some(Value::String(prompt)) => prompt.clone(),
             _ => String::new(),
         };
 
-        let readline_response =
-            server.send_and_receive_response(CoordinatorMessage::GetLine(prompt));
+        let readline_response = self
+            .context_io
+            .send_and_receive_blocking(CoordinatorMessage::GetLine(prompt));
 
         match readline_response {
             Ok(ClientMessage::Line(contents)) => {
@@ -48,64 +42,76 @@ impl Implementation for Readline {
 mod test {
     use flowcore::{Implementation, DONT_RUN_AGAIN, RUN_AGAIN};
     use serde_json::json;
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::Readline;
 
+    fn make_readline() -> (
+        Readline,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (nonblocking_tx, _nonblocking_rx) = std::sync::mpsc::channel();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
+        (
+            Readline {
+                context_io: ContextIO::new(nonblocking_tx, blocking_tx),
+            },
+            blocking_rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn gets_a_line_of_text() {
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::GetLine(String::new()),
-            ClientMessage::Line("line of text".into()),
-        );
-        let reader = &Readline { server_connection } as &dyn Implementation;
-        let (value, run_again) = reader.run(&[]).expect("_readline() failed");
+        let (reader, rx) = make_readline();
+        let handle = std::thread::spawn(move || reader.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        assert!(matches!(req.message, CoordinatorMessage::GetLine(_)));
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Line("line of text".into()))
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
-
-        let val = value.expect("Could not get value returned from implementation");
-        let map = val.as_object().expect("Could not get map of output values");
-        assert_eq!(
-            map.get("string").expect("Could not get string args"),
-            &json!("line of text")
-        );
+        let val = value.expect("No value");
+        let map = val.as_object().expect("Not an object");
+        assert_eq!(map.get("string").unwrap(), &json!("line of text"));
     }
 
     #[test]
-    #[serial]
     fn gets_json() {
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::GetLine(String::new()),
-            ClientMessage::Line("\"json text\"".into()),
-        );
-        let reader = &Readline { server_connection } as &dyn Implementation;
-        let (value, run_again) = reader.run(&[]).expect("_readline() failed");
+        let (reader, rx) = make_readline();
+        let handle = std::thread::spawn(move || reader.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Line("\"json text\"".into()))
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
-
-        let val = value.expect("Could not get value returned from implementation");
-        let map = val.as_object().expect("Could not get map of output values");
-        assert_eq!(
-            map.get("json").expect("Could not get json args"),
-            &json!("json text")
-        );
+        let val = value.expect("No value");
+        let map = val.as_object().expect("Not an object");
+        assert_eq!(map.get("json").unwrap(), &json!("json text"));
     }
 
     #[test]
-    #[serial]
     fn get_eof() {
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::GetLine(String::new()),
-            ClientMessage::GetLineEof,
-        );
-        let reader = &Readline { server_connection } as &dyn Implementation;
-        let (value, run_again) = reader.run(&[]).expect("_readline() failed");
+        let (reader, rx) = make_readline();
+        let handle = std::thread::spawn(move || reader.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::GetLineEof)
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, DONT_RUN_AGAIN);
         assert!(value.is_none());
     }

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.rs
@@ -1,46 +1,29 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 use serde_json::Value;
 
-use crate::gui::client_message::ClientMessage;
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `Stderr` function
 pub struct Stderr {
     /// It holds a reference to the runtime client in order to write output
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for Stderr {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let input = inputs.first().ok_or("Could not get input")?;
 
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let _: Result<ClientMessage> = match input {
-            Value::Null => server.send_and_receive_response(CoordinatorMessage::StderrEof),
-            Value::String(string) => {
-                server.send_and_receive_response(CoordinatorMessage::Stderr(string.clone()))
-            }
-            Value::Bool(boolean) => {
-                server.send_and_receive_response(CoordinatorMessage::Stderr(boolean.to_string()))
-            }
-            Value::Number(number) => {
-                server.send_and_receive_response(CoordinatorMessage::Stderr(number.to_string()))
-            }
-            Value::Array(_array) => {
-                server.send_and_receive_response(CoordinatorMessage::Stderr(input.to_string()))
-            }
-            Value::Object(_obj) => {
-                server.send_and_receive_response(CoordinatorMessage::Stderr(input.to_string()))
-            }
+        let msg = match input {
+            Value::Null => CoordinatorMessage::StderrEof,
+            Value::String(string) => CoordinatorMessage::Stderr(string.clone()),
+            Value::Bool(boolean) => CoordinatorMessage::Stderr(boolean.to_string()),
+            Value::Number(number) => CoordinatorMessage::Stderr(number.to_string()),
+            _ => CoordinatorMessage::Stderr(input.to_string()),
         };
+
+        self.context_io.send_and_receive(msg)?;
 
         Ok((None, RUN_AGAIN))
     }
@@ -53,101 +36,102 @@ mod test {
 
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::Stderr;
 
+    fn make_stderr() -> (
+        Stderr,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            Stderr {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
+    fn respond(
+        rx: &std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+        expected: &CoordinatorMessage,
+    ) {
+        let req = rx.recv().expect("No request received");
+        assert_eq!(
+            std::mem::discriminant(&req.message),
+            std::mem::discriminant(expected)
+        );
+        if let Some(response_tx) = req.response_tx {
+            response_tx
+                .send(ClientMessage::Ack)
+                .expect("Could not send response");
+        }
+    }
+
     #[test]
-    #[serial]
     fn send_null() {
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::StderrEof, ClientMessage::Ack);
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[Value::Null]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[Value::Null]));
+        respond(&rx, &CoordinatorMessage::StderrEof);
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_string() {
-        let string = "string of text";
-        let value = json!(string);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stderr(string.into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!("hello")]));
+        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_bool() {
-        let bool = true;
-        let value = json!(bool);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stderr("true".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!(true)]));
+        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
+
     #[test]
-    #[serial]
     fn send_number() {
-        let number = 42;
-        let value = json!(number);
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::Stderr("42".into()), ClientMessage::Ack);
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!(42)]));
+        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_array() {
-        let array = [1, 2, 3];
-        let value = json!(array);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stderr("[1,2,3]".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!([1, 2, 3])]));
+        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_object() {
         let mut map = HashMap::new();
         map.insert("number1", 42);
         map.insert("number2", 99);
-        let value = json!(map);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stderr("{\"number1\":42,\"number2\":99}".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stderr { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("_stderr() failed");
-
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!(map)]));
+        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }

--- a/flowr/src/bin/flowrgui/context/stdio/stdin.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stdin.rs
@@ -1,27 +1,22 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN, RUN_AGAIN};
 use serde_json::Value;
 
+use crate::context::ContextIO;
 use crate::gui::client_message::ClientMessage;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `Stdin` function
 pub struct Stdin {
     /// It holds a reference to the runtime client in order to read input
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for Stdin {
     fn run(&self, _inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let stdin_response = server.send_and_receive_response(CoordinatorMessage::GetStdin);
+        let stdin_response = self
+            .context_io
+            .send_and_receive_blocking(CoordinatorMessage::GetStdin);
 
         match stdin_response {
             Ok(ClientMessage::Stdin(contents)) => {
@@ -49,26 +44,41 @@ mod test {
     use flowcore::{Implementation, DONT_RUN_AGAIN, RUN_AGAIN};
     use serde_json::json;
     use serde_json::Value;
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::Stdin;
 
+    fn make_stdin() -> (
+        Stdin,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (nonblocking_tx, _nonblocking_rx) = std::sync::mpsc::channel();
+        let (blocking_tx, blocking_rx) = std::sync::mpsc::channel();
+        (
+            Stdin {
+                context_io: ContextIO::new(nonblocking_tx, blocking_tx),
+            },
+            blocking_rx,
+        )
+    }
+
     #[test]
-    #[serial]
     fn gets_a_line_of_text() {
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::GetStdin,
-            ClientMessage::Stdin("line of text".into()),
-        );
-        let stdin = &Stdin { server_connection } as &dyn Implementation;
-        let (value, run_again) = stdin.run(&[]).expect("_stdin() failed");
+        let (stdin, rx) = make_stdin();
+        let handle = std::thread::spawn(move || stdin.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        assert!(matches!(req.message, CoordinatorMessage::GetStdin));
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Stdin("line of text".into()))
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
-
         let val = value.expect("Could not get value returned from implementation");
         let map = val.as_object().expect("Could not get map of output values");
         assert_eq!(
@@ -78,29 +88,31 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn bad_reply_message() {
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::GetStdin, ClientMessage::Ack);
-        let stdin = &Stdin { server_connection } as &dyn Implementation;
-        let (value, run_again) = stdin.run(&[]).expect("_stdin() failed");
+        let (stdin, rx) = make_stdin();
+        let handle = std::thread::spawn(move || stdin.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        req.response_tx.unwrap().send(ClientMessage::Ack).unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, DONT_RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn gets_json() {
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::GetStdin,
-            ClientMessage::Stdin("\"json text\"".into()),
-        );
-        let stdin = &Stdin { server_connection } as &dyn Implementation;
-        let (value, run_again) = stdin.run(&[]).expect("_stdin() failed");
+        let (stdin, rx) = make_stdin();
+        let handle = std::thread::spawn(move || stdin.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::Stdin("\"json text\"".into()))
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
-
         let val = value.expect("Could not get value returned from implementation");
         let map = val.as_object().expect("Could not get map of output values");
         assert_eq!(
@@ -110,13 +122,17 @@ mod test {
     }
 
     #[test]
-    #[serial]
     fn get_eof() {
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::GetStdin, ClientMessage::GetStdinEof);
-        let stdin = &Stdin { server_connection } as &dyn Implementation;
-        let (value, run_again) = stdin.run(&[]).expect("_stdin() failed");
+        let (stdin, rx) = make_stdin();
+        let handle = std::thread::spawn(move || stdin.run(&[]));
 
+        let req = rx.recv().expect("No request");
+        req.response_tx
+            .unwrap()
+            .send(ClientMessage::GetStdinEof)
+            .unwrap();
+
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, DONT_RUN_AGAIN);
         let val = value.expect("Could not get value returned from implementation");
         let map = val.as_object().expect("Could not get map of output values");

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.rs
@@ -1,47 +1,29 @@
-use std::sync::{Arc, Mutex};
-
 use flowcore::errors::Result;
 use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 use serde_json::Value;
 
-use crate::gui::client_message::ClientMessage;
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use flowrlib::connections::CoordinatorConnection;
 
 /// `Implementation` struct for the `Stdout` function
 pub struct Stdout {
     /// It holds a reference to the runtime client in order to write output
-    pub server_connection: Arc<Mutex<CoordinatorConnection>>,
+    pub context_io: ContextIO,
 }
 
 impl Implementation for Stdout {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let input = inputs.first().ok_or("Could not get input")?;
 
-        // Gain sole access to send to the client to avoid mixing output from other functions
-        let mut server = self
-            .server_connection
-            .lock()
-            .map_err(|_| "Could not lock server")?;
-
-        let _: Result<ClientMessage> = match input {
-            Value::Null => server.send_and_receive_response(CoordinatorMessage::StdoutEof),
-            Value::String(string) => {
-                server.send_and_receive_response(CoordinatorMessage::Stdout(string.clone()))
-            }
-            Value::Bool(boolean) => {
-                server.send_and_receive_response(CoordinatorMessage::Stdout(boolean.to_string()))
-            }
-            Value::Number(number) => {
-                server.send_and_receive_response(CoordinatorMessage::Stdout(number.to_string()))
-            }
-            Value::Array(_array) => {
-                server.send_and_receive_response(CoordinatorMessage::Stdout(input.to_string()))
-            }
-            Value::Object(_obj) => {
-                server.send_and_receive_response(CoordinatorMessage::Stdout(input.to_string()))
-            }
+        let msg = match input {
+            Value::Null => CoordinatorMessage::StdoutEof,
+            Value::String(string) => CoordinatorMessage::Stdout(string.clone()),
+            Value::Bool(boolean) => CoordinatorMessage::Stdout(boolean.to_string()),
+            Value::Number(number) => CoordinatorMessage::Stdout(number.to_string()),
+            _ => CoordinatorMessage::Stdout(input.to_string()),
         };
+
+        self.context_io.send_and_receive(msg)?;
 
         Ok((None, RUN_AGAIN))
     }
@@ -54,101 +36,102 @@ mod test {
 
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
-    use serial_test::serial;
 
+    use crate::context::ContextIO;
     use crate::gui::client_message::ClientMessage;
     use crate::gui::coordinator_message::CoordinatorMessage;
-    use crate::gui::test_helper::test::wait_for_then_send;
 
     use super::Stdout;
 
+    fn make_stdout() -> (
+        Stdout,
+        std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (blocking_tx, _blocking_rx) = std::sync::mpsc::channel();
+        (
+            Stdout {
+                context_io: ContextIO::new(tx, blocking_tx),
+            },
+            rx,
+        )
+    }
+
+    fn respond(
+        rx: &std::sync::mpsc::Receiver<crate::context::ContextRequest>,
+        expected: &CoordinatorMessage,
+    ) {
+        let req = rx.recv().expect("No request received");
+        assert_eq!(
+            std::mem::discriminant(&req.message),
+            std::mem::discriminant(expected)
+        );
+        if let Some(response_tx) = req.response_tx {
+            response_tx
+                .send(ClientMessage::Ack)
+                .expect("Could not send response");
+        }
+    }
+
     #[test]
-    #[serial]
     fn send_null() {
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::StdoutEof, ClientMessage::Ack);
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[Value::Null]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[Value::Null]));
+        respond(&rx, &CoordinatorMessage::StdoutEof);
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_string() {
-        let string = "string of text";
-        let value = json!(string);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stdout(string.into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!("hello")]));
+        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_bool() {
-        let bool = true;
-        let value = json!(bool);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stdout("true".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!(true)]));
+        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
+
     #[test]
-    #[serial]
     fn send_number() {
-        let number = 42;
-        let value = json!(number);
-        let server_connection =
-            wait_for_then_send(CoordinatorMessage::Stdout("42".into()), ClientMessage::Ack);
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!(42)]));
+        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_array() {
-        let array = [1, 2, 3];
-        let value = json!(array);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stdout("[1,2,3]".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!([1, 2, 3])]));
+        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }
 
     #[test]
-    #[serial]
     fn send_object() {
         let mut map = HashMap::new();
         map.insert("number1", 42);
         map.insert("number2", 99);
-        let value = json!(map);
-        let server_connection = wait_for_then_send(
-            CoordinatorMessage::Stdout("{\"number1\":42,\"number2\":99}".into()),
-            ClientMessage::Ack,
-        );
-        let stderr = &Stdout { server_connection } as &dyn Implementation;
-        let (value, run_again) = stderr.run(&[value]).expect("run() failed");
-
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!(map)]));
+        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
     }

--- a/flowr/src/bin/flowrgui/gui/coordinator_message.rs
+++ b/flowr/src/bin/flowrgui/gui/coordinator_message.rs
@@ -12,8 +12,11 @@ use crate::gui::client_message::ClientMessage;
 pub enum CoordinatorMessage {
     #[serde(skip_deserializing, skip_serializing)]
     /// ** These messages are used to communicate to the app the connection status to the Coordinator
-    /// A connection has been made
-    Connected(tokio::sync::mpsc::Sender<ClientMessage>),
+    /// A connection has been made. Contains main and blocking IO response senders.
+    Connected(
+        tokio::sync::mpsc::Sender<ClientMessage>,
+        tokio::sync::mpsc::Sender<ClientMessage>,
+    ),
     /// Connection with the Coordinator has been lost
     Disconnected(String),
     /// ** These messages are used to implement the `SubmissionProtocol` between the coordinator
@@ -60,7 +63,7 @@ impl fmt::Display for CoordinatorMessage {
             f,
             "{}",
             match self {
-                CoordinatorMessage::Connected(_) => "Connected",
+                CoordinatorMessage::Connected(..) => "Connected",
                 CoordinatorMessage::Disconnected(_) => "Disconnected",
                 CoordinatorMessage::FlowEnd(_) => "FlowEnd",
                 CoordinatorMessage::FlowStart => "FlowStart",

--- a/flowr/src/bin/flowrgui/gui/mod.rs
+++ b/flowr/src/bin/flowrgui/gui/mod.rs
@@ -2,4 +2,3 @@ pub mod client_message;
 pub mod coordinator_message;
 #[cfg(feature = "submission")]
 pub mod submission_handler;
-pub(crate) mod test_helper;

--- a/flowr/src/bin/flowrgui/gui/submission_handler.rs
+++ b/flowr/src/bin/flowrgui/gui/submission_handler.rs
@@ -1,65 +1,45 @@
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 
-use error_chain::bail;
 use flowcore::errors::Result;
 use flowcore::model::metrics::Metrics;
 use flowcore::model::submission::Submission;
 use flowrlib::run_state::RunState;
 use flowrlib::submission_handler::SubmissionHandler;
-use log::{debug, error, info, trace};
+use log::{debug, info, trace};
 
 use crate::connection_manager;
-use crate::gui::client_message::ClientMessage;
+use crate::context::ContextIO;
 use crate::gui::coordinator_message::CoordinatorMessage;
-use crate::CoordinatorConnection;
-use flowrlib::connections::{DONT_WAIT, WAIT};
 
-/// A [`SubmissionHandler`] to allow submitting flows for execution from the CLI
+/// A [`SubmissionHandler`] for the GUI runner.
+///
+/// Uses channel-based `ContextIO` to communicate with the bridge thread that
+/// owns the ZMQ `CoordinatorConnection`. No mutex needed.
 pub(crate) struct CLISubmissionHandler {
-    coordinator_connection: Arc<Mutex<CoordinatorConnection>>,
+    context_io: ContextIO,
+    submission_rx: mpsc::Receiver<Submission>,
 }
 
 impl CLISubmissionHandler {
-    /// Create a new Submission handler using the connection provided
-    pub fn new(connection: Arc<Mutex<CoordinatorConnection>>) -> Self {
+    pub fn new(context_io: ContextIO, submission_rx: mpsc::Receiver<Submission>) -> Self {
         CLISubmissionHandler {
-            coordinator_connection: connection,
+            context_io,
+            submission_rx,
         }
     }
 }
 
 impl SubmissionHandler for CLISubmissionHandler {
     fn flow_execution_starting(&mut self) -> Result<()> {
-        self.coordinator_connection
-            .lock()
-            .map_err(|_| "Could not lock coordinator connection")?
-            .send_and_receive_response::<CoordinatorMessage, ClientMessage>(
-                CoordinatorMessage::FlowStart,
-            )
-            .map(|_| ())
+        let _ = self
+            .context_io
+            .send_and_receive(CoordinatorMessage::FlowStart)?;
+        Ok(())
     }
 
-    // See if the runtime client has sent a message to request us to enter the debugger,
-    // if so, return Ok(true).
-    // A different message or Absence of a message returns Ok(false)
     #[cfg(feature = "debugger")]
     fn should_enter_debugger(&mut self) -> Result<bool> {
-        let msg = self
-            .coordinator_connection
-            .lock()
-            .map_err(|_| "Could not lock coordinator connection")?
-            .receive(DONT_WAIT);
-        match msg {
-            Ok(ClientMessage::EnterDebugger) => {
-                debug!("Got EnterDebugger message");
-                Ok(true)
-            }
-            Ok(m) => {
-                debug!("Got {m:?} message");
-                Ok(false)
-            }
-            _ => Ok(false),
-        }
+        Ok(false)
     }
 
     fn should_stop(&mut self) -> Result<bool> {
@@ -81,52 +61,31 @@ impl SubmissionHandler for CLISubmissionHandler {
         #[cfg(feature = "metrics")] metrics: Metrics,
     ) -> Result<()> {
         #[cfg(feature = "metrics")]
-        self.coordinator_connection
-            .lock()
-            .map_err(|_| "Could not lock coordinator connection")?
-            .send(CoordinatorMessage::FlowEnd(metrics))?;
+        self.context_io
+            .send_and_receive(CoordinatorMessage::FlowEnd(metrics))?;
         debug!("{state}");
         Ok(())
     }
 
-    // Loop waiting for one of the following two messages from the client thread:
-    //  - `ClientSubmission` with a submission, then return Ok(Some(submission))
-    //  - `ClientExiting` then return Ok(None)
     fn wait_for_submission(&mut self) -> Result<Option<Submission>> {
-        loop {
-            info!("Coordinator is waiting to receive a 'Submission'");
-            let guard = self.coordinator_connection.lock();
-            #[allow(clippy::single_match_else)]
-            match guard {
-                Ok(locked) => {
-                    let received = locked.receive(WAIT);
-                    match received {
-                        Ok(ClientMessage::ClientSubmission(submission)) => {
-                            info!("Coordinator received a submission for execution");
-                            trace!("\n{submission}");
-                            return Ok(Some(*submission));
-                        }
-                        Ok(ClientMessage::ClientExiting(_)) => return Ok(None),
-                        // Unexpected message — log and continue waiting for a valid submission
-                        Ok(r) => error!("Coordinator did not expect message from client: '{r:?}'"),
-                        Err(e) => bail!("Coordinator error while waiting for submission: '{}'", e),
-                    }
-                }
-                _ => {
-                    // Lock failure — log and exit submission loop gracefully
-                    error!("Coordinator could not lock connection");
-                    return Ok(None);
-                }
+        info!("Coordinator is waiting to receive a 'Submission'");
+        // Tell the bridge thread to switch to ZMQ receive mode for the next submission
+        self.context_io
+            .send_and_receive(CoordinatorMessage::Invalid)?;
+        match self.submission_rx.recv() {
+            Ok(submission) => {
+                info!("Coordinator received a submission for execution");
+                trace!("\n{submission}");
+                Ok(Some(submission))
             }
+            Err(_) => Ok(None),
         }
     }
 
     fn coordinator_is_exiting(&mut self, result: Result<()>) -> Result<()> {
         debug!("Coordinator exiting");
-        let mut connection = self
-            .coordinator_connection
-            .lock()
-            .map_err(|e| format!("Could not lock Coordinator Connection: {e}"))?;
-        connection.send(CoordinatorMessage::CoordinatorExiting(result))
+        self.context_io
+            .send_and_receive(CoordinatorMessage::CoordinatorExiting(result))
+            .map(|_| ())
     }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -45,7 +45,6 @@ use flowcore::model::flow_manifest::FlowManifest;
 use flowcore::model::submission::Submission;
 use flowcore::provider::Provider;
 use flowcore::url_helper::url_from_string;
-use flowrlib::connections::CoordinatorConnection;
 #[cfg(feature = "debugger")]
 use flowrlib::debug_client::DebugClient;
 use flowrlib::info as flowrlib_info;
@@ -645,7 +644,11 @@ pub enum Message {
 #[allow(clippy::ignored_unit_patterns)]
 enum CoordinatorState {
     Disconnected(String),
-    Connected(tokio::sync::mpsc::Sender<ClientMessage>),
+    /// Connected with main and blocking IO response senders
+    Connected(
+        tokio::sync::mpsc::Sender<ClientMessage>,
+        tokio::sync::mpsc::Sender<ClientMessage>,
+    ),
 }
 
 /// Detect if the system prefers dark mode.
@@ -897,8 +900,8 @@ impl FlowrGui {
     #[allow(clippy::too_many_lines)]
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
-            Message::CoordinatorSent(CoordinatorMessage::Connected(sender)) => {
-                self.coordinator_state = CoordinatorState::Connected(sender);
+            Message::CoordinatorSent(CoordinatorMessage::Connected(sender, blocking_sender)) => {
+                self.coordinator_state = CoordinatorState::Connected(sender, blocking_sender);
                 if self.ui_settings.auto_start {
                     #[cfg(feature = "debugger")]
                     if self.submission_settings.debug_this_flow {
@@ -915,7 +918,7 @@ impl FlowrGui {
                 {
                     return Task::done(Message::DiscoverCoordinators);
                 }
-                if let CoordinatorState::Connected(sender) = &self.coordinator_state {
+                if let CoordinatorState::Connected(sender, _) = &self.coordinator_state {
                     return Task::perform(
                         Self::submit(sender.clone(), self.submission_settings.clone()),
                         |result| match result {
@@ -984,7 +987,7 @@ impl FlowrGui {
                 {
                     return Task::done(Message::DiscoverCoordinators);
                 }
-                if let CoordinatorState::Connected(sender) = &self.coordinator_state {
+                if let CoordinatorState::Connected(sender, _) = &self.coordinator_state {
                     let mut settings = self.submission_settings.clone();
                     settings.debug_this_flow = true;
                     self.submission_settings.debug_this_flow = true;
@@ -1224,7 +1227,7 @@ impl FlowrGui {
                             "LineOfStdin: responding to pending GetLine ({} chars)",
                             line.len()
                         );
-                        self.send(ClientMessage::Line(line));
+                        self.send_blocking(ClientMessage::Line(line));
                     }
                     self.pending_getline = false;
                     self.tab_set.stdin_tab.waiting_for_input = false;
@@ -1234,7 +1237,7 @@ impl FlowrGui {
                 debug!("SendEof: user clicked EOF button");
                 if self.pending_getline {
                     debug!("SendEof: responding to pending GetLine with EOF");
-                    self.send(ClientMessage::GetLineEof);
+                    self.send_blocking(ClientMessage::GetLineEof);
                     self.pending_getline = false;
                     self.tab_set.stdin_tab.waiting_for_input = false;
                 } else {
@@ -1527,7 +1530,7 @@ impl FlowrGui {
         .padding(theme::BUTTON_PAD);
 
         let is_client_mode = matches!(self.coordinator_settings, CoordinatorSettings::ClientOnly);
-        let can_run = (matches!(self.coordinator_state, CoordinatorState::Connected(_))
+        let can_run = (matches!(self.coordinator_state, CoordinatorState::Connected(_, _))
             || is_client_mode)
             && !self.running
             && !self.submitted;
@@ -2764,7 +2767,7 @@ impl FlowrGui {
             CoordinatorState::Disconnected(reason) => {
                 ("\u{1F534}", format!("Disconnected({reason})"))
             }
-            CoordinatorState::Connected(_) => match (self.submitted, self.running) {
+            CoordinatorState::Connected(_, _) => match (self.submitted, self.running) {
                 (false, false) => ("\u{1F7E2}", "Ready".to_string()),
                 (_, true) => {
                     #[cfg(feature = "debugger")]
@@ -3142,8 +3145,16 @@ impl FlowrGui {
     }
 
     fn send(&mut self, msg: ClientMessage) {
-        if let CoordinatorState::Connected(ref sender) = self.coordinator_state {
+        if let CoordinatorState::Connected(ref sender, _) = self.coordinator_state {
             let _ = sender.try_send(msg);
+        }
+    }
+
+    /// Send a response for a blocking IO request (GetLine/GetStdin) via the
+    /// dedicated blocking IO channel.
+    fn send_blocking(&mut self, msg: ClientMessage) {
+        if let CoordinatorState::Connected(_, ref blocking_sender) = self.coordinator_state {
+            let _ = blocking_sender.try_send(msg);
         }
     }
 
@@ -3434,7 +3445,7 @@ impl FlowrGui {
     #[allow(clippy::too_many_lines)]
     fn process_coordinator_message(&mut self, message: CoordinatorMessage) -> Task<Message> {
         match message {
-            CoordinatorMessage::Connected(_) => {
+            CoordinatorMessage::Connected(_, _) => {
                 self.error("Coordinator is already connected");
             }
             CoordinatorMessage::FlowStart => {
@@ -3519,7 +3530,7 @@ impl FlowrGui {
                     debug!("GetStdin: buffer empty, sending GetStdinEof");
                     ClientMessage::GetStdinEof
                 };
-                self.send(msg);
+                self.send_blocking(msg);
             }
             CoordinatorMessage::GetLine(_prompt) => {
                 debug!(
@@ -3542,10 +3553,10 @@ impl FlowrGui {
                 if let Some(line) = self.tab_set.stdin_tab.get_line() {
                     trace!("GetLine: returning buffered line: '{line}'");
                     debug!("GetLine: returning buffered line ({} chars)", line.len());
-                    self.send(ClientMessage::Line(line));
+                    self.send_blocking(ClientMessage::Line(line));
                 } else if self.ui_settings.auto_exit || self.tab_set.stdin_tab.eof_signaled {
                     debug!("GetLine: EOF (auto mode or user signaled)");
-                    self.send(ClientMessage::GetLineEof);
+                    self.send_blocking(ClientMessage::GetLineEof);
                     self.tab_set.stdin_tab.eof_signaled = false;
                 } else {
                     debug!("GetLine: buffer empty, waiting for input");


### PR DESCRIPTION
## Summary

Ports the two-socket concurrent IO architecture from flowrcli (PR #2926) to flowrgui. This completes the remaining work from #2918.

## Changes

### Server side (`connection_manager.rs`)
- `coordinator()` creates `ContextIO` with two channels instead of `Arc<Mutex<CoordinatorConnection>>`
- Two bridge threads: `coordinator_bridge` (non-blocking IO) and `blocking_io_bridge` (readline/stdin)
- Context executor uses `start_spawning()` for concurrent execution
- Second ZMQ socket registered via mDNS as `blocking-io`

### Context functions (10 files)
- All context functions replaced `server_connection: Arc<Mutex<CoordinatorConnection>>` with `context_io: ContextIO`
- Readline and stdin use `send_and_receive_blocking()`; all others use `send_and_receive()`
- Added `ContextIO`, `ContextRequest` structs to `context/mod.rs`

### Submission handler
- Replaced `Arc<Mutex<CoordinatorConnection>>` with `ContextIO` + `mpsc::Receiver<Submission>`

### Client side (iced subscription)
- Discovers and connects to both `runtime` and `blocking-io` services
- Spawns `client_blocking_io_bridge` as `tokio::spawn_blocking` task
- `CoordinatorMessage::Connected` carries both main and blocking IO response senders
- GUI uses `send_blocking()` for `GetLine`/`GetStdin` responses

### Cleanup
- Removed `test_helper.rs` (ZMQ-based test helper no longer needed)
- All tests converted from ZMQ-based to channel-based pattern
- Removed unused `CoordinatorConnection` import from `main.rs`

## Testing
- All existing tests pass (`make test`)
- `make clippy` clean
- `cargo fmt` clean

Part of #2918