### PR TITLE
Use flowcore route parsing in SVG renderer (#2893)

### DIFF
--- a/flowc/src/lib/graph/renderer.rs
+++ b/flowc/src/lib/graph/renderer.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use svg::node::element::{Group, Style};
 use svg::Document;
 
-use flowcore::graph::layout::{connection_label, split_route};
+use flowcore::graph::layout::{base_port_name, connection_label, derive_short_name, split_route};
 use flowcore::graph::style::NodeCategory;
 use flowcore::model::connection::Connection;
 use flowcore::model::flow_definition::FlowDefinition;
@@ -430,7 +430,7 @@ fn render_connection(
 
     // Resolve source position: boundary input port or internal node output
     let (x1, y1) = if from_node == "input" {
-        let port_base = from_port.split('/').next().unwrap_or(&from_port);
+        let port_base = base_port_name(&from_port);
         if let Some((x, y)) = boundary_ports.and_then(|bp| bp.inputs.get(port_base)) {
             (*x, *y)
         } else {
@@ -440,7 +440,7 @@ fn render_connection(
         let Some(from_layout) = layouts.get(&from_node) else {
             return group;
         };
-        let port_base = from_port.split('/').next().unwrap_or(&from_port);
+        let port_base = base_port_name(&from_port);
         let from_port_idx = from_layout
             .outputs
             .iter()
@@ -458,7 +458,7 @@ fn render_connection(
 
         // Resolve destination position: boundary output port or internal node input
         let (x2, y2) = if to_node == "output" {
-            let to_port_base = to_port.split('/').next().unwrap_or(&to_port);
+            let to_port_base = base_port_name(&to_port);
             if let Some((x, y)) = boundary_ports.and_then(|bp| bp.outputs.get(to_port_base)) {
                 (*x, *y)
             } else {
@@ -468,7 +468,7 @@ fn render_connection(
             let Some(to_layout) = layouts.get(&to_node) else {
                 continue;
             };
-            let to_port_base = to_port.split('/').next().unwrap_or(&to_port);
+            let to_port_base = base_port_name(&to_port);
             let to_port_idx = to_layout
                 .inputs
                 .iter()
@@ -529,7 +529,7 @@ fn render_initializers(
     let loopback_clearance = node_loopbacks as f32 * 25.0;
 
     for (input_path, initializer) in &pr.initializations {
-        let port_name = input_path.rsplit('/').next().unwrap_or(input_path);
+        let port_name = &derive_short_name(input_path);
         let port_idx = layout
             .inputs
             .iter()

--- a/flowcore/src/graph/layout.rs
+++ b/flowcore/src/graph/layout.rs
@@ -86,6 +86,20 @@ pub fn derive_short_name(source: &str) -> String {
     source.rsplit('/').next().unwrap_or(source).to_string()
 }
 
+/// Extract the base port name, stripping any trailing array index.
+///
+/// Uses [`Route::is_array_selector`][crate::model::route::Route::is_array_selector]
+/// to detect numeric array selectors properly, so `"string/1"` becomes `"string"`
+/// but `"array/number"` is left unchanged.
+#[must_use]
+pub fn base_port_name(port: &str) -> &str {
+    if crate::model::route::Route::from(port).is_array_selector() {
+        port.rsplit_once('/').map_or(port, |(base, _)| base)
+    } else {
+        port
+    }
+}
+
 /// Split a route like `"sequence/number"` into `("sequence", "number")`.
 #[must_use]
 pub fn split_route(route: &str) -> (String, String) {
@@ -522,6 +536,31 @@ mod test {
         let h_few = compute_node_height(2, 1);
         let h_many = compute_node_height(10, 1);
         assert!(h_many > h_few);
+    }
+
+    #[test]
+    fn base_port_name_strips_array_index() {
+        assert_eq!(base_port_name("string/1"), "string");
+    }
+
+    #[test]
+    fn base_port_name_preserves_non_array_subroute() {
+        assert_eq!(base_port_name("array/number"), "array/number");
+    }
+
+    #[test]
+    fn base_port_name_simple_name_unchanged() {
+        assert_eq!(base_port_name("value"), "value");
+    }
+
+    #[test]
+    fn base_port_name_empty_string() {
+        assert_eq!(base_port_name(""), "");
+    }
+
+    #[test]
+    fn base_port_name_deep_array_index() {
+        assert_eq!(base_port_name("json/2"), "json");
     }
 
     #[test]

--- a/flowedit/src/utils.rs
+++ b/flowedit/src/utils.rs
@@ -80,13 +80,9 @@ pub(crate) fn truncate_source(source: &str, max_len: usize) -> String {
 }
 
 /// Extract the base port name, stripping any trailing array index.
-/// Uses flowcore's Route to detect array selectors properly.
+/// Delegates to the shared implementation in flowcore.
 pub(crate) fn base_port_name(port: &str) -> &str {
-    if Route::from(port).is_array_selector() {
-        port.rsplit_once('/').map_or(port, |(base, _)| base)
-    } else {
-        port
-    }
+    flowcore::graph::layout::base_port_name(port)
 }
 
 /// Build a rounded rectangle path using quadratic bezier curves at corners.


### PR DESCRIPTION
## Summary

Replaces ad-hoc string splitting in the SVG graph renderer with shared utilities from `flowcore::graph::layout`, as requested in #2893.

## Changes

### `flowcore/src/graph/layout.rs`
- Added `base_port_name(port)`: extracts the base port name by stripping trailing array indices. Uses `Route::is_array_selector()` to correctly distinguish `"string/1"` (array index, strip) from `"array/number"` (type path, keep). Previously this logic existed only in flowedit.
- Added 5 unit tests for `base_port_name`.

### `flowc/src/lib/graph/renderer.rs`
- Replaced 4 occurrences of `port.split('/').next().unwrap_or(&port)` with `base_port_name(&port)` (lines 433, 443, 461, 471).
- Replaced 1 occurrence of `input_path.rsplit('/').next().unwrap_or(input_path)` with `derive_short_name(input_path)` (line 532).

### `flowedit/src/utils.rs`
- `base_port_name()` now delegates to `flowcore::graph::layout::base_port_name()` instead of reimplementing the logic locally.

## Testing
- `make test` passes
- `make clippy` clean
- `cargo fmt` clean

Closes #2893