### PR TITLE
Additional WASM size optimizations (#1609)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,6 @@ jobs:
 
       - name: InstallWasmTools
         run: |
-          which wasm-gc || cargo install wasm-gc
           which wasm-snip || cargo install wasm-snip
 
       - name: cargo-build-flowc
@@ -169,7 +168,6 @@ jobs:
       - name: InstallWasmTools
         shell: bash
         run: |
-          which wasm-gc || cargo install wasm-gc
           which wasm-snip || cargo install wasm-snip
 
       - name: ConfigureCoverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           rm -rf binaryen-${BINARYEN_VERSION} binaryen.tar.gz
 
       - name: Install WASM tools
-        run: cargo install wasm-gc wasm-snip
+        run: cargo install wasm-snip
 
       - name: Install cargo-packager
         run: cargo install cargo-packager --locked

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 	@cargo install mdbook
 	@cargo install mdbook-linkcheck
 	@echo "installing wasm optimization tools"
-	@cargo install wasm-gc wasm-snip
+	@cargo install wasm-snip
 
 .PHONY: clean_examples
 clean_examples:

--- a/flowr/examples/fft/fft_compute/Cargo.toml
+++ b/flowr/examples/fft/fft_compute/Cargo.toml
@@ -12,9 +12,9 @@ path = "fft_compute.rs"
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's'
+opt-level = 'z'
 panic = 'abort'
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/fft/fft_compute/function.toml
+++ b/flowr/examples/fft/fft_compute/function.toml
@@ -12,9 +12,9 @@ path = "fft_compute.rs"
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's'
+opt-level = 'z'
 panic = 'abort'
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/game-of-life/game_step/Cargo.toml
+++ b/flowr/examples/game-of-life/game_step/Cargo.toml
@@ -13,9 +13,9 @@ path = "game_step.rs"
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's'
+opt-level = 'z'
 panic = 'abort'
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/game-of-life/game_step/function.toml
+++ b/flowr/examples/game-of-life/game_step/function.toml
@@ -13,9 +13,9 @@ path = "game_step.rs"
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's'
+opt-level = 'z'
 panic = 'abort'
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/hamming/hamming_step/function.toml
+++ b/flowr/examples/hamming/hamming_step/function.toml
@@ -13,9 +13,9 @@ path = "hamming_step.rs"
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's'
+opt-level = 'z'
 panic = 'abort'
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/mandlebrot/escapes/function.toml
+++ b/flowr/examples/mandlebrot/escapes/function.toml
@@ -8,15 +8,14 @@ edition = "2021"
 name = "escapes"
 crate-type = ["cdylib"]
 path = "escapes.rs"
-rustflags = ["-C", "link-arg=--gc-sections"]
 
 [profile.release]
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's' # Optimize for size
+opt-level = 'z' # Optimize for size
 panic = 'abort' # About unwinding code
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowr/examples/mandlebrot/pixel_to_point/function.toml
+++ b/flowr/examples/mandlebrot/pixel_to_point/function.toml
@@ -8,15 +8,14 @@ edition = "2021"
 name = "pixel_to_point"
 crate-type = ["cdylib"]
 path = "pixel_to_point.rs"
-rustflags = ["-C", "link-arg=--gc-sections"]
 
 [profile.release]
 debug = false
 lto = true
 codegen-units = 1
-opt-level = 's' # Optimize for size
+opt-level = 'z' # Optimize for size
 panic = 'abort' # About unwinding code
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 flowcore = {path = "../../../../flowcore", version = "1"}

--- a/flowstdlib/lib.toml
+++ b/flowstdlib/lib.toml
@@ -66,7 +66,8 @@ flowmacro = {path = "../../flowmacro", version = "1"}
 serde_json = { version = "1.0", default-features = false }
 
 [profile.release]
-opt-level = "s"
+opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
+panic = "abort"


### PR DESCRIPTION
Applies size optimization techniques from min-sized-rust. Measured 16.1% reduction across flowstdlib WASM modules.

Changes:
- opt-level s to z (more aggressive size opt)
- Add panic=abort to flowstdlib lib.toml (eliminates unwinding code)
- Standardize strip=true across all WASM builds
- Remove unused wasm-gc from Makefile/CI install
- Remove dead rustflags from mandlebrot function.toml

flowstdlib results (43 modules):
  Before: 3,573,845 bytes (81.2 KB avg)
  After:  2,997,111 bytes (68.1 KB avg)
  Reduction: 16.1%

Closes #1609