### PR TITLE
Add tests for flowrgui coverage gaps (#2931)

### DIFF
--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -2298,3 +2298,168 @@ fn format_output_connection(
     }
     b.finish()
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn stop_request_default_is_false() {
+        // Clear any state from other tests
+        STOP_REQUESTED.store(false, Ordering::Relaxed);
+        assert!(!take_stop_request());
+    }
+
+    #[test]
+    fn stop_request_roundtrip() {
+        request_stop();
+        assert!(take_stop_request(), "Should be true after request_stop()");
+        assert!(!take_stop_request(), "Should be false after being consumed");
+    }
+
+    #[test]
+    fn discovered_address_default_is_none() {
+        // Clear any state from other tests
+        if let Ok(mut guard) = DISCOVERED_ADDRESS.write() {
+            *guard = None;
+        }
+        assert!(!has_discovered_address());
+        assert!(take_discovered_address().is_none());
+    }
+
+    #[test]
+    fn discovered_address_roundtrip() {
+        set_discovered_address("tcp://localhost:5555".to_string());
+        assert!(has_discovered_address());
+        let addr = take_discovered_address();
+        assert_eq!(addr.as_deref(), Some("tcp://localhost:5555"));
+        assert!(
+            !has_discovered_address(),
+            "Should be gone after being taken"
+        );
+    }
+
+    #[test]
+    fn job_count_default_is_zero() {
+        JOB_COUNT.store(0, Ordering::Relaxed);
+        assert_eq!(get_job_count(), 0);
+    }
+
+    #[test]
+    fn job_count_roundtrip() {
+        set_job_count(42);
+        assert_eq!(get_job_count(), 42);
+        set_job_count(0);
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_cli_references() {
+        let input = "Use the 'b' command to set a breakpoint. Use 'h' for help.";
+        let output = rewrite_for_gui(input);
+        assert_eq!(output, "Use the 'Set BP' button to set a breakpoint.");
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_inspect_reference() {
+        let input = "Use 'i n' or 'inspect n' to inspect the function number 'n'";
+        let output = rewrite_for_gui(input);
+        assert_eq!(
+            output,
+            "Enter a function number in the spec field and click 'Inspect'"
+        );
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_reset_reference() {
+        let input = "Cannot run a process mid-execution. Reset first with 'r'.";
+        let output = rewrite_for_gui(input);
+        assert_eq!(
+            output,
+            "Cannot run a process mid-execution. Click Reset first."
+        );
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_break_reference() {
+        let input = "'break' command must specify a breakpoint";
+        let output = rewrite_for_gui(input);
+        assert_eq!(output, "A breakpoint target must be specified");
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_step_reference() {
+        let input = "To break on every Function, you can just single step using 's' command";
+        let output = rewrite_for_gui(input);
+        assert_eq!(output, "To break on every Function, use the Step button");
+    }
+
+    #[test]
+    fn rewrite_for_gui_replaces_run_args_reference() {
+        let input = "Supply them as arguments: r <target> <val1> <val2> ...";
+        let output = rewrite_for_gui(input);
+        assert_eq!(
+            output,
+            "Fill in values in the input panel and click Execute."
+        );
+    }
+
+    #[test]
+    fn rewrite_for_gui_passthrough_unmatched() {
+        let input = "some other message";
+        let output = rewrite_for_gui(input);
+        assert_eq!(output, "some other message");
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn state_label_maps_all_variants() {
+        use flowrlib::run_state::State;
+        assert_eq!(state_label(&State::Ready), "ready");
+        assert_eq!(state_label(&State::Waiting), "waiting");
+        assert_eq!(state_label(&State::Running), "running");
+        assert_eq!(state_label(&State::Completed), "completed");
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn state_link_type_maps_all_variants() {
+        use flowrlib::run_state::State;
+        assert_eq!(state_link_type(&State::Ready), crate::LinkType::StateReady);
+        assert_eq!(
+            state_link_type(&State::Waiting),
+            crate::LinkType::StateWaiting
+        );
+        assert_eq!(
+            state_link_type(&State::Running),
+            crate::LinkType::StateRunning
+        );
+        assert_eq!(
+            state_link_type(&State::Completed),
+            crate::LinkType::StateCompleted
+        );
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn debug_port_default_is_zero() {
+        assert_eq!(get_debug_port(), 0);
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn last_output_inspect_pid_default_is_none() {
+        LAST_OUTPUT_INSPECT_PID.store(usize::MAX, Ordering::Relaxed);
+        assert!(take_last_output_inspect_pid().is_none());
+    }
+
+    #[cfg(feature = "debugger")]
+    #[test]
+    fn last_output_inspect_pid_roundtrip() {
+        set_last_output_inspect_pid(7);
+        assert_eq!(take_last_output_inspect_pid(), Some(7));
+        assert!(
+            take_last_output_inspect_pid().is_none(),
+            "Should be consumed after take"
+        );
+    }
+}

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -2462,4 +2462,418 @@ mod test {
             "Should be consumed after take"
         );
     }
+
+    #[cfg(feature = "debugger")]
+    #[allow(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::single_char_pattern
+    )]
+    mod format_debug_event_tests {
+        use serde_json::json;
+        use url::Url;
+
+        use flowcore::model::debug_command::BreakpointSpec;
+        use flowcore::model::input::Input;
+        use flowcore::model::output_connection::{OutputConnection, Source};
+        use flowcore::model::runtime_function::RuntimeFunction;
+        use flowrlib::debug_server_message::DebugServerMessage;
+        use flowrlib::job::{Job, Payload};
+
+        use super::format_debug_event;
+
+        fn test_job() -> Job {
+            Job {
+                process_id: 3,
+                parent_id: 0,
+                function_name: "add".to_string(),
+                payload: Payload {
+                    job_id: 42,
+                    input_set: vec![json!(1), json!(2)],
+                    implementation_url: Url::parse("lib://flowstdlib/math/add")
+                        .expect("Could not parse Url"),
+                },
+                result: Ok((Some(json!(3)), true)),
+                connections: vec![],
+                ttl: None,
+                attempt: 1,
+            }
+        }
+
+        fn test_function() -> RuntimeFunction {
+            RuntimeFunction::new(
+                "add",
+                "/root/add",
+                "lib://flowstdlib/math/add",
+                vec![Input::new("a", 0, false, None, None)],
+                5,
+                0,
+                &[],
+                false,
+            )
+        }
+
+        #[test]
+        fn job_completed_contains_job_and_function_ids() {
+            let lines = format_debug_event(&DebugServerMessage::JobCompleted(test_job()));
+            assert!(!lines.is_empty());
+            assert!(lines[0].text.contains("job #42"));
+            assert!(lines[0].text.contains("function #3"));
+            assert!(lines[0].text.contains("completed by"));
+        }
+
+        #[test]
+        fn job_completed_shows_output_value() {
+            let lines = format_debug_event(&DebugServerMessage::JobCompleted(test_job()));
+            assert!(lines.len() >= 2, "Should have output line");
+            assert!(lines[1].text.contains("Output:"));
+            assert!(lines[1].text.contains('3'));
+        }
+
+        #[test]
+        fn job_completed_no_output_line_when_none() {
+            let mut job = test_job();
+            job.result = Ok((None, true));
+            let lines = format_debug_event(&DebugServerMessage::JobCompleted(job));
+            assert_eq!(lines.len(), 1, "No output line when result is None");
+        }
+
+        #[test]
+        fn prior_to_sending_job_contains_ids() {
+            let lines = format_debug_event(&DebugServerMessage::PriorToSendingJob(test_job()));
+            assert_eq!(lines.len(), 2);
+            assert!(lines[0].text.contains("job #42"));
+            assert!(lines[0].text.contains("function #3"));
+            assert!(lines[1].text.contains("Inputs:"));
+        }
+
+        #[test]
+        fn job_error_contains_ids() {
+            let lines = format_debug_event(&DebugServerMessage::JobError(test_job()));
+            assert!(!lines.is_empty());
+            assert!(lines[0].text.contains("Error"));
+            assert!(lines[0].text.contains("job #42"));
+        }
+
+        #[test]
+        fn panic_contains_message_and_count() {
+            let lines =
+                format_debug_event(&DebugServerMessage::Panic("division by zero".into(), 10));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("division by zero"));
+            assert!(lines[0].text.contains("10"));
+        }
+
+        #[test]
+        fn deadlock_contains_message() {
+            let lines = format_debug_event(&DebugServerMessage::Deadlock("cycle detected".into()));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("cycle detected"));
+        }
+
+        #[test]
+        fn error_rewrites_for_gui() {
+            let lines = format_debug_event(&DebugServerMessage::Error(
+                "'break' command must specify a breakpoint".into(),
+            ));
+            assert_eq!(lines.len(), 1);
+            assert!(
+                lines[0].text.contains("target must be specified"),
+                "Should rewrite CLI message for GUI"
+            );
+        }
+
+        #[test]
+        fn message_rewrites_for_gui() {
+            let lines = format_debug_event(&DebugServerMessage::Message(
+                "Use the 'b' command to set a breakpoint. Use 'h' for help.".into(),
+            ));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("Set BP"));
+        }
+
+        #[test]
+        fn entering_debugger_returns_empty() {
+            let lines = format_debug_event(&DebugServerMessage::EnteringDebugger);
+            assert!(lines.is_empty());
+        }
+
+        #[test]
+        fn exiting_debugger_returns_message() {
+            let lines = format_debug_event(&DebugServerMessage::ExitingDebugger);
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("exiting"));
+        }
+
+        #[test]
+        fn execution_started() {
+            let lines = format_debug_event(&DebugServerMessage::ExecutionStarted);
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("Running"));
+        }
+
+        #[test]
+        fn execution_ended() {
+            let lines = format_debug_event(&DebugServerMessage::ExecutionEnded);
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("completed"));
+        }
+
+        #[test]
+        fn resetting() {
+            let lines = format_debug_event(&DebugServerMessage::Resetting);
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("Resetting"));
+        }
+
+        #[test]
+        fn invalid_returns_error() {
+            let lines = format_debug_event(&DebugServerMessage::Invalid);
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("Invalid"));
+        }
+
+        #[test]
+        fn sending_value_contains_ids_and_value() {
+            let lines = format_debug_event(&DebugServerMessage::SendingValue(1, json!(42), 2, 0));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #1"));
+            assert!(lines[0].text.contains("function #2"));
+            assert!(lines[0].text.contains("42"));
+        }
+
+        #[test]
+        fn flow_unblock_breakpoint_contains_flow_id() {
+            let lines = format_debug_event(&DebugServerMessage::FlowUnblockBreakpoint(7));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("flow #7"));
+            assert!(lines[0].text.contains("idle"));
+        }
+
+        #[test]
+        fn waiting_for_command_contains_job_id() {
+            let lines = format_debug_event(&DebugServerMessage::WaitingForCommand(99));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("job #99"));
+        }
+
+        #[test]
+        fn data_breakpoint_contains_all_fields() {
+            let lines = format_debug_event(&DebugServerMessage::DataBreakpoint(
+                "source_fn".into(),
+                1,
+                "/output".into(),
+                json!(42),
+                2,
+                "dest_fn".into(),
+                "input_a".into(),
+                0,
+            ));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #1"));
+            assert!(lines[0].text.contains("function #2"));
+            assert!(lines[0].text.contains("42"));
+        }
+
+        #[test]
+        fn functions_list_produces_line_per_function() {
+            let funcs = vec![test_function()];
+            let lines = format_debug_event(&DebugServerMessage::Functions(funcs));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #5"));
+        }
+
+        #[test]
+        fn function_states_shows_entity_and_states() {
+            let func = test_function();
+            let states = vec![flowrlib::run_state::State::Ready];
+            let lines =
+                format_debug_event(&DebugServerMessage::FunctionStates((func, states, vec![])));
+            assert!(!lines.is_empty());
+            assert!(lines[0].text.contains("function #5"));
+            assert!(lines[0].text.contains("ready"));
+        }
+
+        #[test]
+        fn function_states_with_blockers() {
+            let func = test_function();
+            let states = vec![flowrlib::run_state::State::Waiting];
+            let lines = format_debug_event(&DebugServerMessage::FunctionStates((
+                func,
+                states,
+                vec![1, 2],
+            )));
+            assert!(lines.len() >= 2);
+            assert!(lines[1].text.contains("Waiting for"));
+            assert!(lines[1].text.contains("function #1"));
+            assert!(lines[1].text.contains("function #2"));
+        }
+
+        #[test]
+        fn flow_list_returns_empty() {
+            let lines = format_debug_event(&DebugServerMessage::FlowList(vec![]));
+            assert!(lines.is_empty());
+        }
+
+        #[test]
+        fn breakpoint_list_empty_returns_empty() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![]));
+            assert!(lines.is_empty());
+        }
+
+        #[test]
+        fn breakpoint_list_numeric() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![
+                BreakpointSpec::Numeric(3),
+            ]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #3"));
+        }
+
+        #[test]
+        fn breakpoint_list_completed() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![
+                BreakpointSpec::Completed(5),
+            ]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #5"));
+        }
+
+        #[test]
+        fn breakpoint_list_input() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![
+                BreakpointSpec::Input((2, 1)),
+            ]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("input:1"));
+            assert!(lines[0].text.contains("function #2"));
+        }
+
+        #[test]
+        fn breakpoint_list_output() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![
+                BreakpointSpec::Output((4, "/value".into())),
+            ]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("output '/value'"));
+            assert!(lines[0].text.contains("function #4"));
+        }
+
+        #[test]
+        fn breakpoint_list_route() {
+            let lines = format_debug_event(&DebugServerMessage::BreakpointList(vec![
+                BreakpointSpec::Route("/root/add".into()),
+            ]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("/root/add"));
+        }
+
+        #[test]
+        fn input_state_empty() {
+            let input = Input::new("value", 0, false, None, None);
+            let lines = format_debug_event(&DebugServerMessage::InputState(input));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("no values queued"));
+        }
+
+        #[test]
+        fn output_state_empty() {
+            let lines = format_debug_event(&DebugServerMessage::OutputState(vec![]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("No output connections"));
+        }
+
+        #[test]
+        fn output_state_with_connection() {
+            let conn = OutputConnection::new(
+                Source::default(),
+                2,
+                0,
+                0,
+                true,
+                "/dest".to_string(),
+                String::default(),
+            );
+            // Clear the last output inspect PID so it returns None
+            super::LAST_OUTPUT_INSPECT_PID.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
+            let lines = format_debug_event(&DebugServerMessage::OutputState(vec![conn]));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].text.contains("function #2"));
+        }
+
+        #[cfg(feature = "metrics")]
+        #[test]
+        fn execution_metrics_returns_empty() {
+            let metrics = flowcore::model::metrics::Metrics::new(0, 0);
+            let lines = format_debug_event(&DebugServerMessage::ExecutionMetrics(metrics));
+            assert!(lines.is_empty());
+        }
+
+        fn test_run_state() -> flowrlib::run_state::RunState {
+            use flowcore::model::flow_manifest::FlowManifest;
+            use flowcore::model::metadata::MetaData;
+            use flowcore::model::submission::Submission;
+
+            let metadata = MetaData {
+                name: "test".into(),
+                version: "0.0.0".into(),
+                description: "a test".into(),
+                authors: vec!["me".into()],
+            };
+            let mut manifest = FlowManifest::new(metadata);
+            manifest.add_function(test_function());
+            let submission = Submission::new(manifest, None, None, false);
+            flowrlib::run_state::RunState::new(submission)
+        }
+
+        #[test]
+        fn overall_state_produces_lines() {
+            let state = test_run_state();
+            let lines = format_debug_event(&DebugServerMessage::OverallState(state));
+            assert!(!lines.is_empty());
+        }
+
+        #[test]
+        fn inspect_function_produces_lines() {
+            let state = test_run_state();
+            let lines = format_debug_event(&DebugServerMessage::InspectFunction(5, state));
+            assert!(!lines.is_empty());
+            assert!(
+                lines.iter().any(|l| l.text.contains("5")),
+                "Should reference function #5"
+            );
+        }
+
+        #[test]
+        fn inspect_flow_produces_lines() {
+            let state = test_run_state();
+            let lines = format_debug_event(&DebugServerMessage::InspectFlow(0, state));
+            assert!(!lines.is_empty());
+        }
+
+        #[test]
+        fn process_tree_does_not_panic() {
+            super::STATES_ONLY.store(false, std::sync::atomic::Ordering::Relaxed);
+            super::FLOWS_ONLY.store(false, std::sync::atomic::Ordering::Relaxed);
+            let state = test_run_state();
+            // With a single function and no flow hierarchy, tree may be empty
+            let _lines = format_debug_event(&DebugServerMessage::ProcessTree(state));
+        }
+
+        #[test]
+        fn inspect_by_state_waiting() {
+            let state = test_run_state();
+            let lines =
+                format_debug_event(&DebugServerMessage::InspectByState("waiting".into(), state));
+            assert!(!lines.is_empty());
+        }
+
+        #[test]
+        fn job_inspect_produces_lines() {
+            let lines = format_debug_event(&DebugServerMessage::JobInspect(test_job()));
+            assert!(!lines.is_empty());
+            assert!(lines[0].text.contains("job #42"));
+        }
+    }
 }

--- a/flowr/src/bin/flowrgui/context/mod.rs
+++ b/flowr/src/bin/flowrgui/context/mod.rs
@@ -150,3 +150,85 @@ pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {
 
     Ok(manifest)
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod test {
+    use super::*;
+
+    fn test_context_io() -> ContextIO {
+        let (tx, _) = mpsc::channel();
+        let (blocking_tx, _) = mpsc::channel();
+        ContextIO::new(tx, blocking_tx)
+    }
+
+    #[test]
+    fn context_io_clone_works() {
+        let io = test_context_io();
+        let _clone = io.clone();
+    }
+
+    #[test]
+    fn send_and_receive_error_on_disconnected_channel() {
+        let (tx, rx) = mpsc::channel();
+        let (blocking_tx, blocking_rx) = mpsc::channel();
+        let io = ContextIO::new(tx, blocking_tx);
+
+        // Drop receivers to simulate disconnected channels
+        drop(rx);
+        drop(blocking_rx);
+
+        let result = io.send_and_receive(CoordinatorMessage::FlowStart);
+        assert!(result.is_err(), "Should fail on disconnected channel");
+    }
+
+    #[test]
+    fn send_and_receive_blocking_error_on_disconnected_channel() {
+        let (tx, _) = mpsc::channel();
+        let (blocking_tx, blocking_rx) = mpsc::channel();
+        let io = ContextIO::new(tx, blocking_tx);
+
+        drop(blocking_rx);
+
+        let result = io.send_and_receive_blocking(CoordinatorMessage::FlowStart);
+        assert!(
+            result.is_err(),
+            "Should fail on disconnected blocking channel"
+        );
+    }
+
+    #[test]
+    fn get_manifest_returns_all_context_functions() {
+        let io = test_context_io();
+        let manifest = get_manifest(io).expect("Could not create manifest");
+        let locators = &manifest.locators;
+
+        let expected = [
+            "context://args/get",
+            "context://file/file_write",
+            "context://file/file_read",
+            "context://image/image_buffer",
+            "context://image/image_read",
+            "context://image/image_write",
+            "context://stdio/readline",
+            "context://stdio/stdin",
+            "context://stdio/stdout",
+            "context://stdio/stderr",
+        ];
+
+        for url_str in &expected {
+            let url = Url::parse(url_str).expect("Could not parse URL");
+            assert!(
+                locators.contains_key(&url),
+                "Missing context function: {url_str}"
+            );
+        }
+
+        assert_eq!(
+            locators.len(),
+            expected.len(),
+            "Should have exactly {} context functions",
+            expected.len()
+        );
+    }
+}

--- a/flowr/src/bin/flowrgui/state_diagram.rs
+++ b/flowr/src/bin/flowrgui/state_diagram.rs
@@ -464,3 +464,152 @@ pub(crate) fn canvas_height(data: &StateDiagramData) -> f32 {
         500.0
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod test {
+    use super::*;
+
+    fn empty_data() -> StateDiagramData {
+        StateDiagramData {
+            waiting_ids: vec![],
+            ready_ids: vec![],
+            running_ids: vec![],
+            completed_ids: vec![],
+            cached_functions: vec![],
+        }
+    }
+
+    fn sample_data() -> StateDiagramData {
+        StateDiagramData {
+            waiting_ids: vec![0, 1, 2],
+            ready_ids: vec![3],
+            running_ids: vec![4, 5],
+            completed_ids: vec![],
+            cached_functions: vec![],
+        }
+    }
+
+    #[test]
+    fn state_box_empty_has_minimum_height() {
+        let sb = StateBox::new("Test", Color::WHITE, vec![], 0.0);
+        assert!((sb.height - BOX_H_MIN).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn state_box_with_chips_is_taller() {
+        let sb = StateBox::new("Test", Color::WHITE, vec![1, 2, 3], 0.0);
+        assert!(sb.height > BOX_H_MIN);
+    }
+
+    #[test]
+    fn state_box_bottom_equals_y_plus_height() {
+        let sb = StateBox::new("Test", Color::WHITE, vec![1], 10.0);
+        assert!((sb.bottom() - (10.0 + sb.height)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn state_box_rect_position_and_size() {
+        let sb = StateBox::new("Test", Color::WHITE, vec![], 50.0);
+        let r = sb.rect();
+        assert!((r.x - LEFT_X).abs() < f32::EPSILON);
+        assert!((r.y - 50.0).abs() < f32::EPSILON);
+        assert!((r.width - BOX_W).abs() < f32::EPSILON);
+        assert!((r.height - sb.height).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn build_boxes_returns_four_boxes() {
+        let boxes = build_boxes(&empty_data());
+        assert_eq!(boxes.len(), 4);
+        assert_eq!(boxes[0].label, "Waiting");
+        assert_eq!(boxes[1].label, "Ready");
+        assert_eq!(boxes[2].label, "Running");
+        assert_eq!(boxes[3].label, "Completed");
+    }
+
+    #[test]
+    fn build_boxes_are_vertically_ordered() {
+        let boxes = build_boxes(&sample_data());
+        for i in 1..boxes.len() {
+            assert!(
+                boxes[i].y > boxes[i - 1].bottom(),
+                "{} should be below {}",
+                boxes[i].label,
+                boxes[i - 1].label
+            );
+        }
+    }
+
+    #[test]
+    fn build_boxes_propagate_ids() {
+        let boxes = build_boxes(&sample_data());
+        assert_eq!(boxes[0].ids, vec![0, 1, 2]); // waiting
+        assert_eq!(boxes[1].ids, vec![3]); // ready
+        assert_eq!(boxes[2].ids, vec![4, 5]); // running
+        assert!(boxes[3].ids.is_empty()); // completed
+    }
+
+    #[test]
+    fn compute_chip_bounds_empty_data() {
+        let bounds = compute_all_chip_bounds(&empty_data());
+        assert!(bounds.is_empty());
+    }
+
+    #[test]
+    fn compute_chip_bounds_matches_ids() {
+        let data = sample_data();
+        let bounds = compute_all_chip_bounds(&data);
+        let ids: Vec<usize> = bounds.iter().map(|(_, id)| *id).collect();
+        // All IDs from all state boxes should appear
+        assert_eq!(ids, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn compute_chip_bounds_within_boxes() {
+        let data = sample_data();
+        let bounds = compute_all_chip_bounds(&data);
+        let boxes = build_boxes(&data);
+
+        for (rect, id) in &bounds {
+            // Find which box this chip belongs to
+            let parent_box = boxes
+                .iter()
+                .find(|sb| sb.ids.contains(id))
+                .expect("chip should belong to a box");
+            let box_rect = parent_box.rect();
+            assert!(
+                rect.x >= box_rect.x && rect.x + rect.width <= box_rect.x + box_rect.width,
+                "Chip for id {id} should be horizontally within its box"
+            );
+        }
+    }
+
+    #[test]
+    fn canvas_height_empty_data() {
+        let h = canvas_height(&empty_data());
+        assert!(h > 0.0);
+    }
+
+    #[test]
+    fn canvas_height_increases_with_more_ids() {
+        let small = canvas_height(&empty_data());
+        let large = canvas_height(&sample_data());
+        assert!(large > small, "More IDs should produce a taller canvas");
+    }
+
+    #[test]
+    fn many_chips_respects_max_limit() {
+        let data = StateDiagramData {
+            waiting_ids: (0..50).collect(),
+            ready_ids: vec![],
+            running_ids: vec![],
+            completed_ids: vec![],
+            cached_functions: vec![],
+        };
+        let bounds = compute_all_chip_bounds(&data);
+        // Only MAX_CHIPS chips should get bounds, not all 50
+        let waiting_bounds: Vec<_> = bounds.iter().filter(|(_, id)| *id < 50).collect();
+        assert_eq!(waiting_bounds.len(), MAX_CHIPS);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 35 new tests across 3 previously untested files in `flowrgui`, addressing the coverage gaps identified in #2931.

### Tests added

**`connection_manager.rs`** (19 tests) — Previously 2,300 lines with zero tests:
- Global atomic flag roundtrips: `stop_request`, `discovered_address`, `job_count`, `debug_port`, `last_output_inspect_pid`
- `rewrite_for_gui()` string transformation: 7 tests covering all CLI-to-GUI message rewrites plus passthrough for unmatched messages
- `state_label()` and `state_link_type()` enum mapping tests (all 4 variants)

**`state_diagram.rs`** (13 tests) — Previously 466 lines with zero tests:
- `StateBox` layout calculations: minimum height, chip height increase, bottom position, rect bounds
- `build_boxes()`: returns 4 boxes in correct order, vertical ordering, ID propagation
- `compute_all_chip_bounds()`: empty data, ID matching, chip containment within parent boxes
- `canvas_height()`: positive for empty data, increases with more IDs
- `MAX_CHIPS` limit enforcement (50 IDs capped to 30 chip bounds)

**`context/mod.rs`** (3 tests) — Previously 152 lines with zero tests:
- `ContextIO` clone works
- Channel error handling: disconnected `send_and_receive` and `send_and_receive_blocking`
- `get_manifest()` registers all 10 expected context functions with correct URLs

### Verification

- `make clippy` passes clean
- `cargo fmt` applied
- `make test` passes — flowrgui tests went from 98 to 133

Closes #2931