### PR TITLE
Add time/get context function (#2936)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: cargo-build
         shell: bash
-        run: cargo build
+        run: cargo build --features "online_tests"
 
       - name: find-flow-lib-dir
         shell: bash

--- a/flowr/src/bin/flowrcli/context/mod.rs
+++ b/flowr/src/bin/flowrcli/context/mod.rs
@@ -15,6 +15,7 @@ mod args;
 mod file;
 mod image;
 mod stdio;
+mod time;
 
 /// A request sent from a context function to the ZMQ bridge thread.
 pub struct ContextRequest {
@@ -156,6 +157,10 @@ pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {
     manifest.locators.insert(
         Url::parse("context://stdio/stderr").chain_err(|| "Could not parse url")?,
         Native(Arc::new(stdio::stderr::Stderr { context_io })),
+    );
+    manifest.locators.insert(
+        Url::parse("context://time/get").chain_err(|| "Could not parse url")?,
+        Native(Arc::new(time::get::Get)),
     );
 
     Ok(manifest)

--- a/flowr/src/bin/flowrcli/context/time/get.rs
+++ b/flowr/src/bin/flowrcli/context/time/get.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
-use flowcore::{Implementation, RunAgain, RUN_AGAIN};
+use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
 
 /// `Implementation` struct for the `time/get` context function.
 ///
@@ -48,7 +48,7 @@ impl Implementation for Get {
             "epoch_millis": epoch_millis,
         });
 
-        Ok((Some(output), RUN_AGAIN))
+        Ok((Some(output), DONT_RUN_AGAIN))
     }
 }
 
@@ -97,7 +97,7 @@ mod test {
     fn get_time_now_returns_iso8601() {
         let time_fn = Get;
         let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
-        assert!(run_again, "Should run again");
+        assert!(!run_again, "One-shot time lookup should not run again");
         let value = output.expect("Should have output");
         assert!(value.get("time").is_some(), "Should have 'time' key");
         assert!(

--- a/flowr/src/bin/flowrcli/context/time/get.rs
+++ b/flowr/src/bin/flowrcli/context/time/get.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
-use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
+use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 
 /// `Implementation` struct for the `time/get` context function.
 ///
@@ -48,7 +48,7 @@ impl Implementation for Get {
             "epoch_millis": epoch_millis,
         });
 
-        Ok((Some(output), DONT_RUN_AGAIN))
+        Ok((Some(output), RUN_AGAIN))
     }
 }
 
@@ -97,7 +97,7 @@ mod test {
     fn get_time_now_returns_iso8601() {
         let time_fn = Get;
         let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
-        assert!(!run_again, "One-shot time lookup should not run again");
+        assert!(run_again, "Should run again");
         let value = output.expect("Should have output");
         assert!(value.get("time").is_some(), "Should have 'time' key");
         assert!(

--- a/flowr/src/bin/flowrcli/context/time/get.rs
+++ b/flowr/src/bin/flowrcli/context/time/get.rs
@@ -1,0 +1,193 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+use flowcore::errors::Result;
+use flowcore::{Implementation, RunAgain, RUN_AGAIN};
+
+/// `Implementation` struct for the `time/get` context function.
+///
+/// Returns the current system time. The input specifies the format:
+/// - `"now"` or `"iso8601"` — returns the current time in ISO 8601 format
+/// - `"epoch_secs"` — returns seconds since the Unix epoch as a number
+/// - `"epoch_millis"` — returns milliseconds since the Unix epoch as a number
+/// - any other string — treated as `"iso8601"`
+///
+/// Output is an object with keys:
+/// - `"time"` — the formatted time string or number
+/// - `"epoch_secs"` — seconds since epoch (always included as a number)
+/// - `"epoch_millis"` — milliseconds since epoch (always included as a number)
+#[derive(Debug)]
+pub struct Get;
+
+impl Implementation for Get {
+    fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
+        let format = inputs.first().and_then(Value::as_str).unwrap_or("iso8601");
+
+        let now = SystemTime::now();
+        let duration = now
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| format!("System time before Unix epoch: {e}"))?;
+
+        let epoch_secs = duration.as_secs();
+        let epoch_millis = duration.as_millis();
+
+        let time_value = match format {
+            "epoch_secs" => json!(epoch_secs),
+            "epoch_millis" => json!(epoch_millis),
+            _ => {
+                // ISO 8601 format: construct from epoch
+                let iso = epoch_to_iso8601(epoch_secs);
+                json!(iso)
+            }
+        };
+
+        let output = json!({
+            "time": time_value,
+            "epoch_secs": epoch_secs,
+            "epoch_millis": epoch_millis,
+        });
+
+        Ok((Some(output), RUN_AGAIN))
+    }
+}
+
+/// Convert Unix epoch seconds to an ISO 8601 formatted string (UTC).
+///
+/// Produces format: `YYYY-MM-DDTHH:MM:SSZ`
+fn epoch_to_iso8601(epoch_secs: u64) -> String {
+    // Days calculation from Unix epoch (1970-01-01)
+    let total_days = epoch_secs / 86400;
+    let time_of_day = epoch_secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    let (year, month, day) = days_to_ymd(total_days);
+
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+/// Convert total days since 1970-01-01 to (year, month, day).
+fn days_to_ymd(total_days: u64) -> (u64, u64, u64) {
+    // Algorithm based on Howard Hinnant's civil_from_days
+    let z = total_days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod test {
+    use serde_json::json;
+
+    use flowcore::Implementation;
+
+    use super::Get;
+
+    #[test]
+    fn get_time_now_returns_iso8601() {
+        let time_fn = Get;
+        let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
+        assert!(run_again, "Should run again");
+        let value = output.expect("Should have output");
+        assert!(value.get("time").is_some(), "Should have 'time' key");
+        assert!(
+            value.get("epoch_secs").is_some(),
+            "Should have 'epoch_secs'"
+        );
+        assert!(
+            value.get("epoch_millis").is_some(),
+            "Should have 'epoch_millis'"
+        );
+        // time should be a string in ISO format
+        let time_str = value["time"].as_str().expect("time should be a string");
+        assert!(time_str.ends_with('Z'), "Should end with Z for UTC");
+        assert!(time_str.contains('T'), "Should contain T separator");
+    }
+
+    #[test]
+    fn get_time_iso8601_format() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("iso8601")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let time_str = value["time"].as_str().expect("time should be a string");
+        assert!(time_str.ends_with('Z'));
+    }
+
+    #[test]
+    fn get_time_epoch_secs() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("epoch_secs")]).expect("run failed");
+        let value = output.expect("Should have output");
+        assert!(
+            value["time"].as_u64().is_some(),
+            "epoch_secs time should be a number"
+        );
+        assert!(
+            value["epoch_secs"].as_u64().unwrap() > 0,
+            "epoch_secs should be positive"
+        );
+    }
+
+    #[test]
+    fn get_time_epoch_millis() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("epoch_millis")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let millis = value["time"].as_u64().expect("Should be a number");
+        assert!(millis > 1_000_000_000_000, "Should be in milliseconds");
+    }
+
+    #[test]
+    fn get_time_default_format() {
+        let time_fn = Get;
+        // No input — defaults to iso8601
+        let (output, _) = time_fn.run(&[]).expect("run failed");
+        let value = output.expect("Should have output");
+        assert!(
+            value["time"].as_str().is_some(),
+            "Default format should produce a string"
+        );
+    }
+
+    #[test]
+    fn get_time_unknown_format_defaults_to_iso() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("unknown_format")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let time_str = value["time"].as_str().expect("Should be a string");
+        assert!(time_str.ends_with('Z'));
+    }
+
+    #[test]
+    fn epoch_to_iso8601_known_value() {
+        // 2024-01-01T00:00:00Z = 1704067200 seconds since epoch
+        let iso = super::epoch_to_iso8601(1_704_067_200);
+        assert_eq!(iso, "2024-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn epoch_to_iso8601_epoch_zero() {
+        let iso = super::epoch_to_iso8601(0);
+        assert_eq!(iso, "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn epoch_millis_greater_than_secs() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("now")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let secs = value["epoch_secs"].as_u64().unwrap();
+        let millis = value["epoch_millis"].as_u64().unwrap();
+        assert!(millis >= secs * 1000);
+    }
+}

--- a/flowr/src/bin/flowrcli/context/time/mod.rs
+++ b/flowr/src/bin/flowrcli/context/time/mod.rs
@@ -1,0 +1,2 @@
+/// the `get` module provides a function to get the current time
+pub mod get;

--- a/flowr/src/bin/flowrgui/context/mod.rs
+++ b/flowr/src/bin/flowrgui/context/mod.rs
@@ -16,6 +16,7 @@ mod args;
 mod file;
 mod image;
 mod stdio;
+mod time;
 
 /// A request sent from a context function to the ZMQ bridge thread.
 pub struct ContextRequest {
@@ -147,6 +148,10 @@ pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {
         Url::parse("context://stdio/stderr").chain_err(|| "Could not parse url")?,
         Native(Arc::new(stdio::stderr::Stderr { context_io })),
     );
+    manifest.locators.insert(
+        Url::parse("context://time/get").chain_err(|| "Could not parse url")?,
+        Native(Arc::new(time::get::Get)),
+    );
 
     Ok(manifest)
 }
@@ -214,6 +219,7 @@ mod test {
             "context://stdio/stdin",
             "context://stdio/stdout",
             "context://stdio/stderr",
+            "context://time/get",
         ];
 
         for url_str in &expected {

--- a/flowr/src/bin/flowrgui/context/time/get.rs
+++ b/flowr/src/bin/flowrgui/context/time/get.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
-use flowcore::{Implementation, RunAgain, RUN_AGAIN};
+use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
 
 /// `Implementation` struct for the `time/get` context function.
 ///
@@ -48,7 +48,7 @@ impl Implementation for Get {
             "epoch_millis": epoch_millis,
         });
 
-        Ok((Some(output), RUN_AGAIN))
+        Ok((Some(output), DONT_RUN_AGAIN))
     }
 }
 
@@ -97,7 +97,7 @@ mod test {
     fn get_time_now_returns_iso8601() {
         let time_fn = Get;
         let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
-        assert!(run_again, "Should run again");
+        assert!(!run_again, "One-shot time lookup should not run again");
         let value = output.expect("Should have output");
         assert!(value.get("time").is_some(), "Should have 'time' key");
         assert!(

--- a/flowr/src/bin/flowrgui/context/time/get.rs
+++ b/flowr/src/bin/flowrgui/context/time/get.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use flowcore::errors::Result;
-use flowcore::{Implementation, RunAgain, DONT_RUN_AGAIN};
+use flowcore::{Implementation, RunAgain, RUN_AGAIN};
 
 /// `Implementation` struct for the `time/get` context function.
 ///
@@ -48,7 +48,7 @@ impl Implementation for Get {
             "epoch_millis": epoch_millis,
         });
 
-        Ok((Some(output), DONT_RUN_AGAIN))
+        Ok((Some(output), RUN_AGAIN))
     }
 }
 
@@ -97,7 +97,7 @@ mod test {
     fn get_time_now_returns_iso8601() {
         let time_fn = Get;
         let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
-        assert!(!run_again, "One-shot time lookup should not run again");
+        assert!(run_again, "Should run again");
         let value = output.expect("Should have output");
         assert!(value.get("time").is_some(), "Should have 'time' key");
         assert!(

--- a/flowr/src/bin/flowrgui/context/time/get.rs
+++ b/flowr/src/bin/flowrgui/context/time/get.rs
@@ -1,0 +1,193 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+use flowcore::errors::Result;
+use flowcore::{Implementation, RunAgain, RUN_AGAIN};
+
+/// `Implementation` struct for the `time/get` context function.
+///
+/// Returns the current system time. The input specifies the format:
+/// - `"now"` or `"iso8601"` — returns the current time in ISO 8601 format
+/// - `"epoch_secs"` — returns seconds since the Unix epoch as a number
+/// - `"epoch_millis"` — returns milliseconds since the Unix epoch as a number
+/// - any other string — treated as `"iso8601"`
+///
+/// Output is an object with keys:
+/// - `"time"` — the formatted time string or number
+/// - `"epoch_secs"` — seconds since epoch (always included as a number)
+/// - `"epoch_millis"` — milliseconds since epoch (always included as a number)
+#[derive(Debug)]
+pub struct Get;
+
+impl Implementation for Get {
+    fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
+        let format = inputs.first().and_then(Value::as_str).unwrap_or("iso8601");
+
+        let now = SystemTime::now();
+        let duration = now
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| format!("System time before Unix epoch: {e}"))?;
+
+        let epoch_secs = duration.as_secs();
+        let epoch_millis = duration.as_millis();
+
+        let time_value = match format {
+            "epoch_secs" => json!(epoch_secs),
+            "epoch_millis" => json!(epoch_millis),
+            _ => {
+                // ISO 8601 format: construct from epoch
+                let iso = epoch_to_iso8601(epoch_secs);
+                json!(iso)
+            }
+        };
+
+        let output = json!({
+            "time": time_value,
+            "epoch_secs": epoch_secs,
+            "epoch_millis": epoch_millis,
+        });
+
+        Ok((Some(output), RUN_AGAIN))
+    }
+}
+
+/// Convert Unix epoch seconds to an ISO 8601 formatted string (UTC).
+///
+/// Produces format: `YYYY-MM-DDTHH:MM:SSZ`
+fn epoch_to_iso8601(epoch_secs: u64) -> String {
+    // Days calculation from Unix epoch (1970-01-01)
+    let total_days = epoch_secs / 86400;
+    let time_of_day = epoch_secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    let (year, month, day) = days_to_ymd(total_days);
+
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+/// Convert total days since 1970-01-01 to (year, month, day).
+fn days_to_ymd(total_days: u64) -> (u64, u64, u64) {
+    // Algorithm based on Howard Hinnant's civil_from_days
+    let z = total_days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod test {
+    use serde_json::json;
+
+    use flowcore::Implementation;
+
+    use super::Get;
+
+    #[test]
+    fn get_time_now_returns_iso8601() {
+        let time_fn = Get;
+        let (output, run_again) = time_fn.run(&[json!("now")]).expect("run failed");
+        assert!(run_again, "Should run again");
+        let value = output.expect("Should have output");
+        assert!(value.get("time").is_some(), "Should have 'time' key");
+        assert!(
+            value.get("epoch_secs").is_some(),
+            "Should have 'epoch_secs'"
+        );
+        assert!(
+            value.get("epoch_millis").is_some(),
+            "Should have 'epoch_millis'"
+        );
+        // time should be a string in ISO format
+        let time_str = value["time"].as_str().expect("time should be a string");
+        assert!(time_str.ends_with('Z'), "Should end with Z for UTC");
+        assert!(time_str.contains('T'), "Should contain T separator");
+    }
+
+    #[test]
+    fn get_time_iso8601_format() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("iso8601")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let time_str = value["time"].as_str().expect("time should be a string");
+        assert!(time_str.ends_with('Z'));
+    }
+
+    #[test]
+    fn get_time_epoch_secs() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("epoch_secs")]).expect("run failed");
+        let value = output.expect("Should have output");
+        assert!(
+            value["time"].as_u64().is_some(),
+            "epoch_secs time should be a number"
+        );
+        assert!(
+            value["epoch_secs"].as_u64().unwrap() > 0,
+            "epoch_secs should be positive"
+        );
+    }
+
+    #[test]
+    fn get_time_epoch_millis() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("epoch_millis")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let millis = value["time"].as_u64().expect("Should be a number");
+        assert!(millis > 1_000_000_000_000, "Should be in milliseconds");
+    }
+
+    #[test]
+    fn get_time_default_format() {
+        let time_fn = Get;
+        // No input — defaults to iso8601
+        let (output, _) = time_fn.run(&[]).expect("run failed");
+        let value = output.expect("Should have output");
+        assert!(
+            value["time"].as_str().is_some(),
+            "Default format should produce a string"
+        );
+    }
+
+    #[test]
+    fn get_time_unknown_format_defaults_to_iso() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("unknown_format")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let time_str = value["time"].as_str().expect("Should be a string");
+        assert!(time_str.ends_with('Z'));
+    }
+
+    #[test]
+    fn epoch_to_iso8601_known_value() {
+        // 2024-01-01T00:00:00Z = 1704067200 seconds since epoch
+        let iso = super::epoch_to_iso8601(1_704_067_200);
+        assert_eq!(iso, "2024-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn epoch_to_iso8601_epoch_zero() {
+        let iso = super::epoch_to_iso8601(0);
+        assert_eq!(iso, "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn epoch_millis_greater_than_secs() {
+        let time_fn = Get;
+        let (output, _) = time_fn.run(&[json!("now")]).expect("run failed");
+        let value = output.expect("Should have output");
+        let secs = value["epoch_secs"].as_u64().unwrap();
+        let millis = value["epoch_millis"].as_u64().unwrap();
+        assert!(millis >= secs * 1000);
+    }
+}

--- a/flowr/src/bin/flowrgui/context/time/mod.rs
+++ b/flowr/src/bin/flowrgui/context/time/mod.rs
@@ -1,0 +1,2 @@
+/// the `get` module provides a function to get the current time
+pub mod get;


### PR DESCRIPTION
## Summary

Adds a new context function `context://time/get` that returns the current system time in various formats.

### Input

A format string:
- `"now"` or `"iso8601"` — ISO 8601 format (`YYYY-MM-DDTHH:MM:SSZ`)
- `"epoch_secs"` — seconds since Unix epoch
- `"epoch_millis"` — milliseconds since Unix epoch
- any other string or missing input — defaults to ISO 8601

### Output

A JSON object:
```json
{
  "time": "2024-01-01T00:00:00Z",
  "epoch_secs": 1704067200,
  "epoch_millis": 1704067200000
}
```

### Implementation

- Uses only `std::time` — no external dependencies needed
- No coordinator message passing required (reads system clock directly)
- Registered in both CLI and GUI runners at `context://time/get`
- Includes a pure Rust ISO 8601 formatter (no chrono dependency)
- 9 unit tests per runner (18 total)

### Future extensions (per issue)

The issue mentions potential alarm/duration functionality. The current implementation returns immediately. Blocking timer support could be added later using the blocking IO channel pattern used by `readline`/`stdin`.

Closes #2936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new time context function that returns the current system time.
  * Supports output as ISO 8601, Unix epoch seconds, or Unix epoch milliseconds (with automatic default formatting).
  * Responses include the selected time value plus epoch seconds and epoch milliseconds.
  * Available in both command-line and graphical interfaces.

* **Tests / Chores**
  * Extended test coverage for all supported time formats and updated the GUI/CLI context locator expectations.
  * Build/test job now runs with `online_tests` enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->