### PR TITLE
Use pre-built armhf OpenSSL package instead of building from source (#2824)

### DIFF
--- a/.github/workflows/arm_cross_builds.yml
+++ b/.github/workflows/arm_cross_builds.yml
@@ -31,24 +31,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install armv7 cross-compilation toolchain
+      - name: Install armv7 cross-compilation toolchain and OpenSSL
         run: |
+          sudo dpkg --add-architecture armhf
           sudo apt-get update
-          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf cmake
-
-      - name: Cross-compile OpenSSL for armv7
-        run: |
-          curl -sL https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz | tar xz
-          cd openssl-3.4.1
-          ./Configure linux-armv4 --cross-compile-prefix=arm-linux-gnueabihf- --prefix=$HOME/openssl-armv7 no-shared
-          make -j$(nproc)
-          make install_sw
-          cd ..
+          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+            libssl-dev:armhf
 
       - name: Build for armv7 (Raspberry Pi 2/3/4 32-bit)
         env:
           CC_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
           CXX_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-g++
-          OPENSSL_STATIC: 1
-          OPENSSL_DIR: /home/runner/openssl-armv7
+          OPENSSL_LIB_DIR: /usr/lib/arm-linux-gnueabihf
+          OPENSSL_INCLUDE_DIR: /usr/include
         run: cargo build --target=armv7-unknown-linux-gnueabihf


### PR DESCRIPTION
## Summary

Replaces the cross-compilation of OpenSSL from source with a pre-built multiarch `libssl-dev:armhf` package.

### Before
- Download OpenSSL 3.4.1 source tarball
- Configure, make, make install (~1.5 min)
- Set `OPENSSL_STATIC=1` and `OPENSSL_DIR`

### After
- `dpkg --add-architecture armhf` to enable multiarch
- `apt-get install libssl-dev:armhf` (pre-built package)
- Set `OPENSSL_LIB_DIR` and `OPENSSL_INCLUDE_DIR` to multiarch paths

If the package isn't available or takes longer than building from source, we'll drop this and close the issue.

Closes #2824