### PR TITLE
Add coordination profiling and eliminate unnecessary Value clones (#2949)

### DIFF
--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -294,32 +294,30 @@ impl Input {
         if self.generic {
             self.received.push(value);
         } else {
-            match (
-                DataType::value_array_order(&value) - self.array_order(),
-                &value,
-            ) {
-                (0, _) => self.received.push(value),
-                (1, Value::Array(array)) => self.send_array_elements(array.clone()),
+            let order_diff = DataType::value_array_order(&value) - self.array_order();
+            match (order_diff, value) {
+                (0, v) => self.received.push(v),
+                (1, Value::Array(array)) => self.send_array_elements(array),
                 (2, Value::Array(array_2)) => {
-                    for array in array_2 {
-                        if let Value::Array(sub_array) = array {
-                            self.send_array_elements(sub_array.clone());
+                    for element in array_2 {
+                        if let Value::Array(sub_array) = element {
+                            self.send_array_elements(sub_array);
                         }
                     }
                 }
-                (-1, _) => {
+                (-1, v) => {
                     debug!(
-                        "\t\tSending value '{value}' wrapped in an Array: '{}'",
-                        json!([value])
+                        "\t\tSending value '{v}' wrapped in an Array: '{}'",
+                        json!([&v])
                     );
-                    self.received.push(json!([value]));
+                    self.received.push(json!([v]));
                 }
-                (-2, _) => {
+                (-2, v) => {
                     debug!(
-                        "\t\tSending value '{value}' wrapped in an Array of Array: '{}'",
-                        json!([[value]])
+                        "\t\tSending value '{v}' wrapped in an Array of Array: '{}'",
+                        json!([[&v]])
                     );
-                    self.received.push(json!([[value]]));
+                    self.received.push(json!([[v]]));
                 }
                 _ => return false,
             }
@@ -342,36 +340,34 @@ impl Input {
             self.received.insert(self.internal_count, value);
             self.internal_count += 1;
         } else {
-            match (
-                DataType::value_array_order(&value) - self.array_order(),
-                &value,
-            ) {
-                (0, _) => {
-                    self.received.insert(self.internal_count, value);
+            let order_diff = DataType::value_array_order(&value) - self.array_order();
+            match (order_diff, value) {
+                (0, v) => {
+                    self.received.insert(self.internal_count, v);
                     self.internal_count += 1;
                 }
                 (1, Value::Array(array)) => {
                     for v in array {
-                        self.received.insert(self.internal_count, v.clone());
+                        self.received.insert(self.internal_count, v);
                         self.internal_count += 1;
                     }
                 }
                 (2, Value::Array(array_2)) => {
-                    for array in array_2 {
-                        if let Value::Array(sub_array) = array {
+                    for element in array_2 {
+                        if let Value::Array(sub_array) = element {
                             for v in sub_array {
-                                self.received.insert(self.internal_count, v.clone());
+                                self.received.insert(self.internal_count, v);
                                 self.internal_count += 1;
                             }
                         }
                     }
                 }
-                (-1, _) => {
-                    self.received.insert(self.internal_count, json!([value]));
+                (-1, v) => {
+                    self.received.insert(self.internal_count, json!([v]));
                     self.internal_count += 1;
                 }
-                (-2, _) => {
-                    self.received.insert(self.internal_count, json!([[value]]));
+                (-2, v) => {
+                    self.received.insert(self.internal_count, json!([[v]]));
                     self.internal_count += 1;
                 }
                 _ => return false,

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -390,7 +390,11 @@ impl<'a> Coordinator<'a> {
             Ok(Some((job_id, result))) => {
                 #[cfg(feature = "metrics")]
                 TOTAL_GET_RESULT_US.fetch_add(
-                    get_result_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+                    get_result_start
+                        .elapsed()
+                        .as_micros()
+                        .try_into()
+                        .unwrap_or(u64::MAX),
                     std::sync::atomic::Ordering::Relaxed,
                 );
 
@@ -408,7 +412,11 @@ impl<'a> Coordinator<'a> {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_RETIRE_JOB_US.fetch_add(
-                    retire_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+                    retire_start
+                        .elapsed()
+                        .as_micros()
+                        .try_into()
+                        .unwrap_or(u64::MAX),
                     std::sync::atomic::Ordering::Relaxed,
                 );
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -361,10 +361,11 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    /// Retire as many jobs as possible, based on returned results.
+    /// Retire as many jobs as possible, draining all available results.
     ///
-    /// This may block waiting for results if no jobs are ready to be dispatched
-    /// (see [`get_result`](Self::get_result)).
+    /// Processes results in a tight loop: first blocking for one result if nothing
+    /// else is ready, then draining all immediately available results before
+    /// returning to the dispatch/retire outer loop.
     fn retire_jobs(
         &mut self,
         state: &mut RunState,
@@ -383,71 +384,105 @@ impl<'a> Coordinator<'a> {
             )?;
         }
 
+        // Get the first result (may block if no ready jobs to dispatch)
         #[cfg(feature = "metrics")]
         let get_result_start = Instant::now();
 
-        match self.get_result(state) {
+        let first_result = self.get_result(state);
+
+        #[cfg(feature = "metrics")]
+        TOTAL_GET_RESULT_US.fetch_add(
+            get_result_start
+                .elapsed()
+                .as_micros()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
+        match first_result {
             Ok(Some((job_id, result))) => {
-                #[cfg(feature = "metrics")]
-                TOTAL_GET_RESULT_US.fetch_add(
-                    get_result_start
-                        .elapsed()
-                        .as_micros()
-                        .try_into()
-                        .unwrap_or(u64::MAX),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-
-                #[cfg(feature = "metrics")]
-                let retire_start = Instant::now();
-
-                let (mut action, job) = state.retire_job(
+                let action = self.retire_one_job(
+                    state,
                     job_id,
                     result,
                     #[cfg(feature = "metrics")]
                     metrics,
-                    #[cfg(feature = "debugger")]
-                    &mut self.debugger,
                 )?;
-
-                #[cfg(feature = "metrics")]
-                TOTAL_RETIRE_JOB_US.fetch_add(
-                    retire_start
-                        .elapsed()
-                        .as_micros()
-                        .try_into()
-                        .unwrap_or(u64::MAX),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-
-                #[cfg(feature = "debugger")]
-                if action.should_display() {
-                    action = self.debugger.job_done(state, &job);
-                    if action.should_restart() {
-                        return Ok(action);
-                    }
+                if action.should_restart() || action.should_display() {
+                    return Ok(action);
                 }
-
-                Ok(action)
             }
-
-            Ok(None) => {
-                info!(
-                    "No result was immediately available, but jobs are ready to be dispatched. \
-                     So coordinator avoided blocking for result. Will be received next time around"
-                );
-                Ok(DebugAction::Continue)
-            }
-
+            Ok(None) => return Ok(DebugAction::Continue),
             Err(err) => {
                 error!("\t{err}");
                 #[cfg(feature = "debugger")]
                 if state.submission.debug_enabled {
                     return self.debugger.error(state, err.to_string());
                 }
-                Ok(DebugAction::Continue)
+                return Ok(DebugAction::Continue);
             }
         }
+
+        // Drain all immediately available results without blocking
+        while state.number_jobs_running() > 0 {
+            if let Ok(result) = self.dispatcher.get_next_result(false) {
+                let (job_id, job_result) = result;
+                let action = self.retire_one_job(
+                    state,
+                    job_id,
+                    job_result,
+                    #[cfg(feature = "metrics")]
+                    metrics,
+                )?;
+
+                if action.should_restart() || action.should_display() {
+                    return Ok(action);
+                }
+            } else {
+                break; // no more results immediately available
+            }
+        }
+
+        Ok(DebugAction::Continue)
+    }
+
+    /// Retire a single job result
+    fn retire_one_job(
+        &mut self,
+        state: &mut RunState,
+        job_id: usize,
+        result: Result<(Option<Value>, RunAgain)>,
+        #[cfg(feature = "metrics")] metrics: &mut Metrics,
+    ) -> Result<DebugAction> {
+        #[cfg(feature = "metrics")]
+        let retire_start = Instant::now();
+
+        let (mut action, job) = state.retire_job(
+            job_id,
+            result,
+            #[cfg(feature = "metrics")]
+            metrics,
+            #[cfg(feature = "debugger")]
+            &mut self.debugger,
+        )?;
+
+        #[cfg(feature = "metrics")]
+        TOTAL_RETIRE_JOB_US.fetch_add(
+            retire_start
+                .elapsed()
+                .as_micros()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
+        #[cfg(feature = "debugger")]
+        if action.should_display() {
+            action = self.debugger.job_done(state, &job);
+        }
+
+        Ok(action)
     }
 
     /// Dispatch as many jobs as possible for parallel execution.

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -11,6 +11,9 @@ use flowcore::model::metrics::Metrics;
 use flowcore::model::submission::Submission;
 use flowcore::RunAgain;
 
+#[cfg(feature = "metrics")]
+use std::sync::atomic::AtomicU64;
+
 use crate::debug_action::DebugAction;
 #[cfg(feature = "debugger")]
 use crate::debugger::Debugger;
@@ -44,6 +47,11 @@ pub struct Coordinator<'a> {
     #[cfg(all(not(feature = "debugger"), not(feature = "submission")))]
     _data: PhantomData<&'a Dispatcher>,
 }
+
+#[cfg(feature = "metrics")]
+static TOTAL_GET_RESULT_US: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "metrics")]
+static TOTAL_RETIRE_JOB_US: AtomicU64 = AtomicU64::new(0);
 
 /// Result of running the inner dispatch/retire loop for one iteration of flow execution.
 /// Tells the outer loop whether to restart (debugger reset) or finish.
@@ -135,6 +143,9 @@ impl<'a> Coordinator<'a> {
             {
                 metrics.reset();
                 crate::executor::reset_max_jobs_executing();
+                TOTAL_GET_RESULT_US.store(0, std::sync::atomic::Ordering::Relaxed);
+                TOTAL_RETIRE_JOB_US.store(0, std::sync::atomic::Ordering::Relaxed);
+                crate::run_state::reset_retire_timers();
             }
 
             let iteration_result = self.run_jobs(
@@ -197,12 +208,19 @@ impl<'a> Coordinator<'a> {
         #[cfg(feature = "submission")]
         self.submission_handler.flow_execution_starting()?;
 
+        #[cfg(feature = "metrics")]
+        let mut total_dispatch_us: u128 = 0;
+        #[cfg(feature = "metrics")]
+        let mut total_retire_us: u128 = 0;
+        #[cfg(feature = "metrics")]
+        let mut loop_count: u64 = 0;
+
         loop {
             trace!("{state}");
 
             #[cfg(feature = "submission")]
             if self.submission_handler.should_stop()? {
-                return Ok(FlowIterationResult::Done);
+                break;
             }
 
             #[cfg(all(feature = "debugger", feature = "submission"))]
@@ -213,21 +231,38 @@ impl<'a> Coordinator<'a> {
                 }
             }
 
+            #[cfg(feature = "metrics")]
+            let dispatch_start = Instant::now();
+
             let action = self.dispatch_jobs(
                 state,
                 #[cfg(feature = "metrics")]
                 metrics,
             )?;
 
+            #[cfg(feature = "metrics")]
+            {
+                total_dispatch_us += dispatch_start.elapsed().as_micros();
+            }
+
             if action.should_restart() {
                 return Ok(FlowIterationResult::Restart);
             }
+
+            #[cfg(feature = "metrics")]
+            let retire_start = Instant::now();
 
             let action = self.retire_jobs(
                 state,
                 #[cfg(feature = "metrics")]
                 metrics,
             )?;
+
+            #[cfg(feature = "metrics")]
+            {
+                total_retire_us += retire_start.elapsed().as_micros();
+                loop_count += 1;
+            }
 
             #[cfg(all(feature = "submission", any(feature = "metrics", feature = "debugger")))]
             self.submission_handler
@@ -238,9 +273,29 @@ impl<'a> Coordinator<'a> {
             }
 
             if state.number_jobs_running() == 0 && state.number_jobs_ready() == 0 {
-                return Ok(FlowIterationResult::Done);
+                break;
             }
         }
+
+        #[cfg(feature = "metrics")]
+        {
+            let get_result_ms =
+                TOTAL_GET_RESULT_US.load(std::sync::atomic::Ordering::Relaxed) / 1000;
+            let retire_job_ms =
+                TOTAL_RETIRE_JOB_US.load(std::sync::atomic::Ordering::Relaxed) / 1000;
+            info!(
+                "Coordinator loop: {} iterations, dispatch: {}ms, retire: {}ms \
+                 (get_result: {}ms, retire_job: {}ms)",
+                loop_count,
+                total_dispatch_us / 1000,
+                total_retire_us / 1000,
+                get_result_ms,
+                retire_job_ms,
+            );
+            crate::run_state::log_retire_breakdown();
+        }
+
+        Ok(FlowIterationResult::Done)
     }
 
     /// After a flow execution iteration ends (without restart), finalize metrics and
@@ -328,8 +383,20 @@ impl<'a> Coordinator<'a> {
             )?;
         }
 
+        #[cfg(feature = "metrics")]
+        let get_result_start = Instant::now();
+
         match self.get_result(state) {
             Ok(Some((job_id, result))) => {
+                #[cfg(feature = "metrics")]
+                TOTAL_GET_RESULT_US.fetch_add(
+                    get_result_start.elapsed().as_micros() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+
+                #[cfg(feature = "metrics")]
+                let retire_start = Instant::now();
+
                 let (mut action, job) = state.retire_job(
                     job_id,
                     result,
@@ -338,6 +405,12 @@ impl<'a> Coordinator<'a> {
                     #[cfg(feature = "debugger")]
                     &mut self.debugger,
                 )?;
+
+                #[cfg(feature = "metrics")]
+                TOTAL_RETIRE_JOB_US.fetch_add(
+                    retire_start.elapsed().as_micros() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
 
                 #[cfg(feature = "debugger")]
                 if action.should_display() {

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -390,7 +390,7 @@ impl<'a> Coordinator<'a> {
             Ok(Some((job_id, result))) => {
                 #[cfg(feature = "metrics")]
                 TOTAL_GET_RESULT_US.fetch_add(
-                    get_result_start.elapsed().as_micros() as u64,
+                    get_result_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
                     std::sync::atomic::Ordering::Relaxed,
                 );
 
@@ -408,7 +408,7 @@ impl<'a> Coordinator<'a> {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_RETIRE_JOB_US.fetch_add(
-                    retire_start.elapsed().as_micros() as u64,
+                    retire_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
                     std::sync::atomic::Ordering::Relaxed,
                 );
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -34,10 +34,7 @@ pub fn log_retire_breakdown() {
     let create_ms = TOTAL_CREATE_JOBS_US.load(AtomicOrdering::Relaxed) / 1000;
     let busy_ms = TOTAL_BUSY_STATE_US.load(AtomicOrdering::Relaxed) / 1000;
     log::info!(
-        "retire_job breakdown: send_value: {}ms, create_jobs: {}ms, busy_state: {}ms",
-        send_ms,
-        create_ms,
-        busy_ms,
+        "retire_job breakdown: send_value: {send_ms}ms, create_jobs: {create_ms}ms, busy_state: {busy_ms}ms",
     );
 }
 
@@ -506,7 +503,7 @@ impl RunState {
     /// This removes the job from `running_jobs`, distributes output values to connected
     /// functions, handles run-again vs completed state, and checks if any ancestor flows
     /// have gone idle.
-    #[allow(unused_variables, unused_assignments, unused_mut)]
+    #[allow(unused_variables, unused_assignments, unused_mut, clippy::too_many_lines)]
     pub(crate) fn retire_job(
         &mut self,
         job_id: usize,
@@ -572,7 +569,7 @@ impl RunState {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_SEND_VALUE_US.fetch_add(
-                    send_start.elapsed().as_micros() as u64,
+                    send_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
                     AtomicOrdering::Relaxed,
                 );
 
@@ -601,7 +598,7 @@ impl RunState {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_CREATE_JOBS_US.fetch_add(
-                    create_start.elapsed().as_micros() as u64,
+                    create_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
                     AtomicOrdering::Relaxed,
                 );
             }
@@ -626,7 +623,7 @@ impl RunState {
 
         #[cfg(feature = "metrics")]
         TOTAL_BUSY_STATE_US.fetch_add(
-            busy_start.elapsed().as_micros() as u64,
+            busy_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
             AtomicOrdering::Relaxed,
         );
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -27,9 +27,17 @@ static TOTAL_CREATE_JOBS_US: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "metrics")]
 static TOTAL_BUSY_STATE_US: AtomicU64 = AtomicU64::new(0);
 
-/// Log the `retire_job` sub-operation timing breakdown
+/// Log the `retire_job` sub-operation timing breakdown.
+///
+/// Timer boundaries:
+/// - `send_value`: distributing output values to downstream inputs, includes
+///   `try_create_destination_jobs` for functions that become ready from external sends
+/// - `create_jobs`: re-initializing inputs after execution, checking if the function
+///   can run again, and creating new jobs (excludes jobs created via `send_a_value`)
+/// - `busy_state`: decrementing busy counts and handling idle-flow transitions,
+///   which may also create jobs for functions runnable on internal data
 #[cfg(feature = "metrics")]
-pub fn log_retire_breakdown() {
+pub(crate) fn log_retire_breakdown() {
     let send_ms = TOTAL_SEND_VALUE_US.load(AtomicOrdering::Relaxed) / 1000;
     let create_ms = TOTAL_CREATE_JOBS_US.load(AtomicOrdering::Relaxed) / 1000;
     let busy_ms = TOTAL_BUSY_STATE_US.load(AtomicOrdering::Relaxed) / 1000;
@@ -40,7 +48,7 @@ pub fn log_retire_breakdown() {
 
 /// Reset `retire_job` timing counters
 #[cfg(feature = "metrics")]
-pub fn reset_retire_timers() {
+pub(crate) fn reset_retire_timers() {
     TOTAL_SEND_VALUE_US.store(0, AtomicOrdering::Relaxed);
     TOTAL_CREATE_JOBS_US.store(0, AtomicOrdering::Relaxed);
     TOTAL_BUSY_STATE_US.store(0, AtomicOrdering::Relaxed);
@@ -503,7 +511,12 @@ impl RunState {
     /// This removes the job from `running_jobs`, distributes output values to connected
     /// functions, handles run-again vs completed state, and checks if any ancestor flows
     /// have gone idle.
-    #[allow(unused_variables, unused_assignments, unused_mut, clippy::too_many_lines)]
+    #[allow(
+        unused_variables,
+        unused_assignments,
+        unused_mut,
+        clippy::too_many_lines
+    )]
     pub(crate) fn retire_job(
         &mut self,
         job_id: usize,
@@ -569,7 +582,11 @@ impl RunState {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_SEND_VALUE_US.fetch_add(
-                    send_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+                    send_start
+                        .elapsed()
+                        .as_micros()
+                        .try_into()
+                        .unwrap_or(u64::MAX),
                     AtomicOrdering::Relaxed,
                 );
 
@@ -598,7 +615,11 @@ impl RunState {
 
                 #[cfg(feature = "metrics")]
                 TOTAL_CREATE_JOBS_US.fetch_add(
-                    create_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+                    create_start
+                        .elapsed()
+                        .as_micros()
+                        .try_into()
+                        .unwrap_or(u64::MAX),
                     AtomicOrdering::Relaxed,
                 );
             }
@@ -623,7 +644,11 @@ impl RunState {
 
         #[cfg(feature = "metrics")]
         TOTAL_BUSY_STATE_US.fetch_add(
-            busy_start.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+            busy_start
+                .elapsed()
+                .as_micros()
+                .try_into()
+                .unwrap_or(u64::MAX),
             AtomicOrdering::Relaxed,
         );
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -17,6 +17,38 @@ use flowcore::model::runtime_function::RuntimeFunction;
 use flowcore::model::submission::Submission;
 use flowcore::RunAgain;
 
+#[cfg(feature = "metrics")]
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+#[cfg(feature = "metrics")]
+static TOTAL_SEND_VALUE_US: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "metrics")]
+static TOTAL_CREATE_JOBS_US: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "metrics")]
+static TOTAL_BUSY_STATE_US: AtomicU64 = AtomicU64::new(0);
+
+/// Log the `retire_job` sub-operation timing breakdown
+#[cfg(feature = "metrics")]
+pub fn log_retire_breakdown() {
+    let send_ms = TOTAL_SEND_VALUE_US.load(AtomicOrdering::Relaxed) / 1000;
+    let create_ms = TOTAL_CREATE_JOBS_US.load(AtomicOrdering::Relaxed) / 1000;
+    let busy_ms = TOTAL_BUSY_STATE_US.load(AtomicOrdering::Relaxed) / 1000;
+    log::info!(
+        "retire_job breakdown: send_value: {}ms, create_jobs: {}ms, busy_state: {}ms",
+        send_ms,
+        create_ms,
+        busy_ms,
+    );
+}
+
+/// Reset `retire_job` timing counters
+#[cfg(feature = "metrics")]
+pub fn reset_retire_timers() {
+    TOTAL_SEND_VALUE_US.store(0, AtomicOrdering::Relaxed);
+    TOTAL_CREATE_JOBS_US.store(0, AtomicOrdering::Relaxed);
+    TOTAL_BUSY_STATE_US.store(0, AtomicOrdering::Relaxed);
+}
+
 #[cfg(debug_assertions)]
 use crate::checks;
 use crate::debug_action::DebugAction;
@@ -506,6 +538,9 @@ impl RunState {
                     job.payload.job_id, job.process_id, job.payload.input_set, output_value
                 );
 
+                #[cfg(feature = "metrics")]
+                let send_start = std::time::Instant::now();
+
                 for connection in &job.connections {
                     let value_to_send = match &connection.source {
                         Output(route) => match output_value {
@@ -535,6 +570,15 @@ impl RunState {
                     }
                 }
 
+                #[cfg(feature = "metrics")]
+                TOTAL_SEND_VALUE_US.fetch_add(
+                    send_start.elapsed().as_micros() as u64,
+                    AtomicOrdering::Relaxed,
+                );
+
+                #[cfg(feature = "metrics")]
+                let create_start = std::time::Instant::now();
+
                 if *function_can_run_again {
                     let function = self.get_mut(job.process_id).ok_or("No such function")?;
 
@@ -554,6 +598,12 @@ impl RunState {
                     #[cfg(feature = "trace")]
                     self.record_trace("CompleteJob");
                 }
+
+                #[cfg(feature = "metrics")]
+                TOTAL_CREATE_JOBS_US.fetch_add(
+                    create_start.elapsed().as_micros() as u64,
+                    AtomicOrdering::Relaxed,
+                );
             }
             Err(e) => {
                 error!(
@@ -565,11 +615,20 @@ impl RunState {
             }
         }
 
+        #[cfg(feature = "metrics")]
+        let busy_start = std::time::Instant::now();
+
         action = self.update_flow_busy_state(
             &job,
             #[cfg(feature = "debugger")]
             debugger,
         )?;
+
+        #[cfg(feature = "metrics")]
+        TOTAL_BUSY_STATE_US.fetch_add(
+            busy_start.elapsed().as_micros() as u64,
+            AtomicOrdering::Relaxed,
+        );
 
         #[cfg(debug_assertions)]
         checks::check_invariants(self, job.payload.job_id)?;

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -466,13 +466,19 @@ pub fn execute_flow_client_server(example_name: &str, manifest: PathBuf) {
         }
     }
 
+    // Wait for the client to finish and check its exit status
+    let client_status = runner.wait().expect("Failed to wait for client to exit");
+
     println!("Killing 'flowr' server");
     server.kill().expect("Failed to kill server child process");
     server.wait().expect("Failed to wait for child to exit");
 
-    if !actual_stderr.is_empty() {
+    if !client_status.success() {
         eprintln!("STDERR: {actual_stderr}");
-        panic!("Failed due to STDERR output")
+        panic!(
+            "Client process exited with non-zero status: {:?}",
+            client_status.code()
+        );
     }
 
     let contains_path = samples_dir.join(EXPECTED_CONTAINS_STDOUT_FILENAME);


### PR DESCRIPTION
## Summary

Phase 1 of coordination overhead optimization (#2949): profiling instrumentation and the first optimization.

### Profiling instrumentation

Added timing breakdown to the coordinator loop and `retire_job`, gated behind the `metrics` feature. Output at `info` log level shows:

```
Coordinator loop: 16639 iterations, dispatch: 213ms, retire: 4278ms
  (get_result: 3624ms, retire_job: 579ms)
retire_job breakdown: send_value: 508ms, create_jobs: 56ms, busy_state: 0ms
```

### Value clone elimination

`Input::send()` and `Input::send_internal()` previously matched on `(&value)` which borrowed the owned value, forcing `.clone()` on the array decomposition paths. Now computes array order first, then matches on the owned value — enabling moves instead of clones.

### Profiling findings

| Phase | Time | % |
|-------|------|---|
| dispatch_jobs | 213ms | 5% |
| retire_jobs | 4278ms | 95% |
| - get_result (ZMQ wait) | 3624ms | 85% |
| - retire_job (processing) | 579ms | 14% |
| -- send_value | 508ms | 88% of processing |
| -- create_jobs | 56ms | 10% of processing |
| -- busy_state | 0ms | 0% |

**85% of time is waiting for executors** (legitimate). Within the 14% processing time, `send_a_value` dominates at 508ms across 24934 calls (~20us per call).

### Next optimization targets

1. Reduce per-call overhead of `send_a_value` (function lookup, input queue management)
2. Overlap dispatch and retire (async or batching)
3. Reduce ZMQ serialization cost (binary format)

Partial progress on #2949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary data copying when handling array order mismatches, improving efficiency for complex flows.
  * Continued to preserve array ordering and nesting behavior while streamlining value processing.

* **Monitoring**
  * When metrics are enabled, added more granular timing for coordination phases and retirement work (including output delivery, job creation, and busy-state updates).
  * Improved consolidated loop logging and breakdown reporting for easier performance analysis.

* **Tests**
  * Updated the client/server test harness to wait for the client process and fail based on its exit status, with stderr included on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->