### PR TITLE
Fix max-parallel metric: track after WASM Mutex acquired

### DIFF
--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -37,12 +37,12 @@ pub fn reset_max_jobs_executing() {
     JOBS_EXECUTING.store(0, Ordering::Relaxed);
 }
 
-fn track_execution_start() {
+pub(crate) fn track_execution_start() {
     let current = JOBS_EXECUTING.fetch_add(1, Ordering::Relaxed) + 1;
     MAX_JOBS_EXECUTING.fetch_max(current, Ordering::Relaxed);
 }
 
-fn track_execution_end() {
+pub(crate) fn track_execution_end() {
     JOBS_EXECUTING.fetch_sub(1, Ordering::Relaxed);
 }
 
@@ -364,9 +364,7 @@ fn execute_job_to_string(
     )?;
 
     trace!("Job #{}: Started executing on '{name}'", payload.job_id);
-    track_execution_start();
     let result = implementation.run(&payload.input_set);
-    track_execution_end();
     trace!("Job #{}: Finished executing on '{name}'", payload.job_id);
 
     serde_json::to_string(&(payload.job_id, result))
@@ -478,9 +476,7 @@ fn execute_job(
     )?;
 
     trace!("Job #{}: Started executing on '{name}'", payload.job_id);
-    track_execution_start();
     let result = implementation.run(&payload.input_set);
-    track_execution_end();
     trace!("Job #{}: Finished executing on '{name}'", payload.job_id);
 
     results_sink

--- a/flowr/src/lib/wasm.rs
+++ b/flowr/src/lib/wasm.rs
@@ -115,9 +115,30 @@ impl Executor {
     }
 }
 
+/// RAII guard that calls `track_execution_end` on drop,
+/// ensuring the counter is decremented even if execution fails.
+struct ExecutionGuard;
+
+impl ExecutionGuard {
+    fn new() -> Self {
+        super::executor::track_execution_start();
+        Self
+    }
+}
+
+impl Drop for ExecutionGuard {
+    fn drop(&mut self) {
+        super::executor::track_execution_end();
+    }
+}
+
 impl Implementation for Executor {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
         let mut store = self.store.lock().map_err(|_| "Could not lock WASM store")?;
+        // Track execution AFTER acquiring the Mutex — so we count actual
+        // execution, not time spent waiting for the lock.
+        // The guard ensures the counter is decremented even if execution fails.
+        let _guard = ExecutionGuard::new();
         let (offset, length) = self.send_inputs(&mut store, inputs)?;
         let result_length = self.call(offset, length, &mut store)?;
         assert!(offset >= 0, "offset was negative");


### PR DESCRIPTION
## Summary

The max-parallel-jobs metric was inflated for WASM workloads. It counted threads waiting on the WASM Store Mutex as 'executing'.

### Before
```
Threads 12: max_parallel=12  (11 waiting on Mutex + 1 executing)
```

### After
```
Threads 12: max_parallel=5   (actual concurrent executions)
```

### Change

Moved `track_execution_start/end` from the generic executor path into `wasm::Executor::run()`, placed AFTER the Store Mutex is acquired. Native lib implementations no longer contribute to the metric (they complete in nanoseconds and aren't the interesting measurement).

Related: #2955 (WASM needs per-thread Store for true parallelism)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution tracking for WebAssembly jobs.
  * Peak-concurrency metrics now reflect the full WebAssembly execution lifecycle, including input handling and result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->