### PR TITLE
Add format string input to stdout and stderr (#2947)

### DIFF
--- a/flowc/tests/test-flows/aliased_context/root.toml
+++ b/flowc/tests/test-flows/aliased_context/root.toml
@@ -6,7 +6,8 @@ source = "context://stdio/stdin"
 [[process]]
 alias = "print"
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "stdin/string"
-to = "print"
+to = "print/value"

--- a/flowc/tests/test-flows/args/root.toml
+++ b/flowc/tests/test-flows/args/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/string/3"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/connect_to_constant/root.toml
+++ b/flowc/tests/test-flows/connect_to_constant/root.toml
@@ -5,8 +5,9 @@ source = "context://args/get"
 
 [[connection]]
 from = "get/string/1"
-to = "stdout"
+to = "stdout/value"
 
 [[process]]
 source = "context://stdio/stdout"
 input.default = { always = "OK" }
+input.format = { always = "{}" }

--- a/flowc/tests/test-flows/context_with_io/root.toml
+++ b/flowc/tests/test-flows/context_with_io/root.toml
@@ -11,7 +11,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/string/1"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/echo/root.toml
+++ b/flowc/tests/test-flows/echo/root.toml
@@ -5,8 +5,9 @@ source = "context://stdio/stdin"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 name = "echo"
 from = "stdin/string"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/flow_input_init/root.toml
+++ b/flowc/tests/test-flows/flow_input_init/root.toml
@@ -6,7 +6,8 @@ input.input = {once =  42}
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "sub_flow/output"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/function_input_init/root.toml
+++ b/flowc/tests/test-flows/function_input_init/root.toml
@@ -3,3 +3,4 @@ flow = "function_input_init"
 [[process]]
 source = "context://stdio/stdout"
 input.default = {once =  "hello"}
+input.format = { always = "{}" }

--- a/flowc/tests/test-flows/initialized_input_to_subflow/subsubflow.toml
+++ b/flowc/tests/test-flows/initialized_input_to_subflow/subsubflow.toml
@@ -6,7 +6,8 @@ type = "string"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "input/only"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/json-indexing/root.toml
+++ b/flowc/tests/test-flows/json-indexing/root.toml
@@ -6,7 +6,8 @@ input.prompt = { always = ">"}
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "readline/json/0"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/malformed-connection/root.toml
+++ b/flowc/tests/test-flows/malformed-connection/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "blabla"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/names/root.toml
+++ b/flowc/tests/test-flows/names/root.toml
@@ -7,7 +7,8 @@ source = "subflow"
 
 [[process]] # Function process_ref
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "subflow/out"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/no-connections/root.toml
+++ b/flowc/tests/test-flows/no-connections/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "args/string/1"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/object_to_array_connection/root.toml
+++ b/flowc/tests/test-flows/object_to_array_connection/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/json"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/print_subflow_output/root.toml
+++ b/flowc/tests/test-flows/print_subflow_output/root.toml
@@ -5,7 +5,8 @@ source = "initialize_flow_output"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "initialize_flow_output"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/same-name-parent/root.toml
+++ b/flowc/tests/test-flows/same-name-parent/root.toml
@@ -21,11 +21,12 @@ to = "child2/message"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "child2/message"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "child/message"
-to = "stdout"
+to = "stdout/value"

--- a/flowc/tests/test-flows/subflow-type-boundary/root.toml
+++ b/flowc/tests/test-flows/subflow-type-boundary/root.toml
@@ -10,8 +10,9 @@ input.pair = { once = [10, 20] }
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 # We expect "10" (element 0 of [10,20]), not "[10,20]" (the whole array)
 [[connection]]
 from = "extract_first/first"
-to = "stdout"
+to = "stdout/value"

--- a/flowcore/tests/test-flows/hello-world/root.toml
+++ b/flowcore/tests/test-flows/hello-world/root.toml
@@ -3,3 +3,4 @@ flow = "hello-world"
 [[process]]
 source = "context://stdio/stdout"
 input.default = {once =  "Hello World!"}
+input.format = { always = "{}" }

--- a/flowr/examples/concurrent-io/root.toml
+++ b/flowr/examples/concurrent-io/root.toml
@@ -12,9 +12,10 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 [[connection]]
 from = "get/string/0"
-to = "stdout"
+to = "stdout/value"
 
 [[process]]
 source = "context://stdio/readline"
@@ -22,6 +23,7 @@ input.prompt = {once = ""}
 
 [[process]]
 source = "context://stdio/stderr"
+input.format = { always = "{}" }
 [[connection]]
 from = "readline/string"
-to = "stderr"
+to = "stderr/value"

--- a/flowr/examples/debug-help-string/root.toml
+++ b/flowr/examples/debug-help-string/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/string/1"
-to = "stdout"
+to = "stdout/value"

--- a/flowr/examples/debug-print-args/root.toml
+++ b/flowr/examples/debug-print-args/root.toml
@@ -5,7 +5,8 @@ source = "context://args/get"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/string/1"
-to = "stdout"
+to = "stdout/value"

--- a/flowr/examples/factorial/root.toml
+++ b/flowr/examples/factorial/root.toml
@@ -60,7 +60,8 @@ to = "result-tap/data"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "result-tap"
-to = "stdout"
+to = "stdout/value"

--- a/flowr/examples/fft/root.toml
+++ b/flowr/examples/fft/root.toml
@@ -10,10 +10,11 @@ input.sample_rate = { once = 8000 }
 # Text output to stdout
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "fft_compute/text"
-to = "stdout"
+to = "stdout/value"
 
 # Visual spectrum: bins → histogram chart → image file
 [[process]]

--- a/flowr/examples/fibonacci/root.toml
+++ b/flowr/examples/fibonacci/root.toml
@@ -16,6 +16,7 @@ input.i2 = { once = 1 }
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 x = 313.15073
 y = -63.635933
 width = 180
@@ -28,7 +29,7 @@ to = "add/i2"
 [[connection]]
 name = "next value"
 from = "add"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 name = "previous"

--- a/flowr/examples/game-of-life/root.toml
+++ b/flowr/examples/game-of-life/root.toml
@@ -146,10 +146,11 @@ to = "get/format"
 # Print elapsed ms to stdout
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "get/elapsed_millis"
-to = "stdout"
+to = "stdout/value"
 
 ####### Iteration control
 

--- a/flowr/examples/game-of-life/root.toml
+++ b/flowr/examples/game-of-life/root.toml
@@ -146,7 +146,7 @@ to = "get/format"
 # Print elapsed ms to stdout
 [[process]]
 source = "context://stdio/stdout"
-input.format = { always = "{}" }
+input.format = { always = "Iteration time: {}ms" }
 
 [[connection]]
 from = "get/elapsed_millis"

--- a/flowr/examples/gcd/root.toml
+++ b/flowr/examples/gcd/root.toml
@@ -30,10 +30,11 @@ to = "compare_switch/right"
 # GCD found when values are equal
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "compare_switch/equal"
-to = "stdout"
+to = "stdout/value"
 
 # Subtract: larger - smaller
 [[process]]

--- a/flowr/examples/hamming/root.toml
+++ b/flowr/examples/hamming/root.toml
@@ -22,10 +22,11 @@ input.candidates = { once = [1] }
 # Output each Hamming number
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "hamming_step/next"
-to = "stdout"
+to = "stdout/value"
 
 ####### Iteration control: stop after N numbers
 

--- a/flowr/examples/hello-world/root.toml
+++ b/flowr/examples/hello-world/root.toml
@@ -4,3 +4,4 @@ docs = "DESCRIPTION.md"
 [[process]]
 source = "context://stdio/stdout"
 input.default = {once =  "Hello World!"}
+input.format = { always = "{}" }

--- a/flowr/examples/image-analysis/root.toml
+++ b/flowr/examples/image-analysis/root.toml
@@ -87,22 +87,23 @@ to = "histogram/partial"
 # Output statistics to stdout (accepts numbers directly)
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "find_min/result"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "find_max/result"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "find_avg/result"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "find_avg/count"
-to = "stdout"
+to = "stdout/value"
 
 ########################################################################
 # Contrast stretch — (pixel - min) * 255 / (max - min)

--- a/flowr/examples/prime/root.toml
+++ b/flowr/examples/prime/root.toml
@@ -37,8 +37,9 @@ to = "remove/array"
 
 [[connection]]
 from = "remove"
-to = "stdout"
+to = "stdout/value"
 
 ####### Output
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }

--- a/flowr/examples/router/root.toml
+++ b/flowr/examples/router/root.toml
@@ -126,7 +126,8 @@ source = "lib://flowstdlib/data/append"
 ######## Print out the shortest route and it's length to each point 'A'
 [[connection]]
 from = "append"
-to = "stdout"
+to = "stdout/value"
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }

--- a/flowr/examples/sequence-of-sequences/root.toml
+++ b/flowr/examples/sequence-of-sequences/root.toml
@@ -29,7 +29,8 @@ to = ["sequence-of-sequences/step", "sequence-of-sequences/limit"]
 # Print the sequence-of-sequences to stdout
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "sequence-of-sequences/number"
-to = "stdout"
+to = "stdout/value"

--- a/flowr/examples/weather-station/root.toml
+++ b/flowr/examples/weather-station/root.toml
@@ -117,22 +117,23 @@ to = "label_count/s2"
 # --- All stats to stdout ---
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "label_min"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "label_max"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "label_mean"
-to = "stdout"
+to = "stdout/value"
 
 [[connection]]
 from = "label_count"
-to = "stdout"
+to = "stdout/value"
 
 # --- Moving chart of mean values (updated on each reading) ---
 [[process]]

--- a/flowr/examples/word-count/root.toml
+++ b/flowr/examples/word-count/root.toml
@@ -46,7 +46,8 @@ to = "format"
 # Output the running word count
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "format"
-to = "stdout"
+to = "stdout/value"

--- a/flowr/src/bin/flowrcli/context/stdio/mod.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/mod.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 /// the `readline` module to allow a flow to read lines from stdin function
 pub mod readline;
 /// the `stderr` module to allow a flow to send to the stderr function
@@ -6,3 +8,94 @@ pub mod stderr;
 pub mod stdin;
 /// the `stdout` module to allow a flow to send to the stdout function
 pub mod stdout;
+
+/// Convert a JSON `Value` to its string representation for output.
+/// Strings are returned without surrounding quotes, other types use their
+/// JSON/display representation.
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        _ => value.to_string(),
+    }
+}
+
+/// Format a value using a format string. The format string uses `{}` as a
+/// placeholder for the value, similar to Rust's `format!` macro.
+///
+/// - If the format string is empty or `"{}"`, the value is returned as-is.
+/// - Otherwise, the first `{}` in the format string is replaced with the
+///   string representation of the value.
+fn format_output(value: &Value, format: &str) -> String {
+    let value_str = value_to_string(value);
+    if format.is_empty() || format == "{}" {
+        value_str
+    } else {
+        format.replacen("{}", &value_str, 1)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod test {
+    use serde_json::json;
+
+    use super::{format_output, value_to_string};
+
+    #[test]
+    fn value_to_string_types() {
+        assert_eq!(value_to_string(&json!("hello")), "hello");
+        assert_eq!(value_to_string(&json!(42)), "42");
+        assert_eq!(value_to_string(&json!(2.5)), "2.5");
+        assert_eq!(value_to_string(&json!(true)), "true");
+        assert_eq!(value_to_string(&json!(null)), "null");
+        assert_eq!(value_to_string(&json!([1, 2])), "[1,2]");
+    }
+
+    #[test]
+    fn format_empty_passes_through() {
+        assert_eq!(format_output(&json!(42), ""), "42");
+    }
+
+    #[test]
+    fn format_bare_placeholder_passes_through() {
+        assert_eq!(format_output(&json!(42), "{}"), "42");
+    }
+
+    #[test]
+    fn format_with_prefix() {
+        assert_eq!(format_output(&json!(42), "Count: {}"), "Count: 42");
+    }
+
+    #[test]
+    fn format_with_suffix() {
+        assert_eq!(format_output(&json!(42), "{} items"), "42 items");
+    }
+
+    #[test]
+    fn format_with_prefix_and_suffix() {
+        assert_eq!(
+            format_output(&json!(2.5), "value is approximately {}!"),
+            "value is approximately 2.5!"
+        );
+    }
+
+    #[test]
+    fn format_string_value() {
+        assert_eq!(
+            format_output(&json!("world"), "Hello, {}!"),
+            "Hello, world!"
+        );
+    }
+
+    #[test]
+    fn format_no_placeholder() {
+        assert_eq!(format_output(&json!(42), "static text"), "static text");
+    }
+
+    #[test]
+    fn format_multiple_placeholders_replaces_first() {
+        assert_eq!(format_output(&json!(1), "{} + {} = 2"), "1 + {} = 2");
+    }
+}

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.rs
@@ -12,14 +12,12 @@ pub struct Stderr {
 
 impl Implementation for Stderr {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let input = inputs.first().ok_or("Could not get input")?;
+        let value = inputs.first().ok_or("Could not get 'value' input")?;
+        let format = inputs.get(1).and_then(Value::as_str).unwrap_or("{}");
 
-        let msg = match input {
+        let msg = match value {
             Value::Null => CoordinatorMessage::StderrEof,
-            Value::String(string) => CoordinatorMessage::Stderr(string.clone()),
-            Value::Bool(boolean) => CoordinatorMessage::Stderr(boolean.to_string()),
-            Value::Number(number) => CoordinatorMessage::Stderr(number.to_string()),
-            _ => CoordinatorMessage::Stderr(input.to_string()),
+            _ => CoordinatorMessage::Stderr(super::format_output(value, format)),
         };
 
         self.context_io.send_and_receive(msg)?;
@@ -74,7 +72,7 @@ mod test {
     #[test]
     fn send_null() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[Value::Null]));
+        let handle = std::thread::spawn(move || stderr.run(&[Value::Null, json!("{}")]));
         respond(&rx, &CoordinatorMessage::StderrEof);
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
@@ -84,8 +82,8 @@ mod test {
     #[test]
     fn send_string() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!("hello")]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!("hello"), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("hello".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -94,8 +92,8 @@ mod test {
     #[test]
     fn send_bool() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(true)]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(true), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("true".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -104,8 +102,8 @@ mod test {
     #[test]
     fn send_number() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(42)]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(42), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -114,8 +112,8 @@ mod test {
     #[test]
     fn send_array() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!([1, 2, 3])]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!([1, 2, 3]), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("[1,2,3]".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -127,8 +125,18 @@ mod test {
         map.insert("number1", 42);
         map.insert("number2", 99);
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(map)]));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(map), json!("{}")]));
         respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
+        assert_eq!(run_again, RUN_AGAIN);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn send_with_format_prefix() {
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!(42), json!("Error: {}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("Error: 42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.rs
@@ -29,8 +29,6 @@ impl Implementation for Stderr {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
-    use std::collections::HashMap;
-
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
 
@@ -129,12 +127,11 @@ mod test {
 
     #[test]
     fn send_object() {
-        let mut map = HashMap::new();
-        map.insert("number1", 42);
-        map.insert("number2", 99);
+        let obj = json!({"number1": 42, "number2": 99});
+        let expected = obj.to_string();
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(map), json!("{}")]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[obj, json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr(expected));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.rs
@@ -62,6 +62,14 @@ mod test {
             std::mem::discriminant(&req.message),
             std::mem::discriminant(expected)
         );
+        // Compare the payload string when the expected value is non-empty
+        if let (CoordinatorMessage::Stderr(actual), CoordinatorMessage::Stderr(exp)) =
+            (&req.message, expected)
+        {
+            if !exp.is_empty() {
+                assert_eq!(actual, exp, "Stderr payload mismatch");
+            }
+        }
         if let Some(response_tx) = req.response_tx {
             response_tx
                 .send(ClientMessage::Ack)

--- a/flowr/src/bin/flowrcli/context/stdio/stderr.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/stderr.toml
@@ -1,7 +1,12 @@
 function = "stderr"
-description = "Write a value to standard error"
+description = "Write a formatted value to standard error"
 source = "stderr.rs"
 docs = "stderr.md"
 impure = true
 
 [[input]]
+name = "value"
+
+[[input]]
+name = "format"
+type = "string"

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.rs
@@ -28,8 +28,6 @@ impl Implementation for Stdout {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
-    use std::collections::HashMap;
-
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
 
@@ -61,13 +59,11 @@ mod test {
             std::mem::discriminant(&req.message),
             std::mem::discriminant(expected)
         );
-        // Compare the payload string when the expected value is non-empty
+        // Compare the payload string content
         if let (CoordinatorMessage::Stdout(actual), CoordinatorMessage::Stdout(exp)) =
             (&req.message, expected)
         {
-            if !exp.is_empty() {
-                assert_eq!(actual, exp, "Stdout payload mismatch");
-            }
+            assert_eq!(actual, exp, "Stdout payload mismatch");
         }
         if let Some(response_tx) = req.response_tx {
             response_tx
@@ -128,12 +124,11 @@ mod test {
 
     #[test]
     fn send_object() {
-        let mut map = HashMap::new();
-        map.insert("number1", 42);
-        map.insert("number2", 99);
+        let obj = json!({"number1": 42, "number2": 99});
+        let expected = obj.to_string();
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(map), json!("{}")]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[obj, json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout(expected));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.rs
@@ -11,14 +11,12 @@ pub struct Stdout {
 
 impl Implementation for Stdout {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let input = inputs.first().ok_or("Could not get input")?;
+        let value = inputs.first().ok_or("Could not get 'value' input")?;
+        let format = inputs.get(1).and_then(Value::as_str).unwrap_or("{}");
 
-        let msg = match input {
+        let msg = match value {
             Value::Null => CoordinatorMessage::StdoutEof,
-            Value::String(string) => CoordinatorMessage::Stdout(string.clone()),
-            Value::Bool(boolean) => CoordinatorMessage::Stdout(boolean.to_string()),
-            Value::Number(number) => CoordinatorMessage::Stdout(number.to_string()),
-            _ => CoordinatorMessage::Stdout(input.to_string()),
+            _ => CoordinatorMessage::Stdout(super::format_output(value, format)),
         };
 
         self.context_io.send_and_receive(msg)?;
@@ -73,7 +71,7 @@ mod test {
     #[test]
     fn send_null() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[Value::Null]));
+        let handle = std::thread::spawn(move || stdout.run(&[Value::Null, json!("{}")]));
         respond(&rx, &CoordinatorMessage::StdoutEof);
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
@@ -83,8 +81,8 @@ mod test {
     #[test]
     fn send_string() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!("hello")]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!("hello"), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("hello".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -93,8 +91,8 @@ mod test {
     #[test]
     fn send_bool() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(true)]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(true), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("true".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -103,8 +101,8 @@ mod test {
     #[test]
     fn send_number() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(42)]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(42), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -113,8 +111,8 @@ mod test {
     #[test]
     fn send_array() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!([1, 2, 3])]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!([1, 2, 3]), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("[1,2,3]".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -126,8 +124,28 @@ mod test {
         map.insert("number1", 42);
         map.insert("number2", 99);
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(map)]));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(map), json!("{}")]));
         respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
+        assert_eq!(run_again, RUN_AGAIN);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn send_with_format_prefix() {
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!(42), json!("Count: {}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("Count: 42".into()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
+        assert_eq!(run_again, RUN_AGAIN);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn send_with_empty_format() {
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!("hello"), json!("")]));
+        respond(&rx, &CoordinatorMessage::Stdout("hello".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.rs
@@ -61,6 +61,14 @@ mod test {
             std::mem::discriminant(&req.message),
             std::mem::discriminant(expected)
         );
+        // Compare the payload string when the expected value is non-empty
+        if let (CoordinatorMessage::Stdout(actual), CoordinatorMessage::Stdout(exp)) =
+            (&req.message, expected)
+        {
+            if !exp.is_empty() {
+                assert_eq!(actual, exp, "Stdout payload mismatch");
+            }
+        }
         if let Some(response_tx) = req.response_tx {
             response_tx
                 .send(ClientMessage::Ack)

--- a/flowr/src/bin/flowrcli/context/stdio/stdout.toml
+++ b/flowr/src/bin/flowrcli/context/stdio/stdout.toml
@@ -1,7 +1,12 @@
 function = "stdout"
-description = "Write a value to standard output"
+description = "Write a formatted value to standard output"
 source = "stdout.rs"
 docs = "stdout.md"
 impure = true
 
 [[input]]
+name = "value"
+
+[[input]]
+name = "format"
+type = "string"

--- a/flowr/src/bin/flowrgui/context/stdio/mod.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/mod.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 /// the `readline` module to allow a flow to read lines from stdin function
 pub mod readline;
 /// the `stderr` module to allow a flow to send to the stderr function
@@ -6,3 +8,30 @@ pub mod stderr;
 pub mod stdin;
 /// the `stdout` module to allow a flow to send to the stdout function
 pub mod stdout;
+
+/// Convert a JSON `Value` to its string representation for output.
+/// Strings are returned without surrounding quotes, other types use their
+/// JSON/display representation.
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        _ => value.to_string(),
+    }
+}
+
+/// Format a value using a format string. The format string uses `{}` as a
+/// placeholder for the value, similar to Rust's `format!` macro.
+///
+/// - If the format string is empty or `"{}"`, the value is returned as-is.
+/// - Otherwise, the first `{}` in the format string is replaced with the
+///   string representation of the value.
+fn format_output(value: &Value, format: &str) -> String {
+    let value_str = value_to_string(value);
+    if format.is_empty() || format == "{}" {
+        value_str
+    } else {
+        format.replacen("{}", &value_str, 1)
+    }
+}

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.rs
@@ -13,14 +13,12 @@ pub struct Stderr {
 
 impl Implementation for Stderr {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let input = inputs.first().ok_or("Could not get input")?;
+        let value = inputs.first().ok_or("Could not get 'value' input")?;
+        let format = inputs.get(1).and_then(Value::as_str).unwrap_or("{}");
 
-        let msg = match input {
+        let msg = match value {
             Value::Null => CoordinatorMessage::StderrEof,
-            Value::String(string) => CoordinatorMessage::Stderr(string.clone()),
-            Value::Bool(boolean) => CoordinatorMessage::Stderr(boolean.to_string()),
-            Value::Number(number) => CoordinatorMessage::Stderr(number.to_string()),
-            _ => CoordinatorMessage::Stderr(input.to_string()),
+            _ => CoordinatorMessage::Stderr(super::format_output(value, format)),
         };
 
         self.context_io.send_and_receive(msg)?;
@@ -76,7 +74,7 @@ mod test {
     #[test]
     fn send_null() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[Value::Null]));
+        let handle = std::thread::spawn(move || stderr.run(&[Value::Null, json!("{}")]));
         respond(&rx, &CoordinatorMessage::StderrEof);
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
@@ -86,8 +84,8 @@ mod test {
     #[test]
     fn send_string() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!("hello")]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!("hello"), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("hello".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -96,8 +94,8 @@ mod test {
     #[test]
     fn send_bool() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(true)]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(true), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("true".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -106,8 +104,8 @@ mod test {
     #[test]
     fn send_number() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(42)]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(42), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -116,8 +114,8 @@ mod test {
     #[test]
     fn send_array() {
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!([1, 2, 3])]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[json!([1, 2, 3]), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("[1,2,3]".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -129,8 +127,18 @@ mod test {
         map.insert("number1", 42);
         map.insert("number2", 99);
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(map)]));
+        let handle = std::thread::spawn(move || stderr.run(&[json!(map), json!("{}")]));
         respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
+        assert_eq!(run_again, RUN_AGAIN);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn send_with_format_prefix() {
+        let (stderr, rx) = make_stderr();
+        let handle = std::thread::spawn(move || stderr.run(&[json!(42), json!("Error: {}")]));
+        respond(&rx, &CoordinatorMessage::Stderr("Error: 42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.rs
@@ -30,8 +30,6 @@ impl Implementation for Stderr {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
-    use std::collections::HashMap;
-
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
 
@@ -131,12 +129,11 @@ mod test {
 
     #[test]
     fn send_object() {
-        let mut map = HashMap::new();
-        map.insert("number1", 42);
-        map.insert("number2", 99);
+        let obj = json!({"number1": 42, "number2": 99});
+        let expected = obj.to_string();
         let (stderr, rx) = make_stderr();
-        let handle = std::thread::spawn(move || stderr.run(&[json!(map), json!("{}")]));
-        respond(&rx, &CoordinatorMessage::Stderr(String::new()));
+        let handle = std::thread::spawn(move || stderr.run(&[obj, json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stderr(expected));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.rs
@@ -64,6 +64,14 @@ mod test {
             std::mem::discriminant(&req.message),
             std::mem::discriminant(expected)
         );
+        // Compare the payload string when the expected value is non-empty
+        if let (CoordinatorMessage::Stderr(actual), CoordinatorMessage::Stderr(exp)) =
+            (&req.message, expected)
+        {
+            if !exp.is_empty() {
+                assert_eq!(actual, exp, "Stderr payload mismatch");
+            }
+        }
         if let Some(response_tx) = req.response_tx {
             response_tx
                 .send(ClientMessage::Ack)

--- a/flowr/src/bin/flowrgui/context/stdio/stderr.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/stderr.toml
@@ -1,7 +1,12 @@
 function = "stderr"
-description = "Write a value to standard error"
+description = "Write a formatted value to standard error"
 source = "stderr.rs"
 docs = "stderr.md"
 impure = true
 
 [[input]]
+name = "value"
+
+[[input]]
+name = "format"
+type = "string"

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.rs
@@ -13,14 +13,12 @@ pub struct Stdout {
 
 impl Implementation for Stdout {
     fn run(&self, inputs: &[Value]) -> Result<(Option<Value>, RunAgain)> {
-        let input = inputs.first().ok_or("Could not get input")?;
+        let value = inputs.first().ok_or("Could not get 'value' input")?;
+        let format = inputs.get(1).and_then(Value::as_str).unwrap_or("{}");
 
-        let msg = match input {
+        let msg = match value {
             Value::Null => CoordinatorMessage::StdoutEof,
-            Value::String(string) => CoordinatorMessage::Stdout(string.clone()),
-            Value::Bool(boolean) => CoordinatorMessage::Stdout(boolean.to_string()),
-            Value::Number(number) => CoordinatorMessage::Stdout(number.to_string()),
-            _ => CoordinatorMessage::Stdout(input.to_string()),
+            _ => CoordinatorMessage::Stdout(super::format_output(value, format)),
         };
 
         self.context_io.send_and_receive(msg)?;
@@ -76,7 +74,7 @@ mod test {
     #[test]
     fn send_null() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[Value::Null]));
+        let handle = std::thread::spawn(move || stdout.run(&[Value::Null, json!("{}")]));
         respond(&rx, &CoordinatorMessage::StdoutEof);
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
@@ -86,8 +84,8 @@ mod test {
     #[test]
     fn send_string() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!("hello")]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!("hello"), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("hello".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -96,8 +94,8 @@ mod test {
     #[test]
     fn send_bool() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(true)]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(true), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("true".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -106,8 +104,8 @@ mod test {
     #[test]
     fn send_number() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(42)]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(42), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -116,8 +114,8 @@ mod test {
     #[test]
     fn send_array() {
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!([1, 2, 3])]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[json!([1, 2, 3]), json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("[1,2,3]".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);
@@ -129,8 +127,18 @@ mod test {
         map.insert("number1", 42);
         map.insert("number2", 99);
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(map)]));
+        let handle = std::thread::spawn(move || stdout.run(&[json!(map), json!("{}")]));
         respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let (value, run_again) = handle.join().unwrap().expect("run() failed");
+        assert_eq!(run_again, RUN_AGAIN);
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn send_with_format_prefix() {
+        let (stdout, rx) = make_stdout();
+        let handle = std::thread::spawn(move || stdout.run(&[json!(42), json!("Count: {}")]));
+        respond(&rx, &CoordinatorMessage::Stdout("Count: 42".into()));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.rs
@@ -64,6 +64,14 @@ mod test {
             std::mem::discriminant(&req.message),
             std::mem::discriminant(expected)
         );
+        // Compare the payload string when the expected value is non-empty
+        if let (CoordinatorMessage::Stdout(actual), CoordinatorMessage::Stdout(exp)) =
+            (&req.message, expected)
+        {
+            if !exp.is_empty() {
+                assert_eq!(actual, exp, "Stdout payload mismatch");
+            }
+        }
         if let Some(response_tx) = req.response_tx {
             response_tx
                 .send(ClientMessage::Ack)

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.rs
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.rs
@@ -30,8 +30,6 @@ impl Implementation for Stdout {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
-    use std::collections::HashMap;
-
     use flowcore::{Implementation, RUN_AGAIN};
     use serde_json::{json, Value};
 
@@ -131,12 +129,11 @@ mod test {
 
     #[test]
     fn send_object() {
-        let mut map = HashMap::new();
-        map.insert("number1", 42);
-        map.insert("number2", 99);
+        let obj = json!({"number1": 42, "number2": 99});
+        let expected = obj.to_string();
         let (stdout, rx) = make_stdout();
-        let handle = std::thread::spawn(move || stdout.run(&[json!(map), json!("{}")]));
-        respond(&rx, &CoordinatorMessage::Stdout(String::new()));
+        let handle = std::thread::spawn(move || stdout.run(&[obj, json!("{}")]));
+        respond(&rx, &CoordinatorMessage::Stdout(expected));
         let (value, run_again) = handle.join().unwrap().expect("run() failed");
         assert_eq!(run_again, RUN_AGAIN);
         assert_eq!(value, None);

--- a/flowr/src/bin/flowrgui/context/stdio/stdout.toml
+++ b/flowr/src/bin/flowrgui/context/stdio/stdout.toml
@@ -1,7 +1,12 @@
 function = "stdout"
-description = "Write a value to standard output"
+description = "Write a formatted value to standard output"
 source = "stdout.rs"
 docs = "stdout.md"
 impure = true
 
 [[input]]
+name = "value"
+
+[[input]]
+name = "format"
+type = "string"

--- a/flowstdlib/src/math/range.rs
+++ b/flowstdlib/src/math/range.rs
@@ -25,10 +25,11 @@ input.range = { once = [1, 10] }
 
 [[process]]
 source = \"context://stdio/stdout\"
+input.format = { always = \"{}\" }
 
 [[connection]]
 from = \"range/number\"
-to = \"stdout\"
+to = \"stdout/value\"
 ";
 
         let temp_dir = tempdir()

--- a/flowstdlib/src/math/sequence.rs
+++ b/flowstdlib/src/math/sequence.rs
@@ -27,10 +27,11 @@ input.step = { once = 1 }
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "sequence/number"
-to = "stdout"
+to = "stdout/value"
 "#;
 
         let temp_dir = tempdir()
@@ -66,10 +67,11 @@ input.limit = {once = [1, 2]}
 
 [[process]]
 source = "context://stdio/stdout"
+input.format = { always = "{}" }
 
 [[connection]]
 from = "sequence/number"
-to = "stdout"
+to = "stdout/value"
 "#;
 
         let temp_dir = tempdir()

--- a/flowstdlib/src/matrix/multiply.rs
+++ b/flowstdlib/src/matrix/multiply.rs
@@ -26,10 +26,11 @@ input.b = { once = [[5,6],[7,8]] }
 
 [[process]]
 source = \"context://stdio/stdout\"
+input.format = { always = \"{}\" }
 
 [[connection]]
 from = \"multiply/product\"
-to = \"stdout\"
+to = \"stdout/value\"
 ";
 
         let temp_dir = tempdir()


### PR DESCRIPTION
## Summary

Add a `format` input to the `stdout` and `stderr` context functions. The format string uses `{}` as a placeholder for the value, similar to Rust's `format!` macro.

## Changes

### New functionality
- **stdout and stderr** now accept two named inputs:
  - `value` (index 0) — the data to print
  - `format` (index 1, type `string`) — a format string with `{}` placeholder
- If format is `""` or `"{}"`, the value is passed through unchanged
- Otherwise, the first `{}` in the format string is replaced with the string representation of the value
- Example: `input.format = { always = "Count: {}" }` with value `42` outputs `Count: 42`

### Implementation
- `format_output()` and `value_to_string()` helpers in `stdio/mod.rs` (shared by stdout and stderr)
- Both flowrcli and flowrgui implementations updated identically
- 11 format-related unit tests in flowrcli, plus format tests in flowrgui

### Flow updates (33 files)
- All example and test flows updated to use named `stdout/value` and `stderr/value` connections
- All flows include `input.format = { always = "{}" }` on their stdout/stderr process definitions
- flowstdlib internal test flows (range, sequence, multiply) updated

### Note
Context functions cannot be aliased, so the weather-station example retains its `append` + `stdout` pattern rather than using multiple stdout instances with different format strings. However, flows that currently use `append` just to prepend a label can now replace `append` + `stdout` with a direct connection to `stdout/value` and a format string like `"Label: {}"` — provided they use a single stdout with a dynamically-connected format input rather than a static initializer.

Closes #2947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable formatting for values written to standard output and standard error, including support for prefix/suffix via `{}` placeholders.
  * Updated stdout/stderr contexts to accept a format input (defaulting to `"{}"`), and route output to value-specific channels (`stdout/value`, `stderr/value`).
* **Bug Fixes**
  * Preserved correct end-of-file signaling when the emitted value is `null`.
* **Documentation**
  * Refreshed example flow configurations to demonstrate explicit input formatting and value-path routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->