### PR TITLE
Add flow restart breakpoint (idle->busy transition) (#2965)

### DIFF
--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -138,10 +138,15 @@ impl<'a> Debugger<'a> {
 
     /// Check if any newly-busy flows have breakpoints set. If so, enter the debugger.
     /// Called after `create_jobs` populates `newly_busy_flows`.
+    /// Unprocessed flow IDs are preserved for future checks.
     pub fn check_flow_restarts(&mut self, state: &mut RunState) -> Result<DebugAction> {
         let newly_busy = state.drain_newly_busy_flows();
-        for flow_id in newly_busy {
+        for (i, &flow_id) in newly_busy.iter().enumerate() {
             if self.process_breakpoints.contains(&flow_id) {
+                // Preserve remaining unprocessed IDs for future checks
+                if let Some(remaining) = newly_busy.get(i + 1..) {
+                    state.newly_busy_flows.extend_from_slice(remaining);
+                }
                 self.debug_server.flow_unblock_breakpoint(flow_id);
                 return self.wait_for_command(state);
             }

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -136,6 +136,19 @@ impl<'a> Debugger<'a> {
         Ok(DebugAction::Continue)
     }
 
+    /// Check if any newly-busy flows have breakpoints set. If so, enter the debugger.
+    /// Called after `create_jobs` populates `newly_busy_flows`.
+    pub fn check_flow_restarts(&mut self, state: &mut RunState) -> Result<DebugAction> {
+        let newly_busy = state.drain_newly_busy_flows();
+        for flow_id in newly_busy {
+            if self.process_breakpoints.contains(&flow_id) {
+                self.debug_server.flow_unblock_breakpoint(flow_id);
+                return self.wait_for_command(state);
+            }
+        }
+        Ok(DebugAction::Continue)
+    }
+
     /// An error occurred while executing a flow. Let the debug client know, enter the client
     /// and wait for a user command.
     ///
@@ -1050,6 +1063,7 @@ mod test {
     use flowcore::model::runtime_function::RuntimeFunction;
     use flowcore::model::submission::Submission;
 
+    use crate::debug_action::DebugAction;
     use crate::debug_command::{BreakpointSpec, DebugCommand};
     use crate::debugger::Debugger;
     use crate::debugger_handler::DebuggerHandler;
@@ -1244,6 +1258,34 @@ mod test {
         let _ = debugger.check_prior_to_flow_unblock(&mut state, 0);
 
         // check the breakpoint triggered when the flow was unblocked as expected
+        assert_eq!(server.flow_unblock_breakpoint, 0);
+    }
+
+    #[test]
+    fn test_check_flow_restarts_no_breakpoint() {
+        let mut state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+
+        // Simulate flow #5 becoming busy — no breakpoint set
+        state.newly_busy_flows.push(5);
+        let action = debugger
+            .check_flow_restarts(&mut state)
+            .expect("check_flow_restarts failed");
+        assert_eq!(action, DebugAction::Continue);
+    }
+
+    #[test]
+    fn test_check_flow_restarts_with_breakpoint() {
+        let mut state = RunState::new(test_submission(vec![test_function(0)]));
+        let mut server = DummyServer::new();
+        let mut debugger = Debugger::new(&mut server);
+
+        // Set a process breakpoint on flow #0, then simulate it becoming busy
+        debugger.process_breakpoints.insert(0);
+        state.newly_busy_flows.push(0);
+        let _ = debugger.check_flow_restarts(&mut state);
+        // The breakpoint should have triggered
         assert_eq!(server.flow_unblock_breakpoint, 0);
     }
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -216,6 +216,10 @@ pub struct RunState {
     functions_by_flow: HashMap<usize, Vec<usize>>,
     /// Precomputed ancestor chains: flow ID → [self, parent, grandparent, ...root]
     ancestors_by_flow: HashMap<usize, Vec<usize>>,
+    /// Flow IDs that transitioned from idle to busy during the last `create_jobs` call.
+    /// Drained by the caller to check debugger breakpoints.
+    #[cfg(feature = "debugger")]
+    pub(crate) newly_busy_flows: Vec<usize>,
     #[cfg(feature = "trace")]
     #[serde(skip)]
     trace: flowcore::model::trace::Trace,
@@ -265,6 +269,8 @@ impl RunState {
             jobs_per_function: vec![0; num_processes],
             functions_by_flow,
             ancestors_by_flow,
+            #[cfg(feature = "debugger")]
+            newly_busy_flows: Vec::new(),
             #[cfg(feature = "trace")]
             trace,
         }
@@ -661,6 +667,12 @@ impl RunState {
         );
         job.result = result;
 
+        // Check for flow restart breakpoints after all job creation is done
+        #[cfg(feature = "debugger")]
+        if action == DebugAction::Continue {
+            action = debugger.check_flow_restarts(self)?;
+        }
+
         Ok((action, job))
     }
 
@@ -751,6 +763,13 @@ impl RunState {
         self.running_jobs.len()
     }
 
+    /// Drain and return the IDs of flows that transitioned from idle to busy
+    /// since the last drain. Used by the debugger for flow restart breakpoints.
+    #[cfg(feature = "debugger")]
+    pub(crate) fn drain_newly_busy_flows(&mut self) -> Vec<usize> {
+        std::mem::take(&mut self.newly_busy_flows)
+    }
+
     /// Return how many jobs are ready to be run, but not running yet
     #[must_use]
     pub fn number_jobs_ready(&self) -> usize {
@@ -817,7 +836,14 @@ impl RunState {
                 *self.busy_count.entry(process_id).or_insert(0) += 1;
                 let ancestors = self.ancestors(parent_id).to_vec();
                 for ancestor in ancestors {
-                    *self.busy_count.entry(ancestor).or_insert(0) += 1;
+                    let count = self.busy_count.entry(ancestor).or_insert(0);
+                    #[cfg(feature = "debugger")]
+                    let was_idle = *count == 0;
+                    *count += 1;
+                    #[cfg(feature = "debugger")]
+                    if was_idle {
+                        self.newly_busy_flows.push(ancestor);
+                    }
                 }
                 #[cfg(feature = "trace")]
                 self.record_trace("CreateJob");
@@ -1920,6 +1946,24 @@ mod test {
             state.create_jobs(0, 0).expect("Could not create jobs");
 
             state.get_next_job().expect("Couldn't get next job");
+        }
+
+        #[cfg(feature = "debugger")]
+        #[test]
+        fn drain_newly_busy_flows_works() {
+            let mut state = RunState::new(super::test_submission(test_functions()));
+
+            // Initially empty
+            assert!(state.drain_newly_busy_flows().is_empty());
+
+            // Manually simulate flows becoming busy
+            state.newly_busy_flows.push(1);
+            state.newly_busy_flows.push(2);
+            let busy = state.drain_newly_busy_flows();
+            assert_eq!(busy, vec![1, 2]);
+
+            // Draining again should return empty
+            assert!(state.drain_newly_busy_flows().is_empty());
         }
 
         #[test]

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -300,6 +300,8 @@ impl RunState {
         self.completed.clear();
         self.number_of_jobs_created = 0;
         self.busy_count.clear();
+        #[cfg(feature = "debugger")]
+        self.newly_busy_flows.clear();
         #[cfg(feature = "trace")]
         self.trace.events.clear();
     }


### PR DESCRIPTION
## Summary

Complete the unified flow/function breakpoint support from PR #2964 by adding flow restart breakpoints — the debugger now breaks when a flow transitions from idle to busy.

## How it works

When `create_jobs()` increments an ancestor flow's `busy_count` from 0 to 1 (idle → busy), the flow ID is recorded in `newly_busy_flows`. After `retire_job()` finishes all job creation and value distribution, it calls `debugger.check_flow_restarts()` which drains the list and checks each ID against `process_breakpoints`.

This means `b <flow_id>` now triggers on both:
- Flow going busy (restart) — new in this PR
- Job dispatch for functions — already worked from #2964

## Changes

- **`run_state.rs`**: Add `newly_busy_flows: Vec<usize>` field (behind `#[cfg(debugger)]`), detect 0→1 transitions in `create_jobs()`, add `drain_newly_busy_flows()` method, call `check_flow_restarts` from `retire_job`
- **`debugger.rs`**: Add `check_flow_restarts()` method that drains newly-busy flows and checks breakpoints

## Tests
- `drain_newly_busy_flows_works` — verifies drain/accumulate semantics
- `test_check_flow_restarts_no_breakpoint` — no breakpoint set, returns Continue
- `test_check_flow_restarts_with_breakpoint` — breakpoint triggers on newly-busy flow

Closes #2965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debugger support to detect flows that become active after job creation and pause when they match configured process breakpoints.
* **Bug Fixes**
  * Improved flow restart handling to avoid dropping newly-identified active flows before breakpoint checks.
  * Ensured breakpoint unblock notifications are sent when a matching process breakpoint is hit.
* **Tests**
  * Added unit tests covering continue behavior when no breakpoint matches and verifying the unblock notification when a match occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->