### PR TITLE
Add RON as a supported notation (#2275)

### DIFF
--- a/.claude/skills/start-new-issue/SKILL.md
+++ b/.claude/skills/start-new-issue/SKILL.md
@@ -36,6 +36,12 @@ Before committing new work to a branch, the following checks should pass:
 - `cargo fmt` either to check or directly to reformat code.
 - tests pass via `make test` if that Makefile target exists, or `cargo test` if not
 
+Expect the PR checks to check for:
+- non-reducing code coverage of the project and the patch (lines changed), add tests to reduce the possibility
+  of these checks failing after pushing. Use local test coverage report if possible.
+- Code review by a bot like code rabbit. Perform your own code review before pushing and fix issues, to attempt
+  to avoid the PR check failing after push.
+
 ## When is a PR ready to be merged?
 
 A PR can be considered ready to be merged when:
@@ -43,7 +49,10 @@ A PR can be considered ready to be merged when:
 - There are no local committed changes that have not been pushed
 - All the points in the GH issue have been addressed via committed, pushed and reviewed changes
 - There is no code review in progress since the last pushed change
-- There are no unaddressed code review comments since the last change was pushed 
+- There are no unaddressed code review comments since the last change was pushed
 - All the comments from code reviews have been addressed, even the Nit ones.
+
+If code coverage checks or code review fails in the PR checks, then iterate with fixes until the PR
+is green, all checks pass, and it is ready to be considered for merge.
 
 Don't suggest merging until the above list is met.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +335,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -1349,6 +1358,7 @@ dependencies = [
  "directories",
  "log",
  "mdns-sd",
+ "ron",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3946,6 +3956,19 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "ron"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
+dependencies = [
+ "base64",
+ "bitflags 2.11.1",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
 
 [[package]]
 name = "roxmltree"

--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -45,6 +45,7 @@ log = {version = "0.4.32"}
 serde = { version = "~1.0.228"}
 toml = { version = "1.1.2" }
 serde_yml = "0.0.13"
+ron = "0.9"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 curl = {version = "~0.4" }

--- a/flowcore/src/deserializers/deserializer.rs
+++ b/flowcore/src/deserializers/deserializer.rs
@@ -9,6 +9,7 @@ enum Format {
     Toml,
     Yaml,
     Json,
+    Ron,
 }
 
 impl Format {
@@ -18,6 +19,7 @@ impl Format {
             Some("toml") => Ok(Format::Toml),
             Some("yaml" | "yml") => Ok(Format::Yaml),
             Some("json") => Ok(Format::Json),
+            Some("ron") => Ok(Format::Ron),
             Some(_) => {
                 bail!("Unknown file extension so cannot determine which deserializer to use")
             }
@@ -31,6 +33,7 @@ impl Format {
             Format::Toml => "Toml",
             Format::Yaml => "Yaml",
             Format::Json => "Json",
+            Format::Ron => "Ron",
         }
     }
 }
@@ -55,6 +58,9 @@ where
             .chain_err(|| format!("Error deserializing Yaml from: '{url}'")),
         Format::Json => serde_json::from_str(contents)
             .chain_err(|| format!("Error deserializing Json from: '{url}'")),
+        Format::Ron => {
+            ron::from_str(contents).chain_err(|| format!("Error deserializing Ron from: '{url}'"))
+        }
     }
 }
 
@@ -201,5 +207,25 @@ mod test {
     fn invalid_yaml_content() {
         let url = Url::parse("file:///test.yaml").expect("Could not create Url");
         assert!(deserialize::<TestStruct>(&url, "\t invalid: [yaml").is_err());
+    }
+
+    #[test]
+    fn ron_format_name() {
+        let url = Url::parse("file:///filename.ron").expect("Could not create Url");
+        assert_eq!(format_name(&url).expect("Could not get format name"), "Ron");
+    }
+
+    #[test]
+    fn deserialize_ron() {
+        let url = Url::parse("file:///test.ron").expect("Could not create Url");
+        let result: TestStruct =
+            deserialize(&url, "(name: \"hello\")").expect("Could not deserialize");
+        assert_eq!(result.name, "hello");
+    }
+
+    #[test]
+    fn invalid_ron_content() {
+        let url = Url::parse("file:///test.ron").expect("Could not create Url");
+        assert!(deserialize::<TestStruct>(&url, "{invalid ron").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Add RON (Rusty Object Notation) as a fourth deserialization format for flow definition files.

## Changes

- **`flowcore/Cargo.toml`**: Add `ron = "0.9"` dependency
- **`flowcore/src/deserializers/deserializer.rs`**: Add `Ron` variant to `Format` enum, `.ron` extension support, and `ron::from_str` deserialization arm

## Tests

- `ron_format_name` — verifies `.ron` extension maps to "Ron"
- `deserialize_ron` — deserializes `(name: "hello")` successfully
- `invalid_ron_content` — verifies malformed RON returns an error

## Usage

Flow definitions can now use `.ron` file extension:
```ron
(
    flow: "my-flow",
    process: [
        (source: "context://stdio/stdout"),
    ],
)
```

Closes #2275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and deserializing RON-formatted files based on their `.ron` extension.
  * Added clear error handling for invalid RON content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->