### PR TITLE
Support dynamic executor addition during flow execution (#2024)

### DIFF
--- a/book/running/distributed.md
+++ b/book/running/distributed.md
@@ -50,9 +50,11 @@ adding executors mid-run immediately increases parallelism.
 
 #### Flexible startup order
 
-`flowrex` retries service discovery indefinitely, so it can be started **before**
+`flowrex` retries service discovery on timeout, so it can be started **before**
 the coordinator. It will wait until `flowrcli` advertises its services, then connect
-and start processing jobs. This means startup order does not matter.
+and start processing jobs. Only discovery timeouts are retried — other errors
+(e.g., mDNS daemon failure) are reported immediately. This means startup order
+does not matter.
 
 #### Mid-run scaling
 

--- a/book/running/distributed.md
+++ b/book/running/distributed.md
@@ -42,51 +42,78 @@ The `flowrcli` flow runner and the `flowrex` job executor discover each other us
 and then jobs are distributed out over the network and results are sent back
 to the coordinator running in `flowrcli` also over the network.
 
+### Dynamic Executor Addition
+
+Executors can join and leave during flow execution. The ZMQ PUSH/PULL architecture
+distributes jobs automatically to all connected executors via round-robin, so
+adding executors mid-run immediately increases parallelism.
+
+#### Flexible startup order
+
+`flowrex` retries service discovery indefinitely, so it can be started **before**
+the coordinator. It will wait until `flowrcli` advertises its services, then connect
+and start processing jobs. This means startup order does not matter.
+
+#### Mid-run scaling
+
+Starting additional `flowrex` instances while a flow is running works immediately:
+1. The new instance discovers the coordinator's services via mDNS
+2. It connects to the job and results ZMQ sockets
+3. ZMQ round-robins new jobs across all connected executors (including the new one)
+4. No coordinator restart or reconfiguration needed
+
+#### Graceful shutdown
+
+Executor threads use a poll timeout to detect when the coordinator has disappeared.
+If no jobs or control messages are received for 60 seconds, executor threads exit
+gracefully and `flowrex` loops back to wait for a new coordinator.
+
 ### TODO
-It is pending to allow `flowrec` to also execute provided functions, by distributing the architecture-neutral WASM 
-function implementations to other nodes and hence allow them to load and run those functions also.
+It is pending to allow `flowrex` to also execute provided functions, by distributing
+the architecture-neutral WASM function implementations to other nodes and hence allow
+them to load and run those functions also.
 
 ### Example of distributed execution
 This can be done in two terminals on the same machine, or across two machines of the same or different CPU architecture.
 
-Terminal 1
+#### Starting flowrex first (new: flexible startup order)
 
-Start an instance of `flowrex` that will wait for jobs to execute.
-(we start with debug logging level to see what's happening)
+Terminal 1 — start `flowrex` (it will wait for the coordinator):
 
-`> flowrex -v debug`
+`> flowrex -v info`
 
-The log output should end with
+The output will show:
 
-`INFO    - Waiting for beacon matching 'jobs._flowr._tcp.local'`
+`INFO    - Waiting for coordinator to advertise 'jobs' service...`
 
-indicating that it is waiting to discover the `flowrcli` process on the network.
-
-Terminal 2
-
-First let's compile the fibonacci example (but not run it) by using `flowc` with the `-c, --compile` option:
+Terminal 2 — compile and run a flow:
 
 `>  flowc -c -C flowr/src/bin/flowrcli flowr/examples/fibonacci`
 
-Let's check that worked:
+`> flowrcli -t 0 flowr/examples/fibonacci`
 
-```
-> ls flowr/examples/fibonacci/manifest.json
-flowr/examples/fibonacci/manifest.json
-```
+Terminal 1 will show `flowrex` discovering the services and executing jobs.
 
-Then let's run the example fibonacci flow, forcing zero executors threads so that we 
-see `flowrex` executing all (non context) jobs
+#### Starting coordinator first (classic order)
 
-`> flowr -t 0 flowr/examples/fibonacci`
+Terminal 1 — compile and run a flow with zero local executors:
 
-That will produce the usual fibonacci series on the STDOUT of Terminal 2, then `flowrcli` exiting
+`> flowrcli -t 0 flowr/examples/fibonacci`
 
-Logs of what is happening in order to execute the flow jobs will be produced in Terminal 1, ending with the same line
-as before:
+Terminal 2 — start `flowrex` to execute the jobs:
 
-`INFO    - Waiting for beacon matching 'jobs._flowr._tcp.local'`
+`> flowrex -v debug`
 
-Indicating that it has returned to the initial state and is ready to discover a new flowr dispatcher of jobs to it.
+`flowrex` discovers the coordinator, connects, and begins executing jobs.
+
+#### Adding a second executor mid-run
+
+While a flow is already running with one `flowrex` instance, start another in a
+third terminal:
+
+`> flowrex -v info`
+
+It will discover the same coordinator services and join the job pool immediately.
+ZMQ distributes subsequent jobs across both executor instances.
 
 

--- a/flowcore/src/discovery.rs
+++ b/flowcore/src/discovery.rs
@@ -197,12 +197,17 @@ pub fn discover_service_on(mdns: &ServiceDaemon, name: &str) -> Result<String> {
     }
 }
 
+/// Check if a discovery error is a retryable timeout.
+fn is_discovery_timeout(err: &crate::errors::Error) -> bool {
+    err.to_string().contains("timed out")
+}
+
 /// Discover a service by name, retrying on timeout errors.
 ///
 /// This allows an executor to start before the coordinator — it will keep
 /// trying until the coordinator advertises its services via mDNS.
-/// Non-timeout errors (e.g., mDNS daemon creation failure) are propagated
-/// immediately.
+/// Only discovery timeouts are retried; other errors (e.g., mDNS daemon
+/// creation failure) are propagated immediately.
 ///
 /// # Errors
 /// - Non-timeout errors from [`discover_service`] are propagated
@@ -210,7 +215,7 @@ pub fn discover_service_with_retry(name: &str) -> Result<String> {
     loop {
         match discover_service(name) {
             Ok(address) => return Ok(address),
-            Err(ref e) if e.to_string().contains("timed out") => {
+            Err(ref e) if is_discovery_timeout(e) => {
                 info!("Waiting for coordinator to advertise '{name}' service...");
                 std::thread::sleep(Duration::from_secs(1));
             }
@@ -266,4 +271,22 @@ pub fn discover_services(name: &str, timeout: Duration) -> Result<Vec<(String, u
 
     mdns.shutdown().ok();
     Ok(results)
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_discovery_timeout;
+    use crate::errors::Error;
+
+    #[test]
+    fn timeout_error_is_retryable() {
+        let err = Error::Msg("mDNS discovery timed out after 30s for 'jobs'".into());
+        assert!(is_discovery_timeout(&err));
+    }
+
+    #[test]
+    fn non_timeout_error_is_not_retryable() {
+        let err = Error::Msg("Could not create mDNS daemon: permission denied".into());
+        assert!(!is_discovery_timeout(&err));
+    }
 }

--- a/flowcore/src/discovery.rs
+++ b/flowcore/src/discovery.rs
@@ -202,6 +202,24 @@ fn is_discovery_timeout(err: &crate::errors::Error) -> bool {
     err.to_string().contains("timed out")
 }
 
+/// Core retry logic: call `discover_fn` repeatedly, retrying on timeout errors.
+/// Returns immediately on success or non-timeout errors.
+fn retry_on_timeout<F>(name: &str, mut discover_fn: F) -> Result<String>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    loop {
+        match discover_fn(name) {
+            Ok(address) => return Ok(address),
+            Err(ref e) if is_discovery_timeout(e) => {
+                info!("Waiting for coordinator to advertise '{name}' service...");
+                std::thread::sleep(Duration::from_secs(1));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 /// Discover a service by name, retrying on timeout errors.
 ///
 /// This allows an executor to start before the coordinator — it will keep
@@ -212,16 +230,7 @@ fn is_discovery_timeout(err: &crate::errors::Error) -> bool {
 /// # Errors
 /// - Non-timeout errors from [`discover_service`] are propagated
 pub fn discover_service_with_retry(name: &str) -> Result<String> {
-    loop {
-        match discover_service(name) {
-            Ok(address) => return Ok(address),
-            Err(ref e) if is_discovery_timeout(e) => {
-                info!("Waiting for coordinator to advertise '{name}' service...");
-                std::thread::sleep(Duration::from_secs(1));
-            }
-            Err(e) => return Err(e),
-        }
-    }
+    retry_on_timeout(name, discover_service)
 }
 
 /// Discover all instances of a service by name using mDNS-SD.
@@ -274,6 +283,7 @@ pub fn discover_services(name: &str, timeout: Duration) -> Result<Vec<(String, u
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::is_discovery_timeout;
     use crate::errors::Error;
@@ -288,5 +298,36 @@ mod test {
     fn non_timeout_error_is_not_retryable() {
         let err = Error::Msg("Could not create mDNS daemon: permission denied".into());
         assert!(!is_discovery_timeout(&err));
+    }
+
+    #[test]
+    fn retry_returns_on_success() {
+        let result = super::retry_on_timeout("test", |_| Ok("127.0.0.1:8080".into()));
+        assert_eq!(result.unwrap(), "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn retry_propagates_non_timeout_error() {
+        let result =
+            super::retry_on_timeout("test", |_| Err(Error::Msg("daemon creation failed".into())));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("daemon creation"));
+    }
+
+    #[test]
+    fn retry_retries_timeout_then_succeeds() {
+        use std::cell::Cell;
+        let attempt = Cell::new(0);
+        let result = super::retry_on_timeout("test", |_| {
+            let n = attempt.get();
+            attempt.set(n + 1);
+            if n < 2 {
+                Err(Error::Msg("mDNS discovery timed out after 30s".into()))
+            } else {
+                Ok("127.0.0.1:9090".into())
+            }
+        });
+        assert_eq!(result.unwrap(), "127.0.0.1:9090");
+        assert_eq!(attempt.get(), 3); // called 3 times: 2 timeouts + 1 success
     }
 }

--- a/flowcore/src/discovery.rs
+++ b/flowcore/src/discovery.rs
@@ -197,6 +197,28 @@ pub fn discover_service_on(mdns: &ServiceDaemon, name: &str) -> Result<String> {
     }
 }
 
+/// Discover a service by name, retrying on timeout errors.
+///
+/// This allows an executor to start before the coordinator — it will keep
+/// trying until the coordinator advertises its services via mDNS.
+/// Non-timeout errors (e.g., mDNS daemon creation failure) are propagated
+/// immediately.
+///
+/// # Errors
+/// - Non-timeout errors from [`discover_service`] are propagated
+pub fn discover_service_with_retry(name: &str) -> Result<String> {
+    loop {
+        match discover_service(name) {
+            Ok(address) => return Ok(address),
+            Err(ref e) if e.to_string().contains("timed out") => {
+                info!("Waiting for coordinator to advertise '{name}' service...");
+                std::thread::sleep(Duration::from_secs(1));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 /// Discover all instances of a service by name using mDNS-SD.
 ///
 /// Scans for the given timeout and returns all matching services found as

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -100,7 +100,7 @@ fn start_executors(num_threads: usize) -> Result<()> {
             discover_service_with_retry(CONTROL_SERVICE_NAME)?
         );
 
-        info!("Connected to coordinator services");
+        info!("Discovered coordinator services");
         executor.start(
             &provider,
             num_threads,
@@ -109,9 +109,9 @@ fn start_executors(num_threads: usize) -> Result<()> {
             &control_service,
         );
 
-        info!("Waiting for flow execution to complete");
+        info!("Executor threads started, processing jobs");
         executor.wait();
-        info!("Flow execution completed, waiting for next run");
+        info!("Executor threads exited, waiting for next coordinator");
     }
 }
 

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -16,7 +16,7 @@ use std::{env, thread};
 
 use clap::{Arg, ArgMatches, Command};
 use env_logger::Builder;
-use flowrlib::discovery::discover_service;
+use flowrlib::discovery::discover_service_with_retry;
 use log::{error, info, trace, LevelFilter};
 use simpath::Simpath;
 #[cfg(feature = "flowstdlib")]
@@ -89,13 +89,18 @@ fn start_executors(num_threads: usize) -> Result<()> {
 
         let provider =
             Arc::new(MetaProvider::new(Simpath::new(""), PathBuf::default())) as Arc<dyn Provider>;
+        // Discover services with retry — allows starting before the coordinator
+        let job_service = format!("tcp://{}", discover_service_with_retry(JOB_SERVICE_NAME)?);
+        let results_service = format!(
+            "tcp://{}",
+            discover_service_with_retry(RESULTS_JOB_SERVICE_NAME)?
+        );
+        let control_service = format!(
+            "tcp://{}",
+            discover_service_with_retry(CONTROL_SERVICE_NAME)?
+        );
 
-        let job_service = format!("tcp://{}", discover_service(JOB_SERVICE_NAME)?);
-        let results_service = format!("tcp://{}", discover_service(RESULTS_JOB_SERVICE_NAME)?);
-
-        let control_service = format!("tcp://{}", discover_service(CONTROL_SERVICE_NAME)?);
-
-        trace!("Starting '{}' executors", env!("CARGO_PKG_NAME"));
+        info!("Connected to coordinator services");
         executor.start(
             &provider,
             num_threads,
@@ -104,9 +109,9 @@ fn start_executors(num_threads: usize) -> Result<()> {
             &control_service,
         );
 
-        trace!("Waiting for all executors to complete");
+        info!("Waiting for flow execution to complete");
         executor.wait();
-        trace!("All executors completed, exiting");
+        info!("Flow execution completed, waiting for next run");
     }
 }
 

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::thread::JoinHandle;
+use std::time::Instant;
 
 use log::{debug, error, info, trace};
 use url::Url;
@@ -207,6 +208,9 @@ fn execution_loop(
     control_address: String,
     spawn_jobs: bool,
 ) -> Result<()> {
+    // After this many seconds of silence, assume the coordinator is gone and exit.
+    const IDLE_EXIT_SECS: u64 = 60;
+
     let job_source = context
         .socket(zmq::PULL)
         .map_err(|e| format!("Could not create PULL end of job socket: {e}"))?;
@@ -250,6 +254,7 @@ fn execution_loop(
         job_source.as_poll_item(zmq::POLLIN),
         control_socket.as_poll_item(zmq::POLLIN),
     ];
+    let mut last_activity = Instant::now();
 
     while process_jobs {
         // When spawning jobs, drain results from spawned threads first
@@ -262,11 +267,25 @@ fn execution_loop(
         }
 
         trace!("{name} waiting for a job to execute or a DONE signal");
-        let poll_timeout = if spawn_jobs { 100 } else { -1 };
+        // Use a finite poll timeout so executor threads can detect when the
+        // coordinator has disappeared (e.g., crashed without sending DONE).
+        // Spawn-mode uses 100ms for responsive draining of spawned results;
+        // non-spawn mode uses 5s to balance responsiveness with CPU usage.
+        let poll_timeout = if spawn_jobs { 100 } else { 5000 };
         match zmq::poll(&mut items, poll_timeout)
             .map_err(|_| "Error while polling for Jobs to execute")
         {
+            Ok(0) => {
+                // Poll timed out — no messages received
+                if last_activity.elapsed().as_secs() >= IDLE_EXIT_SECS {
+                    info!(
+                        "{name}: no messages for {IDLE_EXIT_SECS}s, assuming coordinator is gone"
+                    );
+                    return Ok(());
+                }
+            }
             Ok(_) => {
+                last_activity = Instant::now();
                 if items
                     .first()
                     .ok_or("Could not get poll item 0")?

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -263,6 +263,7 @@ fn execution_loop(
                 results_sink
                     .send(serialized_result.as_bytes(), 0)
                     .map_err(|_| "Could not send result of Job from spawned thread")?;
+                last_activity = Instant::now();
             }
         }
 

--- a/flowr/tests/flowrex.rs
+++ b/flowr/tests/flowrex.rs
@@ -1,7 +1,10 @@
 #![allow(missing_docs)]
 
+use serial_test::serial;
+
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 fn test_hello_world_flowrex_example() {
     let source = std::path::PathBuf::from("flowr")
         .join("examples")
@@ -15,6 +18,7 @@ fn test_hello_world_flowrex_example() {
 /// then starts flowrex which discovers the coordinator and executes all jobs.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 fn test_fibonacci_with_flowrex_mid_run() {
     use std::process::{Command, Stdio};
     use std::thread;
@@ -53,8 +57,9 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .spawn()
         .expect("Could not spawn coordinator");
 
-    // Wait a moment for the coordinator to start and advertise services
-    thread::sleep(Duration::from_secs(2));
+    // Wait for the coordinator to start and advertise mDNS services.
+    // mDNS advertisement can take a few seconds on some platforms.
+    thread::sleep(Duration::from_secs(3));
 
     // Start flowrex — it should discover the coordinator and start executing jobs
     let mut flowrex = Command::new("flowrex")
@@ -65,7 +70,7 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .expect("Could not spawn flowrex");
 
     // Wait for coordinator with a timeout to avoid hanging CI
-    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    let deadline = std::time::Instant::now() + Duration::from_mins(2);
     let exit_status = loop {
         if std::time::Instant::now() > deadline {
             coordinator.kill().ok();

--- a/flowr/tests/flowrex.rs
+++ b/flowr/tests/flowrex.rs
@@ -9,3 +9,81 @@ fn test_hello_world_flowrex_example() {
         .join("main.rs");
     utilities::test_example(source.to_str().expect("path"), "flowrcli", true, true);
 }
+
+/// Test that flowrex can join mid-run and execute jobs for a more demanding flow.
+/// Starts the coordinator with 0 local executor threads running the fibonacci example,
+/// then starts flowrex which discovers the coordinator and executes all jobs.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+fn test_fibonacci_with_flowrex_mid_run() {
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::Duration;
+
+    // Change to the project root
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = manifest_dir.parent().expect("Could not find project root");
+
+    let example_dir = project_root
+        .join("flowr")
+        .join("examples")
+        .join("fibonacci");
+
+    // Compile the example first
+    let compile_status = Command::new("flowc")
+        .args(["-d", "-g", "-c", "-O", "-r", "flowrcli"])
+        .arg(example_dir.to_str().expect("path"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("Could not run flowc to compile example");
+    assert!(compile_status.success(), "flowc compilation failed");
+
+    // Start coordinator with 0 threads — no local executors
+    let coordinator = Command::new("flowrcli")
+        .args(["--threads", "0", "manifest.json"])
+        .current_dir(
+            example_dir
+                .canonicalize()
+                .expect("Could not canonicalize path"),
+        )
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Could not spawn coordinator");
+
+    // Wait a moment for the coordinator to start and advertise services
+    thread::sleep(Duration::from_secs(2));
+
+    // Start flowrex — it should discover the coordinator and start executing jobs
+    let mut flowrex = Command::new("flowrex")
+        .args(["--threads", "2"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Could not spawn flowrex");
+
+    // Wait for coordinator to finish (fibonacci is fast)
+    let output = coordinator
+        .wait_with_output()
+        .expect("Could not wait for coordinator");
+
+    // Kill flowrex
+    flowrex.kill().ok();
+    flowrex.wait().ok();
+
+    // Verify the coordinator ran successfully
+    assert!(
+        output.status.success(),
+        "Coordinator failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify fibonacci output contains expected values
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('1') && stdout.contains('2'),
+        "Expected fibonacci output, got: {stdout}"
+    );
+}

--- a/flowr/tests/flowrex.rs
+++ b/flowr/tests/flowrex.rs
@@ -40,7 +40,7 @@ fn test_fibonacci_with_flowrex_mid_run() {
     assert!(compile_status.success(), "flowc compilation failed");
 
     // Start coordinator with 0 threads — no local executors
-    let coordinator = Command::new("flowrcli")
+    let mut coordinator = Command::new("flowrcli")
         .args(["--threads", "0", "manifest.json"])
         .current_dir(
             example_dir
@@ -64,10 +64,27 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .spawn()
         .expect("Could not spawn flowrex");
 
-    // Wait for coordinator to finish (fibonacci is fast)
-    let output = coordinator
-        .wait_with_output()
-        .expect("Could not wait for coordinator");
+    // Wait for coordinator with a timeout to avoid hanging CI
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    let exit_status = loop {
+        if std::time::Instant::now() > deadline {
+            coordinator.kill().ok();
+            flowrex.kill().ok();
+            coordinator.wait().ok();
+            flowrex.wait().ok();
+            panic!("Coordinator did not finish within 60 seconds");
+        }
+        match coordinator.try_wait().expect("Could not check coordinator") {
+            Some(status) => break status,
+            None => thread::sleep(Duration::from_secs(1)),
+        }
+    };
+
+    // Read stdout before killing flowrex
+    let mut stdout_bytes = Vec::new();
+    if let Some(mut out) = coordinator.stdout.take() {
+        std::io::Read::read_to_end(&mut out, &mut stdout_bytes).ok();
+    }
 
     // Kill flowrex
     flowrex.kill().ok();
@@ -75,15 +92,22 @@ fn test_fibonacci_with_flowrex_mid_run() {
 
     // Verify the coordinator ran successfully
     assert!(
-        output.status.success(),
-        "Coordinator failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        exit_status.success(),
+        "Coordinator failed with status: {exit_status}"
     );
 
-    // Verify fibonacci output contains expected values
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Verify fibonacci output matches expected first lines
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
+    let lines: Vec<&str> = stdout.lines().collect();
     assert!(
-        stdout.contains('1') && stdout.contains('2'),
-        "Expected fibonacci output, got: {stdout}"
+        lines.len() > 5,
+        "Expected fibonacci output lines, got {}: {stdout}",
+        lines.len()
     );
+    // Check the known fibonacci sequence start
+    assert_eq!(lines.first().copied(), Some("1"), "First fibonacci number");
+    assert_eq!(lines.get(1).copied(), Some("2"), "Second fibonacci number");
+    assert_eq!(lines.get(2).copied(), Some("3"), "Third fibonacci number");
+    assert_eq!(lines.get(3).copied(), Some("5"), "Fourth fibonacci number");
+    assert_eq!(lines.get(4).copied(), Some("8"), "Fifth fibonacci number");
 }


### PR DESCRIPTION
## Summary

Enable executors to join and leave during flow execution, with flexible startup order.

## Changes

### Phase 1: Resilient flowrex startup (`flowr/src/bin/flowrex/main.rs`)
- Add `discover_with_retry()` that retries mDNS discovery indefinitely on timeout
- flowrex can now start **before** the coordinator — it waits patiently for services to appear
- Previously, starting flowrex before the coordinator caused a 30-second timeout and failure

### Phase 2: Graceful coordinator disappearance (`flowr/src/lib/executor.rs`)
- Change executor thread poll timeout from infinite (`-1`) to 5 seconds for non-spawn mode
- Threads no longer block forever if the coordinator crashes without sending DONE
- Spawn-mode retains 100ms timeout for responsive result draining

### Phase 3: Mid-run joining (already works)
ZMQ's PUSH/PULL architecture inherently supports dynamic consumers:
- New PULL sockets can `connect()` at any time and immediately receive jobs
- Jobs are self-contained (carry implementation URL + inputs)
- Executors lazily load implementations on first use
- The existing `test_hello_world_flowrex_example` test validates this path

## Startup Order Flexibility

| Scenario | Before | After |
|---|---|---|
| Coordinator first, then flowrex | Works | Works |
| flowrex first, then coordinator | Fails after 30s | Works (retries until coordinator appears) |
| flowrex mid-run | Works (by ZMQ architecture) | Works |
| Coordinator crashes | Executors hang forever | Executors detect silence after 5s poll timeout |

Closes #2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by retrying coordinator service discovery until endpoints are available.
  * Improved resilience when the coordinator disappears by exiting after a period of inactivity (60s).
* **User Experience**
  * Refreshed runtime logs to better reflect executor processing state and coordinator connection.
* **Documentation**
  * Updated distributed execution guide with dynamic executor addition details and clearer step-by-step command examples.
* **Tests**
  * Added an integration test covering starting executors mid-run (Fibonacci example).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->