### PR TITLE
Decouple image writing from rendering (#2679)

### DIFF
--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -184,16 +184,16 @@ impl CliRuntimeClient {
         }
     }
 
-    fn flush_image_buffers(&mut self) {
-        // Render any pending grids into image buffers
-        for (name, grid) in self.pending_grids.drain() {
+    /// Render a pending grid into the image buffer for the given name.
+    fn materialize_pending_grid(&mut self, name: &str) {
+        if let Some(grid) = self.pending_grids.remove(name) {
             let height = u32::try_from(grid.len()).unwrap_or(0);
             let width = grid
                 .first()
                 .map_or(0, |row| u32::try_from(row.len()).unwrap_or(0));
             let image = self
                 .image_buffers
-                .entry(name)
+                .entry(name.to_string())
                 .or_insert_with(|| RgbImage::new(width, height));
             for (y, row) in grid.iter().enumerate() {
                 for (x, &val) in row.iter().enumerate() {
@@ -204,6 +204,14 @@ impl CliRuntimeClient {
                     );
                 }
             }
+        }
+    }
+
+    fn flush_image_buffers(&mut self) {
+        // Render any remaining pending grids into image buffers
+        let names: Vec<String> = self.pending_grids.keys().cloned().collect();
+        for name in names {
+            self.materialize_pending_grid(&name);
         }
 
         // Save all image buffers to disk
@@ -291,6 +299,9 @@ impl CliRuntimeClient {
             },
             #[allow(clippy::many_single_char_names)]
             CoordinatorMessage::PixelWrite((x, y), (r, g, b), (width, height), name) => {
+                // Materialize any pending grid for this image before applying
+                // pixel writes, preserving message ordering.
+                self.materialize_pending_grid(&name);
                 let image = self
                     .image_buffers
                     .entry(name)
@@ -640,5 +651,65 @@ mod test {
         ));
 
         assert!(handle.await.unwrap().is_ok());
+    }
+
+    #[test]
+    fn test_image_write_stores_pending_grid() {
+        let mut client = make_client();
+        let grid = vec![vec![0, 128, 255], vec![64, 192, 32]];
+        client.process_coordinator_message(CoordinatorMessage::ImageWrite(
+            grid.clone(),
+            "test.png".into(),
+        ));
+        assert!(
+            client.pending_grids.contains_key("test.png"),
+            "Grid should be stored in pending_grids"
+        );
+        assert!(
+            client.image_buffers.is_empty(),
+            "Image buffer should not be created yet"
+        );
+    }
+
+    #[test]
+    fn test_image_write_latest_frame_wins() {
+        let mut client = make_client();
+        let grid1 = vec![vec![0, 0], vec![0, 0]];
+        let grid2 = vec![vec![255, 255], vec![255, 255]];
+        client
+            .process_coordinator_message(CoordinatorMessage::ImageWrite(grid1, "test.png".into()));
+        client.process_coordinator_message(CoordinatorMessage::ImageWrite(
+            grid2.clone(),
+            "test.png".into(),
+        ));
+        assert_eq!(
+            client.pending_grids.get("test.png"),
+            Some(&grid2),
+            "Latest grid should overwrite previous"
+        );
+    }
+
+    #[test]
+    fn test_pixel_write_materializes_pending_grid() {
+        let mut client = make_client();
+        let grid = vec![vec![0, 0], vec![0, 0]];
+        // Store a grid via ImageWrite
+        client.process_coordinator_message(CoordinatorMessage::ImageWrite(grid, "test.png".into()));
+        // PixelWrite should materialize the grid first
+        client.process_coordinator_message(CoordinatorMessage::PixelWrite(
+            (0, 0),
+            (255, 0, 0),
+            (2, 2),
+            "test.png".into(),
+        ));
+        // Grid should be materialized and no longer pending
+        assert!(
+            !client.pending_grids.contains_key("test.png"),
+            "Grid should have been materialized"
+        );
+        assert!(
+            client.image_buffers.contains_key("test.png"),
+            "Image buffer should exist after materialization"
+        );
     }
 }

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -27,6 +27,8 @@ pub struct CliRuntimeClient {
     args: Vec<String>,
     override_args: Arc<Mutex<Vec<String>>>,
     image_buffers: HashMap<String, ImageBuffer<Rgb<u8>, Vec<u8>>>,
+    /// Latest grid data per image name — rendered only at flush time
+    pending_grids: HashMap<String, Vec<Vec<u8>>>,
     #[cfg(feature = "metrics")]
     display_metrics: bool,
 }
@@ -42,6 +44,7 @@ impl CliRuntimeClient {
             args,
             override_args,
             image_buffers: HashMap::<String, ImageBuffer<Rgb<u8>, Vec<u8>>>::new(),
+            pending_grids: HashMap::new(),
             #[cfg(feature = "metrics")]
             display_metrics,
         }
@@ -182,6 +185,28 @@ impl CliRuntimeClient {
     }
 
     fn flush_image_buffers(&mut self) {
+        // Render any pending grids into image buffers
+        for (name, grid) in self.pending_grids.drain() {
+            let height = u32::try_from(grid.len()).unwrap_or(0);
+            let width = grid
+                .first()
+                .map_or(0, |row| u32::try_from(row.len()).unwrap_or(0));
+            let image = self
+                .image_buffers
+                .entry(name)
+                .or_insert_with(|| RgbImage::new(width, height));
+            for (y, row) in grid.iter().enumerate() {
+                for (x, &val) in row.iter().enumerate() {
+                    image.put_pixel(
+                        u32::try_from(x).unwrap_or(0),
+                        u32::try_from(y).unwrap_or(0),
+                        Rgb([val, val, val]),
+                    );
+                }
+            }
+        }
+
+        // Save all image buffers to disk
         for (filename, image_buffer) in self.image_buffers.drain() {
             info!("Flushing ImageBuffer to file: {filename}");
             if let Err(e) = image_buffer.save_with_format(Path::new(&filename), ImageFormat::Png) {
@@ -274,24 +299,10 @@ impl CliRuntimeClient {
                 ClientMessage::Ack
             }
             CoordinatorMessage::ImageWrite(grid, name) => {
-                let height = u32::try_from(grid.len()).unwrap_or(0);
-                let width = grid
-                    .first()
-                    .map_or(0, |row| u32::try_from(row.len()).unwrap_or(0));
-                let image = self
-                    .image_buffers
-                    .entry(name)
-                    .or_insert_with(|| RgbImage::new(width, height));
-                for (y, row) in grid.iter().enumerate() {
-                    for (x, &val) in row.iter().enumerate() {
-                        let gray = val;
-                        image.put_pixel(
-                            u32::try_from(x).unwrap_or(0),
-                            u32::try_from(y).unwrap_or(0),
-                            Rgb([gray, gray, gray]),
-                        );
-                    }
-                }
+                // Store the latest grid — rendering is deferred to flush_image_buffers.
+                // This avoids per-pixel rendering on every frame when only the final
+                // frame is saved to disk.
+                self.pending_grids.insert(name, grid);
                 ClientMessage::Ack
             }
             CoordinatorMessage::GetArgs => {

--- a/flowr/src/bin/flowrcli/context/image/image_write.rs
+++ b/flowr/src/bin/flowrcli/context/image/image_write.rs
@@ -51,8 +51,11 @@ impl Implementation for ImageWrite {
             flat.chunks(width).map(<[u8]>::to_vec).collect()
         };
 
+        // Fire-and-forget: the bridge thread completes the ZMQ round-trip,
+        // but the context executor thread is freed immediately to process
+        // other context jobs. image_write produces no output value.
         self.context_io
-            .send_and_receive(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
+            .send_no_reply(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
 
         Ok((None, RUN_AGAIN))
     }

--- a/flowr/src/bin/flowrcli/context/mod.rs
+++ b/flowr/src/bin/flowrcli/context/mod.rs
@@ -78,7 +78,7 @@ impl ContextIO {
     }
 
     /// Send a message without waiting for a response (fire-and-forget).
-    #[allow(dead_code)]
+    /// The bridge thread still completes the ZMQ round-trip.
     pub fn send_no_reply(&self, message: CoordinatorMessage) -> Result<()> {
         self.tx
             .send(ContextRequest {

--- a/flowr/src/bin/flowrgui/context/image/image_write.rs
+++ b/flowr/src/bin/flowrgui/context/image/image_write.rs
@@ -52,8 +52,11 @@ impl Implementation for ImageWrite {
             flat.chunks(width).map(<[u8]>::to_vec).collect()
         };
 
+        // Fire-and-forget: the bridge thread completes the ZMQ round-trip,
+        // but the context executor thread is freed immediately to process
+        // other context jobs. image_write produces no output value.
         self.context_io
-            .send_and_receive(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
+            .send_no_reply(CoordinatorMessage::ImageWrite(grid, filename.to_string()))?;
 
         Ok((None, RUN_AGAIN))
     }

--- a/flowr/src/bin/flowrgui/context/mod.rs
+++ b/flowr/src/bin/flowrgui/context/mod.rs
@@ -63,6 +63,17 @@ impl ContextIO {
             .map_err(|e| format!("Could not receive from bridge: {e}").into())
     }
 
+    /// Send a message without waiting for a response (fire-and-forget).
+    /// The bridge thread still completes the ZMQ round-trip.
+    pub fn send_no_reply(&self, message: CoordinatorMessage) -> Result<()> {
+        self.tx
+            .send(ContextRequest {
+                message,
+                response_tx: None,
+            })
+            .map_err(|e| format!("Could not send to bridge: {e}").into())
+    }
+
     /// Send a message on the blocking IO channel and wait for the client's response.
     /// Used by context functions that may block for user input (readline, stdin).
     pub fn send_and_receive_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {


### PR DESCRIPTION
## Summary

Decouple image data reception from pixel rendering to eliminate the context executor bottleneck during sustained image output.

## Changes

### 1. Fire-and-forget `image_write` (flowrcli + flowrgui)
- Change `send_and_receive` → `send_no_reply` in both runners
- The bridge thread still completes the ZMQ REQ/REP cycle
- The context executor thread is freed immediately (~microseconds vs ~milliseconds)
- Add `send_no_reply` to flowrgui's `ContextIO` (flowrcli already had it)

### 2. Deferred rendering in flowrcli
- `ImageWrite` handler now stores the latest grid in `pending_grids` instead of rendering pixels
- Intermediate frames are naturally skipped — only the latest grid per image name is kept
- `flush_image_buffers()` renders and saves at flow end (called on `FlowEnd`)
- Existing `PixelWrite` (used by mandlebrot etc.) is unchanged

## Effect on long-running flows
Before: every generation rendered pixel-by-pixel into the image buffer, blocking the single context executor thread for the full ZMQ round-trip. After 50+ iterations, rendering fell behind computation.

After: grid data is queued in microseconds. Only the final frame is rendered and saved. The context executor thread stays responsive for stdout and other context functions.

Partial progress on #2679 — remaining items: bulk pixel rendering, flowrgui live display optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image writing reliability by staging image updates before rendering and saving PNG files.
  * Prevented image operations from blocking while waiting for background processing to complete.
  * Ensured image updates continue processing without producing unnecessary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->