### PR TITLE
Replace function reference fields with FunctionReference enum (#1182)

### DIFF
--- a/flowc/src/lib/compiler/compile.rs
+++ b/flowc/src/lib/compiler/compile.rs
@@ -184,7 +184,10 @@ fn compile_supplied_implementations(
     #[cfg(feature = "debugger")] source_urls: &mut BTreeMap<String, Url>,
 ) -> Result<String> {
     for function in tables.functions.values_mut() {
-        if function.get_lib_reference().is_none() && function.get_context_reference().is_none() {
+        if matches!(
+            function.reference(),
+            flowcore::model::function_definition::FunctionReference::Supplied(_)
+        ) {
             let (implementation_source_path, wasm_destination) = get_paths(out_dir, function)?;
             let mut cargo_target_dir = implementation_source_path
                 .parent()
@@ -332,7 +335,7 @@ mod test {
 
     use flowcore::model::datatype::STRING_TYPE;
     use flowcore::model::flow_definition::FlowDefinition;
-    use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::function_definition::{FunctionDefinition, FunctionReference};
     use flowcore::model::io::IO;
     use flowcore::model::name::{HasName, Name};
     use flowcore::model::output_connection::{OutputConnection, Source};
@@ -450,8 +453,9 @@ mod test {
             vec![],
             Url::parse("context://stdio/stdout.toml").expect("Could not parse Url"),
             Route::from("/print"),
-            None,
-            Some(Url::parse("context://stdio/stdout.toml").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout.toml").expect("Could not parse Url"),
+            ),
             vec![],
             0,
             0,
@@ -512,8 +516,9 @@ mod test {
             )
             .expect("Could not create source Url"),
             Route::from("/flow0/stdout"),
-            Some(Url::parse("lib::/tests/test-functions/test/test").expect("Could not parse Url")),
-            None,
+            FunctionReference::Library(
+                Url::parse("lib::/tests/test-functions/test/test").expect("Could not parse Url"),
+            ),
             vec![OutputConnection::new(
                 Source::default(),
                 1,

--- a/flowc/src/lib/compiler/compile_wasm.rs
+++ b/flowc/src/lib/compiler/compile_wasm.rs
@@ -309,6 +309,7 @@ mod test {
     }
 
     fn test_function() -> FunctionDefinition {
+        use flowcore::model::function_definition::FunctionReference;
         FunctionDefinition::new(
             "Stdout".into(),
             false,
@@ -325,8 +326,9 @@ mod test {
             )
             .expect("Could not create source Url"),
             Route::from("/flow0/stdout"),
-            Some(Url::parse("lib::/tests/test-functions/test/test").expect("Could not parse Url")),
-            None,
+            FunctionReference::Library(
+                Url::parse("lib::/tests/test-functions/test/test").expect("Could not parse Url"),
+            ),
             vec![OutputConnection::new(
                 Source::default(),
                 1,

--- a/flowc/src/lib/compiler/optimizer.rs
+++ b/flowc/src/lib/compiler/optimizer.rs
@@ -121,7 +121,7 @@ mod test {
     use url::Url;
 
     use flowcore::model::connection::Connection;
-    use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::function_definition::{FunctionDefinition, FunctionReference};
     use flowcore::model::io::{IOSet, IOType};
 
     use crate::compiler::compile::CompilerTables;
@@ -137,8 +137,7 @@ mod test {
             IOSet::new(),
             Url::parse("file:///fake/pure").expect("Could not parse Url"),
             "/root/pure_function".into(),
-            None,
-            None,
+            FunctionReference::Supplied(String::new()),
             vec![],
             0,
             0,
@@ -155,8 +154,7 @@ mod test {
             IOSet::new(),
             Url::parse("file:///fake/impure").expect("Could not parse Url"),
             "/root/impure_function".into(),
-            None,
-            None,
+            FunctionReference::Supplied(String::new()),
             vec![],
             1,
             0,

--- a/flowc/src/lib/compiler/parser.rs
+++ b/flowc/src/lib/compiler/parser.rs
@@ -207,11 +207,15 @@ fn parse_process_refs(
 
         match &process {
             FunctionProcess(function) => {
-                if let Some(lib_ref) = function.get_lib_reference() {
-                    flow.lib_references.insert(lib_ref.clone());
-                }
-                if let Some(context_ref) = function.get_context_reference() {
-                    flow.context_references.insert(context_ref.clone());
+                use flowcore::model::function_definition::FunctionReference;
+                match function.reference() {
+                    FunctionReference::Library(url) => {
+                        flow.lib_references.insert(url.clone());
+                    }
+                    FunctionReference::Context(url) => {
+                        flow.context_references.insert(url.clone());
+                    }
+                    FunctionReference::Supplied(_) => {}
                 }
             }
             FlowProcess(sub_flow) => {

--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -189,28 +189,29 @@ fn implementation_location_relative(
     function: &FunctionDefinition,
     manifest_url: &Url,
 ) -> Result<String> {
-    if let Some(ref lib_reference) = function.get_lib_reference() {
-        Ok(lib_reference.to_string())
-    } else if let Some(ref context_reference) = function.get_context_reference() {
-        Ok(context_reference.to_string())
-    } else {
-        let implementation_path = function.get_implementation();
-        let implementation_url = Url::from_file_path(implementation_path)
-            .map_err(|()| format!("Could not create Url from file path: {implementation_path}"))?
-            .to_string();
+    use flowcore::model::function_definition::FunctionReference;
+    match function.reference() {
+        FunctionReference::Library(url) | FunctionReference::Context(url) => Ok(url.to_string()),
+        FunctionReference::Supplied(implementation_path) => {
+            let implementation_url = Url::from_file_path(implementation_path)
+                .map_err(|()| {
+                    format!("Could not create Url from file path: {implementation_path}")
+                })?
+                .to_string();
 
-        let mut manifest_base_url = manifest_url.clone();
-        manifest_base_url
-            .path_segments_mut()
-            .map_err(|()| "cannot be base")?
-            .pop();
+            let mut manifest_base_url = manifest_url.clone();
+            manifest_base_url
+                .path_segments_mut()
+                .map_err(|()| "cannot be base")?
+                .pop();
 
-        info!("Manifest base = '{manifest_base_url}'");
-        info!("Absolute implementation path = '{implementation_path}'");
-        let relative_path =
-            implementation_url.replace(&format!("{}/", manifest_base_url.as_str()), "");
-        info!("Relative implementation path = '{relative_path}'");
-        Ok(relative_path)
+            info!("Manifest base = '{manifest_base_url}'");
+            info!("Absolute implementation path = '{implementation_path}'");
+            let relative_path =
+                implementation_url.replace(&format!("{}/", manifest_base_url.as_str()), "");
+            info!("Relative implementation path = '{relative_path}'");
+            Ok(relative_path)
+        }
     }
 }
 
@@ -221,7 +222,7 @@ mod test {
     use url::Url;
 
     use flowcore::model::datatype::{ARRAY_TYPE, GENERIC_TYPE, STRING_TYPE};
-    use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::function_definition::{FunctionDefinition, FunctionReference};
     use flowcore::model::input::InputInitializer;
     use flowcore::model::io::IO;
     use flowcore::model::name::Name;
@@ -245,8 +246,9 @@ mod test {
             ],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![
                 OutputConnection::new(
                     Source::default(),
@@ -319,8 +321,9 @@ mod test {
             vec![IO::new(vec![STRING_TYPE.into()], Route::default())],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![OutputConnection::new(
                 Source::default(),
                 1,
@@ -377,8 +380,9 @@ mod test {
             vec![],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![],
             0,
             0,
@@ -425,8 +429,9 @@ mod test {
             vec![],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![],
             0,
             0,
@@ -471,8 +476,9 @@ mod test {
             vec![],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![],
             0,
             0,
@@ -512,8 +518,9 @@ mod test {
             vec![IO::new(vec![STRING_TYPE.into()], Route::default())],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![OutputConnection::new(
                 Source::default(),
                 1,
@@ -586,8 +593,9 @@ mod test {
             vec![IO::new(vec![ARRAY_TYPE.into()], Route::default())],
             Url::parse("file:///fake/file").expect("Could not parse Url"),
             Route::from("/flow0/stdout"),
-            None,
-            Some(Url::parse("context://stdio/stdout").expect("Could not parse Url")),
+            FunctionReference::Context(
+                Url::parse("context://stdio/stdout").expect("Could not parse Url"),
+            ),
             vec![OutputConnection::new(
                 Output("/0".into()),
                 1,

--- a/flowcore/src/graph/style.rs
+++ b/flowcore/src/graph/style.rs
@@ -122,12 +122,11 @@ impl NodeCategory {
         match process {
             Some(Process::FlowProcess(_)) => Self::Subflow,
             Some(Process::FunctionProcess(f)) => {
-                if f.get_lib_reference().is_some() {
-                    Self::Library
-                } else if f.get_context_reference().is_some() {
-                    Self::Context
-                } else {
-                    Self::Custom
+                use crate::model::function_definition::FunctionReference;
+                match f.reference() {
+                    FunctionReference::Library(_) => Self::Library,
+                    FunctionReference::Context(_) => Self::Context,
+                    FunctionReference::Supplied(_) => Self::Custom,
                 }
             }
             None => Self::classify_from_source(source),
@@ -155,18 +154,20 @@ impl NodeCategory {
 mod test {
     use super::*;
     use crate::model::flow_definition::FlowDefinition;
-    use crate::model::function_definition::FunctionDefinition;
+    use crate::model::function_definition::{FunctionDefinition, FunctionReference};
     use url::Url;
 
     fn lib_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
-        f.lib_reference = Some(Url::parse("lib://flowstdlib/math/add").expect("valid url"));
+        f.reference =
+            FunctionReference::Library(Url::parse("lib://flowstdlib/math/add").expect("valid url"));
         f
     }
 
     fn context_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
-        f.context_reference = Some(Url::parse("context://stdio/stdout").expect("valid url"));
+        f.reference =
+            FunctionReference::Context(Url::parse("context://stdio/stdout").expect("valid url"));
         f
     }
 

--- a/flowcore/src/model/function_definition.rs
+++ b/flowcore/src/model/function_definition.rs
@@ -23,6 +23,23 @@ fn is_false(b: &bool) -> bool {
     !b
 }
 
+/// Describes where a function's implementation comes from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FunctionReference {
+    /// From a library (lib:// URL)
+    Library(Url),
+    /// From a context provider (context:// URL)
+    Context(Url),
+    /// Supplied implementation compiled to WASM (relative path to .wasm)
+    Supplied(String),
+}
+
+impl Default for FunctionReference {
+    fn default() -> Self {
+        FunctionReference::Supplied(String::new())
+    }
+}
+
 /// `FunctionDefinition` defines a Function (compile time) that implements some processing in the flow hierarchy
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -60,15 +77,9 @@ pub struct FunctionDefinition {
     /// the `route` in the flow hierarchy where this function is located
     #[serde(skip)]
     pub route: Route,
-    /// Implementation is the relative path from the lib root to the compiled wasm implementation
+    /// Where this function's implementation comes from
     #[serde(skip)]
-    pub implementation: String,
-    /// Is the function being used part of a library and where is it found
-    #[serde(skip)]
-    pub lib_reference: Option<Url>,
-    /// Is the function a context function and where is it found
-    #[serde(skip)]
-    pub context_reference: Option<Url>,
+    pub reference: FunctionReference,
     /// The output connections from this function to other processes (functions or flows)
     #[serde(skip)]
     pub output_connections: Vec<OutputConnection>,
@@ -94,9 +105,7 @@ impl Default for FunctionDefinition {
             alias: String::default(),
             source_url: FunctionDefinition::default_url(),
             route: Route::default(),
-            implementation: String::new(),
-            lib_reference: None,
-            context_reference: None,
+            reference: FunctionReference::Supplied(String::new()),
             output_connections: vec![],
             process_id: 0,
             parent_id: 0,
@@ -140,8 +149,7 @@ impl FunctionDefinition {
         outputs: IOSet,
         source_url: Url,
         route: Route,
-        lib_reference: Option<Url>,
-        context_reference: Option<Url>,
+        reference: FunctionReference,
         output_connections: Vec<OutputConnection>,
         id: usize,
         parent_id: usize,
@@ -156,9 +164,7 @@ impl FunctionDefinition {
             outputs,
             source_url,
             route,
-            implementation: String::default(),
-            lib_reference,
-            context_reference,
+            reference,
             output_connections,
             process_id: id,
             parent_id,
@@ -192,9 +198,9 @@ impl FunctionDefinition {
                     if !alias.is_empty() {
                         bail!("context:// functions cannot be aliased");
                     }
-                    self.set_context_reference(Some(function_reference));
+                    self.reference = FunctionReference::Context(function_reference);
                 }
-                "lib" => self.set_lib_reference(Some(function_reference)),
+                "lib" => self.reference = FunctionReference::Library(function_reference),
                 _ => {}
             }
         }
@@ -275,15 +281,24 @@ impl FunctionDefinition {
         &self.output_connections
     }
 
-    /// Get a reference to the implementation of this function
+    /// Get the implementation path if this is a supplied function
     #[must_use]
-    pub fn get_implementation(&self) -> &str {
-        &self.implementation
+    pub fn implementation(&self) -> Option<&str> {
+        match &self.reference {
+            FunctionReference::Supplied(s) => Some(s),
+            _ => None,
+        }
     }
 
-    /// Set the implementation location of this function
-    pub fn set_implementation(&mut self, implementation: &str) {
-        implementation.clone_into(&mut self.implementation);
+    /// Set the implementation location of this function (marks it as Supplied)
+    pub fn set_implementation(&mut self, impl_path: &str) {
+        self.reference = FunctionReference::Supplied(impl_path.to_string());
+    }
+
+    /// Get a reference to this function's `FunctionReference`
+    #[must_use]
+    pub fn reference(&self) -> &FunctionReference {
+        &self.reference
     }
 
     /// Set the source field of the function
@@ -356,26 +371,22 @@ impl FunctionDefinition {
             .set_flow_initializer(flow_initializer)
     }
 
-    // Set the lib reference of this function
-    fn set_lib_reference(&mut self, lib_reference: Option<Url>) {
-        self.lib_reference = lib_reference;
-    }
-
-    /// Get the lib reference of this function
+    /// Get the lib reference of this function, if it is a library function
     #[must_use]
-    pub fn get_lib_reference(&self) -> &Option<Url> {
-        &self.lib_reference
+    pub fn lib_reference(&self) -> Option<&Url> {
+        match &self.reference {
+            FunctionReference::Library(url) => Some(url),
+            _ => None,
+        }
     }
 
-    // Set the context reference of this function
-    fn set_context_reference(&mut self, context_reference: Option<Url>) {
-        self.context_reference = context_reference;
-    }
-
-    /// Get the context reference of this function
+    /// Get the context reference of this function, if it is a context function
     #[must_use]
-    pub fn get_context_reference(&self) -> &Option<Url> {
-        &self.context_reference
+    pub fn context_reference(&self) -> Option<&Url> {
+        match &self.reference {
+            FunctionReference::Context(url) => Some(url),
+            _ => None,
+        }
     }
 
     /// Convert a `FunctionDefinition` filename into the name of the struct used to implement it
@@ -472,7 +483,7 @@ mod test {
     use crate::model::route::SetRoute;
     use crate::model::validation::Validate;
 
-    use super::FunctionDefinition;
+    use super::{FunctionDefinition, FunctionReference};
 
     #[test]
     fn function_with_no_io_not_valid() {
@@ -698,9 +709,7 @@ mod test {
         func.alias = "my_alias".into();
         func.set_source_url(&Url::parse("file:///tmp/test.toml").expect("valid url"));
         func.route = Route::from("/flow/my_alias");
-        func.implementation = "test.wasm".into();
-        func.lib_reference = Some(Url::parse("lib://testlib").expect("valid url"));
-        func.context_reference = Some(Url::parse("context://stdio").expect("valid url"));
+        func.reference = FunctionReference::Supplied("test.wasm".into());
         func.set_id(42);
 
         let serialized = toml::to_string(&func).expect("serialization failed");
@@ -717,16 +726,8 @@ mod test {
             "route should not be serialized"
         );
         assert!(
-            !serialized.contains("implementation"),
-            "implementation should not be serialized"
-        );
-        assert!(
-            !serialized.contains("lib_reference"),
-            "lib_reference should not be serialized"
-        );
-        assert!(
-            !serialized.contains("context_reference"),
-            "context_reference should not be serialized"
+            !serialized.contains("reference"),
+            "reference should not be serialized"
         );
         assert!(
             !serialized.contains("output_connections"),

--- a/flowedit/src/flow_canvas.rs
+++ b/flowedit/src/flow_canvas.rs
@@ -2349,7 +2349,9 @@ mod test {
 
     fn lib_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
-        f.lib_reference = Some(Url::parse("lib://test").expect("valid url"));
+        f.reference = flowcore::model::function_definition::FunctionReference::Library(
+            Url::parse("lib://test").expect("valid url"),
+        );
         f
     }
 

--- a/flowedit/src/hierarchy_panel.rs
+++ b/flowedit/src/hierarchy_panel.rs
@@ -145,8 +145,10 @@ impl FlowHierarchy {
                         col = col.push(self.view_flow(sub_flow, &child_path));
                     }
                     Some(Process::FunctionProcess(func)) => {
-                        let is_library = func.get_lib_reference().is_some()
-                            || func.get_context_reference().is_some();
+                        let is_library = !matches!(
+                            func.reference(),
+                            flowcore::model::function_definition::FunctionReference::Supplied(_)
+                        );
                         col = col.push(view_leaf(
                             &alias,
                             func.route.clone(),

--- a/flowedit/src/node_layout.rs
+++ b/flowedit/src/node_layout.rs
@@ -144,7 +144,10 @@ impl<'a> NodeLayout<'a> {
         match &self.process {
             Some(Process::FlowProcess(_)) => true,
             Some(Process::FunctionProcess(f)) => {
-                f.get_lib_reference().is_none() && f.get_context_reference().is_none()
+                matches!(
+                    f.reference(),
+                    flowcore::model::function_definition::FunctionReference::Supplied(_)
+                )
             }
             None => {
                 !self.source().starts_with("lib://") && !self.source().starts_with("context://")
@@ -340,7 +343,7 @@ pub(crate) fn compute_topological_layout(
 #[allow(clippy::indexing_slicing)]
 mod test {
     use super::*;
-    use flowcore::model::function_definition::FunctionDefinition;
+    use flowcore::model::function_definition::{FunctionDefinition, FunctionReference};
     use flowcore::model::io::IO;
     use flowcore::model::route::Route;
     use iced::Point;
@@ -375,13 +378,14 @@ mod test {
 
     fn lib_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
-        f.lib_reference = Some(Url::parse("lib://test").expect("valid url"));
+        f.reference = FunctionReference::Library(Url::parse("lib://test").expect("valid url"));
         f
     }
 
     fn context_function() -> FunctionDefinition {
         let mut f = FunctionDefinition::default();
-        f.context_reference = Some(Url::parse("context://stdio/stdout").expect("valid url"));
+        f.reference =
+            FunctionReference::Context(Url::parse("context://stdio/stdout").expect("valid url"));
         f
     }
 


### PR DESCRIPTION
## Summary

Replace three mutually-exclusive `Option` fields on `FunctionDefinition` with a single `FunctionReference` enum, enforcing exclusivity at the type level.

## Before
```rust
pub implementation: String,           // relative path to .wasm
pub lib_reference: Option<Url>,       // lib:// URL if from a library
pub context_reference: Option<Url>,   // context:// URL if from context
```

## After
```rust
pub enum FunctionReference {
    Library(Url),      // from a lib:// library
    Context(Url),      // from a context:// provider
    Supplied(String),  // locally compiled WASM
}

pub reference: FunctionReference,     // single field
```

## Changes (10 files)
- **flowcore**: Enum definition, struct field, Default, getters/setters
- **flowc**: generator, parser, compiler, optimizer, compile_wasm — all updated from chained `if let`/`is_some()` to `match` on the enum
- **flowedit**: node_layout, hierarchy_panel, flow_canvas — `matches!()` for classification

## Benefits
- Mutual exclusivity enforced at compile time (was runtime-only)
- 6 chained `if let`/`is_some()` patterns replaced with clean `match` expressions
- Eliminates impossible states (e.g., both `lib_reference` and `context_reference` set)
- Net +27 lines (mostly the enum definition)

Closes #1182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified function reference handling for supplied, library, and context implementations.
  * Improved access to implementation, library, and context reference information.

* **Bug Fixes**
  * Corrected compilation, parsing, generation, graph classification, and editor behavior for functions backed by different reference types.
  * Improved validation and handling of supplied implementations and referenced sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->