### PR TITLE
Expand trace to capture actual input/output values (#245)

### DIFF
--- a/flowcore/src/model/input.rs
+++ b/flowcore/src/model/input.rs
@@ -410,7 +410,6 @@ impl Input {
     }
 
     /// Get the queued values for inspection
-    #[cfg(feature = "debugger")]
     #[must_use]
     pub fn received_values(&self) -> &[Value] {
         &self.received

--- a/flowcore/src/model/trace.rs
+++ b/flowcore/src/model/trace.rs
@@ -3,12 +3,13 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Snapshot of runtime state variables at a point in execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceState {
-    /// Per-process, per-input queue contents (each value represented as 1)
-    pub input_q: BTreeMap<usize, BTreeMap<usize, Vec<i64>>>,
+    /// Per-process, per-input queue contents (actual values)
+    pub input_q: BTreeMap<usize, BTreeMap<usize, Vec<Value>>>,
     /// Per-process, per-input count of internal values at front of queue
     pub int_count: BTreeMap<usize, BTreeMap<usize, usize>>,
     /// Reference count of busy markers per process/flow ID
@@ -28,6 +29,18 @@ pub struct TraceState {
 pub struct TraceEvent {
     /// Name of the action (e.g. "Init", "Dispatch")
     pub action: String,
+    /// Job ID that triggered this event (if applicable)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<usize>,
+    /// Process (function) ID associated with this event (if applicable)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<usize>,
+    /// Input values the job was executed with (for Retire/Complete/Error events)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_inputs: Option<Vec<Value>>,
+    /// Output value produced by the job (for Retire/Complete events)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_output: Option<Value>,
     /// State snapshot after the action
     pub state: TraceState,
 }
@@ -107,6 +120,10 @@ mod test {
         trace.topology.flows.insert(10);
         trace.events.push(TraceEvent {
             action: "Init".to_string(),
+            job_id: None,
+            process_id: None,
+            job_inputs: None,
+            job_output: None,
             state: TraceState {
                 input_q: BTreeMap::new(),
                 int_count: BTreeMap::new(),

--- a/flowcore/src/model/trace.rs
+++ b/flowcore/src/model/trace.rs
@@ -73,7 +73,11 @@ pub struct TraceTopology {
     pub parent: BTreeMap<usize, Option<usize>>,
 }
 
-/// A complete execution trace: topology plus sequence of state transitions
+/// A complete execution trace: topology plus sequence of state transitions.
+///
+/// **Note:** Trace files may contain the actual data values flowing through
+/// the system (input/output values of every job). When writing traces via
+/// `FLOW_TRACE`, be aware the file may contain sensitive data from the flow.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Trace {
     /// The static flow topology
@@ -141,5 +145,85 @@ mod test {
         assert_eq!(parsed.events[0].action, "Init");
         assert_eq!(parsed.events[0].state.ready, vec![[0, 1]]);
         assert_eq!(parsed.topology.procs.len(), 2);
+    }
+
+    #[test]
+    fn state_only_event_omits_job_fields() {
+        let event = TraceEvent {
+            action: "Init".to_string(),
+            job_id: None,
+            process_id: None,
+            job_inputs: None,
+            job_output: None,
+            state: TraceState {
+                input_q: BTreeMap::new(),
+                int_count: BTreeMap::new(),
+                busy_count: BTreeMap::new(),
+                ready: vec![],
+                running: vec![],
+                done: BTreeSet::new(),
+                job_counter: 0,
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // None fields should be omitted, not serialized as null
+        assert!(!json.contains("job_id"), "job_id should be omitted");
+        assert!(!json.contains("process_id"), "process_id should be omitted");
+        assert!(!json.contains("job_inputs"), "job_inputs should be omitted");
+        assert!(!json.contains("job_output"), "job_output should be omitted");
+    }
+
+    #[test]
+    fn job_event_roundtrips_with_values() {
+        use serde_json::json;
+
+        let event = TraceEvent {
+            action: "RetireAndSend".to_string(),
+            job_id: Some(42),
+            process_id: Some(3),
+            job_inputs: Some(vec![json!(1), json!([0, 1, 0])]),
+            job_output: Some(json!({"chunk": [1, 0, 1], "partial": []})),
+            state: TraceState {
+                input_q: BTreeMap::new(),
+                int_count: BTreeMap::new(),
+                busy_count: BTreeMap::new(),
+                ready: vec![],
+                running: vec![],
+                done: BTreeSet::new(),
+                job_counter: 42,
+            },
+        };
+        let json = serde_json::to_string_pretty(&event).unwrap();
+        let parsed: TraceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.job_id, Some(42));
+        assert_eq!(parsed.process_id, Some(3));
+        assert_eq!(parsed.job_inputs.as_ref().unwrap().len(), 2);
+        assert!(parsed.job_output.is_some());
+    }
+
+    #[test]
+    fn job_output_with_real_value_roundtrips() {
+        use serde_json::json;
+
+        let event = TraceEvent {
+            action: "RetireAndSend".to_string(),
+            job_id: Some(1),
+            process_id: Some(0),
+            job_inputs: Some(vec![json!(1)]),
+            job_output: Some(json!(42)),
+            state: TraceState {
+                input_q: BTreeMap::new(),
+                int_count: BTreeMap::new(),
+                busy_count: BTreeMap::new(),
+                ready: vec![],
+                running: vec![],
+                done: BTreeSet::new(),
+                job_counter: 1,
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("job_output"), "Some(42) should be serialized");
+        let parsed: TraceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.job_output, Some(json!(42)));
     }
 }

--- a/flowr/src/bin/flowr-tla-check/main.rs
+++ b/flowr/src/bin/flowr-tla-check/main.rs
@@ -260,22 +260,16 @@ fn format_input_queues(state: &TraceState, topo: &TraceTopology) -> String {
                 let input_parts: Vec<String> = inputs
                     .iter()
                     .map(|i| {
-                        let q = state
+                        let q_len = state
                             .input_q
                             .get(p)
                             .and_then(|m| m.get(i))
-                            .cloned()
-                            .unwrap_or_default();
-                        let seq = if q.is_empty() {
+                            .map_or(0, Vec::len);
+                        let seq = if q_len == 0 {
                             "<<>>".to_string()
                         } else {
-                            format!(
-                                "<<{}>>",
-                                q.iter()
-                                    .map(ToString::to_string)
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            )
+                            // TLA+ only needs queue lengths, not actual values
+                            format!("<<{}>>", vec!["1"; q_len].join(", "))
                         };
                         format!("{i} :> {seq}")
                     })

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -460,9 +460,21 @@ impl RunState {
     /// Moves the job into the `running_jobs` map, keyed by `job_id`, so that
     /// incoming results from executors can be matched back to the originating job.
     pub(crate) fn start_job(&mut self, job: Job) {
-        self.running_jobs.insert(job.payload.job_id, job);
+        let job_id = job.payload.job_id;
+        let process_id = job.process_id;
         #[cfg(feature = "trace")]
-        self.record_trace("Dispatch");
+        let job_inputs = job.payload.input_set.clone();
+        self.running_jobs.insert(job_id, job);
+        #[cfg(feature = "trace")]
+        self.record_trace_with_job(
+            "Dispatch",
+            Some(&crate::trace::JobContext {
+                job_id,
+                process_id,
+                inputs: job_inputs,
+                output: None,
+            }),
+        );
     }
 
     /// Check for running jobs that have exceeded their TTL.
@@ -613,12 +625,28 @@ impl RunState {
                         self.create_jobs(job.process_id, job.parent_id)?;
                     }
                     #[cfg(feature = "trace")]
-                    self.record_trace("RetireAndSend");
+                    self.record_trace_with_job(
+                        "RetireAndSend",
+                        Some(&crate::trace::JobContext {
+                            job_id: job.payload.job_id,
+                            process_id: job.process_id,
+                            inputs: job.payload.input_set.clone(),
+                            output: output_value.clone(),
+                        }),
+                    );
                 } else {
                     // otherwise mark it as completed as it will never run again
                     self.mark_as_completed(job.process_id);
                     #[cfg(feature = "trace")]
-                    self.record_trace("CompleteJob");
+                    self.record_trace_with_job(
+                        "CompleteJob",
+                        Some(&crate::trace::JobContext {
+                            job_id: job.payload.job_id,
+                            process_id: job.process_id,
+                            inputs: job.payload.input_set.clone(),
+                            output: output_value.clone(),
+                        }),
+                    );
                 }
 
                 #[cfg(feature = "metrics")]
@@ -637,7 +665,15 @@ impl RunState {
                     job.payload.job_id, job.process_id, job.payload.implementation_url
                 );
                 #[cfg(feature = "trace")]
-                self.record_trace("JobError");
+                self.record_trace_with_job(
+                    "JobError",
+                    Some(&crate::trace::JobContext {
+                        job_id: job.payload.job_id,
+                        process_id: job.process_id,
+                        inputs: job.payload.input_set.clone(),
+                        output: None,
+                    }),
+                );
             }
         }
 
@@ -1055,6 +1091,14 @@ impl RunState {
 
     #[cfg(feature = "trace")]
     fn record_trace(&mut self, action: &str) {
+        self.record_trace_with_job(action, None);
+    }
+
+    fn record_trace_with_job(
+        &mut self,
+        action: &str,
+        job_context: Option<&crate::trace::JobContext>,
+    ) {
         crate::trace::record_event(
             &mut self.trace,
             action,
@@ -1064,6 +1108,7 @@ impl RunState {
             &self.running_jobs,
             &self.completed,
             self.number_of_jobs_created,
+            job_context,
         );
     }
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1094,6 +1094,7 @@ impl RunState {
         self.record_trace_with_job(action, None);
     }
 
+    #[cfg(feature = "trace")]
     fn record_trace_with_job(
         &mut self,
         action: &str,

--- a/flowr/src/lib/trace.rs
+++ b/flowr/src/lib/trace.rs
@@ -55,6 +55,15 @@ pub(crate) fn topology_from_submission(submission: &Submission) -> Trace {
 /// Takes individual fields to avoid borrowing the entire `RunState`
 /// (which would conflict with the mutable borrow of the `trace` field).
 #[allow(clippy::too_many_arguments)]
+/// Job context for trace events — captures the job that triggered the event.
+pub(crate) struct JobContext {
+    pub job_id: usize,
+    pub process_id: usize,
+    pub inputs: Vec<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn record_event(
     trace: &mut Trace,
     action: &str,
@@ -64,6 +73,7 @@ pub(crate) fn record_event(
     running_jobs: &HashMap<usize, Job>,
     completed: &HashSet<usize>,
     number_of_jobs_created: usize,
+    job_context: Option<&JobContext>,
 ) {
     let state = capture_state(
         manifest,
@@ -75,6 +85,10 @@ pub(crate) fn record_event(
     );
     trace.events.push(TraceEvent {
         action: action.to_string(),
+        job_id: job_context.map(|j| j.job_id),
+        process_id: job_context.map(|j| j.process_id),
+        job_inputs: job_context.map(|j| j.inputs.clone()),
+        job_output: job_context.and_then(|j| j.output.clone()),
         state,
     });
 }
@@ -94,7 +108,7 @@ fn capture_state(
         let mut q_map = BTreeMap::new();
         let mut ic_map = BTreeMap::new();
         for (idx, input) in function.inputs().iter().enumerate() {
-            q_map.insert(idx, vec![1i64; input.values_available()]);
+            q_map.insert(idx, input.received_values().to_vec());
             ic_map.insert(idx, input.internal_count());
         }
         input_q.insert(*id, q_map);


### PR DESCRIPTION
## Summary

Enhance the `trace` feature to record a complete execution history with actual data values, enabling post-mortem debugging and replay.

## Changes

### TraceEvent — new fields
| Field | Type | When set |
|---|---|---|
| `job_id` | `Option<usize>` | Dispatch, RetireAndSend, CompleteJob, JobError |
| `process_id` | `Option<usize>` | Same as above |
| `job_inputs` | `Option<Vec<Value>>` | Same — actual input values the job ran with |
| `job_output` | `Option<Value>` | RetireAndSend, CompleteJob — the produced output |

All new fields use `#[serde(skip_serializing_if = "Option::is_none")]` so Init/CreateJob/FlowGoesIdle events remain compact.

### TraceState.input_q — actual values
Changed from `Vec<i64>` (placeholder `vec![1; count]`) to `Vec<Value>` (actual `serde_json::Value` entries). Every state snapshot now captures the real data in each function's input queues.

### TLA+ check compatibility
`flowr-tla-check` updated to derive queue lengths from the `Value` vectors (TLA+ model only needs counts, not actual values).

## What this enables
- **Post-mortem debugging**: load a trace JSON, see exactly what each function received and produced
- **Execution replay**: the trace + manifest is a complete deterministic record
- **Root cause analysis**: find where bad values enter the pipeline by tracing backwards from errors

## Example trace event
```json
{
  "action": "RetireAndSend",
  "job_id": 42,
  "process_id": 3,
  "job_inputs": [1, [0, 0, 1], 1024],
  "job_output": {"chunk": [...], "partial": [], "chunk_size": 1024},
  "state": { ... }
}
```

Partial progress on #245 — trace viewing, filtering, and debugger integration remain as future work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Trace data now includes job and process details, input values, and output values when available.
  - Runtime input queue snapshots preserve the actual JSON values received, improving trace accuracy and diagnostics.
  - Trace metadata supports JSON inputs and scalar outputs for more complete event history.

- **Bug Fixes**
  - Empty and populated input queues are represented more consistently in TLA+ verification output.

- **Documentation**
  - Trace documentation now notes that serialized traces may contain sensitive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->