### PR TITLE
Add --trace CLI option for trace file output

### DIFF
--- a/flowcore/Cargo.toml
+++ b/flowcore/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/lib.rs"
 default = []
 context = []  # whether this library is aware of the flow context functions or not
 debugger = [] # feature to add the debugger
+trace = [] # feature to enable execution tracing
 online_tests = []
 meta_provider = []
 file_provider = []

--- a/flowcore/src/model/submission.rs
+++ b/flowcore/src/model/submission.rs
@@ -19,6 +19,9 @@ pub struct Submission {
     /// Whether debugging is enabled or not for the flow
     #[cfg(feature = "debugger")]
     pub debug_enabled: bool,
+    /// Optional file path to write the execution trace to
+    #[cfg(feature = "trace")]
+    pub trace_file: Option<String>,
 }
 
 impl Submission {
@@ -31,6 +34,7 @@ impl Submission {
         max_parallel_jobs: Option<usize>,
         job_timeout: Option<Duration>,
         #[cfg(feature = "debugger")] debug: bool,
+        #[cfg(feature = "trace")] trace_file: Option<String>,
     ) -> Submission {
         if let Some(limit) = max_parallel_jobs {
             info!("Maximum jobs in parallel limited to {limit}");
@@ -42,6 +46,8 @@ impl Submission {
             job_timeout,
             #[cfg(feature = "debugger")]
             debug_enabled: debug,
+            #[cfg(feature = "trace")]
+            trace_file,
         }
     }
 }

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -70,7 +70,7 @@ metrics = []
 # feature to include ability to receive a submission of a flow
 submission = []
 # feature to emit structured trace events during execution
-trace = []
+trace = ["flowcore/trace"]
 # feature to include context functions, make sure flowcore is compiled with it if we plan to use it
 context = ["flowcore/context"]
 

--- a/flowr/src/bin/flowrcli/cli/cli_debug_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_debug_client.rs
@@ -451,6 +451,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             true,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -676,6 +676,10 @@ fn client(
         job_timeout,
         #[cfg(feature = "debugger")]
         debug_this_flow,
+        #[cfg(feature = "trace")]
+        matches
+            .get_one::<String>("trace")
+            .map(std::string::ToString::to_string),
     );
 
     trace!("Creating CliRuntimeClient");
@@ -783,6 +787,11 @@ fn get_matches() -> ArgMatches {
             .value_parser(clap::value_parser!(usize))
             .value_name("THREADS")
             .help("Set number of threads to use to execute jobs (min: 1, default: cores available)"))
+        .arg(Arg::new("trace")
+            .long("trace")
+            .number_of_values(1)
+            .value_name("TRACE_FILE")
+            .help("Write execution trace to the specified file (JSON format)"))
         .arg(Arg::new("verbosity")
             .short('v')
             .long("verbosity")

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -787,11 +787,6 @@ fn get_matches() -> ArgMatches {
             .value_parser(clap::value_parser!(usize))
             .value_name("THREADS")
             .help("Set number of threads to use to execute jobs (min: 1, default: cores available)"))
-        .arg(Arg::new("trace")
-            .long("trace")
-            .number_of_values(1)
-            .value_name("TRACE_FILE")
-            .help("Write execution trace to the specified file (JSON format)"))
         .arg(Arg::new("verbosity")
             .short('v')
             .long("verbosity")
@@ -805,6 +800,15 @@ fn get_matches() -> ArgMatches {
             .num_args(0..)
             .trailing_var_arg(true)
             .help("A list of arguments to pass to the flow."));
+
+    #[cfg(feature = "trace")]
+    let app = app.arg(
+        Arg::new("trace")
+            .long("trace")
+            .number_of_values(1)
+            .value_name("TRACE_FILE")
+            .help("Write execution trace to the specified file (JSON format)"),
+    );
 
     app.get_matches()
 }

--- a/flowr/src/bin/flowrgui/connection_manager.rs
+++ b/flowr/src/bin/flowrgui/connection_manager.rs
@@ -2838,7 +2838,14 @@ mod test {
             };
             let mut manifest = FlowManifest::new(metadata);
             manifest.add_function(test_function());
-            let submission = Submission::new(manifest, None, None, false);
+            let submission = Submission::new(
+                manifest,
+                None,
+                None,
+                false,
+                #[cfg(feature = "trace")]
+                None,
+            );
             flowrlib::run_state::RunState::new(submission)
         }
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1481,6 +1481,8 @@ impl FlowrGui {
             job_timeout,
             #[cfg(feature = "debugger")]
             settings.debug_this_flow,
+            #[cfg(feature = "trace")]
+            None, // flowrgui doesn't support trace file via CLI yet
         );
 
         info!("Sending submission to Coordinator");

--- a/flowr/src/lib/checks.rs
+++ b/flowr/src/lib/checks.rs
@@ -185,6 +185,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             true,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -650,6 +650,8 @@ mod test {
             Some(Duration::from_millis(100)),
             #[cfg(feature = "debugger")]
             false,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 
@@ -816,6 +818,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             false,
+            #[cfg(feature = "trace")]
+            None,
         );
         let result = coordinator.execute_flow(submission);
         assert!(
@@ -849,6 +853,8 @@ mod test {
             Some(Duration::from_millis(100)),
             #[cfg(feature = "debugger")]
             false,
+            #[cfg(feature = "trace")]
+            None,
         );
         let result = coordinator.execute_flow(submission);
         assert!(
@@ -880,6 +886,8 @@ mod test {
             None,
             Some(Duration::from_millis(100)),
             true, // debug_enabled
+            #[cfg(feature = "trace")]
+            None,
         );
         // ExitDebugger causes a "Debugger Exit" error — expected for empty flows
         // since Continue loops forever when no jobs have been created

--- a/flowr/src/lib/debug_client.rs
+++ b/flowr/src/lib/debug_client.rs
@@ -559,7 +559,14 @@ mod test {
     }
 
     fn test_submission(functions: Vec<RuntimeFunction>) -> Submission {
-        Submission::new(test_manifest(functions), None, None, true)
+        Submission::new(
+            test_manifest(functions),
+            None,
+            None,
+            true,
+            #[cfg(feature = "trace")]
+            None,
+        )
     }
 
     #[test]

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -1160,6 +1160,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             true,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -1123,14 +1123,22 @@ impl RunState {
         )
     }
 
-    /// Write the trace to the path specified by the `FLOW_TRACE` env var
+    /// Write the trace to the path from the submission's `trace_file` option,
+    /// falling back to the `FLOW_TRACE` environment variable.
     #[cfg(feature = "trace")]
     pub(crate) fn write_trace(&mut self) -> flowcore::errors::Result<()> {
-        if let Ok(trace_path) = std::env::var("FLOW_TRACE") {
+        let trace_path = self
+            .submission
+            .trace_file
+            .clone()
+            .or_else(|| std::env::var("FLOW_TRACE").ok());
+
+        if let Some(path) = trace_path {
             let trace = self.take_trace();
             let trace_json = trace.to_json();
-            std::fs::write(&trace_path, &trace_json)
-                .map_err(|e| format!("Could not write trace to {trace_path}: {e}"))?;
+            std::fs::write(&path, &trace_json)
+                .map_err(|e| format!("Could not write trace to {path}: {e}"))?;
+            info!("Trace written to '{path}'");
         }
         Ok(())
     }
@@ -1382,6 +1390,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             true,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 

--- a/flowr/src/lib/trace.rs
+++ b/flowr/src/lib/trace.rs
@@ -188,6 +188,8 @@ mod test {
             None,
             #[cfg(feature = "debugger")]
             true,
+            #[cfg(feature = "trace")]
+            None,
         )
     }
 


### PR DESCRIPTION
## Summary

Replace the `FLOW_TRACE` environment variable with a proper `--trace` CLI option on flowrcli. The env var still works as a fallback for backward compatibility.

## Usage

```
flowrcli --trace output.json -n manifest.json [flow args...]
```

## Changes

- **flowcore**: Add `trace` feature, add `trace_file: Option<String>` to `Submission`
- **flowr**: Propagate `trace` feature to `flowcore/trace`
- **flowrcli**: Add `--trace <TRACE_FILE>` CLI arg
- **write_trace()**: Use `submission.trace_file` with `FLOW_TRACE` env var fallback
- Update all 13 `Submission::new()` call sites

## Verified

Tested locally: `flowrcli --trace /tmp/trace.json -n fibonacci/manifest.json` produces a 551-event trace file with correct fibonacci values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional execution tracing for flow runs.
  * The command-line interface now accepts a trace output filename.
  * Trace output can be configured per run, with the existing environment-based setting used as a fallback.
  * Enabled tracing consistently across command-line and graphical application configurations.

* **Bug Fixes**
  * Updated submission handling to preserve compatibility when tracing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->