### PR TITLE
Bulk pixel rendering for image write (#2679)

### DIFF
--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -195,13 +195,17 @@ impl CliRuntimeClient {
                 .image_buffers
                 .entry(name.to_string())
                 .or_insert_with(|| RgbImage::new(width, height));
+            // Bulk row copy — writes RGB pixels directly to the buffer
+            let buf = image.as_mut();
             for (y, row) in grid.iter().enumerate() {
+                let row_offset = y * (width as usize) * 3;
                 for (x, &val) in row.iter().enumerate() {
-                    image.put_pixel(
-                        u32::try_from(x).unwrap_or(0),
-                        u32::try_from(y).unwrap_or(0),
-                        Rgb([val, val, val]),
-                    );
+                    let offset = row_offset + x * 3;
+                    if let Some([r, g, b]) = buf.get_mut(offset..offset + 3) {
+                        *r = val;
+                        *g = val;
+                        *b = val;
+                    }
                 }
             }
         }

--- a/flowr/src/bin/flowrcli/cli/cli_client.rs
+++ b/flowr/src/bin/flowrcli/cli/cli_client.rs
@@ -195,11 +195,16 @@ impl CliRuntimeClient {
                 .image_buffers
                 .entry(name.to_string())
                 .or_insert_with(|| RgbImage::new(width, height));
-            // Bulk row copy — writes RGB pixels directly to the buffer
+            // Recreate the buffer when dimensions change
+            if image.width() != width || image.height() != height {
+                *image = RgbImage::new(width, height);
+            }
+            // Use buffer width for row stride, not grid row length
+            let buf_width = image.width() as usize;
             let buf = image.as_mut();
             for (y, row) in grid.iter().enumerate() {
-                let row_offset = y * (width as usize) * 3;
-                for (x, &val) in row.iter().enumerate() {
+                let row_offset = y * buf_width * 3;
+                for (x, &val) in row.iter().take(buf_width).enumerate() {
                     let offset = row_offset + x * 3;
                     if let Some([r, g, b]) = buf.get_mut(offset..offset + 3) {
                         *r = val;
@@ -715,5 +720,44 @@ mod test {
             client.image_buffers.contains_key("test.png"),
             "Image buffer should exist after materialization"
         );
+    }
+
+    #[test]
+    fn test_image_write_recreates_on_dimension_change() {
+        use image::Rgb;
+        let mut client = make_client();
+        // First write: 2x1
+        let grid1 = vec![vec![10, 20]];
+        client
+            .process_coordinator_message(CoordinatorMessage::ImageWrite(grid1, "test.png".into()));
+        client.materialize_pending_grid("test.png");
+        let img = client.image_buffers.get("test.png").unwrap();
+        assert_eq!(img.width(), 2);
+        assert_eq!(img.height(), 1);
+        assert_eq!(*img.get_pixel(0, 0), Rgb([10, 10, 10]));
+        // Second write: 3x2 — buffer should be recreated
+        let grid2 = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        client
+            .process_coordinator_message(CoordinatorMessage::ImageWrite(grid2, "test.png".into()));
+        client.materialize_pending_grid("test.png");
+        let img = client.image_buffers.get("test.png").unwrap();
+        assert_eq!(img.width(), 3);
+        assert_eq!(img.height(), 2);
+        assert_eq!(*img.get_pixel(2, 1), Rgb([6, 6, 6]));
+    }
+
+    #[test]
+    fn test_image_write_truncates_long_rows() {
+        use image::Rgb;
+        let mut client = make_client();
+        // Grid where second row is longer than the first
+        let grid = vec![vec![10, 20], vec![30, 40, 50]];
+        client.process_coordinator_message(CoordinatorMessage::ImageWrite(grid, "test.png".into()));
+        client.materialize_pending_grid("test.png");
+        let img = client.image_buffers.get("test.png").unwrap();
+        assert_eq!(img.width(), 2);
+        // Only first 2 values of each row should be written
+        assert_eq!(*img.get_pixel(0, 1), Rgb([30, 30, 30]));
+        assert_eq!(*img.get_pixel(1, 1), Rgb([40, 40, 40]));
     }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3706,14 +3706,19 @@ impl FlowrGui {
                         height,
                         data: RgbaImage::new(width, height),
                     });
+                // Bulk row copy — writes RGBA pixels directly to the image buffer
+                // instead of calling put_pixel for each pixel individually
+                let buf = data.data.as_mut();
                 for (y, row) in grid.iter().enumerate() {
+                    let row_offset = y * (width as usize) * 4;
                     for (x, &val) in row.iter().enumerate() {
-                        let gray = val;
-                        data.data.put_pixel(
-                            u32::try_from(x).unwrap_or(0),
-                            u32::try_from(y).unwrap_or(0),
-                            Rgba([gray, gray, gray, 255]),
-                        );
+                        let offset = row_offset + x * 4;
+                        if let Some([r, g, b, a]) = buf.get_mut(offset..offset + 4) {
+                            *r = val;
+                            *g = val;
+                            *b = val;
+                            *a = 255;
+                        }
                     }
                 }
                 if self.tab_set.active_tab != 3 {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3706,12 +3706,18 @@ impl FlowrGui {
                         height,
                         data: RgbaImage::new(width, height),
                     });
-                // Bulk row copy — writes RGBA pixels directly to the image buffer
-                // instead of calling put_pixel for each pixel individually
+                // Recreate the buffer when dimensions change
+                if data.width != width || data.height != height {
+                    data.width = width;
+                    data.height = height;
+                    data.data = RgbaImage::new(width, height);
+                }
+                // Use buffer width for row stride, not grid row length
+                let buf_width = data.width as usize;
                 let buf = data.data.as_mut();
                 for (y, row) in grid.iter().enumerate() {
-                    let row_offset = y * (width as usize) * 4;
-                    for (x, &val) in row.iter().enumerate() {
+                    let row_offset = y * buf_width * 4;
+                    for (x, &val) in row.iter().take(buf_width).enumerate() {
                         let offset = row_offset + x * 4;
                         if let Some([r, g, b, a]) = buf.get_mut(offset..offset + 4) {
                             *r = val;
@@ -4282,5 +4288,75 @@ mod test {
         );
         assert!(!gui.running);
         assert!(gui.last_metrics.is_some());
+    }
+
+    #[test]
+    fn image_write_stores_pixels() {
+        let mut gui = test_gui();
+        gui.running = true;
+        let grid = vec![vec![255, 0], vec![0, 128]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid,
+                "test.png".into(),
+            ))),
+        );
+        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
+        assert_eq!(img.width, 2);
+        assert_eq!(img.height, 2);
+        // Top-left pixel should be (255,255,255,255)
+        assert_eq!(img.data.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
+        // Top-right pixel should be (0,0,0,255)
+        assert_eq!(img.data.get_pixel(1, 0), &Rgba([0, 0, 0, 255]));
+        // Bottom-right pixel should be (128,128,128,255)
+        assert_eq!(img.data.get_pixel(1, 1), &Rgba([128, 128, 128, 255]));
+    }
+
+    #[test]
+    fn image_write_recreates_on_dimension_change() {
+        let mut gui = test_gui();
+        gui.running = true;
+        // First write: 2x1
+        let grid1 = vec![vec![10, 20]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid1,
+                "test.png".into(),
+            ))),
+        );
+        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
+        assert_eq!(img.width, 2);
+        assert_eq!(img.height, 1);
+        // Second write: 3x2 — should recreate the buffer
+        let grid2 = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid2,
+                "test.png".into(),
+            ))),
+        );
+        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
+        assert_eq!(img.width, 3);
+        assert_eq!(img.height, 2);
+        assert_eq!(img.data.get_pixel(2, 1), &Rgba([6, 6, 6, 255]));
+    }
+
+    #[test]
+    fn image_write_truncates_long_rows() {
+        let mut gui = test_gui();
+        gui.running = true;
+        // Grid with a row longer than the first row — should truncate
+        let grid = vec![vec![10, 20], vec![30, 40, 50]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid,
+                "test.png".into(),
+            ))),
+        );
+        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
+        assert_eq!(img.width, 2);
+        // Only first 2 values of the second row should be written
+        assert_eq!(img.data.get_pixel(0, 1), &Rgba([30, 30, 30, 255]));
+        assert_eq!(img.data.get_pixel(1, 1), &Rgba([40, 40, 40, 255]));
     }
 }


### PR DESCRIPTION
## Summary

Replace per-pixel `put_pixel()` calls with direct buffer writes in both flowrcli and flowrgui `ImageWrite` handlers.

## Changes

### flowrgui (`main.rs`)
Write RGBA pixels directly to `RgbaImage` buffer:
```rust
// Before: put_pixel with coordinate conversion per pixel
data.data.put_pixel(x as u32, y as u32, Rgba([gray, gray, gray, 255]));

// After: direct buffer write with bounds check
if let Some([r, g, b, a]) = buf.get_mut(offset..offset + 4) {
    *r = val; *g = val; *b = val; *a = 255;
}
```

### flowrcli (`cli_client.rs`)
Same optimization for the deferred rendering in `materialize_pending_grid`:
```rust
// Before: put_pixel per pixel
image.put_pixel(x as u32, y as u32, Rgb([val, val, val]));

// After: direct RGB buffer write
if let Some([r, g, b]) = buf.get_mut(offset..offset + 3) {
    *r = val; *g = val; *b = val;
}
```

## Impact

Eliminates `put_pixel`'s per-pixel overhead (bounds checking, coordinate-to-offset conversion) by computing offsets once per row and using slice destructuring. For a 64x64 grid, this avoids 4096 coordinate conversions per frame.

Partial progress on #2679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved image rendering efficiency when displaying grayscale grid data.
  * Added safer bounds handling during image updates to prevent invalid writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->