### PR TITLE
Replace iced_aw::Card with Container for modal dialogs (#2981)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,6 @@ dependencies = [
  "flowr-utilities",
  "flowstdlib",
  "iced",
- "iced_aw",
  "iced_test",
  "image",
  "log",
@@ -1940,19 +1939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_aw"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b7f923642b024c415150b70ef84ee5c11626e3b0af73b954d817d573bcd0a4"
-dependencies = [
- "cfg-if",
- "iced_core",
- "iced_fonts",
- "iced_widget",
- "web-time",
-]
-
-[[package]]
 name = "iced_beacon"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,29 +1995,6 @@ dependencies = [
  "iced_program",
  "iced_widget",
  "log",
-]
-
-[[package]]
-name = "iced_fonts"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214cff7c8499e328774216690e58e315a1a5f8f6fdd1035aed6298e62ffc4c1d"
-dependencies = [
- "iced_core",
- "iced_fonts_macros",
- "iced_widget",
-]
-
-[[package]]
-name = "iced_fonts_macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef5125e110cb19cd1910a28298661c98c5d9ab02eef43594968352940e8752e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "ttf-parser",
 ]
 
 [[package]]

--- a/flowr/Cargo.toml
+++ b/flowr/Cargo.toml
@@ -105,7 +105,7 @@ wasmtime = { version = "47.0.2", default-features = false, features = ["runtime"
 
 # for flowrgui
 iced = { version = "0.14.0", default-features = false, features = ["canvas", "tokio", "debug", "wgpu", "tiny-skia", "image", "wayland", "x11", "unconditional-rendering"] }
-iced_aw = { version = "0.14.1", default-features = false, features = ["tabs", "card"] }
+
 once_cell = "1.21.4"
 rfd = "0.17"
 tokio = { version = "1", features = ["sync", "fs", "io-util", "rt", "macros"] }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -32,9 +32,11 @@ use clap::Command as ClapCommand;
 use clap::{Arg, ArgMatches};
 use env_logger::Builder;
 use iced::widget::operation::{self, RelativeOffset};
-use iced::widget::{center, mouse_area, opaque, stack, text_input, Button, Column, Id, Row, Text};
-use iced::{Center, Element, Fill, Subscription, Task};
-use iced_aw::Card;
+use iced::widget::{
+    center, mouse_area, opaque, stack, text_input, Button, Column, Container, Id, Row, Text,
+};
+use iced::{Center, Color, Element, Fill, Subscription, Task};
+
 use image::{ImageBuffer, Rgba, RgbaImage};
 use log::{debug, info, trace, LevelFilter};
 use simpath::Simpath;
@@ -1355,19 +1357,26 @@ impl FlowrGui {
         }
 
         if self.show_modal {
-            let modal_card = Card::new(
-                Text::new(self.modal_content.clone().0),
-                Text::new(self.modal_content.clone().1),
+            let modal_card = Container::new(
+                Column::new()
+                    .spacing(theme::SPACE_MD)
+                    .padding(theme::SPACE_LG)
+                    .push(
+                        Text::new(self.modal_content.clone().0)
+                            .size(theme::FONT_DEFAULT)
+                            .color(Color::WHITE),
+                    )
+                    .push(Text::new(self.modal_content.clone().1))
+                    .push(
+                        Row::new().spacing(10).padding(5).width(Fill).push(
+                            Button::new(Text::new("OK").align_x(Center))
+                                .width(Fill)
+                                .style(theme::pill_button)
+                                .on_press(Message::CloseModal),
+                        ),
+                    ),
             )
-            .foot(
-                Row::new().spacing(10).padding(5).width(Fill).push(
-                    Button::new(Text::new("OK").align_x(Center))
-                        .width(Fill)
-                        .style(theme::pill_button)
-                        .on_press(Message::CloseModal),
-                ),
-            )
-            .style(theme::popup_card)
+            .style(theme::modal_dialog)
             .max_width(300.0);
 
             stack![
@@ -1582,7 +1591,7 @@ impl FlowrGui {
             .push(debug_play)
     }
 
-    fn coordinator_picker_card(&self) -> Card<'_, Message> {
+    fn coordinator_picker_card(&self) -> Container<'_, Message> {
         use iced::widget::scrollable::Scrollable;
         use iced::Length;
 
@@ -1634,16 +1643,26 @@ impl FlowrGui {
 
         let body = Column::new().spacing(8).push(list);
 
-        Card::new(Text::new("Discover Coordinators"), body)
-            .foot(
-                Button::new(Text::new("Close").align_x(Center))
-                    .width(Fill)
-                    .on_press(Message::CloseCoordinatorPicker)
-                    .style(theme::pill_button)
-                    .padding([4.0, 8.0]),
-            )
-            .style(theme::popup_card)
-            .max_width(450.0)
+        Container::new(
+            Column::new()
+                .spacing(theme::SPACE_MD)
+                .padding(theme::SPACE_LG)
+                .push(
+                    Text::new("Discover Coordinators")
+                        .size(theme::FONT_DEFAULT)
+                        .color(Color::WHITE),
+                )
+                .push(body)
+                .push(
+                    Button::new(Text::new("Close").align_x(Center))
+                        .width(Fill)
+                        .on_press(Message::CloseCoordinatorPicker)
+                        .style(theme::pill_button)
+                        .padding([4.0, 8.0]),
+                ),
+        )
+        .style(theme::modal_dialog)
+        .max_width(450.0)
     }
 
     #[cfg(feature = "debugger")]

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -35,7 +35,7 @@ use iced::widget::operation::{self, RelativeOffset};
 use iced::widget::{
     center, mouse_area, opaque, stack, text_input, Button, Column, Container, Id, Row, Text,
 };
-use iced::{Center, Color, Element, Fill, Subscription, Task};
+use iced::{Center, Element, Fill, Subscription, Task};
 
 use image::{ImageBuffer, Rgba, RgbaImage};
 use log::{debug, info, trace, LevelFilter};
@@ -1361,11 +1361,7 @@ impl FlowrGui {
                 Column::new()
                     .spacing(theme::SPACE_MD)
                     .padding(theme::SPACE_LG)
-                    .push(
-                        Text::new(self.modal_content.clone().0)
-                            .size(theme::FONT_DEFAULT)
-                            .color(Color::WHITE),
-                    )
+                    .push(Text::new(self.modal_content.clone().0).size(theme::FONT_DEFAULT))
                     .push(Text::new(self.modal_content.clone().1))
                     .push(
                         Row::new().spacing(10).padding(5).width(Fill).push(
@@ -1647,11 +1643,7 @@ impl FlowrGui {
             Column::new()
                 .spacing(theme::SPACE_MD)
                 .padding(theme::SPACE_LG)
-                .push(
-                    Text::new("Discover Coordinators")
-                        .size(theme::FONT_DEFAULT)
-                        .color(Color::WHITE),
-                )
+                .push(Text::new("Discover Coordinators").size(theme::FONT_DEFAULT))
                 .push(body)
                 .push(
                     Button::new(Text::new("Close").align_x(Center))

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -473,22 +473,26 @@ pub fn pill_input(
     }
 }
 
-// ── Card/popup style ────────────────────────────────────────────────────────
+// ── Dialog/popup style ──────────────────────────────────────────────────────
 
-pub fn popup_card(theme: &Theme, _status: iced_aw::style::Status) -> iced_aw::style::card::Style {
-    let palette = theme.palette();
-    iced_aw::style::card::Style {
-        background: Background::Color(SURFACE_BUTTON),
-        border_radius: RADIUS_MD,
-        border_width: 2.0,
-        border_color: Color { a: 0.7, ..ACCENT },
-        head_background: Background::Color(Color::TRANSPARENT),
-        head_text_color: Color::WHITE,
-        body_background: Background::Color(SURFACE_BUTTON),
-        body_text_color: palette.text,
-        foot_background: Background::Color(SURFACE_BUTTON),
-        foot_text_color: palette.text,
-        close_color: Color::WHITE,
+/// Container style for modal dialogs — single continuous border with rounded corners.
+pub fn modal_dialog(_theme: &Theme) -> iced::widget::container::Style {
+    iced::widget::container::Style {
+        background: Some(Background::Color(SURFACE_BUTTON)),
+        border: Border {
+            radius: RADIUS_MD.into(),
+            width: 2.0,
+            color: Color { a: 0.7, ..ACCENT },
+        },
+        shadow: Shadow {
+            color: Color {
+                a: 0.4,
+                ..Color::BLACK
+            },
+            offset: Vector::new(0.0, 4.0),
+            blur_radius: 12.0,
+        },
+        ..iced::widget::container::Style::default()
     }
 }
 

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -492,6 +492,7 @@ pub fn modal_dialog(_theme: &Theme) -> iced::widget::container::Style {
             offset: Vector::new(0.0, 4.0),
             blur_radius: 12.0,
         },
+        text_color: Some(Color::WHITE),
         ..iced::widget::container::Style::default()
     }
 }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -461,6 +461,7 @@ impl RunState {
     /// incoming results from executors can be matched back to the originating job.
     pub(crate) fn start_job(&mut self, job: Job) {
         let job_id = job.payload.job_id;
+        #[cfg(feature = "trace")]
         let process_id = job.process_id;
         #[cfg(feature = "trace")]
         let job_inputs = job.payload.input_set.clone();


### PR DESCRIPTION
## Problem

The error dialog border in flowrgui has gaps — the border is not continuous around the dialog.

## Root Cause

The `iced_aw::Card` widget draws section backgrounds (head, body, foot) on top of the outer border, overpainting the left and right sides of the border in the body and foot areas.

## Fix

Replace `iced_aw::Card` with a plain iced `Container` wrapping a `Column` layout. A single `Container` renders one continuous border with rounded corners, avoiding the multi-layer painting issue.

## Changes

- **flowr/Cargo.toml**: Remove `iced_aw` dependency (no longer used anywhere)
- **flowr/src/bin/flowrgui/main.rs**: Replace `Card` with `Container` + `Column` for both the error modal and the coordinator picker dialog
- **flowr/src/bin/flowrgui/theme.rs**: Replace `popup_card` (iced_aw style) with `modal_dialog` (iced container style) using continuous border + drop shadow

Closes #2981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated error dialogs and coordinator discovery panels with a cleaner, more consistent modal design.
  * Improved modal layouts with clearer headers, content spacing, padding, and button placement.
  * Refined pop-up windows with rounded borders, dark surfaces, accented outlines, and drop shadows.
  * Preserved existing functionality while improving the overall visual presentation and readability of dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->