### PR TITLE
Add executor ID to job results for executor visibility (#2983)

### DIFF
--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::collections::HashMap;
 use std::fmt;
 use std::time::Instant;
 
@@ -19,6 +20,8 @@ pub struct Metrics {
     jobs_retried: usize,
     jobs_per_function: Vec<usize>,
     function_names: Vec<(String, String)>,
+    /// Per-executor job counts, keyed by executor ID
+    jobs_per_executor: HashMap<String, usize>,
 }
 
 impl Metrics {
@@ -35,6 +38,7 @@ impl Metrics {
             jobs_retried: 0,
             jobs_per_function: vec![0; num_processes],
             function_names: Vec::new(),
+            jobs_per_executor: HashMap::new(),
         }
     }
 
@@ -61,6 +65,7 @@ impl Metrics {
         self.max_simultaneous_jobs = 0;
         self.jobs_retried = 0;
         self.jobs_per_function.fill(0);
+        self.jobs_per_executor.clear();
     }
 
     /// Set the number of jobs created in `Metrics` to the `jobs` value
@@ -104,6 +109,20 @@ impl Metrics {
         self.max_simultaneous_jobs = max(self.max_simultaneous_jobs, jobs_running);
     }
 
+    /// Record that an executor completed a job, incrementing its per-executor count
+    pub fn record_executor(&mut self, executor_id: &str) {
+        *self
+            .jobs_per_executor
+            .entry(executor_id.to_string())
+            .or_insert(0) += 1;
+    }
+
+    /// Get the per-executor job counts
+    #[must_use]
+    pub fn jobs_per_executor(&self) -> &HashMap<String, usize> {
+        &self.jobs_per_executor
+    }
+
     /// Return the start time for flow execution - used for tracking wall-clock time for
     /// the execution
     #[must_use]
@@ -131,6 +150,16 @@ impl fmt::Display for Metrics {
         for (id, &count) in self.jobs_per_function.iter().enumerate() {
             if count > 0 {
                 write!(f, "  #{id}:{count}")?;
+            }
+        }
+        if !self.jobs_per_executor.is_empty() {
+            writeln!(f)?;
+            writeln!(f, "Executors: {}", self.jobs_per_executor.len())?;
+            write!(f, "Jobs per Executor:")?;
+            let mut executors: Vec<_> = self.jobs_per_executor.iter().collect();
+            executors.sort_by_key(|(id, _)| (*id).clone());
+            for (id, count) in &executors {
+                write!(f, "  {id}:{count}")?;
             }
         }
         Ok(())

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -409,7 +409,7 @@ impl<'a> Coordinator<'a> {
     }
 
     /// Try to get a result back from an executor, using a strategy that avoids unnecessary
-    /// blocking:
+    /// blocking. Returns the next result tuple or `None` if there are ready jobs to dispatch.
     ///
     /// 1. First, attempt a **non-blocking** receive. If a result is already available,
     ///    return it immediately.
@@ -423,7 +423,7 @@ impl<'a> Coordinator<'a> {
     fn get_result(
         &mut self,
         state: &RunState,
-    ) -> Result<Option<(usize, Result<(Option<Value>, RunAgain)>)>> {
+    ) -> Result<Option<(usize, String, Result<(Option<Value>, RunAgain)>)>> {
         // Step 1: Non-blocking attempt
         if let Ok(result) = self.dispatcher.get_next_result(false) {
             return Ok(Some(result));
@@ -475,7 +475,9 @@ impl<'a> Coordinator<'a> {
         };
 
         match first_result {
-            Ok(Some((job_id, result))) => {
+            Ok(Some((job_id, executor_id, result))) => {
+                #[cfg(feature = "metrics")]
+                metrics.record_executor(&executor_id);
                 let action = self.retire_one_job(
                     state,
                     job_id,
@@ -497,7 +499,9 @@ impl<'a> Coordinator<'a> {
         // Drain all immediately available results without blocking
         while state.number_jobs_running() > 0 {
             if let Ok(result) = self.dispatcher.get_next_result(false) {
-                let (job_id, job_result) = result;
+                let (job_id, executor_id, job_result) = result;
+                #[cfg(feature = "metrics")]
+                metrics.record_executor(&executor_id);
                 let action = self.retire_one_job(
                     state,
                     job_id,

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -102,12 +102,13 @@ impl Dispatcher {
         .map_err(|e| format!("Error setting results timeout: {e}").into())
     }
 
-    // Wait for, then return the next Result returned from executors
+    /// Wait for, then return the next Result returned from executors.
+    /// Returns `(job_id, executor_id, result)`.
     #[allow(clippy::type_complexity)]
     pub(crate) fn get_next_result(
         &mut self,
         block: bool,
-    ) -> Result<(usize, Result<(Option<Value>, RunAgain)>)> {
+    ) -> Result<(usize, String, Result<(Option<Value>, RunAgain)>)> {
         let flags = if block { WAIT } else { DONTWAIT };
 
         let msg = self
@@ -272,13 +273,17 @@ mod test {
         let result: Result<(Option<Value>, RunAgain)> = Ok((None, DONT_RUN_AGAIN));
         results_sink
             .send(
-                serde_json::to_string(&(0, result))
+                serde_json::to_string(&(0, "test-executor", result))
                     .expect("Could not convert to serde")
                     .as_bytes(),
                 0,
             )
             .expect("Could not send result of Job");
 
-        assert!(dispatcher.get_next_result(true).is_ok());
+        let received = dispatcher.get_next_result(true);
+        assert!(received.is_ok());
+        let (job_id, executor_id, _) = received.unwrap();
+        assert_eq!(job_id, 0);
+        assert_eq!(executor_id, "test-executor");
     }
 }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::panic;
+use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
@@ -45,6 +46,11 @@ pub(crate) fn track_execution_start() {
 
 pub(crate) fn track_execution_end() {
     JOBS_EXECUTING.fetch_sub(1, Ordering::Relaxed);
+}
+
+/// Generate a unique executor ID for a thread: `pid-N`
+fn make_executor_id(thread_number: usize) -> String {
+    format!("{}-{thread_number}", process::id())
 }
 
 /// An `Executor` struct is used to receive jobs, execute them, and return results.
@@ -168,11 +174,12 @@ impl Executor {
             let results_sink = results_service.into();
             let job_source = job_service.into();
             let control_address = control_service.into();
+            let executor_id = make_executor_id(executor_number);
             self.executors.push(thread::spawn(move || {
-                trace!("Executor #{executor_number} entering execution loop");
+                trace!("Executor {executor_id} entering execution loop");
                 if let Err(e) = execution_loop(
                     &thread_provider,
-                    &format!("Executor #{executor_number}"),
+                    &executor_id,
                     &thread_context,
                     &thread_implementations,
                     &thread_loaded_manifests,
@@ -372,7 +379,7 @@ fn execution_loop(
 fn execute_job_to_string(
     provider: &Arc<dyn Provider>,
     payload: &Payload,
-    name: &str,
+    executor_id: &str,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
 ) -> Result<String> {
@@ -383,11 +390,17 @@ fn execute_job_to_string(
         loaded_lib_manifests,
     )?;
 
-    trace!("Job #{}: Started executing on '{name}'", payload.job_id);
+    trace!(
+        "Job #{}: Started executing on '{executor_id}'",
+        payload.job_id
+    );
     let result = implementation.run(&payload.input_set);
-    trace!("Job #{}: Finished executing on '{name}'", payload.job_id);
+    trace!(
+        "Job #{}: Finished executing on '{executor_id}'",
+        payload.job_id
+    );
 
-    serde_json::to_string(&(payload.job_id, result))
+    serde_json::to_string(&(payload.job_id, executor_id, result))
         .map_err(|e| format!("Could not serialize job result: {e}").into())
 }
 
@@ -484,7 +497,7 @@ fn execute_job(
     provider: &Arc<dyn Provider>,
     payload: &Payload,
     results_sink: &zmq::Socket,
-    name: &str,
+    executor_id: &str,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
 ) -> Result<bool> {
@@ -495,13 +508,19 @@ fn execute_job(
         loaded_lib_manifests,
     )?;
 
-    trace!("Job #{}: Started executing on '{name}'", payload.job_id);
+    trace!(
+        "Job #{}: Started executing on '{executor_id}'",
+        payload.job_id
+    );
     let result = implementation.run(&payload.input_set);
-    trace!("Job #{}: Finished executing on '{name}'", payload.job_id);
+    trace!(
+        "Job #{}: Finished executing on '{executor_id}'",
+        payload.job_id
+    );
 
     results_sink
         .send(
-            serde_json::to_string(&(payload.job_id, result))?.as_bytes(),
+            serde_json::to_string(&(payload.job_id, executor_id, result))?.as_bytes(),
             0,
         )
         .map_err(|_| "Could not send result of Job")?;
@@ -1264,11 +1283,12 @@ mod test {
         )
         .expect("execute_job_to_string failed");
 
-        // The serialized string should be a JSON tuple (job_id, Result)
-        let parsed: (usize, Result<(Option<serde_json::Value>, bool)>) =
+        // The serialized string should be a JSON tuple (job_id, executor_id, Result)
+        let parsed: (usize, String, Result<(Option<serde_json::Value>, bool)>) =
             serde_json::from_str(&serialized).expect("could not parse result JSON");
         assert_eq!(parsed.0, 42, "job_id should match");
-        let (value, run_again) = parsed.1.expect("inner result should be Ok");
+        assert_eq!(parsed.1, "test", "executor_id should match");
+        let (value, run_again) = parsed.2.expect("inner result should be Ok");
         assert_eq!(value, Some(serde_json::json!("hello")));
         assert!(!run_again);
     }
@@ -1399,10 +1419,11 @@ mod test {
         // Verify the result arrived on the PULL socket
         let msg = results_pull.recv_msg(0).expect("should receive result");
         let msg_str = msg.as_str().expect("result should be str");
-        let parsed: (usize, Result<(Option<serde_json::Value>, bool)>) =
+        let parsed: (usize, String, Result<(Option<serde_json::Value>, bool)>) =
             serde_json::from_str(msg_str).expect("should parse result");
         assert_eq!(parsed.0, 7);
-        let (value, run_again) = parsed.1.expect("inner should be Ok");
+        assert_eq!(parsed.1, "test");
+        let (value, run_again) = parsed.2.expect("inner should be Ok");
         assert_eq!(value, Some(serde_json::json!(42)));
         assert!(!run_again);
     }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -48,9 +48,13 @@ pub(crate) fn track_execution_end() {
     JOBS_EXECUTING.fetch_sub(1, Ordering::Relaxed);
 }
 
+/// Global counter for generating unique executor thread IDs across all `Executor` instances.
+static NEXT_EXECUTOR_ID: AtomicUsize = AtomicUsize::new(0);
+
 /// Generate a unique executor ID for a thread: `pid-N`
-fn make_executor_id(thread_number: usize) -> String {
-    format!("{}-{thread_number}", process::id())
+fn make_executor_id() -> String {
+    let n = NEXT_EXECUTOR_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{n}", process::id())
 }
 
 /// An `Executor` struct is used to receive jobs, execute them, and return results.
@@ -166,7 +170,7 @@ impl Executor {
             Arc::new(RwLock::new(HashMap::<Url, Arc<dyn Implementation>>::new()));
 
         info!("Starting {number_of_executors} executor threads");
-        for executor_number in 0..number_of_executors {
+        for _executor_number in 0..number_of_executors {
             let thread_provider = provider.clone();
             let thread_context = zmq::Context::new();
             let thread_implementations = loaded_implementations.clone();
@@ -174,7 +178,7 @@ impl Executor {
             let results_sink = results_service.into();
             let job_source = job_service.into();
             let control_address = control_service.into();
-            let executor_id = make_executor_id(executor_number);
+            let executor_id = make_executor_id();
             self.executors.push(thread::spawn(move || {
                 trace!("Executor {executor_id} entering execution loop");
                 if let Err(e) = execution_loop(


### PR DESCRIPTION
## Problem

There is no way to see how many executors are working on jobs or monitor their individual performance. Executors are anonymous — the coordinator has no way to know how many are connected.

## Solution

Each executor thread generates a unique ID (`pid-threadN`) and includes it in every job result sent over ZMQ. The coordinator tracks these IDs and counts jobs per executor in Metrics.

### Wire format change

Results sent from executors change from:
```
(job_id, result)
```
to:
```
(job_id, executor_id, result)
```

### Changes

- **`flowr/src/lib/executor.rs`**: Generate unique executor ID per thread (`pid-N`), pass to `execute_job` and `execute_job_to_string`, include in serialized result
- **`flowr/src/lib/dispatcher.rs`**: Deserialize 3-tuple result format, return executor ID
- **`flowr/src/lib/coordinator.rs`**: Record executor ID in metrics on each retired job
- **`flowcore/src/model/metrics.rs`**: Add `jobs_per_executor: HashMap<String, usize>`, `record_executor()` method, display executor count and per-executor job counts in `Display`
- Tests updated for new wire format

### Example Metrics output

```
Executors: 8
Jobs per Executor:  1234-0:15  1234-1:12  1234-2:14  ...
```

When `flowrex` remote executors are used, their IDs will appear with different PIDs, making them distinguishable from local executors.

Closes #2983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics showing how many jobs each executor completes.
  * Execution results now include the executor identifier for improved visibility and tracking.
  * Executor identifiers are included in execution logs and formatted metrics output.

* **Bug Fixes**
  * Improved consistency when recording executor activity across initial and subsequent job results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->