### PR TITLE
Notify client when debugger ends session early

### DIFF
--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -93,6 +93,20 @@ enum FlowIterationResult {
     Restart,
 }
 
+/// Returns true if `err` is the error raised when the debug client ends the debug session
+/// (e.g. the 'e' command). This is handled specially so the client is still notified that the
+/// flow has ended and can exit cleanly.
+#[cfg(feature = "debugger")]
+fn is_debugger_exit_error(err: &flowcore::errors::Error) -> bool {
+    err.to_string() == crate::debugger::DEBUGGER_EXIT_MESSAGE
+}
+
+/// When the debugger feature is disabled this error can never be raised, so never matches.
+#[cfg(not(feature = "debugger"))]
+fn is_debugger_exit_error(_err: &flowcore::errors::Error) -> bool {
+    false
+}
+
 // --- Debugger wrapper methods ---
 // Encapsulate `#[cfg(feature = "debugger")]` branching so the main coordinator
 // logic reads cleanly without conditional compilation noise.
@@ -226,7 +240,7 @@ impl<'a> Coordinator<'a> {
         self.debugger_start(&state);
 
         // Outer loop: allows the debugger to restart execution from scratch
-        loop {
+        let flow_result = loop {
             state.init()?;
             #[cfg(feature = "metrics")]
             {
@@ -237,30 +251,46 @@ impl<'a> Coordinator<'a> {
                 crate::run_state::reset_retire_timers();
             }
 
-            let iteration_result = self.run_jobs(
+            // If the debug client ended the session (e.g. the 'e' command), stop the outer
+            // loop rather than returning immediately, so the client can still be notified
+            // that execution has ended.
+            let iteration_result = match self.run_jobs(
                 &mut state,
                 #[cfg(feature = "metrics")]
                 &mut metrics,
-            )?;
+            ) {
+                Ok(result) => result,
+                Err(err) if is_debugger_exit_error(&err) => break Err(err),
+                Err(err) => return Err(err),
+            };
 
             // After execution ends, give the debugger a chance to inspect final state
             // and potentially request a restart
-            let restart = matches!(iteration_result, FlowIterationResult::Restart)
-                || self.debugger_end_of_execution(
+            let restart = if matches!(iteration_result, FlowIterationResult::Restart) {
+                true
+            } else {
+                match self.debugger_end_of_execution(
                     &mut state,
                     #[cfg(feature = "metrics")]
                     &mut metrics,
-                )?;
+                ) {
+                    Ok(restart) => restart,
+                    Err(err) if is_debugger_exit_error(&err) => break Err(err),
+                    Err(err) => return Err(err),
+                }
+            };
 
             if !restart {
-                break;
+                break Ok(());
             }
-        }
+        };
 
         #[cfg(feature = "trace")]
         state.write_trace()?;
 
-        // Finalize metrics and notify the submission handler that execution has ended
+        // Finalize metrics and notify the submission handler that execution has ended, even
+        // when the debug client ended the session early — the client needs the notification
+        // to exit cleanly (e.g. flowrcli)
         #[cfg(feature = "metrics")]
         metrics.stop_timer();
         #[cfg(feature = "metrics")]
@@ -271,7 +301,7 @@ impl<'a> Coordinator<'a> {
         #[cfg(all(feature = "submission", not(feature = "metrics")))]
         self.submission_handler.flow_execution_ended(&state)?;
 
-        Ok(())
+        flow_result
     }
 
     /// Run the inner dispatch/retire loop until no more jobs remain or the debugger

--- a/flowr/src/lib/debugger.rs
+++ b/flowr/src/lib/debugger.rs
@@ -22,6 +22,12 @@ use crate::debugger_handler::DebuggerHandler;
 use crate::job::Job;
 use crate::run_state::{RunState, State};
 
+/// Error message raised when the debug client ends the debug session (e.g. the 'e' command).
+///
+/// The coordinator uses this to distinguish a normal end of the debug session from other
+/// execution errors, so it can still notify the client that the flow has ended.
+pub const DEBUGGER_EXIT_MESSAGE: &str = "Debugger Exit";
+
 /// Debugger struct contains all the info necessary to conduct a debugging session, storing
 /// set breakpoints, connections to the debug client etc
 pub struct Debugger<'a> {
@@ -396,7 +402,7 @@ impl<'a> Debugger<'a> {
                 }
                 Ok(ExitDebugger) => {
                     self.debug_server.debugger_exiting();
-                    bail!("Debugger Exit");
+                    bail!(DEBUGGER_EXIT_MESSAGE);
                 }
             }
         }

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -181,26 +181,35 @@ mod test {
     use crate::job::Payload;
     use crate::test_helper::fixtures::{get_bind_addresses, get_four_ports};
 
+    /// Create a `Dispatcher` for testing, re-picking ports and retrying a few times to
+    /// tolerate the occasional race where another process grabs a freshly picked port.
+    fn new_dispatcher() -> (super::Dispatcher, (u16, u16, u16, u16)) {
+        for _ in 0..10 {
+            let ports = get_four_ports();
+            if let Ok(dispatcher) = super::Dispatcher::new(&get_bind_addresses(ports)) {
+                return (dispatcher, ports);
+            }
+        }
+        panic!("Could not create dispatcher after 10 attempts");
+    }
+
     #[test]
     #[serial]
     fn test_constructor() {
-        let dispatcher = super::Dispatcher::new(&get_bind_addresses(get_four_ports()));
-        assert!(dispatcher.is_ok());
+        let (_dispatcher, _ports) = new_dispatcher();
     }
 
     #[test]
     #[serial]
     fn set_timeout_to_none() {
-        let mut dispatcher = super::Dispatcher::new(&get_bind_addresses(get_four_ports()))
-            .expect("Could not create dispatcher");
+        let (mut dispatcher, _ports) = new_dispatcher();
         assert!(dispatcher.set_results_timeout(None).is_ok());
     }
 
     #[test]
     #[serial]
     fn set_timeout() {
-        let mut dispatcher = super::Dispatcher::new(&get_bind_addresses(get_four_ports()))
-            .expect("Could not create dispatcher");
+        let (mut dispatcher, _ports) = new_dispatcher();
         assert!(dispatcher
             .set_results_timeout(Some(Duration::from_millis(10)))
             .is_ok());
@@ -216,9 +225,7 @@ mod test {
                 .expect("Could not parse Url"),
         };
 
-        let ports = get_four_ports();
-        let mut dispatcher = super::Dispatcher::new(&get_bind_addresses(ports))
-            .expect("Could not create dispatcher");
+        let (mut dispatcher, ports) = new_dispatcher();
 
         let context = zmq::Context::new();
         let job_source = context
@@ -240,9 +247,7 @@ mod test {
             implementation_url: Url::parse("context://stdio/stdout").expect("Could not parse Url"),
         };
 
-        let ports = get_four_ports();
-        let mut dispatcher = super::Dispatcher::new(&get_bind_addresses(ports))
-            .expect("Could not create dispatcher");
+        let (mut dispatcher, ports) = new_dispatcher();
 
         let context = zmq::Context::new();
         let context_job_source = context
@@ -258,9 +263,7 @@ mod test {
     #[test]
     #[serial]
     fn get_job() {
-        let ports = get_four_ports();
-        let mut dispatcher = super::Dispatcher::new(&get_bind_addresses(ports))
-            .expect("Could not create dispatcher");
+        let (mut dispatcher, ports) = new_dispatcher();
 
         let context = zmq::Context::new();
         let results_sink = context

--- a/flowr/src/lib/test_helper.rs
+++ b/flowr/src/lib/test_helper.rs
@@ -12,11 +12,18 @@ pub(crate) mod fixtures {
     use flowcore::model::runtime_function::RuntimeFunction;
 
     pub fn get_four_ports() -> (u16, u16, u16, u16) {
+        let mut ports = Vec::with_capacity(4);
+        while ports.len() < 4 {
+            let port = pick_unused_port().expect("No ports free");
+            if !ports.contains(&port) {
+                ports.push(port);
+            }
+        }
         (
-            pick_unused_port().expect("No ports free"),
-            pick_unused_port().expect("No ports free"),
-            pick_unused_port().expect("No ports free"),
-            pick_unused_port().expect("No ports free"),
+            ports.first().copied().expect("Four ports must be picked"),
+            ports.get(1).copied().expect("Four ports must be picked"),
+            ports.get(2).copied().expect("Four ports must be picked"),
+            ports.get(3).copied().expect("Four ports must be picked"),
         )
     }
 


### PR DESCRIPTION
## Problem

`make test` hung in the `debug-print-args` example: each of its 22 `#[serial]` debugger tests hit the full 10s kill grace period in `DebugSession::finish()`, and the suite never finished within the 300s test timeout.

Root cause: when the debug client sends `e` (ExitDebugger), the debugger raises a "Debugger Exit" error (debugger.rs:405). That error propagated out of `run_jobs`, so `execute_flow` returned early via `?` **without** calling `flow_execution_ended`. The client (flowrcli) never received `FlowEnd`, so its event loop blocked forever on `event_rx.recv()`. The bridge's special case for `CoordinatorExiting` (main.rs:586-594) deliberately does not forward that message, because it assumes the client already exited via `FlowEnd → ClientExiting` — which only happens for normal completion.

## Fix

Restructure `Coordinator::execute_flow` so a debugger-exit error breaks the outer restart loop (carrying the error) instead of returning immediately. The code after the loop then still finalizes metrics and calls `flow_execution_ended`, so the client gets `FlowEnd` and exits cleanly, before the original error is returned.

- New shared constant `DEBUGGER_EXIT_MESSAGE` in debugger.rs, used by the `bail!` and by `is_debugger_exit_error` in coordinator.rs (with a non-debugger cfg fallback).
- Both surface points are covered: the debugger-exit raised at session start (via `run_jobs` → `debugger_wait_if_enabled`) and after flow completion (via `debugger_end_of_execution`).

## Verification

- `cargo build -p flowr --all-features` and without the `debugger` feature both compile.
- `cargo test --example debug-print-args`: 22/22 pass in 59s (previously hung >300s).
- `cargo test -p flowr --lib`: 139/139 pass.
- `make clippy` clean, `cargo fmt --check` clean.
- Full `make test`: 40 suites all green.