### PR TITLE
Add executor bar chart to flowrgui metrics panel (#2983)

### DIFF
--- a/flowcore/src/model/metrics.rs
+++ b/flowcore/src/model/metrics.rs
@@ -152,11 +152,17 @@ impl fmt::Display for Metrics {
                 write!(f, "  #{id}:{count}")?;
             }
         }
-        if !self.jobs_per_executor.is_empty() {
+        // Filter out context executors (prefixed with "ctx:")
+        let job_executors: Vec<_> = self
+            .jobs_per_executor
+            .iter()
+            .filter(|(id, _)| !id.starts_with("ctx:"))
+            .collect();
+        if !job_executors.is_empty() {
             writeln!(f)?;
-            writeln!(f, "Executors: {}", self.jobs_per_executor.len())?;
+            writeln!(f, "Executors: {}", job_executors.len())?;
             write!(f, "Jobs per Executor:")?;
-            let mut executors: Vec<_> = self.jobs_per_executor.iter().collect();
+            let mut executors = job_executors;
             executors.sort_by_key(|(id, _)| (*id).clone());
             for (id, count) in &executors {
                 write!(f, "  {id}:{count}")?;

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2022,6 +2022,10 @@ impl FlowrGui {
                 sorted_executors.sort_by_key(|(id, _)| (*id).clone());
                 let id_width = sorted_executors.last().map_or(1, |(id, _)| id.len());
 
+                // Fixed label width in pixels based on longest ID
+                #[allow(clippy::cast_precision_loss)]
+                let label_px = Length::Fixed(id_width as f32 * 7.5 + 4.0);
+
                 for (exec_id, &count) in &sorted_executors {
                     let label = format!("{exec_id:>id_width$}");
                     #[allow(clippy::cast_possible_truncation)]
@@ -2042,10 +2046,14 @@ impl FlowrGui {
                         .spacing(4)
                         .align_y(iced::alignment::Vertical::Center)
                         .push(
-                            Text::new(label)
-                                .size(theme::FONT_SM)
-                                .font(iced::Font::MONOSPACE)
-                                .color(theme::EXECUTOR_COLOR),
+                            Container::new(
+                                Text::new(label)
+                                    .size(theme::FONT_SM)
+                                    .font(iced::Font::MONOSPACE)
+                                    .color(theme::EXECUTOR_COLOR),
+                            )
+                            .width(label_px)
+                            .align_x(iced::alignment::Horizontal::Right),
                         )
                         .push(bar)
                         .push(

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2024,7 +2024,7 @@ impl FlowrGui {
 
                 // Fixed label width in pixels based on longest ID
                 #[allow(clippy::cast_precision_loss)]
-                let label_px = Length::Fixed(id_width as f32 * 7.5 + 4.0);
+                let label_px = Length::Fixed(id_width as f32 * 8.5 + 8.0);
 
                 for (exec_id, &count) in &sorted_executors {
                     let label = format!("{exec_id:>id_width$}");

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1999,17 +1999,26 @@ impl FlowrGui {
                 }
             }
 
-            // Executor bar chart
+            // Executor bar chart — filter out context executors (prefixed with "ctx:")
             let executor_counts = metrics.jobs_per_executor();
-            if !executor_counts.is_empty() {
+            let job_executors: Vec<_> = executor_counts
+                .iter()
+                .filter(|(id, _)| !id.starts_with("ctx:"))
+                .collect();
+            if !job_executors.is_empty() {
                 col = col.push(
-                    Text::new(format!("Executors: {}", executor_counts.len()))
+                    Text::new(format!("Executors: {}", job_executors.len()))
                         .size(theme::FONT_MD)
                         .color(theme::TEXT_SECONDARY),
                 );
 
-                let exec_max = executor_counts.values().copied().max().unwrap_or(1).max(1);
-                let mut sorted_executors: Vec<_> = executor_counts.iter().collect();
+                let exec_max = job_executors
+                    .iter()
+                    .map(|(_, &c)| c)
+                    .max()
+                    .unwrap_or(1)
+                    .max(1);
+                let mut sorted_executors = job_executors;
                 sorted_executors.sort_by_key(|(id, _)| (*id).clone());
                 let id_width = sorted_executors.last().map_or(1, |(id, _)| id.len());
 

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2084,7 +2084,7 @@ impl FlowrGui {
             .push(iced::widget::Scrollable::new(content).height(Length::Fill));
 
         Container::new(panel_content)
-            .width(Length::Fixed(300.0))
+            .width(Length::Fixed(350.0))
             .height(Length::Fill)
             .padding(theme::SPACE_MD)
             .style(|_: &iced::Theme| iced::widget::container::Style {

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -1998,6 +1998,58 @@ impl FlowrGui {
                     col = col.push(row);
                 }
             }
+
+            // Executor bar chart
+            let executor_counts = metrics.jobs_per_executor();
+            if !executor_counts.is_empty() {
+                col = col.push(
+                    Text::new(format!("Executors: {}", executor_counts.len()))
+                        .size(theme::FONT_MD)
+                        .color(theme::TEXT_SECONDARY),
+                );
+
+                let exec_max = executor_counts.values().copied().max().unwrap_or(1).max(1);
+                let mut sorted_executors: Vec<_> = executor_counts.iter().collect();
+                sorted_executors.sort_by_key(|(id, _)| (*id).clone());
+
+                for (exec_id, &count) in &sorted_executors {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let portion = (count.saturating_mul(100) / exec_max).max(1) as u16;
+                    let bar = Container::new(Text::new("").size(1))
+                        .width(Length::FillPortion(portion))
+                        .height(Length::Fixed(14.0))
+                        .style(move |_: &iced::Theme| iced::widget::container::Style {
+                            background: Some(iced::Background::Color(theme::EXECUTOR_COLOR)),
+                            border: iced::Border {
+                                radius: 3.0.into(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        });
+                    let spacer_portion = (100 - portion).max(1);
+                    let row = Row::new()
+                        .spacing(4)
+                        .align_y(iced::alignment::Vertical::Center)
+                        .push(
+                            Text::new(*exec_id)
+                                .size(theme::FONT_SM)
+                                .font(iced::Font::MONOSPACE)
+                                .color(theme::EXECUTOR_COLOR),
+                        )
+                        .push(bar)
+                        .push(
+                            iced::widget::container(Text::new("").size(1))
+                                .width(Length::FillPortion(spacer_portion)),
+                        )
+                        .push(
+                            Text::new(count.to_string())
+                                .size(theme::FONT_SM)
+                                .color(theme::TEXT_SECONDARY),
+                        );
+                    col = col.push(row);
+                }
+            }
+
             col
         } else {
             Column::new().push(

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -2011,8 +2011,10 @@ impl FlowrGui {
                 let exec_max = executor_counts.values().copied().max().unwrap_or(1).max(1);
                 let mut sorted_executors: Vec<_> = executor_counts.iter().collect();
                 sorted_executors.sort_by_key(|(id, _)| (*id).clone());
+                let id_width = sorted_executors.last().map_or(1, |(id, _)| id.len());
 
                 for (exec_id, &count) in &sorted_executors {
+                    let label = format!("{exec_id:>id_width$}");
                     #[allow(clippy::cast_possible_truncation)]
                     let portion = (count.saturating_mul(100) / exec_max).max(1) as u16;
                     let bar = Container::new(Text::new("").size(1))
@@ -2031,7 +2033,7 @@ impl FlowrGui {
                         .spacing(4)
                         .align_y(iced::alignment::Vertical::Center)
                         .push(
-                            Text::new(*exec_id)
+                            Text::new(label)
                                 .size(theme::FONT_SM)
                                 .font(iced::Font::MONOSPACE)
                                 .color(theme::EXECUTOR_COLOR),
@@ -4210,6 +4212,25 @@ mod test {
         use iced_test::simulator::simulator;
         let mut gui = test_gui();
         gui.active_panel = Some(PanelKind::Metrics);
+        let view = gui.view();
+        let _ui = simulator(view);
+    }
+
+    #[test]
+    fn view_renders_metrics_with_executors() {
+        use flowcore::model::metrics::Metrics;
+        use iced_test::simulator::simulator;
+        let mut gui = test_gui();
+        gui.active_panel = Some(PanelKind::Metrics);
+        let mut metrics = Metrics::new(3, 3);
+        metrics.set_jobs_created(10);
+        metrics.record_executor("100-0");
+        metrics.record_executor("100-0");
+        metrics.record_executor("100-1");
+        metrics.record_executor("100-1");
+        metrics.record_executor("100-1");
+        metrics.record_executor("200-0");
+        gui.last_metrics = Some(metrics);
         let view = gui.view();
         let _ui = simulator(view);
     }

--- a/flowr/src/bin/flowrgui/theme.rs
+++ b/flowr/src/bin/flowrgui/theme.rs
@@ -52,6 +52,13 @@ pub const ACCENT: Color = Color {
     a: 1.0,
 };
 
+pub const EXECUTOR_COLOR: Color = Color {
+    r: 0.2,
+    g: 0.7,
+    b: 0.5,
+    a: 1.0,
+};
+
 // ── Entity type colors (consistent across the app) ──────────────────────────
 
 #[allow(dead_code)]

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -245,7 +245,6 @@ impl<'a> Coordinator<'a> {
             #[cfg(feature = "metrics")]
             {
                 metrics.reset();
-                crate::executor::reset_max_jobs_executing();
                 TOTAL_GET_RESULT_US.store(0, std::sync::atomic::Ordering::Relaxed);
                 TOTAL_RETIRE_JOB_US.store(0, std::sync::atomic::Ordering::Relaxed);
                 crate::run_state::reset_retire_timers();
@@ -622,7 +621,7 @@ impl<'a> Coordinator<'a> {
         state.start_job(job);
 
         #[cfg(feature = "metrics")]
-        metrics.track_max_jobs(crate::executor::max_jobs_executing());
+        metrics.track_max_jobs(state.number_jobs_running());
 
         Ok(action)
     }

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -116,8 +116,10 @@ impl Dispatcher {
             .recv_msg(flags)
             .map_err(|_| "Error receiving result")?;
         let message_string = msg.as_str().ok_or("Could not get message as str")?;
-        serde_json::from_str(message_string)
-            .map_err(|_| "Could not Deserialize from zmq message string".into())
+        serde_json::from_str(message_string).map_err(|e| {
+            error!("Could not deserialize result from executor (version mismatch?): {e}");
+            "Could not Deserialize from zmq message string".into()
+        })
     }
 
     // Send a `Job` for execution to executors.

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -178,7 +178,11 @@ impl Executor {
             let results_sink = results_service.into();
             let job_source = job_service.into();
             let control_address = control_service.into();
-            let executor_id = make_executor_id();
+            let executor_id = if spawn_jobs {
+                format!("ctx:{}", make_executor_id())
+            } else {
+                make_executor_id()
+            };
             self.executors.push(thread::spawn(move || {
                 trace!("Executor {executor_id} entering execution loop");
                 if let Err(e) = execution_loop(

--- a/flowr/tests/flowrex.rs
+++ b/flowr/tests/flowrex.rs
@@ -134,3 +134,130 @@ fn test_fibonacci_with_flowrex_mid_run() {
          should appear in metrics, but stdout was:\n{stdout}"
     );
 }
+
+/// Test that flowrex and local executor threads share work when both are active.
+/// Starts the coordinator with 1 local thread for a long-running flow (mandlebrot),
+/// then starts flowrex with 2 threads. Verifies that both the coordinator's and
+/// flowrex's executor IDs appear in the metrics output.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[serial]
+fn test_flowrex_shares_work_with_local_executors() {
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::Duration;
+
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = manifest_dir.parent().expect("Could not find project root");
+
+    let example_dir = project_root
+        .join("flowr")
+        .join("examples")
+        .join("mandlebrot");
+
+    // Compile the example
+    let compile_status = Command::new("flowc")
+        .args(["-d", "-g", "-c", "-O", "-r", "flowrcli"])
+        .arg(example_dir.to_str().expect("path"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("Could not run flowc to compile example");
+    assert!(compile_status.success(), "flowc compilation failed");
+
+    // Start coordinator with 1 local thread and metrics.
+    // Use a 200x150 mandlebrot to generate enough jobs (~90k) that the flow
+    // runs long enough for flowrex to discover and join mid-run.
+    let mut coordinator = Command::new("flowrcli")
+        .args([
+            "--threads",
+            "1",
+            "-m",
+            "manifest.json",
+            "--",
+            "/dev/null",
+            "[200,150]",
+            "[[-1.20,0.35],[-1,0.20]]",
+        ])
+        .current_dir(
+            example_dir
+                .canonicalize()
+                .expect("Could not canonicalize path"),
+        )
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Could not spawn coordinator");
+
+    let coordinator_pid = coordinator.id();
+
+    // Start flowrex immediately — it will discover the coordinator via mDNS
+    // while the flow is running. With ~90k jobs and 1 local thread, the flow
+    // takes long enough for flowrex to connect and pick up jobs.
+    let mut flowrex = Command::new("flowrex")
+        .args(["--threads", "2"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Could not spawn flowrex");
+
+    let flowrex_pid = flowrex.id();
+
+    // Wait for coordinator with a timeout
+    let deadline = std::time::Instant::now() + Duration::from_mins(2);
+    let exit_status = loop {
+        if std::time::Instant::now() > deadline {
+            coordinator.kill().ok();
+            flowrex.kill().ok();
+            coordinator.wait().ok();
+            flowrex.wait().ok();
+            panic!("Coordinator did not finish within 120 seconds");
+        }
+        match coordinator.try_wait().expect("Could not check coordinator") {
+            Some(status) => break status,
+            None => thread::sleep(Duration::from_secs(1)),
+        }
+    };
+
+    // Read stdout
+    let mut stdout_bytes = Vec::new();
+    if let Some(mut out) = coordinator.stdout.take() {
+        std::io::Read::read_to_end(&mut out, &mut stdout_bytes).ok();
+    }
+
+    // Read stderr for error diagnostics
+    let mut stderr_bytes = Vec::new();
+    if let Some(mut err) = coordinator.stderr.take() {
+        std::io::Read::read_to_end(&mut err, &mut stderr_bytes).ok();
+    }
+    let stderr = String::from_utf8_lossy(&stderr_bytes);
+
+    // Kill flowrex
+    flowrex.kill().ok();
+    flowrex.wait().ok();
+
+    assert!(
+        exit_status.success(),
+        "Coordinator failed with status: {exit_status}\nstderr: {stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
+
+    // Verify both coordinator and flowrex executor IDs appear in metrics
+    let coordinator_prefix = format!("{coordinator_pid}-");
+    let flowrex_prefix = format!("{flowrex_pid}-");
+    assert!(
+        stdout.contains(&coordinator_prefix),
+        "Metrics should contain coordinator executor IDs (prefix '{coordinator_prefix}'), \
+         but stdout was:\n{stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains(&flowrex_prefix),
+        "Metrics should contain flowrex executor IDs (prefix '{flowrex_prefix}'), \
+         but stdout was:\n{stdout}\nstderr: {stderr}"
+    );
+
+    // Allow mDNS goodbye packets to propagate before the next serial test
+    thread::sleep(Duration::from_secs(3));
+}

--- a/flowr/tests/flowrex.rs
+++ b/flowr/tests/flowrex.rs
@@ -43,9 +43,9 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .expect("Could not run flowc to compile example");
     assert!(compile_status.success(), "flowc compilation failed");
 
-    // Start coordinator with 0 threads — no local executors
+    // Start coordinator with 0 threads and metrics — no local executors
     let mut coordinator = Command::new("flowrcli")
-        .args(["--threads", "0", "manifest.json"])
+        .args(["--threads", "0", "-m", "manifest.json"])
         .current_dir(
             example_dir
                 .canonicalize()
@@ -56,6 +56,8 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .stderr(Stdio::piped())
         .spawn()
         .expect("Could not spawn coordinator");
+
+    let coordinator_pid = coordinator.id();
 
     // Wait for the coordinator to start and advertise mDNS services.
     // mDNS advertisement can take a few seconds on some platforms.
@@ -68,6 +70,8 @@ fn test_fibonacci_with_flowrex_mid_run() {
         .stderr(Stdio::null())
         .spawn()
         .expect("Could not spawn flowrex");
+
+    let flowrex_pid = flowrex.id();
 
     // Wait for coordinator with a timeout to avoid hanging CI
     let deadline = std::time::Instant::now() + Duration::from_mins(2);
@@ -115,4 +119,18 @@ fn test_fibonacci_with_flowrex_mid_run() {
     assert_eq!(lines.get(2).copied(), Some("3"), "Third fibonacci number");
     assert_eq!(lines.get(3).copied(), Some("5"), "Fourth fibonacci number");
     assert_eq!(lines.get(4).copied(), Some("8"), "Fifth fibonacci number");
+
+    // Verify flowrex executor IDs appear in metrics (format: "pid-N:count")
+    let flowrex_prefix = format!("{flowrex_pid}-");
+    let coordinator_prefix = format!("{coordinator_pid}-");
+    assert!(
+        stdout.contains(&flowrex_prefix),
+        "Metrics should contain flowrex executor IDs (prefix '{flowrex_prefix}'), \
+         but stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(&coordinator_prefix),
+        "With --threads 0, no coordinator executor IDs (prefix '{coordinator_prefix}') \
+         should appear in metrics, but stdout was:\n{stdout}"
+    );
 }


### PR DESCRIPTION
## Changes

Adds a per-executor job count bar chart to the flowrgui metrics panel, below the existing per-function chart. Uses green bars (`EXECUTOR_COLOR`) to distinguish from the purple function bars.

Each executor thread's ID and job count is shown, making it easy to see:
- How many executor threads participated in the flow
- Whether work was evenly distributed across executors
- Which executors (local vs remote via flowrex) handled the most jobs

## Testing findings

**Game-of-life max WASM grid size:**
- 100x100 (10,000 cells) works
- 102x102 fails — `extract_neighborhoods.wasm` hits a memory error (the output JSON for 10,000+ neighborhoods exceeds WASM linear memory)

**Mandlebrot performance:**
- 200x150 takes ~11s — suitable for observing executor load distribution

## Files changed

- `flowr/src/bin/flowrgui/main.rs`: Executor bar chart in metrics panel
- `flowr/src/bin/flowrgui/theme.rs`: `EXECUTOR_COLOR` constant

Ref #2983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a per-executor job-count bar chart to the metrics panel when executor metrics are available.
  - Charts show sorted executor labels, relative job-count scaling, distinct colors, and total executor counts for easier comparison.
  - Context executors are excluded from executor counts and job listings to keep displayed metrics focused on regular executors.

- **Bug Fixes**
  - Improved maximum running-job metrics to reflect current flow activity more accurately.
  - Added clearer diagnostics when result data cannot be deserialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->