### PR TITLE
Add sub-flow extraction from FlowManifest (#2990)

### DIFF
--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -2,6 +2,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 
@@ -217,6 +218,114 @@ impl FlowManifest {
         &self.source_urls
     }
 
+    /// Extract a sub-flow and all its descendants into a standalone `FlowManifest`.
+    ///
+    /// The target flow becomes the root of the new manifest (`parent_id` = `None`).
+    /// All functions belonging to the target flow or any of its descendant sub-flows
+    /// are included. Output connections that reference functions outside the extracted
+    /// sub-flow are removed (they become the sub-flow's boundary).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the target `flow_id` is not found in the manifest.
+    pub fn extract_subflow(&self, flow_id: usize) -> Result<FlowManifest> {
+        if !self.flows.contains_key(&flow_id) {
+            crate::bail!("Flow #{flow_id} not found in manifest");
+        }
+
+        // Collect all descendant flow IDs (including the target itself)
+        let mut flow_ids = HashSet::new();
+        Self::collect_descendant_flows(flow_id, &self.flows, &mut flow_ids);
+
+        // Collect all functions belonging to the target flow or its descendants
+        let mut extracted_functions = HashMap::new();
+        let function_ids: HashSet<usize> = self
+            .functions
+            .iter()
+            .filter(|(_, f)| flow_ids.contains(&f.get_parent_id()))
+            .map(|(&id, _)| id)
+            .collect();
+
+        for &func_id in &function_ids {
+            if let Some(func) = self.functions.get(&func_id) {
+                let mut cloned = func.clone();
+                // Remove output connections that target functions outside the sub-flow
+                cloned.retain_connections(|conn| function_ids.contains(&conn.destination_id));
+                extracted_functions.insert(func_id, cloned);
+            }
+        }
+
+        // Build the flow hierarchy for the extracted sub-flow
+        let mut extracted_flows = HashMap::new();
+        for &fid in &flow_ids {
+            if let Some(flow_info) = self.flows.get(&fid) {
+                let mut cloned = flow_info.clone();
+                // Make the target flow the root
+                if fid == flow_id {
+                    cloned.parent_id = None;
+                }
+                // Keep only sub-flow IDs that are in the extracted set
+                cloned.sub_flow_ids.retain(|id| flow_ids.contains(id));
+                extracted_flows.insert(fid, cloned);
+            }
+        }
+
+        // Collect lib and context references from extracted functions
+        let mut lib_refs = BTreeSet::new();
+        let mut context_refs = BTreeSet::new();
+        for func in extracted_functions.values() {
+            let url = func.get_implementation_url();
+            match url.scheme() {
+                "lib" => {
+                    lib_refs.insert(url.clone());
+                }
+                "context" => {
+                    context_refs.insert(url.clone());
+                }
+                _ => {}
+            }
+        }
+
+        #[cfg(feature = "debugger")]
+        let flow_name = self
+            .flows
+            .get(&flow_id)
+            .map_or_else(String::new, |f| f.name.clone());
+        #[cfg(not(feature = "debugger"))]
+        let flow_name = String::new();
+        let metadata = MetaData {
+            name: flow_name,
+            ..MetaData::default()
+        };
+
+        let mut manifest = FlowManifest {
+            metadata,
+            lib_references: lib_refs,
+            context_references: context_refs,
+            functions: extracted_functions,
+            flows: extracted_flows,
+            #[cfg(feature = "debugger")]
+            source_urls: BTreeMap::new(),
+        };
+
+        manifest.mark_internal_inputs();
+        Ok(manifest)
+    }
+
+    /// Recursively collect all descendant flow IDs (including the given flow itself).
+    fn collect_descendant_flows(
+        flow_id: usize,
+        flows: &HashMap<usize, FlowInfo>,
+        result: &mut HashSet<usize>,
+    ) {
+        result.insert(flow_id);
+        if let Some(flow_info) = flows.get(&flow_id) {
+            for &child_id in &flow_info.sub_flow_ids {
+                Self::collect_descendant_flows(child_id, flows, result);
+            }
+        }
+    }
+
     /// Load, or Deserialize, a manifest from a `source` Url using `provider`
     /// Sets all `location_url` fields to be URLs, a file URL for provided implementations
     ///
@@ -362,5 +471,148 @@ mod test {
             &Url::parse("http://ibm.com/fake.json").expect("Could not parse URL"),
         )
         .expect("Could not load manifest");
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn extract_subflow_basic() {
+        use super::FlowInfo;
+        use crate::model::output_connection::{OutputConnection, Source};
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Flow hierarchy: root (#0) contains child (#1)
+        // Root has function #10, child has functions #20 and #21
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            #[cfg(feature = "debugger")]
+            name: "child".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/child".into(),
+        });
+
+        // Function #10 in root, connects to #20 in child (cross-flow)
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func10",
+            #[cfg(feature = "debugger")]
+            "/root/func10",
+            "lib://flowstdlib/math/add",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "a",
+                0,
+                false,
+                None,
+                None,
+            )],
+            10,
+            0,
+            &[OutputConnection::new(
+                Source::default(),
+                20,
+                0,
+                1,
+                false,
+                String::new(),
+                #[cfg(feature = "debugger")]
+                String::new(),
+            )],
+            false,
+        ));
+
+        // Function #20 in child, connects to #21 (internal)
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func20",
+            #[cfg(feature = "debugger")]
+            "/root/child/func20",
+            "file://test/func20.wasm",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "in",
+                0,
+                false,
+                None,
+                None,
+            )],
+            20,
+            1,
+            &[OutputConnection::new(
+                Source::default(),
+                21,
+                0,
+                1,
+                true,
+                String::new(),
+                #[cfg(feature = "debugger")]
+                String::new(),
+            )],
+            false,
+        ));
+
+        // Function #21 in child, no outputs
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func21",
+            #[cfg(feature = "debugger")]
+            "/root/child/func21",
+            "file://test/func21.wasm",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "in",
+                0,
+                false,
+                None,
+                None,
+            )],
+            21,
+            1,
+            &[],
+            false,
+        ));
+
+        manifest.mark_internal_inputs();
+
+        // Extract child flow #1
+        let extracted = manifest.extract_subflow(1).expect("extract failed");
+
+        // Should contain functions #20 and #21 only
+        assert_eq!(extracted.functions().len(), 2);
+        assert!(extracted.functions().contains_key(&20));
+        assert!(extracted.functions().contains_key(&21));
+        assert!(!extracted.functions().contains_key(&10));
+
+        // Child flow should be root (parent_id = None)
+        assert_eq!(extracted.flows().len(), 1);
+        assert!(extracted.flows().get(&1).unwrap().parent_id.is_none());
+
+        // Internal connection #20 -> #21 should be preserved
+        assert_eq!(
+            extracted
+                .functions()
+                .get(&20)
+                .unwrap()
+                .get_output_connections()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn extract_subflow_not_found() {
+        let manifest = FlowManifest::new(test_meta_data());
+        assert!(manifest.extract_subflow(99).is_err());
     }
 }

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -270,19 +270,21 @@ impl FlowManifest {
             }
         }
 
-        // Collect lib and context references from extracted functions
+        // Collect lib and context references from extracted functions.
+        // Use implementation_location (the source string) rather than
+        // implementation_url, which is only populated after manifest loading.
         let mut lib_refs = BTreeSet::new();
         let mut context_refs = BTreeSet::new();
         for func in extracted_functions.values() {
-            let url = func.get_implementation_url();
-            match url.scheme() {
-                "lib" => {
-                    lib_refs.insert(url.clone());
+            let loc = func.get_implementation_location();
+            if loc.starts_with("lib://") {
+                if let Ok(url) = Url::parse(loc) {
+                    lib_refs.insert(url);
                 }
-                "context" => {
-                    context_refs.insert(url.clone());
+            } else if loc.starts_with("context://") {
+                if let Ok(url) = Url::parse(loc) {
+                    context_refs.insert(url);
                 }
-                _ => {}
             }
         }
 
@@ -312,16 +314,20 @@ impl FlowManifest {
         Ok(manifest)
     }
 
-    /// Recursively collect all descendant flow IDs (including the given flow itself).
+    /// Collect all descendant flow IDs (including the given flow itself).
+    /// Uses an iterative work list to avoid stack overflow on deep hierarchies
+    /// and skips already-visited IDs to handle cycles safely.
     fn collect_descendant_flows(
         flow_id: usize,
         flows: &HashMap<usize, FlowInfo>,
         result: &mut HashSet<usize>,
     ) {
-        result.insert(flow_id);
-        if let Some(flow_info) = flows.get(&flow_id) {
-            for &child_id in &flow_info.sub_flow_ids {
-                Self::collect_descendant_flows(child_id, flows, result);
+        let mut work = vec![flow_id];
+        while let Some(id) = work.pop() {
+            if result.insert(id) {
+                if let Some(flow_info) = flows.get(&id) {
+                    work.extend(&flow_info.sub_flow_ids);
+                }
             }
         }
     }
@@ -614,5 +620,38 @@ mod test {
     fn extract_subflow_not_found() {
         let manifest = FlowManifest::new(test_meta_data());
         assert!(manifest.extract_subflow(99).is_err());
+    }
+
+    #[test]
+    fn extract_subflow_handles_cycle() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Create a cycle: flow #0 -> flow #1 -> flow #0
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            #[cfg(feature = "debugger")]
+            name: "a".into(),
+            #[cfg(feature = "debugger")]
+            route: "/a".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![0], // cycle back to root
+            #[cfg(feature = "debugger")]
+            name: "b".into(),
+            #[cfg(feature = "debugger")]
+            route: "/b".into(),
+        });
+
+        // Should not hang or panic — cycle is handled by visited set
+        let result = manifest.extract_subflow(0);
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert_eq!(extracted.flows().len(), 2);
     }
 }

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -263,6 +263,16 @@ impl RuntimeFunction {
         }
     }
 
+    /// Retain only output connections that satisfy the predicate.
+    /// Invalidates the cached `output_connections_arc`.
+    pub fn retain_connections<F>(&mut self, f: F)
+    where
+        F: FnMut(&OutputConnection) -> bool,
+    {
+        self.output_connections.retain(f);
+        self.output_connections_arc = None;
+    }
+
     /// Get a reference to the `implementation_location`
     #[must_use]
     pub fn get_implementation_location(&self) -> &str {


### PR DESCRIPTION
## Phase 1 of Distributed Coordination (#1454)

Adds the ability to extract a sub-flow and all its descendants from a `FlowManifest` into a standalone manifest. This is the foundation for distributed sub-flow execution.

### `FlowManifest::extract_subflow(flow_id)`

Given a flow ID, produces a new `FlowManifest` containing:
- All functions belonging to the target flow or any descendant sub-flows
- The flow hierarchy for the target and descendants
- The target flow as the new root (`parent_id = None`)
- Internal connections preserved
- Cross-flow connections (to functions outside the sub-flow) removed

### `RuntimeFunction::retain_connections()`

New method to filter output connections by predicate. Used during extraction to remove connections that cross the sub-flow boundary.

### Tests

- `extract_subflow_basic`: Build a 2-level hierarchy, extract the child flow, verify correct functions/flows/connections
- `extract_subflow_not_found`: Error on invalid flow ID

### Next Steps (remaining Phase 1 tasks)

- Construct a `RunState` from an extracted sub-flow partition
- Run an extracted sub-flow independently with injected inputs and verify outputs

Ref #2990, #1454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to extract a standalone subflow from an existing flow.
  - Extracted subflows retain their descendant flows, functions, hierarchy, relevant references, debugger metadata, and recalculated internal inputs.
  - Connections to flows outside the extracted subflow are removed automatically.
- **Bug Fixes**
  - Added clear error handling when attempting to extract a flow that does not exist.
- **Tests**
  - Added coverage for successful subflow extraction and missing-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->