### PR TITLE
Fix book build with current mdbook and un-pin it in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,15 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: install mdbook
-        run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
-      - name: install link checker
-        run: |
-          curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip > mdbook-linkcheck.zip
-          mkdir -p $HOME/.cargo/bin
-          unzip mdbook-linkcheck.zip -d $HOME/.cargo/bin
-          chmod +x $HOME/.cargo/bin/mdbook-linkcheck
-          echo "PATH=$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install book tools
+        run: make book-tools
       - name: make book
         run: make book
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,15 +225,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install book tools
+        run: make book-tools
       - name: Build book
-        run: |
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
-          curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip > mdbook-linkcheck.zip
-          mkdir -p $HOME/.cargo/bin
-          unzip mdbook-linkcheck.zip -d $HOME/.cargo/bin
-          chmod +x $HOME/.cargo/bin/mdbook-linkcheck
-          echo "PATH=$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"
-          make book
+        run: make book
       - name: Deploy book
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,16 @@ else ifneq ($(BREW),)
 endif
 	@echo "Installing grcov using cargo"
 	@cargo install grcov
-	@echo "Installing mdbook and mdbook-linkcheck using cargo"
-	@cargo install mdbook
-	@cargo install mdbook-linkcheck
+	@echo "Installing book building tools"
+	@$(MAKE) book-tools
 	@echo "installing wasm optimization tools"
 	@cargo install wasm-snip
+
+.PHONY: book-tools
+book-tools:
+	@echo "Installing mdbook and mdbook-linkcheck2 using cargo"
+	@cargo install mdbook
+	@cargo install mdbook-linkcheck2
 
 .PHONY: clean_examples
 clean_examples:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 #NOTE: Linux distros may also have brew installed - so I put it last. WIll probably only be used for mac
 .PHONY: config
 config: rustup
-	@export PATH="$$PATH:~/.cargo/bin"
+	@export PATH="$$PATH:$(HOME)/.cargo/bin"
 	@echo "Installing stable toolchain with rustup"
 	@echo "Installing clippy component using rustup"
 	@rustup --quiet component add clippy

--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,6 @@
 title = "The 'flow' book"
 authors = ["Andrew Mackenzie"]
 description = "What is 'flow' and how to use it?"
-multilingual = false
 src = "."
 
 [build]
@@ -13,4 +12,4 @@ use-default-preprocessors = false
 [output.html]
 [preprocessor.links]
 
-[output.linkcheck]
+[output.linkcheck2]

--- a/book/developing/overview.md
+++ b/book/developing/overview.md
@@ -9,7 +9,7 @@ To build and test flow you need:
 - Rust toolchain (`rustup`, `cargo`, `rustc`) with the `wasm32-unknown-unknown` target
 - `clippy` for lint checks
 - `zmq` (Zero Message Queue) library
-- `mdbook` and `mdbook-linkcheck` for building the book
+- `mdbook` and `mdbook-linkcheck2` for building the book
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

`make book` fails on a fresh checkout from master because CI and local development had drifted to different mdbook versions:

- CI pinned **mdbook v0.4.27** (downloaded as a prebuilt binary), while the Makefile `config` target installs the **latest** via `cargo install mdbook`.
- mdbook **0.5** removed the deprecated `book.multilingual` config field and made unknown config fields a hard error, so the current `book.toml` builds on CI's 0.4.27 but fails locally with 0.5.4.

## Changes

- **`book.toml`**: remove the deprecated `multilingual = false` field (compatible with both 0.4 and 0.5)
- **`book.toml`**: use `[output.linkcheck2]` renderer — `mdbook-linkcheck` 0.7.7 is unmaintained and incompatible with mdbook 0.5 (RenderContext JSON schema changed); `mdbook-linkcheck2` is the maintained fork that mdBook now recommends
- **`Makefile`**: add a `book-tools` target (`cargo install mdbook` + `cargo install mdbook-linkcheck2`), invoked from the `config` target
- **CI** (`build_and_test.yml` `test-book-build` and `release.yml` `build-and-publish-book`): replace the pinned v0.4.27 curl downloads with `make book-tools`, un-pinning mdbook so CI and developers use the same current toolchain
- **`book/developing/overview.md`**: update tool docs

## Verification

- `make book` passes locally with mdbook 0.5.4 + mdbook-linkcheck2 0.12.2 (HTML + linkcheck)
- `make test`, `make clippy`, `cargo fmt` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated book-building instructions to use the newer link-checking tool.
  * Simplified book configuration and removed an obsolete setting.

* **Chores**
  * Standardized documentation builds and publishing around the stable Rust toolchain.
  * Centralized installation of book-building tools for more consistent local and automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->