### PR TITLE
Add subflow:// URL scheme and executor registration (#2991)

### DIFF
--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -318,7 +318,7 @@ impl FlowManifest {
             .get(&flow_id)
             .and_then(|f| f.parent_id)
             .unwrap_or(0);
-        let proxy = crate::model::runtime_function::RuntimeFunction::new(
+        let mut proxy = crate::model::runtime_function::RuntimeFunction::new(
             #[cfg(feature = "debugger")]
             format!("subflow_{flow_id}"),
             #[cfg(feature = "debugger")]
@@ -330,6 +330,10 @@ impl FlowManifest {
             &[], // no output connections — routing is in the boundary outputs
             false,
         );
+        // Set the implementation_url from implementation_location.
+        // subflow:// URLs parse directly, no manifest base URL needed.
+        let dummy_base = Url::parse("file:///").map_err(|e| format!("{e}"))?;
+        proxy.set_implementation_url(&dummy_base)?;
         self.functions.insert(flow_id, proxy);
 
         Ok(extracted)
@@ -882,8 +886,9 @@ mod test {
         assert!(manifest.functions().contains_key(&10));
         assert!(manifest.functions().contains_key(&1)); // proxy replaces flow
 
-        // Proxy function should use subflow:// URL
+        // Proxy function should use subflow:// URL in both location and url
         let proxy = manifest.functions().get(&1).unwrap();
         assert_eq!(proxy.get_implementation_location(), "subflow://1");
+        assert_eq!(proxy.get_implementation_url().scheme(), "subflow");
     }
 }

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -269,6 +269,72 @@ impl FlowManifest {
         Ok((inputs, outputs))
     }
 
+    /// Delegate a sub-flow: remove its internal functions and replace with a
+    /// single proxy function that uses a `subflow://` implementation URL.
+    ///
+    /// The proxy function inherits the sub-flow's external input connections
+    /// (as flow initializers) and the sub-flow's flow hierarchy entry is preserved
+    /// but its `sub_flow_ids` are cleared.
+    ///
+    /// Returns the extracted sub-flow manifest for registration with executors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `flow_id` is not found.
+    pub fn delegate_subflow(&mut self, flow_id: usize) -> Result<FlowManifest> {
+        // Extract the sub-flow manifest first
+        let extracted = self.extract_subflow(flow_id)?;
+
+        // Find all function IDs inside the sub-flow
+        let mut flow_ids = HashSet::new();
+        Self::collect_descendant_flows(flow_id, &self.flows, &mut flow_ids);
+        let inside_func_ids: Vec<usize> = self
+            .functions
+            .iter()
+            .filter(|(_, f)| flow_ids.contains(&f.get_parent_id()))
+            .map(|(&id, _)| id)
+            .collect();
+
+        // Remove internal functions
+        for func_id in &inside_func_ids {
+            self.functions.remove(func_id);
+        }
+
+        // Remove descendant flow entries (but keep the target flow itself)
+        for &fid in &flow_ids {
+            if fid != flow_id {
+                self.flows.remove(&fid);
+            }
+        }
+        // Clear sub-flow IDs on the target flow
+        if let Some(flow_info) = self.flows.get_mut(&flow_id) {
+            flow_info.sub_flow_ids.clear();
+        }
+
+        // Create a proxy function with subflow:// URL
+        let subflow_url = format!("subflow://{flow_id}");
+        let parent_id = self
+            .flows
+            .get(&flow_id)
+            .and_then(|f| f.parent_id)
+            .unwrap_or(0);
+        let proxy = crate::model::runtime_function::RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            format!("subflow_{flow_id}"),
+            #[cfg(feature = "debugger")]
+            format!("/subflow/{flow_id}"),
+            &subflow_url,
+            vec![],  // inputs will be injected by the sub-flow implementation
+            flow_id, // use the flow's process_id for the proxy
+            parent_id,
+            &[], // no output connections — routing is in the boundary outputs
+            false,
+        );
+        self.functions.insert(flow_id, proxy);
+
+        Ok(extracted)
+    }
+
     /// Extract a sub-flow and all its descendants into a standalone `FlowManifest`.
     ///
     /// The target flow becomes the root of the new manifest (`parent_id` = `None`).
@@ -705,5 +771,119 @@ mod test {
         assert!(result.is_ok());
         let extracted = result.unwrap();
         assert_eq!(extracted.flows().len(), 2);
+    }
+
+    #[test]
+    fn delegate_subflow_replaces_with_proxy() {
+        use super::FlowInfo;
+        use crate::model::output_connection::{OutputConnection, Source};
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Root flow with function #10, child flow with functions #20 and #21
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            #[cfg(feature = "debugger")]
+            name: "child".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/child".into(),
+        });
+
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func10",
+            #[cfg(feature = "debugger")]
+            "/root/func10",
+            "lib://flowstdlib/math/add",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "a",
+                0,
+                false,
+                None,
+                None,
+            )],
+            10,
+            0,
+            &[],
+            false,
+        ));
+
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func20",
+            #[cfg(feature = "debugger")]
+            "/root/child/func20",
+            "file://test/func20.wasm",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "in",
+                0,
+                false,
+                None,
+                None,
+            )],
+            20,
+            1,
+            &[OutputConnection::new(
+                Source::default(),
+                21,
+                0,
+                1,
+                true,
+                String::new(),
+                #[cfg(feature = "debugger")]
+                String::new(),
+            )],
+            false,
+        ));
+
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "func21",
+            #[cfg(feature = "debugger")]
+            "/root/child/func21",
+            "file://test/func21.wasm",
+            vec![Input::new(
+                #[cfg(feature = "debugger")]
+                "in",
+                0,
+                false,
+                None,
+                None,
+            )],
+            21,
+            1,
+            &[],
+            false,
+        ));
+
+        // Delegate child flow #1
+        let extracted = manifest.delegate_subflow(1).expect("delegate failed");
+
+        // Extracted manifest should have the original child functions
+        assert_eq!(extracted.functions().len(), 2);
+        assert!(extracted.functions().contains_key(&20));
+        assert!(extracted.functions().contains_key(&21));
+
+        // Parent manifest should have func10 + proxy at flow_id 1
+        assert_eq!(manifest.functions().len(), 2);
+        assert!(manifest.functions().contains_key(&10));
+        assert!(manifest.functions().contains_key(&1)); // proxy replaces flow
+
+        // Proxy function should use subflow:// URL
+        let proxy = manifest.functions().get(&1).unwrap();
+        assert_eq!(proxy.get_implementation_location(), "subflow://1");
     }
 }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -65,6 +65,10 @@ pub struct Executor {
     // (e.g. lib:://flowstdlib), and the entry is a tuple of the LibraryManifest
     // and the resolved Url of where the manifest was read from
     loaded_lib_manifests: Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    // HashMap of registered sub-flow manifests for sub-flow execution.
+    // Key is the subflow:// URL (e.g. subflow://4), value is the FlowManifest.
+    loaded_subflow_manifests:
+        Arc<RwLock<HashMap<Url, flowcore::model::flow_manifest::FlowManifest>>>,
     executors: Vec<JoinHandle<()>>,
 }
 
@@ -82,6 +86,7 @@ impl Executor {
             loaded_lib_manifests: Arc::new(RwLock::new(
                 HashMap::<Url, (LibraryManifest, Url)>::new(),
             )),
+            loaded_subflow_manifests: Arc::new(RwLock::new(HashMap::new())),
             executors: vec![],
         }
     }
@@ -108,6 +113,25 @@ impl Executor {
 
         lib_manifests.insert(lib_manifest.lib_url.clone(), (lib_manifest, resolved_url));
 
+        Ok(())
+    }
+
+    /// Register a sub-flow manifest for execution via `subflow://` URLs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest cannot be registered.
+    pub fn add_subflow(
+        &mut self,
+        subflow_url: Url,
+        manifest: flowcore::model::flow_manifest::FlowManifest,
+    ) -> Result<()> {
+        let mut manifests = self
+            .loaded_subflow_manifests
+            .write()
+            .map_err(|_| "Could not gain write access to subflow manifests")?;
+        info!("Sub-flow manifest registered at '{subflow_url}'");
+        manifests.insert(subflow_url, manifest);
         Ok(())
     }
 
@@ -175,6 +199,7 @@ impl Executor {
             let thread_context = zmq::Context::new();
             let thread_implementations = loaded_implementations.clone();
             let thread_loaded_manifests = self.loaded_lib_manifests.clone();
+            let thread_subflow_manifests = self.loaded_subflow_manifests.clone();
             let results_sink = results_service.into();
             let job_source = job_service.into();
             let control_address = control_service.into();
@@ -191,6 +216,7 @@ impl Executor {
                     &thread_context,
                     &thread_implementations,
                     &thread_loaded_manifests,
+                    &thread_subflow_manifests,
                     job_source,
                     results_sink,
                     control_address,
@@ -218,6 +244,9 @@ fn execution_loop(
     context: &zmq::Context,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    loaded_subflow_manifests: &Arc<
+        RwLock<HashMap<Url, flowcore::model::flow_manifest::FlowManifest>>,
+    >,
     job_service: String,
     results_service: String,
     control_address: String,
@@ -328,12 +357,13 @@ fn execution_loop(
                         let sn = name.to_string();
                         let si = loaded_implementations.clone();
                         let sm = loaded_lib_manifests.clone();
+                        let ssm = loaded_subflow_manifests.clone();
                         let stx = spawn_result_tx
                             .as_ref()
                             .map(|(tx, _)| tx.clone())
                             .ok_or("spawn_result_tx missing")?;
                         thread::spawn(move || {
-                            match execute_job_to_string(&sp, &payload, &sn, &si, &sm) {
+                            match execute_job_to_string(&sp, &payload, &sn, &si, &sm, &ssm) {
                                 Ok(serialized) => {
                                     let _ = stx.send(serialized);
                                 }
@@ -348,6 +378,7 @@ fn execution_loop(
                             name,
                             &loaded_implementations.clone(),
                             &loaded_lib_manifests.clone(),
+                            &loaded_subflow_manifests.clone(),
                         ) {
                             Ok(keep_processing) => process_jobs = keep_processing,
                             Err(e) => error!("{e}"),
@@ -390,12 +421,16 @@ fn execute_job_to_string(
     executor_id: &str,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    loaded_subflow_manifests: &Arc<
+        RwLock<HashMap<Url, flowcore::model::flow_manifest::FlowManifest>>,
+    >,
 ) -> Result<String> {
     let implementation = get_or_load_implementation(
         provider,
         payload,
         loaded_implementations,
         loaded_lib_manifests,
+        loaded_subflow_manifests,
     )?;
 
     trace!(
@@ -433,6 +468,9 @@ fn get_or_load_implementation(
     payload: &Payload,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    loaded_subflow_manifests: &Arc<
+        RwLock<HashMap<Url, flowcore::model::flow_manifest::FlowManifest>>,
+    >,
 ) -> Result<Arc<dyn Implementation>> {
     // First try a read lock to avoid contention
     let needs_load = {
@@ -477,6 +515,22 @@ fn get_or_load_implementation(
                 "file" | "http" | "https" => {
                     Arc::new(wasm::load(provider, &payload.implementation_url)?)
                 }
+                "subflow" => {
+                    let manifests = loaded_subflow_manifests
+                        .read()
+                        .map_err(|_| "Could not read subflow manifests")?;
+                    let manifest = manifests.get(&payload.implementation_url).ok_or_else(|| {
+                        format!(
+                            "Sub-flow manifest not registered: {}",
+                            payload.implementation_url
+                        )
+                    })?;
+                    Arc::new(crate::subflow::SubFlowImplementation::new(
+                        manifest.clone(),
+                        provider.clone(),
+                        vec![], // TODO: interface inputs from parent
+                    ))
+                }
                 _ => bail!("Unsupported scheme on implementation_url"),
             };
             implementations.insert(payload.implementation_url.clone(), impl_arc);
@@ -510,12 +564,16 @@ fn execute_job(
     executor_id: &str,
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
+    loaded_subflow_manifests: &Arc<
+        RwLock<HashMap<Url, flowcore::model::flow_manifest::FlowManifest>>,
+    >,
 ) -> Result<bool> {
     let implementation = get_or_load_implementation(
         provider,
         payload,
         loaded_implementations,
         loaded_lib_manifests,
+        loaded_subflow_manifests,
     )?;
 
     trace!(
@@ -617,7 +675,13 @@ mod test {
     use flowcore::provider::Provider;
     use flowcore::Implementation;
 
+    use flowcore::model::flow_manifest::FlowManifest;
+
     use crate::job::{Job, Payload};
+
+    fn empty_subflow_manifests() -> Arc<RwLock<HashMap<Url, FlowManifest>>> {
+        Arc::new(RwLock::new(HashMap::new()))
+    }
 
     use super::Executor;
 
@@ -853,6 +917,7 @@ mod test {
             "test executor",
             &loaded_implementations,
             &loaded_lib_manifests,
+            &empty_subflow_manifests(),
         );
 
         assert!(result.is_err(), "Unsupported scheme should return an error");
@@ -907,6 +972,7 @@ mod test {
             "test executor",
             &loaded_implementations,
             &loaded_lib_manifests,
+            &empty_subflow_manifests(),
         );
 
         assert!(
@@ -963,6 +1029,7 @@ mod test {
             "test executor",
             &loaded_implementations,
             &loaded_lib_manifests,
+            &empty_subflow_manifests(),
         );
 
         assert!(
@@ -1016,6 +1083,7 @@ mod test {
             "test executor",
             &loaded_implementations,
             &loaded_lib_manifests,
+            &empty_subflow_manifests(),
         );
 
         assert!(
@@ -1206,6 +1274,7 @@ mod test {
                 "test executor",
                 &loaded_implementations,
                 &loaded_lib_manifests,
+                &empty_subflow_manifests(),
             )
             .is_err());
         }
@@ -1258,6 +1327,7 @@ mod test {
             &payload,
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("first get_or_load failed");
 
@@ -1267,6 +1337,7 @@ mod test {
             &payload,
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("second get_or_load failed");
 
@@ -1290,6 +1361,7 @@ mod test {
             "test",
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("execute_job_to_string failed");
 
@@ -1320,6 +1392,7 @@ mod test {
             &payload,
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         );
         assert!(result.is_err(), "should fail for unknown implementation");
     }
@@ -1358,6 +1431,7 @@ mod test {
             &payload,
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("first load from manifest failed");
 
@@ -1373,6 +1447,7 @@ mod test {
             &payload,
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("second load (cached) failed");
 
@@ -1421,6 +1496,7 @@ mod test {
             "test",
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         )
         .expect("execute_job should succeed");
 
@@ -1457,6 +1533,7 @@ mod test {
             "test",
             &loaded_impls,
             &loaded_manifests,
+            &empty_subflow_manifests(),
         );
         assert!(
             result.is_err(),

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -615,32 +615,68 @@ impl RunState {
                 #[cfg(feature = "metrics")]
                 let send_start = std::time::Instant::now();
 
-                for connection in job.connections.iter() {
-                    let value_to_send = match &connection.source {
-                        Output(route) => match output_value {
-                            Some(output_v) => output_v.pointer(route),
-                            None => None,
-                        },
-                        Input(index) => job.payload.input_set.get(*index),
-                    };
+                // Sub-flow results contain boundary outputs with embedded
+                // routing info. Unpack each and deliver via send_a_value.
+                if job.payload.implementation_url.scheme() == "subflow" {
+                    if let Some(Value::Array(boundary_outputs)) = output_value {
+                        for bo in boundary_outputs {
+                            if let (Some(dest_id), Some(dest_io), Some(value)) = (
+                                bo.get("destination_id").and_then(Value::as_u64),
+                                bo.get("destination_io_number").and_then(Value::as_u64),
+                                bo.get("value"),
+                            ) {
+                                #[allow(clippy::cast_possible_truncation)]
+                                let conn = OutputConnection::new(
+                                    Output(String::new()),
+                                    dest_id as usize,
+                                    dest_io as usize,
+                                    job.parent_id,
+                                    false,
+                                    String::new(),
+                                    #[cfg(feature = "debugger")]
+                                    String::new(),
+                                );
+                                action = self.send_a_value(
+                                    job.process_id,
+                                    job.parent_id,
+                                    &conn,
+                                    value.clone(),
+                                    #[cfg(feature = "metrics")]
+                                    metrics,
+                                    #[cfg(feature = "debugger")]
+                                    debugger,
+                                )?;
+                            }
+                        }
+                    }
+                } else {
+                    for connection in job.connections.iter() {
+                        let value_to_send = match &connection.source {
+                            Output(route) => match output_value {
+                                Some(output_v) => output_v.pointer(route),
+                                None => None,
+                            },
+                            Input(index) => job.payload.input_set.get(*index),
+                        };
 
-                    if let Some(value) = value_to_send {
-                        action = self.send_a_value(
-                            job.process_id,
-                            job.parent_id,
-                            connection,
-                            value.clone(),
-                            #[cfg(feature = "metrics")]
-                            metrics,
-                            #[cfg(feature = "debugger")]
-                            debugger,
-                        )?;
-                    } else {
-                        trace!(
-                            "Job #{}:\t\tNo value found at '{}'",
-                            job.payload.job_id,
-                            connection.source
-                        );
+                        if let Some(value) = value_to_send {
+                            action = self.send_a_value(
+                                job.process_id,
+                                job.parent_id,
+                                connection,
+                                value.clone(),
+                                #[cfg(feature = "metrics")]
+                                metrics,
+                                #[cfg(feature = "debugger")]
+                                debugger,
+                            )?;
+                        } else {
+                            trace!(
+                                "Job #{}:\t\tNo value found at '{}'",
+                                job.payload.job_id,
+                                connection.source
+                            );
+                        }
                     }
                 }
 

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -545,6 +545,32 @@ fn subflow_captures_boundary_outputs() {
     );
 }
 
+/// Test that `Executor::add_subflow` registers a manifest that can be used
+/// for `subflow://` URL resolution.
+#[test]
+fn executor_registers_subflow_manifest() {
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::metadata::MetaData;
+    use flowrlib::executor::Executor;
+
+    let mut manifest = FlowManifest::new(MetaData::default());
+    manifest.add_flow_info(FlowInfo {
+        process_id: 0,
+        parent_id: None,
+        sub_flow_ids: vec![],
+        #[cfg(feature = "debugger")]
+        name: "test".into(),
+        #[cfg(feature = "debugger")]
+        route: "/test".into(),
+    });
+
+    let mut executor = Executor::new();
+    let subflow_url = url::Url::parse("subflow://0").expect("subflow URL");
+    executor
+        .add_subflow(subflow_url, manifest)
+        .expect("add_subflow should succeed");
+}
+
 /// Minimal provider that reads files from the filesystem.
 struct TestProvider;
 


### PR DESCRIPTION
## Phase 2: Sub-flow Delegation Infrastructure

### What's implemented (foundation + stepping stone)

**Foundation (reusable):**
- `FlowManifest::subflow_interface()` — computes boundary connections
- `FlowManifest::extract_subflow()` — extracts sub-flow into standalone manifest (preserves boundary output connections)
- `BoundaryOutput` capture in `RunState::send_a_value()` — intercepts values destined for non-existent destinations (with `is_subflow` safety flag)
- `RunState::drain_boundary_outputs()` — retrieves captured values
- `Coordinator::execute_subflow()` — runs flow and returns RunState with boundary outputs
- `Coordinator::send_done()` — signals executor shutdown

**Local execution stepping stone (to be refactored for peer coordinator model):**
- `SubFlowImplementation` — wraps sub-flow execution in `Implementation::run()`
- `Executor::add_subflow()` — registers sub-flow manifests
- `subflow://` URL scheme handling in executor
- `delegate_subflow()` — proxy function approach
- Boundary output unpacking in `retire_job()`

### Architectural direction (from design discussion)

The proxy function / local executor approach should be replaced with **direct peer coordinator communication**:

- flowrex evolves into a peer coordinator that accepts sub-flow submissions
- Parent coordinator communicates directly with peer coordinators (not through local executor threads)
- Boundary outputs are streamed back as they're produced
- A sub-flow with initializers and iteration can produce many outputs independently
- Job IDs from the sub-flow are internal — the parent receives values identified by output connection routing info

See design discussion on #2991 for full details.

### Tests (7 total)
1. `extract_and_init_subflow` — real manifest extraction + RunState
2. `subflow_interface_identifies_boundary_connections` — boundary detection
3. `subflow_implementation_executes` — nested coordinator with initializers
4. `subflow_implementation_with_injected_inputs` — input injection
5. `subflow_captures_boundary_outputs` — boundary output capture + routing
6. `executor_registers_subflow_manifest` — executor registration
7. `delegate_subflow_replaces_with_proxy` — manifest transformation

Ref #2991, #1454