### PR TITLE
Add peer coordinator protocol for sub-flow delegation (#2991)

### DIFF
--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -91,6 +91,14 @@ mod debugger;
 /// Sub-flow execution: run an extracted sub-flow through a nested coordinator
 pub mod subflow;
 
+/// Protocol messages for peer coordinator communication
+pub mod peer_protocol;
+
+/// [`SubmissionHandler`][submission_handler::SubmissionHandler] for receiving
+/// sub-flow submissions from a parent coordinator
+#[cfg(feature = "submission")]
+pub mod peer_submission_handler;
+
 /// `wasmtime` module contains a number of implementations of the wasm execution
 mod wasm;
 

--- a/flowr/src/lib/peer_protocol.rs
+++ b/flowr/src/lib/peer_protocol.rs
@@ -1,0 +1,54 @@
+//! Protocol messages for peer coordinator communication.
+//!
+//! When a parent coordinator delegates a sub-flow to a peer coordinator,
+//! these messages are exchanged over ZMQ.
+
+use flowcore::model::flow_manifest::FlowManifest;
+use flowcore::model::output_connection::OutputConnection;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Messages sent from parent coordinator to peer coordinator.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum PeerRequest {
+    /// Submit a sub-flow for execution with initial input values.
+    /// The peer coordinator will create a `RunState` and execute the flow.
+    Submit(Box<SubflowSubmission>),
+
+    /// Signal that the parent flow is complete and the peer should clean up.
+    Done,
+}
+
+/// A sub-flow submission from a parent coordinator.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SubflowSubmission {
+    /// The sub-flow manifest to execute
+    pub manifest: FlowManifest,
+    /// Initial input values mapped to boundary function inputs.
+    /// Each entry is (`destination_function_id`, `destination_io_number`, value).
+    pub inputs: Vec<(usize, usize, Value)>,
+}
+
+/// Messages sent from peer coordinator back to parent coordinator.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum PeerResponse {
+    /// A value produced at a boundary connection, destined for a function
+    /// in the parent flow.
+    BoundaryOutput {
+        /// The output connection that produced this value (contains
+        /// `destination_id`, `destination_io_number`, etc.)
+        connection: OutputConnection,
+        /// The value produced
+        value: Value,
+    },
+
+    /// The sub-flow has processed all current inputs and is idle.
+    /// The parent can send more inputs or signal Done.
+    Idle,
+
+    /// An error occurred during sub-flow execution.
+    Error(String),
+
+    /// Acknowledgement that the peer received the Done signal.
+    DoneAck,
+}

--- a/flowr/src/lib/peer_submission_handler.rs
+++ b/flowr/src/lib/peer_submission_handler.rs
@@ -1,0 +1,148 @@
+//! A [`SubmissionHandler`] for receiving sub-flow submissions from a parent
+//! coordinator (peer-to-peer delegation).
+//!
+//! This handler receives a sub-flow manifest via a ZMQ REP socket, runs it
+//! through the coordinator's normal `execute_flow`, and relays boundary
+//! outputs back to the parent.
+
+use flowcore::errors::Result;
+#[cfg(feature = "metrics")]
+use flowcore::model::metrics::Metrics;
+use flowcore::model::submission::Submission;
+use log::{debug, info};
+
+use crate::peer_protocol::{PeerRequest, PeerResponse};
+use crate::run_state::{BoundaryOutput, RunState};
+use crate::submission_handler::SubmissionHandler;
+
+/// A [`SubmissionHandler`] that receives sub-flow submissions from a parent
+/// coordinator via a ZMQ REP socket.
+pub struct PeerSubmissionHandler {
+    /// ZMQ REP socket for receiving sub-flow submissions
+    socket: zmq::Socket,
+}
+
+impl PeerSubmissionHandler {
+    /// Create a new peer submission handler bound to the given address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ZMQ socket cannot be created or bound.
+    pub fn new(context: &zmq::Context, bind_address: &str) -> Result<Self> {
+        let socket = context
+            .socket(zmq::REP)
+            .map_err(|e| format!("Could not create peer REP socket: {e}"))?;
+        socket
+            .bind(bind_address)
+            .map_err(|e| format!("Could not bind peer socket to {bind_address}: {e}"))?;
+        info!("Peer coordinator listening on {bind_address}");
+        Ok(PeerSubmissionHandler { socket })
+    }
+
+    /// Send a response back to the parent coordinator.
+    fn send_response(&self, response: &PeerResponse) -> Result<()> {
+        let json = serde_json::to_string(response)
+            .map_err(|e| format!("Could not serialize peer response: {e}"))?;
+        self.socket
+            .send(json.as_bytes(), 0)
+            .map_err(|e| format!("Could not send peer response: {e}"))?;
+        Ok(())
+    }
+
+    /// Send boundary outputs back to the parent coordinator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any output cannot be serialized or sent.
+    pub fn relay_boundary_outputs(&self, outputs: &[BoundaryOutput]) -> Result<()> {
+        for output in outputs {
+            self.send_response(&PeerResponse::BoundaryOutput {
+                connection: output.connection.clone(),
+                value: output.value.clone(),
+            })?;
+            // After each send on REP, we need to receive before sending again.
+            // REP socket requires strict recv-send-recv-send alternation.
+            // For streaming, we'd need DEALER/ROUTER instead.
+            // For now, the parent must acknowledge each output.
+            let _ack = self
+                .socket
+                .recv_msg(0)
+                .map_err(|e| format!("Could not receive ack: {e}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl SubmissionHandler for PeerSubmissionHandler {
+    fn flow_execution_starting(&mut self) -> Result<()> {
+        debug!("Peer coordinator: flow execution starting");
+        Ok(())
+    }
+
+    #[cfg(feature = "debugger")]
+    fn should_enter_debugger(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn flow_execution_ended(
+        &mut self,
+        _state: &RunState,
+        #[cfg(feature = "metrics")] _metrics: Metrics,
+    ) -> Result<()> {
+        debug!("Peer coordinator: flow execution ended");
+        // Signal idle to parent
+        self.send_response(&PeerResponse::Idle)?;
+        Ok(())
+    }
+
+    fn wait_for_submission(&mut self) -> Result<Option<Submission>> {
+        info!("Peer coordinator waiting for sub-flow submission");
+
+        let msg = self
+            .socket
+            .recv_msg(0)
+            .map_err(|e| format!("Could not receive peer request: {e}"))?;
+        let msg_str = msg
+            .as_str()
+            .ok_or("Could not convert peer message to string")?;
+
+        let request: PeerRequest = serde_json::from_str(msg_str)
+            .map_err(|e| format!("Could not deserialize peer request: {e}"))?;
+
+        match request {
+            PeerRequest::Submit(submission) => {
+                let manifest = submission.manifest;
+                let inputs = submission.inputs;
+                info!(
+                    "Peer coordinator received sub-flow with {} functions, {} inputs",
+                    manifest.functions().len(),
+                    inputs.len()
+                );
+
+                // TODO: inject inputs into the manifest's boundary functions
+
+                let submission = Submission::new(
+                    manifest,
+                    None,
+                    None,
+                    #[cfg(feature = "debugger")]
+                    false,
+                    #[cfg(feature = "trace")]
+                    None,
+                );
+
+                Ok(Some(submission))
+            }
+            PeerRequest::Done => {
+                info!("Peer coordinator received Done signal");
+                self.send_response(&PeerResponse::DoneAck)?;
+                Ok(None) // Exit submission loop
+            }
+        }
+    }
+
+    fn coordinator_is_exiting(&mut self, _result: Result<()>) -> Result<()> {
+        debug!("Peer coordinator exiting");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Peer Coordinator Communication Protocol

Defines the message types and submission handler for direct coordinator-to-coordinator sub-flow delegation.

### Protocol Messages

**Parent → Peer:**
- `Submit(SubflowSubmission)` — send sub-flow manifest + initial inputs
- `Done` — signal parent flow complete

**Peer → Parent:**
- `BoundaryOutput(connection, value)` — relay boundary value to parent
- `Idle` — sub-flow finished processing
- `Error(String)` — execution error
- `DoneAck` — acknowledge cleanup

### `PeerSubmissionHandler`

Implements `SubmissionHandler`, allowing any coordinator to receive sub-flow submissions via ZMQ REP socket. This is the key piece that enables:
- flowrex to evolve into a peer coordinator
- Any flowrcli instance to accept sub-flow delegations
- The same `execute_flow()` code path for both root flows and sub-flows

### What remains for Phase 2
- Modify flowrex to use `PeerSubmissionHandler`
- Boundary output relay after `execute_flow`
- Parent-side delegation logic
- End-to-end test

Ref #2991, #1454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer-to-peer coordination for distributed sub-flow execution.
  * Added support for submitting sub-flows with manifests and boundary inputs.
  * Added communication for boundary outputs, completion status, idle state, and execution errors.
  * Added a submission handler for receiving and processing sub-flow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->