### PR TITLE
flowrex peer coordinator with end-to-end sub-flow delegation (#2991)

### DIFF
--- a/flowcore/src/model/submission.rs
+++ b/flowcore/src/model/submission.rs
@@ -22,6 +22,9 @@ pub struct Submission {
     /// Optional file path to write the execution trace to
     #[cfg(feature = "trace")]
     pub trace_file: Option<String>,
+    /// Whether this is a sub-flow submission (enables boundary output capture)
+    #[serde(default)]
+    pub is_subflow: bool,
 }
 
 impl Submission {
@@ -48,6 +51,7 @@ impl Submission {
             debug_enabled: debug,
             #[cfg(feature = "trace")]
             trace_file,
+            is_subflow: false,
         }
     }
 }

--- a/flowcore/src/services.rs
+++ b/flowcore/src/services.rs
@@ -21,3 +21,6 @@ pub const BLOCKING_IO_SERVICE_NAME: &str = "blocking-io";
 /// Use this to discover the debug service by name
 #[cfg(feature = "debugger")]
 pub const DEBUG_SERVICE_NAME: &str = "debug";
+
+/// Use this to discover a peer coordinator that can accept sub-flow submissions
+pub const PEER_COORDINATOR_SERVICE_NAME: &str = "peer-coordinator";

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -77,25 +77,29 @@ fn run() -> Result<()> {
 
     let num_threads = num_threads(&matches);
 
-    // Start executor threads for pulling individual jobs (existing behavior)
-    let executor_handle = {
-        thread::spawn(move || {
-            if let Err(e) = start_executors(num_threads) {
-                error!("Executor error: {e}");
-            }
-        })
-    };
+    // Use a channel so either thread can signal the main thread to exit
+    let (exit_tx, exit_rx) = std::sync::mpsc::channel::<String>();
 
-    // Start peer coordinator for accepting sub-flow submissions
-    let peer_handle = thread::spawn(|| {
-        if let Err(e) = run_peer_coordinator() {
-            error!("Peer coordinator error: {e}");
+    // Start executor threads for pulling individual jobs (existing behavior)
+    let exit_tx_exec = exit_tx.clone();
+    thread::spawn(move || {
+        if let Err(e) = start_executors(num_threads) {
+            let _ = exit_tx_exec.send(format!("Executor error: {e}"));
         }
     });
 
-    // Wait for either thread to finish (normally they loop forever)
-    let _ = executor_handle.join();
-    let _ = peer_handle.join();
+    // Start peer coordinator for accepting sub-flow submissions
+    thread::spawn(move || {
+        if let Err(e) = run_peer_coordinator() {
+            let _ = exit_tx.send(format!("Peer coordinator error: {e}"));
+        }
+    });
+
+    // Wait for either thread to signal an error
+    // Both threads loop forever in normal operation
+    if let Ok(msg) = exit_rx.recv() {
+        error!("{msg}");
+    }
 
     info!("'{}' has exited", env!("CARGO_PKG_NAME"));
 

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -1,12 +1,14 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
-//! `flowrex` is the minimal executor of flow jobs. It loads a native version of 'flowstdlib'
-//! flow library to allow execution of jobs using functions provided by 'flowstdlib', but it does
-//! *not* load 'context' and hence will not execute any jobs interacting with the context.
-//! It attempts to be as small as possible, and only accepts jobs for execution over the network
-//! and does not load flows, accept flow submissions run a coordinator or access the file system.
-//! Any implementations are either preloaded static linked binary functions or loaded from WASM
-//! from peers.
+//! `flowrex` is a remote executor and peer coordinator for flow execution.
+//!
+//! It operates in two modes simultaneously:
+//! - **Executor mode**: pulls individual jobs from a parent coordinator's ZMQ PUSH socket
+//! - **Peer coordinator mode**: accepts sub-flow submissions from parent coordinators,
+//!   runs them through its own coordinator loop, and relays boundary outputs back
+//!
+//! It loads a native version of `flowstdlib` for executing library functions, and can
+//! load WASM implementations via HTTP from the parent coordinator's WASM server.
 
 use core::str::FromStr;
 use std::path::PathBuf;
@@ -20,16 +22,25 @@ use flowrlib::discovery::discover_service_with_retry;
 use log::{error, info, trace, LevelFilter};
 use simpath::Simpath;
 #[cfg(feature = "flowstdlib")]
+#[cfg(feature = "flowstdlib")]
 use url::Url;
 
+use flowcore::discovery::{create_service_daemon, register_service, shutdown_service_daemon};
 use flowcore::errors::Result;
 #[cfg(feature = "flowstdlib")]
 use flowcore::errors::ResultExt;
 use flowcore::meta_provider::MetaProvider;
 use flowcore::provider::Provider;
+use flowrlib::coordinator::Coordinator;
+use flowrlib::dispatcher::Dispatcher;
 use flowrlib::executor::Executor;
 use flowrlib::info as flowrlib_info;
-use flowrlib::services::{CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME};
+use flowrlib::peer_submission_handler::PeerSubmissionHandler;
+use flowrlib::services::{
+    CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, PEER_COORDINATOR_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
+};
+use flowrlib::wasm_server::WasmServer;
+use portpicker::pick_unused_port;
 
 /// We'll put our errors in an `errors` module, and other modules in this crate will
 /// `use crate::errors::*;` to get access to everything `thiserror` creates.
@@ -47,6 +58,7 @@ fn main() {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn run() -> Result<()> {
     let matches = get_matches();
 
@@ -63,11 +75,110 @@ fn run() -> Result<()> {
     );
     info!("'flowrlib' version {}", flowrlib_info::version());
 
-    start_executors(num_threads(&matches))?;
+    let num_threads = num_threads(&matches);
+
+    // Start executor threads for pulling individual jobs (existing behavior)
+    let executor_handle = {
+        thread::spawn(move || {
+            if let Err(e) = start_executors(num_threads) {
+                error!("Executor error: {e}");
+            }
+        })
+    };
+
+    // Start peer coordinator for accepting sub-flow submissions
+    let peer_handle = thread::spawn(|| {
+        if let Err(e) = run_peer_coordinator() {
+            error!("Peer coordinator error: {e}");
+        }
+    });
+
+    // Wait for either thread to finish (normally they loop forever)
+    let _ = executor_handle.join();
+    let _ = peer_handle.join();
 
     info!("'{}' has exited", env!("CARGO_PKG_NAME"));
 
     Ok(())
+}
+
+/// Run a peer coordinator that accepts sub-flow submissions from parent
+/// coordinators. Advertises itself via mDNS and listens on a ZMQ REP socket.
+fn run_peer_coordinator() -> Result<()> {
+    let peer_port = pick_unused_port().ok_or("No ports free for peer coordinator")?;
+    let bind_address = format!("tcp://*:{peer_port}");
+
+    let mdns = create_service_daemon()?;
+    let fullname = register_service(&mdns, PEER_COORDINATOR_SERVICE_NAME, peer_port)?;
+    info!("Peer coordinator advertised on port {peer_port}");
+
+    let zmq_context = zmq::Context::new();
+    let mut peer_handler = PeerSubmissionHandler::new(&zmq_context, &bind_address)?;
+
+    // Set up dispatcher and executor for running received sub-flows
+    let ports = (
+        pick_unused_port().ok_or("No ports free")?,
+        pick_unused_port().ok_or("No ports free")?,
+        pick_unused_port().ok_or("No ports free")?,
+        pick_unused_port().ok_or("No ports free")?,
+    );
+    let bind_addrs = (
+        format!("tcp://*:{}", ports.0),
+        format!("tcp://*:{}", ports.1),
+        format!("tcp://*:{}", ports.2),
+        format!("tcp://*:{}", ports.3),
+    );
+    let connect_addrs = (
+        format!("tcp://127.0.0.1:{}", ports.0),
+        format!("tcp://127.0.0.1:{}", ports.1),
+        format!("tcp://127.0.0.1:{}", ports.2),
+        format!("tcp://127.0.0.1:{}", ports.3),
+    );
+
+    let dispatcher = Dispatcher::new(&bind_addrs)?;
+
+    let provider =
+        Arc::new(MetaProvider::new(Simpath::new(""), PathBuf::default())) as Arc<dyn Provider>;
+
+    let mut executor = Executor::new();
+    #[cfg(feature = "flowstdlib")]
+    executor.add_lib(
+        flowstdlib::manifest::get().chain_err(|| "Could not get 'native' flowstdlib manifest")?,
+        Url::parse("memory://")?,
+    )?;
+    executor.start(
+        &provider,
+        thread::available_parallelism().map_or(1, std::num::NonZero::get),
+        &connect_addrs.0,
+        &connect_addrs.2,
+        &connect_addrs.3,
+    );
+
+    // Start WASM server for sub-flow WASM files
+    let _wasm_server = WasmServer::start(std::path::Path::new("/")).ok();
+
+    #[cfg(feature = "debugger")]
+    let mut debug_handler = flowrlib::subflow::NoOpDebugHandler;
+
+    let mut coordinator = Coordinator::new(
+        dispatcher,
+        #[cfg(feature = "submission")]
+        &mut peer_handler,
+        #[cfg(feature = "debugger")]
+        &mut debug_handler,
+    );
+
+    info!("Peer coordinator entering submission loop");
+    let result = coordinator.submission_loop(true);
+
+    // Cleanup
+    let _ = coordinator.send_done();
+    executor.wait();
+    if let Err(e) = shutdown_service_daemon(&mdns, &[fullname]) {
+        error!("Could not shut down peer mDNS: {e}");
+    }
+
+    result
 }
 
 fn start_executors(num_threads: usize) -> Result<()> {

--- a/flowr/src/bin/flowrex/main.rs
+++ b/flowr/src/bin/flowrex/main.rs
@@ -25,21 +25,28 @@ use simpath::Simpath;
 #[cfg(feature = "flowstdlib")]
 use url::Url;
 
-use flowcore::discovery::{create_service_daemon, register_service, shutdown_service_daemon};
 use flowcore::errors::Result;
 #[cfg(feature = "flowstdlib")]
 use flowcore::errors::ResultExt;
 use flowcore::meta_provider::MetaProvider;
 use flowcore::provider::Provider;
-use flowrlib::coordinator::Coordinator;
-use flowrlib::dispatcher::Dispatcher;
 use flowrlib::executor::Executor;
 use flowrlib::info as flowrlib_info;
+use flowrlib::services::{CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME};
+
+#[cfg(feature = "submission")]
+use flowcore::discovery::{create_service_daemon, register_service, shutdown_service_daemon};
+#[cfg(feature = "submission")]
+use flowrlib::coordinator::Coordinator;
+#[cfg(feature = "submission")]
+use flowrlib::dispatcher::Dispatcher;
+#[cfg(feature = "submission")]
 use flowrlib::peer_submission_handler::PeerSubmissionHandler;
-use flowrlib::services::{
-    CONTROL_SERVICE_NAME, JOB_SERVICE_NAME, PEER_COORDINATOR_SERVICE_NAME, RESULTS_JOB_SERVICE_NAME,
-};
+#[cfg(feature = "submission")]
+use flowrlib::services::PEER_COORDINATOR_SERVICE_NAME;
+#[cfg(feature = "submission")]
 use flowrlib::wasm_server::WasmServer;
+#[cfg(feature = "submission")]
 use portpicker::pick_unused_port;
 
 /// We'll put our errors in an `errors` module, and other modules in this crate will
@@ -89,11 +96,14 @@ fn run() -> Result<()> {
     });
 
     // Start peer coordinator for accepting sub-flow submissions
+    #[cfg(feature = "submission")]
     thread::spawn(move || {
         if let Err(e) = run_peer_coordinator() {
             let _ = exit_tx.send(format!("Peer coordinator error: {e}"));
         }
     });
+    #[cfg(not(feature = "submission"))]
+    drop(exit_tx);
 
     // Wait for either thread to signal an error
     // Both threads loop forever in normal operation
@@ -108,6 +118,7 @@ fn run() -> Result<()> {
 
 /// Run a peer coordinator that accepts sub-flow submissions from parent
 /// coordinators. Advertises itself via mDNS and listens on a ZMQ REP socket.
+#[cfg(feature = "submission")]
 fn run_peer_coordinator() -> Result<()> {
     let peer_port = pick_unused_port().ok_or("No ports free for peer coordinator")?;
     let bind_address = format!("tcp://*:{peer_port}");

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -99,6 +99,9 @@ pub mod peer_protocol;
 #[cfg(feature = "submission")]
 pub mod peer_submission_handler;
 
+/// Client for connecting to peer coordinators and delegating sub-flows
+pub mod peer_client;
+
 /// `wasmtime` module contains a number of implementations of the wasm execution
 mod wasm;
 

--- a/flowr/src/lib/peer_client.rs
+++ b/flowr/src/lib/peer_client.rs
@@ -1,0 +1,132 @@
+//! Client for communicating with a peer coordinator.
+//!
+//! Used by a parent coordinator to delegate sub-flows to discovered peer
+//! coordinators on the network.
+
+use flowcore::errors::Result;
+use flowcore::model::flow_manifest::FlowManifest;
+use log::{debug, info};
+use serde_json::Value;
+
+use crate::peer_protocol::{PeerRequest, PeerResponse, SubflowSubmission};
+use crate::run_state::BoundaryOutput;
+
+/// A client connection to a peer coordinator for sub-flow delegation.
+pub struct PeerClient {
+    socket: zmq::Socket,
+    address: String,
+}
+
+impl PeerClient {
+    /// Connect to a peer coordinator at the given address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ZMQ socket cannot be created or connected.
+    pub fn connect(context: &zmq::Context, address: &str) -> Result<Self> {
+        let socket = context
+            .socket(zmq::REQ)
+            .map_err(|e| format!("Could not create peer REQ socket: {e}"))?;
+        let tcp_address = format!("tcp://{address}");
+        socket
+            .connect(&tcp_address)
+            .map_err(|e| format!("Could not connect to peer coordinator at {tcp_address}: {e}"))?;
+        info!("Connected to peer coordinator at {address}");
+        Ok(PeerClient {
+            socket,
+            address: address.to_string(),
+        })
+    }
+
+    /// Get the address of this peer coordinator.
+    #[must_use]
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Submit a sub-flow for execution on the peer coordinator.
+    /// Returns the boundary outputs produced by the sub-flow.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the submission cannot be sent or the response
+    /// cannot be received/parsed.
+    pub fn submit_subflow(
+        &self,
+        manifest: FlowManifest,
+        inputs: Vec<(usize, usize, Value)>,
+    ) -> Result<Vec<BoundaryOutput>> {
+        let request = PeerRequest::Submit(Box::new(SubflowSubmission { manifest, inputs }));
+        let json = serde_json::to_string(&request)
+            .map_err(|e| format!("Could not serialize peer request: {e}"))?;
+
+        self.socket
+            .send(json.as_bytes(), 0)
+            .map_err(|e| format!("Could not send to peer: {e}"))?;
+
+        // Receive responses until Idle or Error
+        let mut boundary_outputs = Vec::new();
+        loop {
+            let msg = self
+                .socket
+                .recv_msg(0)
+                .map_err(|e| format!("Could not receive from peer: {e}"))?;
+            let msg_str = msg
+                .as_str()
+                .ok_or("Could not convert peer response to string")?;
+            let response: PeerResponse = serde_json::from_str(msg_str)
+                .map_err(|e| format!("Could not deserialize peer response: {e}"))?;
+
+            match response {
+                PeerResponse::BoundaryOutput { connection, value } => {
+                    debug!(
+                        "Peer boundary output: -> #{}:{}",
+                        connection.destination_id, connection.destination_io_number
+                    );
+                    boundary_outputs.push(BoundaryOutput { connection, value });
+                    // Acknowledge so peer can send next output (REQ/REP pattern)
+                    self.socket
+                        .send("ack".as_bytes(), 0)
+                        .map_err(|e| format!("Could not send ack: {e}"))?;
+                }
+                PeerResponse::Idle => {
+                    info!(
+                        "Peer sub-flow idle ({} boundary outputs)",
+                        boundary_outputs.len()
+                    );
+                    break;
+                }
+                PeerResponse::Error(msg) => {
+                    return Err(format!("Peer coordinator error: {msg}").into());
+                }
+                PeerResponse::DoneAck => {
+                    break;
+                }
+            }
+        }
+
+        Ok(boundary_outputs)
+    }
+
+    /// Signal the peer coordinator that the parent flow is done.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the done signal cannot be sent.
+    pub fn signal_done(&self) -> Result<()> {
+        let request = PeerRequest::Done;
+        let json = serde_json::to_string(&request)
+            .map_err(|e| format!("Could not serialize done request: {e}"))?;
+        self.socket
+            .send(json.as_bytes(), 0)
+            .map_err(|e| format!("Could not send done to peer: {e}"))?;
+
+        // Wait for ack
+        let _msg = self
+            .socket
+            .recv_msg(0)
+            .map_err(|e| format!("Could not receive done ack: {e}"))?;
+
+        Ok(())
+    }
+}

--- a/flowr/src/lib/peer_submission_handler.rs
+++ b/flowr/src/lib/peer_submission_handler.rs
@@ -86,10 +86,21 @@ impl SubmissionHandler for PeerSubmissionHandler {
 
     fn flow_execution_ended(
         &mut self,
-        _state: &RunState,
+        state: &RunState,
         #[cfg(feature = "metrics")] _metrics: Metrics,
     ) -> Result<()> {
         debug!("Peer coordinator: flow execution ended");
+
+        // Relay boundary outputs to parent before signaling idle
+        let outputs = state.boundary_outputs();
+        if !outputs.is_empty() {
+            info!(
+                "Peer coordinator relaying {} boundary outputs",
+                outputs.len()
+            );
+            self.relay_boundary_outputs(outputs)?;
+        }
+
         // Signal idle to parent
         self.send_response(&PeerResponse::Idle)?;
         Ok(())
@@ -121,7 +132,7 @@ impl SubmissionHandler for PeerSubmissionHandler {
 
                 // TODO: inject inputs into the manifest's boundary functions
 
-                let submission = Submission::new(
+                let mut submission = Submission::new(
                     manifest,
                     None,
                     None,
@@ -130,6 +141,7 @@ impl SubmissionHandler for PeerSubmissionHandler {
                     #[cfg(feature = "trace")]
                     None,
                 );
+                submission.is_subflow = true;
 
                 Ok(Some(submission))
             }

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -293,6 +293,7 @@ impl RunState {
         };
         #[cfg(feature = "trace")]
         let trace = crate::trace::topology_from_submission(&submission);
+        let is_subflow = submission.is_subflow;
         RunState {
             submission,
             ready_jobs: VecDeque::<Job>::new(),
@@ -308,7 +309,7 @@ impl RunState {
             newly_busy_flows: Vec::new(),
             #[cfg(feature = "trace")]
             trace,
-            is_subflow: false,
+            is_subflow,
             boundary_outputs: Vec::new(),
         }
     }
@@ -1032,6 +1033,12 @@ impl RunState {
     #[must_use]
     pub fn jobs_per_function(&self) -> &[usize] {
         &self.jobs_per_function
+    }
+
+    /// Get a reference to the boundary outputs collected during sub-flow execution.
+    #[must_use]
+    pub fn boundary_outputs(&self) -> &[BoundaryOutput] {
+        &self.boundary_outputs
     }
 
     /// Drain all boundary outputs collected during sub-flow execution.

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -172,7 +172,8 @@ impl Implementation for SubFlowImplementation {
 // --- No-op handlers for sub-flow coordinator ---
 
 #[cfg(feature = "submission")]
-struct NoOpSubmissionHandler;
+/// No-op submission handler for sub-flow execution (used by `SubFlowImplementation`).
+pub struct NoOpSubmissionHandler;
 
 #[cfg(feature = "submission")]
 impl SubmissionHandler for NoOpSubmissionHandler {
@@ -208,7 +209,8 @@ impl SubmissionHandler for NoOpSubmissionHandler {
 }
 
 #[cfg(feature = "debugger")]
-struct NoOpDebugHandler;
+/// No-op debugger handler for sub-flow and peer coordinator execution.
+pub struct NoOpDebugHandler;
 
 #[cfg(feature = "debugger")]
 impl DebuggerHandler for NoOpDebugHandler {

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -571,6 +571,177 @@ fn executor_registers_subflow_manifest() {
         .expect("add_subflow should succeed");
 }
 
+/// End-to-end test: submit a sub-flow to a peer coordinator running in
+/// a background thread, verify boundary outputs come back.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[allow(clippy::too_many_lines)]
+fn peer_coordinator_executes_subflow() {
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::input::{Input, InputInitializer};
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowrlib::peer_client::PeerClient;
+    use std::sync::Arc;
+
+    // Build a sub-flow: add(7,3)=10 with boundary output to #10:0
+    let mut manifest = FlowManifest::new(MetaData::default());
+    manifest.add_flow_info(FlowInfo {
+        process_id: 0,
+        parent_id: None,
+        sub_flow_ids: vec![],
+        #[cfg(feature = "debugger")]
+        name: "subflow".into(),
+        #[cfg(feature = "debugger")]
+        route: "/subflow".into(),
+    });
+
+    let mut func = RuntimeFunction::new(
+        #[cfg(feature = "debugger")]
+        "add",
+        #[cfg(feature = "debugger")]
+        "/subflow/add",
+        "lib://flowstdlib/math/add",
+        vec![
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i1",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(7))),
+                None,
+            ),
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i2",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(3))),
+                None,
+            ),
+        ],
+        1,
+        0,
+        &[OutputConnection::new(
+            Source::default(),
+            10,
+            0,
+            0,
+            false,
+            String::new(),
+            #[cfg(feature = "debugger")]
+            String::new(),
+        )],
+        false,
+    );
+    let dummy_url = url::Url::parse("file:///dummy/manifest.json").expect("URL");
+    func.set_implementation_url(&dummy_url).expect("set URL");
+    manifest.add_function(func);
+
+    // Start a peer coordinator in a background thread
+    let peer_port = portpicker::pick_unused_port().expect("port");
+    let bind_address = format!("tcp://*:{peer_port}");
+    let peer_thread = std::thread::spawn(move || {
+        let zmq_context = zmq::Context::new();
+        let mut handler = flowrlib::peer_submission_handler::PeerSubmissionHandler::new(
+            &zmq_context,
+            &bind_address,
+        )
+        .expect("handler");
+
+        // Set up coordinator infrastructure
+        let ports = (
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+        );
+        let bind_addrs = (
+            format!("tcp://*:{}", ports.0),
+            format!("tcp://*:{}", ports.1),
+            format!("tcp://*:{}", ports.2),
+            format!("tcp://*:{}", ports.3),
+        );
+        let connect_addrs = (
+            format!("tcp://127.0.0.1:{}", ports.0),
+            format!("tcp://127.0.0.1:{}", ports.1),
+            format!("tcp://127.0.0.1:{}", ports.2),
+            format!("tcp://127.0.0.1:{}", ports.3),
+        );
+
+        let dispatcher = flowrlib::dispatcher::Dispatcher::new(&bind_addrs).expect("dispatcher");
+        let provider = Arc::new(TestProvider) as Arc<dyn flowcore::provider::Provider>;
+
+        let mut executor = flowrlib::executor::Executor::new();
+        #[cfg(feature = "flowstdlib")]
+        executor
+            .add_lib(
+                flowstdlib::manifest::get().expect("flowstdlib"),
+                url::Url::parse("memory://").expect("url"),
+            )
+            .expect("add_lib");
+        executor.start(
+            &provider,
+            1,
+            &connect_addrs.0,
+            &connect_addrs.2,
+            &connect_addrs.3,
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        #[cfg(feature = "debugger")]
+        let mut debug_handler = flowrlib::subflow::NoOpDebugHandler;
+
+        let mut coordinator = flowrlib::coordinator::Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_handler,
+        );
+
+        // Run one submission then exit
+        let _ = coordinator.submission_loop(false);
+        let _ = coordinator.send_done();
+        executor.wait();
+    });
+
+    // Give peer coordinator time to start
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Connect as parent and submit the sub-flow
+    let zmq_context = zmq::Context::new();
+    let peer_address = format!("127.0.0.1:{peer_port}");
+    let client = PeerClient::connect(&zmq_context, &peer_address).expect("connect");
+
+    let outputs = client
+        .submit_subflow(manifest, vec![])
+        .expect("submit failed");
+
+    // Should have boundary output: add(7,3)=10 -> #10:0
+    assert!(
+        !outputs.is_empty(),
+        "Should have boundary outputs from peer"
+    );
+    assert_eq!(
+        outputs.first().map(|o| &o.value),
+        Some(&serde_json::json!(10))
+    );
+    assert_eq!(
+        outputs.first().map(|o| o.connection.destination_id),
+        Some(10)
+    );
+
+    // Peer exits after one submission (loop_forever = false), no need to signal done.
+    // Drop the client to close the socket.
+    drop(client);
+
+    // Wait for peer thread
+    let _ = peer_thread.join();
+}
+
 /// Minimal provider that reads files from the filesystem.
 struct TestProvider;
 


### PR DESCRIPTION
## Phase 2: Peer Coordinator Sub-Flow Delegation

### What's implemented

**flowrex as peer coordinator:**
- Runs executor mode AND peer coordinator mode concurrently
- Advertises `peer-coordinator` mDNS service
- Creates own coordinator/dispatcher/executor stack for sub-flows
- Uses `PeerSubmissionHandler` in submission loop

**`PeerClient` (parent side):**
- Connects to peer coordinators via ZMQ REQ
- Sends `SubflowSubmission` (manifest + inputs)
- Receives boundary outputs and idle signals

**`Submission.is_subflow` flag:**
- Enables boundary output capture in normal `execute_flow` path
- Set by `PeerSubmissionHandler` when receiving sub-flow submissions
- No separate `execute_subflow` needed

**End-to-end test:**
Submits add(7,3)=10 sub-flow with boundary output to a peer coordinator
in a background thread. Verifies output value and routing info received.

### Services added
- `PEER_COORDINATOR_SERVICE_NAME` (`peer-coordinator`) for mDNS discovery

Ref #2991, #1454