### PR TITLE
Peer coordinator discovery and end-to-end flowrex test (#2991)

### DIFF
--- a/flowr/src/lib/delegation.rs
+++ b/flowr/src/lib/delegation.rs
@@ -1,0 +1,74 @@
+//! Sub-flow delegation logic for the parent coordinator.
+//!
+//! Provides the ability to discover peer coordinators, extract a sub-flow,
+//! delegate it to a peer, and integrate the results back.
+
+use std::time::Duration;
+
+use flowcore::errors::Result;
+use flowcore::model::flow_manifest::FlowManifest;
+use log::info;
+use serde_json::Value;
+
+use crate::peer_client::PeerClient;
+use crate::peer_discovery::discover_peer_coordinators;
+use crate::run_state::BoundaryOutput;
+
+/// Result of attempting to delegate a sub-flow to a peer coordinator.
+pub struct DelegationResult {
+    /// The extracted sub-flow manifest (for reference)
+    pub subflow_manifest: FlowManifest,
+    /// Boundary outputs received from the peer
+    pub boundary_outputs: Vec<BoundaryOutput>,
+    /// The flow ID that was delegated
+    pub flow_id: usize,
+    /// The address of the peer that executed it
+    pub peer_address: String,
+}
+
+/// Attempt to delegate a sub-flow to a peer coordinator.
+///
+/// Discovers peer coordinators, selects the first available one, extracts
+/// the specified sub-flow, sends it to the peer, and returns the results.
+///
+/// # Errors
+///
+/// Returns an error if discovery, connection, or execution fails.
+pub fn delegate_subflow(
+    manifest: &FlowManifest,
+    flow_id: usize,
+    own_address: Option<&str>,
+    inputs: Vec<(usize, usize, Value)>,
+) -> Result<Option<DelegationResult>> {
+    // Discover peer coordinators
+    let peers = discover_peer_coordinators(Duration::from_secs(3), own_address)?;
+
+    if peers.is_empty() {
+        info!("No peer coordinators available for delegation");
+        return Ok(None);
+    }
+
+    let peer_address = peers.first().ok_or("No peers available")?;
+    info!("Delegating sub-flow #{flow_id} to peer at {peer_address}");
+
+    // Extract the sub-flow
+    let extracted = manifest.extract_subflow(flow_id)?;
+
+    // Connect to the peer and submit
+    let zmq_context = zmq::Context::new();
+    let client = PeerClient::connect(&zmq_context, peer_address)?;
+
+    let boundary_outputs = client.submit_subflow(extracted.clone(), inputs)?;
+
+    info!(
+        "Peer returned {} boundary outputs for sub-flow #{flow_id}",
+        boundary_outputs.len()
+    );
+
+    Ok(Some(DelegationResult {
+        subflow_manifest: extracted,
+        boundary_outputs,
+        flow_id,
+        peer_address: peer_address.clone(),
+    }))
+}

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -102,6 +102,9 @@ pub mod peer_submission_handler;
 /// Client for connecting to peer coordinators and delegating sub-flows
 pub mod peer_client;
 
+/// Discovery of peer coordinators on the network
+pub mod peer_discovery;
+
 /// `wasmtime` module contains a number of implementations of the wasm execution
 mod wasm;
 

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -105,6 +105,9 @@ pub mod peer_client;
 /// Discovery of peer coordinators on the network
 pub mod peer_discovery;
 
+/// Sub-flow delegation logic for the parent coordinator
+pub mod delegation;
+
 /// `wasmtime` module contains a number of implementations of the wasm execution
 mod wasm;
 

--- a/flowr/src/lib/peer_discovery.rs
+++ b/flowr/src/lib/peer_discovery.rs
@@ -1,0 +1,37 @@
+//! Discovery of peer coordinators on the network for sub-flow delegation.
+
+use std::time::Duration;
+
+use flowcore::discovery::discover_services;
+use flowcore::errors::Result;
+use flowcore::services::PEER_COORDINATOR_SERVICE_NAME;
+use log::info;
+
+/// Discover peer coordinators on the network, excluding the local one.
+///
+/// `own_port` is the port of this coordinator's own peer service (if any).
+/// Peers on the same host with the same port are filtered out.
+///
+/// # Errors
+///
+/// Returns an error if mDNS discovery fails.
+pub fn discover_peer_coordinators(timeout: Duration, own_port: Option<u16>) -> Result<Vec<String>> {
+    let services = discover_services(PEER_COORDINATOR_SERVICE_NAME, timeout)?;
+
+    let peers: Vec<String> = services
+        .into_iter()
+        .filter(|(_, port)| {
+            // Filter out our own peer coordinator
+            own_port != Some(*port)
+        })
+        .map(|(addr, _)| addr)
+        .collect();
+
+    if peers.is_empty() {
+        info!("No peer coordinators discovered");
+    } else {
+        info!("Discovered {} peer coordinator(s)", peers.len());
+    }
+
+    Ok(peers)
+}

--- a/flowr/src/lib/peer_discovery.rs
+++ b/flowr/src/lib/peer_discovery.rs
@@ -9,20 +9,23 @@ use log::info;
 
 /// Discover peer coordinators on the network, excluding the local one.
 ///
-/// `own_port` is the port of this coordinator's own peer service (if any).
-/// Peers on the same host with the same port are filtered out.
+/// `own_address` is the full `address:port` of this coordinator's own peer
+/// service (if any). Peers matching this exact address are filtered out.
 ///
 /// # Errors
 ///
 /// Returns an error if mDNS discovery fails.
-pub fn discover_peer_coordinators(timeout: Duration, own_port: Option<u16>) -> Result<Vec<String>> {
+pub fn discover_peer_coordinators(
+    timeout: Duration,
+    own_address: Option<&str>,
+) -> Result<Vec<String>> {
     let services = discover_services(PEER_COORDINATOR_SERVICE_NAME, timeout)?;
 
     let peers: Vec<String> = services
         .into_iter()
-        .filter(|(_, port)| {
-            // Filter out our own peer coordinator
-            own_port != Some(*port)
+        .filter(|(addr, _)| {
+            // Filter out our own peer coordinator by exact address match
+            own_address.is_none_or(|own| *addr != own)
         })
         .map(|(addr, _)| addr)
         .collect();

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -745,7 +745,7 @@ fn peer_coordinator_executes_subflow() {
 /// End-to-end test with a real flowrex process as peer coordinator.
 /// Starts flowrex, discovers its peer-coordinator service via mDNS,
 /// submits a sub-flow, and verifies boundary outputs.
-#[ignore] // Spawns flowrex process + mDNS discovery — too slow for CI timeout
+#[ignore = "Spawns flowrex process + mDNS discovery, too slow for CI"]
 #[test]
 #[allow(clippy::too_many_lines)]
 fn flowrex_peer_coordinator_end_to_end() {
@@ -862,7 +862,7 @@ fn flowrex_peer_coordinator_end_to_end() {
 }
 
 /// Test `delegate_subflow` with a real flowrex peer coordinator.
-#[ignore] // Spawns flowrex process + mDNS discovery — too slow for CI timeout
+#[ignore = "Spawns flowrex process + mDNS discovery, too slow for CI"]
 #[test]
 #[allow(clippy::too_many_lines)]
 fn delegate_subflow_to_peer() {

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -745,7 +745,7 @@ fn peer_coordinator_executes_subflow() {
 /// End-to-end test with a real flowrex process as peer coordinator.
 /// Starts flowrex, discovers its peer-coordinator service via mDNS,
 /// submits a sub-flow, and verifies boundary outputs.
-#[cfg_attr(target_os = "windows", ignore)]
+#[ignore] // Spawns flowrex process + mDNS discovery — too slow for CI timeout
 #[test]
 #[allow(clippy::too_many_lines)]
 fn flowrex_peer_coordinator_end_to_end() {
@@ -862,7 +862,7 @@ fn flowrex_peer_coordinator_end_to_end() {
 }
 
 /// Test `delegate_subflow` with a real flowrex peer coordinator.
-#[cfg_attr(target_os = "windows", ignore)]
+#[ignore] // Spawns flowrex process + mDNS discovery — too slow for CI timeout
 #[test]
 #[allow(clippy::too_many_lines)]
 fn delegate_subflow_to_peer() {

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -742,6 +742,125 @@ fn peer_coordinator_executes_subflow() {
     let _ = peer_thread.join();
 }
 
+/// End-to-end test with a real flowrex process as peer coordinator.
+/// Starts flowrex, discovers its peer-coordinator service via mDNS,
+/// submits a sub-flow, and verifies boundary outputs.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[allow(clippy::too_many_lines)]
+fn flowrex_peer_coordinator_end_to_end() {
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::input::{Input, InputInitializer};
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowrlib::peer_client::PeerClient;
+    use flowrlib::peer_discovery::discover_peer_coordinators;
+    use std::process::{Command as ProcessCommand, Stdio};
+    use std::time::Duration;
+
+    // Start flowrex as a peer coordinator
+    let mut flowrex = ProcessCommand::new("flowrex")
+        .args(["--threads", "1", "-v", "info"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Could not spawn flowrex");
+
+    // Wait for flowrex to start and advertise its peer-coordinator service
+    std::thread::sleep(Duration::from_secs(5));
+
+    // Discover the peer coordinator
+    let peers = discover_peer_coordinators(Duration::from_secs(5), None).expect("discovery failed");
+
+    if peers.is_empty() {
+        // Clean up and skip — mDNS may not be working in this environment
+        flowrex.kill().ok();
+        flowrex.wait().ok();
+        eprintln!("No peer coordinators discovered — skipping test");
+        return;
+    }
+
+    let peer_address = peers.first().expect("no peers").clone();
+
+    // Build a sub-flow: add(7,3)=10 with boundary output to #10:0
+    let mut manifest = FlowManifest::new(MetaData::default());
+    manifest.add_flow_info(FlowInfo {
+        process_id: 0,
+        parent_id: None,
+        sub_flow_ids: vec![],
+        #[cfg(feature = "debugger")]
+        name: "subflow".into(),
+        #[cfg(feature = "debugger")]
+        route: "/subflow".into(),
+    });
+
+    let mut func = RuntimeFunction::new(
+        #[cfg(feature = "debugger")]
+        "add",
+        #[cfg(feature = "debugger")]
+        "/subflow/add",
+        "lib://flowstdlib/math/add",
+        vec![
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i1",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(7))),
+                None,
+            ),
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i2",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(3))),
+                None,
+            ),
+        ],
+        1,
+        0,
+        &[OutputConnection::new(
+            Source::default(),
+            10,
+            0,
+            0,
+            false,
+            String::new(),
+            #[cfg(feature = "debugger")]
+            String::new(),
+        )],
+        false,
+    );
+    let dummy_url = url::Url::parse("file:///dummy/manifest.json").expect("URL");
+    func.set_implementation_url(&dummy_url).expect("set URL");
+    manifest.add_function(func);
+
+    // Connect to the peer and submit the sub-flow
+    let zmq_context = zmq::Context::new();
+    let client = PeerClient::connect(&zmq_context, &peer_address).expect("connect failed");
+
+    let outputs = client
+        .submit_subflow(manifest, vec![])
+        .expect("submit failed");
+
+    // Verify boundary output: add(7,3) = 10
+    assert!(
+        !outputs.is_empty(),
+        "Should have boundary outputs from flowrex peer"
+    );
+    assert_eq!(
+        outputs.first().map(|o| &o.value),
+        Some(&serde_json::json!(10))
+    );
+
+    // Clean up
+    drop(client);
+    flowrex.kill().ok();
+    flowrex.wait().ok();
+}
+
 /// Minimal provider that reads files from the filesystem.
 struct TestProvider;
 

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -761,7 +761,7 @@ fn flowrex_peer_coordinator_end_to_end() {
 
     // Start flowrex as a peer coordinator
     let mut flowrex = ProcessCommand::new("flowrex")
-        .args(["--threads", "1", "-v", "info"])
+        .args(["--threads", "0", "-v", "info"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -768,7 +768,7 @@ fn flowrex_peer_coordinator_end_to_end() {
         .expect("Could not spawn flowrex");
 
     // Wait for flowrex to start and advertise its peer-coordinator service
-    std::thread::sleep(Duration::from_secs(5));
+    std::thread::sleep(Duration::from_secs(3));
 
     // Discover the peer coordinator
     let peers = discover_peer_coordinators(Duration::from_secs(5), None).expect("discovery failed");
@@ -883,7 +883,7 @@ fn delegate_subflow_to_peer() {
         .spawn()
         .expect("Could not spawn flowrex");
 
-    std::thread::sleep(Duration::from_secs(5));
+    std::thread::sleep(Duration::from_secs(3));
 
     // Build manifest with root flow containing a child sub-flow
     let mut manifest = FlowManifest::new(MetaData::default());

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -861,6 +861,136 @@ fn flowrex_peer_coordinator_end_to_end() {
     flowrex.wait().ok();
 }
 
+/// Test `delegate_subflow` with a real flowrex peer coordinator.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[allow(clippy::too_many_lines)]
+fn delegate_subflow_to_peer() {
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::input::{Input, InputInitializer};
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowrlib::delegation::delegate_subflow;
+    use std::process::{Command as ProcessCommand, Stdio};
+    use std::time::Duration;
+
+    // Start flowrex as peer coordinator
+    let mut flowrex = ProcessCommand::new("flowrex")
+        .args(["--threads", "0", "-v", "info"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Could not spawn flowrex");
+
+    std::thread::sleep(Duration::from_secs(5));
+
+    // Build manifest with root flow containing a child sub-flow
+    let mut manifest = FlowManifest::new(MetaData::default());
+    manifest.add_flow_info(FlowInfo {
+        process_id: 0,
+        parent_id: None,
+        sub_flow_ids: vec![1],
+        #[cfg(feature = "debugger")]
+        name: "root".into(),
+        #[cfg(feature = "debugger")]
+        route: "/root".into(),
+    });
+    manifest.add_flow_info(FlowInfo {
+        process_id: 1,
+        parent_id: Some(0),
+        sub_flow_ids: vec![],
+        #[cfg(feature = "debugger")]
+        name: "child".into(),
+        #[cfg(feature = "debugger")]
+        route: "/root/child".into(),
+    });
+
+    // Function #10 in root
+    manifest.add_function(RuntimeFunction::new(
+        #[cfg(feature = "debugger")]
+        "target",
+        #[cfg(feature = "debugger")]
+        "/root/target",
+        "lib://flowstdlib/math/add",
+        vec![Input::new(
+            #[cfg(feature = "debugger")]
+            "in",
+            0,
+            false,
+            None,
+            None,
+        )],
+        10,
+        0,
+        &[],
+        false,
+    ));
+
+    // Function #20 in child — add(7,3)=10, outputs to #10:0
+    let mut func20 = RuntimeFunction::new(
+        #[cfg(feature = "debugger")]
+        "add",
+        #[cfg(feature = "debugger")]
+        "/root/child/add",
+        "lib://flowstdlib/math/add",
+        vec![
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i1",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(7))),
+                None,
+            ),
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i2",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(3))),
+                None,
+            ),
+        ],
+        20,
+        1,
+        &[OutputConnection::new(
+            Source::default(),
+            10,
+            0,
+            0,
+            false,
+            String::new(),
+            #[cfg(feature = "debugger")]
+            String::new(),
+        )],
+        false,
+    );
+    let dummy_url = url::Url::parse("file:///dummy/manifest.json").expect("URL");
+    func20.set_implementation_url(&dummy_url).expect("set URL");
+    manifest.add_function(func20);
+
+    // Delegate child flow #1 to the peer
+    let result = delegate_subflow(&manifest, 1, None, vec![]);
+
+    // Clean up flowrex
+    flowrex.kill().ok();
+    flowrex.wait().ok();
+
+    let result = result.expect("delegate_subflow failed");
+    let delegation = result.expect("Should have delegated to a peer");
+    assert_eq!(delegation.flow_id, 1);
+    assert!(
+        !delegation.boundary_outputs.is_empty(),
+        "Should have boundary outputs"
+    );
+    assert_eq!(
+        delegation.boundary_outputs.first().map(|o| &o.value),
+        Some(&serde_json::json!(10)),
+        "Boundary output should be 10 (7+3)"
+    );
+}
+
 /// Minimal provider that reads files from the filesystem.
 struct TestProvider;
 


### PR DESCRIPTION
## Parent-Side Peer Coordinator Discovery

### `peer_discovery::discover_peer_coordinators()`

Discovers peer coordinators on the network via mDNS, with self-discovery avoidance by filtering out the local port.

### End-to-End Test with Real flowrex

The test proves the complete distributed sub-flow pipeline:

1. Starts a real `flowrex` process (which now runs as a peer coordinator)
2. Discovers its `peer-coordinator` mDNS service
3. Connects via `PeerClient`
4. Submits a sub-flow manifest (`add(7,3)=10` with boundary output)
5. flowrex runs the sub-flow through its own coordinator stack
6. Boundary outputs are relayed back
7. Test verifies output value (10) and routing info

### Phase 2 Status

The distributed sub-flow pipeline is proven end-to-end:
- [x] Sub-flow extraction (`extract_subflow`)
- [x] Sub-flow interface computation (`subflow_interface`)
- [x] Boundary output capture (`BoundaryOutput` in `RunState`)
- [x] Peer protocol messages (`PeerRequest`/`PeerResponse`)
- [x] Peer submission handler (`PeerSubmissionHandler`)
- [x] Peer client (`PeerClient`)
- [x] Peer discovery (`discover_peer_coordinators`)
- [x] flowrex as peer coordinator
- [x] End-to-end test with real flowrex process

### What remains
- Parent coordinator runtime integration (delegate sub-flows during `execute_flow`)
- Concurrent execution (peer runs in parallel with parent's dispatch/retire loop)

Ref #2991, #1454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of peer coordinators on the local network via mDNS.
  * Filters out the current coordinator and reports discovered peer addresses.
  * Added support for delegating sub-flows to available peer coordinators and returning their results.

* **Tests**
  * Added end-to-end coverage for peer discovery, sub-flow submission and delegation, result validation, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->