### PR TITLE
Phase 3: Remove local delegation fallback, require remote peer (#2992)

### DIFF
--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -743,20 +743,20 @@ fn client(
             .get_one::<String>("trace")
             .map(std::string::ToString::to_string),
     );
-    submission.delegate_flow_id = delegate_flow_id;
 
-    // If delegating, try to discover a peer coordinator for remote execution
-    if delegate_flow_id.is_some() {
+    // Only delegate if a peer coordinator is available — otherwise run normally
+    if let Some(flow_id) = delegate_flow_id {
         match flowrlib::peer_discovery::discover_peer_coordinators(Duration::from_secs(3), None) {
             Ok(peers) => {
                 if let Some(addr) = peers.into_iter().next() {
-                    info!("Discovered peer coordinator at {addr} — will delegate remotely");
+                    info!("Discovered peer coordinator at {addr} — delegating sub-flow #{flow_id}");
+                    submission.delegate_flow_id = Some(flow_id);
                     submission.peer_address = Some(addr);
                 } else {
-                    info!("No peer coordinators found — will delegate locally");
+                    info!("No peer coordinators found — running flow normally");
                 }
             }
-            Err(e) => info!("Peer discovery failed ({e}) — will delegate locally"),
+            Err(e) => info!("Peer discovery failed ({e}) — running flow normally"),
         }
     }
 

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -235,14 +235,18 @@ impl<'a> Coordinator<'a> {
     ///
     #[cfg(feature = "submission")]
     pub fn submission_loop(&mut self, loop_forever: bool) -> Result<()> {
+        let mut last_result: Result<()> = Ok(());
         while let Some(submission) = self.submission_handler.wait_for_submission()? {
-            let _ = self.execute_flow(submission);
+            last_result = self.execute_flow(submission);
+            if let Err(ref e) = last_result {
+                error!("Flow execution failed: {e}");
+            }
             if !loop_forever {
                 break;
             }
         }
 
-        self.submission_handler.coordinator_is_exiting(Ok(()))
+        self.submission_handler.coordinator_is_exiting(last_result)
     }
 
     /// Execute a sub-flow and return its `RunState`, which may contain boundary
@@ -277,12 +281,17 @@ impl<'a> Coordinator<'a> {
     }
 
     /// Connect to a peer coordinator at the given address.
+    /// If already connected to a different peer, reconnects to the new one.
     ///
     /// # Errors
     ///
     /// Returns an error if the connection cannot be established.
     fn connect_to_peer(&mut self, peer_addr: &str) -> Result<()> {
-        if self.peer_client.is_none() {
+        let needs_connect = self
+            .peer_client
+            .as_ref()
+            .is_none_or(|client| client.address() != peer_addr);
+        if needs_connect {
             let zmq_ctx = zmq::Context::new();
             let client = crate::peer_client::PeerClient::connect(&zmq_ctx, peer_addr)
                 .map_err(|e| format!("Could not connect to peer at {peer_addr}: {e}"))?;
@@ -1117,6 +1126,72 @@ mod test {
         assert!(
             result.is_ok(),
             "submission_loop should return Ok when no submission is available"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn delegate_without_registry_fails() {
+        let dispatcher = test_dispatcher();
+        #[cfg(feature = "submission")]
+        let mut submission_handler = DummySubmissionHandler;
+        #[cfg(feature = "debugger")]
+        let mut debug_server = DummyDebugServer {
+            exit_immediately: false,
+        };
+
+        let mut coordinator = Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut submission_handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_server,
+        );
+
+        // Set peer_address but no subflow_registry → should fail
+        let mut submission = test_submission(vec![]);
+        submission.delegate_flow_id = Some(1);
+        submission.peer_address = Some("127.0.0.1:9999".to_string());
+        let result = coordinator.execute_flow(submission);
+        assert!(
+            result.is_err(),
+            "Delegation without a subflow registry should fail"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn delegate_without_peer_fails() {
+        let dispatcher = test_dispatcher();
+        #[cfg(feature = "submission")]
+        let mut submission_handler = DummySubmissionHandler;
+        #[cfg(feature = "debugger")]
+        let mut debug_server = DummyDebugServer {
+            exit_immediately: false,
+        };
+
+        let mut coordinator = Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut submission_handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_server,
+        );
+
+        // Set up registry but no peer_address → delegate_flow_id is set
+        // but connect_to_peer is never called, so peer_client is None
+        let executor = crate::executor::Executor::new();
+        coordinator.set_subflow_registry(executor.subflow_registry());
+
+        let mut submission = test_submission(vec![]);
+        submission.delegate_flow_id = Some(1);
+        // No peer_address set → connect_to_peer not called
+        // delegate_subflow will fail because flow_id 1 doesn't exist
+        // in the empty manifest, but that's the first error hit
+        let result = coordinator.execute_flow(submission);
+        assert!(
+            result.is_err(),
+            "Delegation without a valid sub-flow should fail"
         );
     }
 }

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -276,21 +276,20 @@ impl<'a> Coordinator<'a> {
         Ok(state)
     }
 
-    /// Connect to a peer coordinator if a peer address is available on the
-    /// submission and no peer client is already set.
-    fn connect_to_peer(&mut self, peer_addr: &str) {
+    /// Connect to a peer coordinator at the given address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection cannot be established.
+    fn connect_to_peer(&mut self, peer_addr: &str) -> Result<()> {
         if self.peer_client.is_none() {
             let zmq_ctx = zmq::Context::new();
-            match crate::peer_client::PeerClient::connect(&zmq_ctx, peer_addr) {
-                Ok(client) => {
-                    info!("Connected to peer coordinator at {peer_addr}");
-                    self.set_peer_client(client);
-                }
-                Err(e) => {
-                    error!("Could not connect to peer at {peer_addr}: {e} — will delegate locally");
-                }
-            }
+            let client = crate::peer_client::PeerClient::connect(&zmq_ctx, peer_addr)
+                .map_err(|e| format!("Could not connect to peer at {peer_addr}: {e}"))?;
+            info!("Connected to peer coordinator at {peer_addr}");
+            self.set_peer_client(client);
         }
+        Ok(())
     }
 
     /// Execute a flow by looping while there are jobs to be processed.
@@ -305,7 +304,7 @@ impl<'a> Coordinator<'a> {
     pub fn execute_flow(&mut self, mut submission: Submission) -> Result<()> {
         // Connect to a discovered peer coordinator if one was found
         if let Some(ref peer_addr) = submission.peer_address.clone() {
-            self.connect_to_peer(peer_addr);
+            self.connect_to_peer(peer_addr)?;
         }
 
         // Handle sub-flow delegation if requested
@@ -328,15 +327,17 @@ impl<'a> Coordinator<'a> {
                 "Registered sub-flow #{flow_id} with {} functions",
                 extracted.functions().len()
             );
-            let peer_addr = self.peer_client.as_ref().map(|c| c.address().to_string());
-            if peer_addr.is_some() {
-                info!("Sub-flow #{flow_id} will be executed on remote peer");
-            }
+            let peer_addr = self
+                .peer_client
+                .as_ref()
+                .map(|c| c.address().to_string())
+                .ok_or("Sub-flow delegation requires a connected peer coordinator")?;
+            info!("Sub-flow #{flow_id} will be executed on remote peer at {peer_addr}");
             // Preserve the extracted manifest for possible reconstitution
             submission
                 .extracted_subflows
                 .insert(flow_id, extracted.clone());
-            manifests.insert(subflow_url, (extracted, input_map, peer_addr));
+            manifests.insert(subflow_url, (extracted, input_map, Some(peer_addr)));
         }
 
         self.job_timeout = submission.job_timeout;

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -545,6 +545,12 @@ fn get_or_load_implementation(
                                 payload.implementation_url
                             )
                         })?;
+                    let addr = peer_address.as_ref().ok_or_else(|| {
+                        format!(
+                            "Sub-flow {} has no peer address — delegation requires a remote peer",
+                            payload.implementation_url
+                        )
+                    })?;
                     let interface_inputs: Vec<crate::subflow::InterfaceInput> = input_map
                         .iter()
                         .map(|(dest_id, dest_io)| crate::subflow::InterfaceInput {
@@ -552,20 +558,12 @@ fn get_or_load_implementation(
                             destination_io_number: *dest_io,
                         })
                         .collect();
-                    if let Some(addr) = peer_address {
-                        info!("Creating remote sub-flow implementation for peer at {addr}");
-                        Arc::new(crate::subflow::RemoteSubFlowImplementation::new(
-                            manifest.clone(),
-                            interface_inputs,
-                            addr.clone(),
-                        )) as Arc<dyn Implementation>
-                    } else {
-                        Arc::new(crate::subflow::SubFlowImplementation::new(
-                            manifest.clone(),
-                            provider.clone(),
-                            interface_inputs,
-                        )) as Arc<dyn Implementation>
-                    }
+                    info!("Creating remote sub-flow implementation for peer at {addr}");
+                    Arc::new(crate::subflow::RemoteSubFlowImplementation::new(
+                        manifest.clone(),
+                        interface_inputs,
+                        addr.clone(),
+                    )) as Arc<dyn Implementation>
                 }
                 _ => bail!("Unsupported scheme on implementation_url"),
             };


### PR DESCRIPTION
Simplifies the delegation model for Phase 3 (#2992).

## Problem

`--delegate` previously fell back to running the sub-flow locally via `SubFlowImplementation` when no peer was found. This added overhead (sub-flow extraction, proxy creation, nested coordinator) for zero benefit — the result was identical to running without `--delegate`.

## Fix

- **flowrcli**: Only set `delegate_flow_id` when a peer is actually discovered via mDNS. If no peer, log and run the flow normally.
- **Coordinator**: `connect_to_peer` returns an error instead of silently falling back. Requires `peer_client` when registering a delegated sub-flow.
- **Executor**: Requires peer address for `subflow://` implementations. Removes the local `SubFlowImplementation` fallback from the delegation path. (`SubFlowImplementation` is still used by flowrex's `PeerSubmissionHandler` for executing received sub-flows.)

## Behavior

- `flowrcli --delegate` with a peer running → discovers peer, delegates remotely (unchanged)
- `flowrcli --delegate` without a peer → logs 'No peer coordinators found — running flow normally', runs flow without any delegation overhead (new)
- `flowrcli` without `--delegate` → runs flow normally (unchanged)

Closes #2992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sub-flow delegation to use a peer coordinator only when one is successfully discovered and connected.
  - Added clear errors when remote sub-flow routing lacks a configured peer address.
  - Prevented silent fallback to local execution when peer connection or routing setup fails.
  - Recorded the delegated sub-flow identifier and peer address when remote delegation is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->