### PR TITLE
Enable delegation of sub-flows containing WASM functions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,7 @@ coverage:
       default:
         target: auto
         threshold: 20%
-        after_n_builds: 3
     patch:
       default:
         target: auto
         threshold: 20%
-        after_n_builds: 3

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,9 @@ coverage:
       default:
         target: auto
         threshold: 20%
+        after_n_builds: 3
     patch:
       default:
         target: auto
         threshold: 20%
+        after_n_builds: 3

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -489,6 +489,24 @@ impl FlowManifest {
         Ok(manifest)
     }
 
+    /// Rewrite all `file://` implementation URLs in this manifest to `http://`
+    /// URLs using the given WASM server base URL.
+    ///
+    /// This is used before sending a sub-flow manifest to a peer coordinator:
+    /// the peer cannot access `file://` paths on the root machine, so the URLs
+    /// are rewritten to point at the root's WASM HTTP server.
+    ///
+    /// Returns the number of URLs that were rewritten.
+    pub fn rewrite_wasm_urls(&mut self, wasm_base_url: &Url) -> usize {
+        let mut count = 0;
+        for func in self.functions.values_mut() {
+            if func.rewrite_file_url_to_http(wasm_base_url) {
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Collect all descendant flow IDs (including the given flow itself).
     /// Uses an iterative work list to avoid stack overflow on deep hierarchies
     /// and skips already-visited IDs to handle cycles safely.
@@ -970,5 +988,105 @@ mod test {
         assert_eq!(conn.destination_id, 1);
         assert_eq!(conn.destination_io_number, 0);
         assert!(!conn.internal);
+    }
+
+    #[test]
+    fn rewrite_wasm_urls_rewrites_file_to_http() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![],
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+
+        // Add a file:// WASM function
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "wasm_func",
+            #[cfg(feature = "debugger")]
+            "/root/wasm_func",
+            "file:///path/to/module.wasm",
+            vec![],
+            1,
+            0,
+            &[],
+            false,
+        );
+        let base = Url::parse("file:///").unwrap();
+        func.set_implementation_url(&base).unwrap();
+        manifest.add_function(func);
+
+        // Add a lib:// function (should not be rewritten)
+        let mut lib_func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "lib_func",
+            #[cfg(feature = "debugger")]
+            "/root/lib_func",
+            "lib://flowstdlib/math/add",
+            vec![],
+            2,
+            0,
+            &[],
+            false,
+        );
+        lib_func.set_implementation_url(&base).unwrap();
+        manifest.add_function(lib_func);
+
+        let wasm_base = Url::parse("http://192.168.1.1:12345").unwrap();
+        let count = manifest.rewrite_wasm_urls(&wasm_base);
+
+        assert_eq!(count, 1, "Should have rewritten exactly one URL");
+
+        // The file:// function should now have an http:// URL
+        let wasm_func = manifest.functions().get(&1).unwrap();
+        assert_eq!(wasm_func.get_implementation_url().scheme(), "http");
+        assert!(
+            wasm_func
+                .get_implementation_url()
+                .as_str()
+                .contains("module.wasm"),
+            "Rewritten URL should contain the original path"
+        );
+        assert!(
+            wasm_func
+                .get_implementation_location()
+                .starts_with("http://"),
+            "implementation_location should also be rewritten"
+        );
+
+        // The lib:// function should be unchanged
+        let lib_func = manifest.functions().get(&2).unwrap();
+        assert_eq!(lib_func.get_implementation_url().scheme(), "lib");
+    }
+
+    #[test]
+    fn rewrite_wasm_urls_no_file_urls_returns_zero() {
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        let mut lib_func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "lib_func",
+            #[cfg(feature = "debugger")]
+            "/root/lib_func",
+            "lib://flowstdlib/math/add",
+            vec![],
+            1,
+            0,
+            &[],
+            false,
+        );
+        let base = Url::parse("file:///").unwrap();
+        lib_func.set_implementation_url(&base).unwrap();
+        manifest.add_function(lib_func);
+
+        let wasm_base = Url::parse("http://192.168.1.1:12345").unwrap();
+        let count = manifest.rewrite_wasm_urls(&wasm_base);
+        assert_eq!(count, 0, "No file:// URLs to rewrite");
     }
 }

--- a/flowcore/src/model/runtime_function.rs
+++ b/flowcore/src/model/runtime_function.rs
@@ -314,6 +314,25 @@ impl RuntimeFunction {
         &self.implementation_url
     }
 
+    /// Rewrite a `file://` implementation URL to an `http://` URL using the
+    /// given base URL (from a WASM HTTP server). Returns `true` if the URL
+    /// was rewritten.
+    ///
+    /// This is used when delegating a sub-flow to a peer coordinator: the peer
+    /// cannot access `file://` paths on the root machine, so we rewrite them
+    /// to point at the root's WASM HTTP server.
+    pub fn rewrite_file_url_to_http(&mut self, wasm_base_url: &Url) -> bool {
+        if self.implementation_url.scheme() == "file" {
+            let path = self.implementation_url.path();
+            if let Ok(http_url) = wasm_base_url.join(path) {
+                self.implementation_url = http_url.clone();
+                self.implementation_location = http_url.to_string();
+                return true;
+            }
+        }
+        false
+    }
+
     fn location_to_url(manifest_url: &Url, location: &str) -> Result<Url> {
         Url::parse(location)
             .or_else(|_| manifest_url.clone().join(location))
@@ -432,6 +451,7 @@ impl RuntimeFunction {
 mod test {
     use serde_json::json;
     use serde_json::value::Value;
+    use url::Url;
 
     use crate::model::input::Input;
     use crate::model::output_connection::OutputConnection;
@@ -847,5 +867,61 @@ mod test {
         );
         func.send_internal(0, json!(1)).unwrap();
         assert!(!func.would_consume_external_on_internal_input());
+    }
+
+    #[test]
+    fn rewrite_file_url_to_http_rewrites() {
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "wasm",
+            #[cfg(feature = "debugger")]
+            "/wasm",
+            "file:///path/to/module.wasm",
+            vec![],
+            0,
+            0,
+            &[],
+            false,
+        );
+        let base = Url::parse("file:///").unwrap();
+        func.set_implementation_url(&base).unwrap();
+        assert_eq!(func.get_implementation_url().scheme(), "file");
+
+        let wasm_base = Url::parse("http://192.168.1.1:12345").unwrap();
+        assert!(func.rewrite_file_url_to_http(&wasm_base));
+        assert_eq!(func.get_implementation_url().scheme(), "http");
+        assert!(func
+            .get_implementation_url()
+            .as_str()
+            .contains("module.wasm"));
+        assert!(func.get_implementation_location().starts_with("http://"));
+    }
+
+    #[test]
+    fn rewrite_file_url_to_http_skips_lib() {
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "lib",
+            #[cfg(feature = "debugger")]
+            "/lib",
+            "lib://flowstdlib/math/add",
+            vec![],
+            0,
+            0,
+            &[],
+            false,
+        );
+        // Resolve the implementation URL from the location string
+        let base = Url::parse("file:///").unwrap();
+        func.set_implementation_url(&base).unwrap();
+        // lib:// URLs parse directly, not as file:// URLs
+        assert_eq!(func.get_implementation_url().scheme(), "lib");
+
+        let wasm_base = Url::parse("http://192.168.1.1:12345").unwrap();
+        assert!(!func.rewrite_file_url_to_http(&wasm_base));
+        assert_eq!(
+            func.get_implementation_location(),
+            "lib://flowstdlib/math/add"
+        );
     }
 }

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -709,8 +709,10 @@ fn client(
         .get_one::<u64>("job-timeout")
         .map(|secs| Duration::from_secs(*secs));
     // If --delegate is set, find the best sub-flow to delegate.
-    // We pick the sub-flow with the largest function subtree whose entire
-    // descendant tree uses only lib:// implementations.
+    // We pick the sub-flow with the largest function subtree whose functions
+    // use only lib:// or file:// (WASM) implementations. Sub-flows containing
+    // context:// functions cannot be delegated (they interact with the local
+    // environment).
     let mut delegate_flow_id = None;
     if matches.get_flag("delegate") {
         let mut best: Option<(usize, usize)> = None; // (flow_id, function_count)
@@ -730,16 +732,16 @@ fn client(
                 }
                 idx += 1;
             }
-            // Check all functions in the subtree
+            // Check all functions in the subtree — reject context:// functions
             let subtree_funcs: Vec<_> = flow_manifest
                 .functions()
                 .values()
                 .filter(|f| descendant_flows.contains(&f.get_parent_id()))
                 .collect();
-            let all_lib = subtree_funcs
+            let no_context = subtree_funcs
                 .iter()
-                .all(|f| f.get_implementation_location().starts_with("lib://"));
-            if all_lib && !subtree_funcs.is_empty() {
+                .all(|f| !f.get_implementation_location().starts_with("context://"));
+            if no_context && !subtree_funcs.is_empty() {
                 let count = subtree_funcs.len();
                 if best.is_none_or(|(_, best_count)| count > best_count) {
                     best = Some((flow_id, count));

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -318,35 +318,7 @@ impl<'a> Coordinator<'a> {
 
         // Handle sub-flow delegation if requested
         if let Some(flow_id) = submission.delegate_flow_id.take() {
-            let registry = self
-                .subflow_registry
-                .as_ref()
-                .ok_or("Sub-flow delegation requested but no sub-flow registry is configured")?;
-            info!("Delegating sub-flow #{flow_id}");
-            let (extracted, input_map) = submission
-                .manifest
-                .delegate_subflow(flow_id)
-                .map_err(|e| format!("Could not delegate sub-flow #{flow_id}: {e}"))?;
-            let subflow_url = url::Url::parse(&format!("subflow://{flow_id}"))
-                .map_err(|e| format!("Invalid subflow URL: {e}"))?;
-            let mut manifests = registry
-                .write()
-                .map_err(|_| "Could not gain write access to the sub-flow registry")?;
-            info!(
-                "Registered sub-flow #{flow_id} with {} functions",
-                extracted.functions().len()
-            );
-            let peer_addr = self
-                .peer_client
-                .as_ref()
-                .map(|c| c.address().to_string())
-                .ok_or("Sub-flow delegation requires a connected peer coordinator")?;
-            info!("Sub-flow #{flow_id} will be executed on remote peer at {peer_addr}");
-            // Preserve the extracted manifest for possible reconstitution
-            submission
-                .extracted_subflows
-                .insert(flow_id, extracted.clone());
-            manifests.insert(subflow_url, (extracted, input_map, Some(peer_addr)));
+            self.setup_delegation(flow_id, &mut submission)?;
         }
 
         self.job_timeout = submission.job_timeout;
@@ -432,6 +404,52 @@ impl<'a> Coordinator<'a> {
         self.submission_handler.flow_execution_ended(&state)?;
 
         flow_result
+    }
+
+    /// Extract a sub-flow from the submission, rewrite WASM URLs for remote
+    /// access, and register it in the sub-flow registry for delegation to
+    /// a peer coordinator.
+    fn setup_delegation(&self, flow_id: usize, submission: &mut Submission) -> Result<()> {
+        let registry = self
+            .subflow_registry
+            .as_ref()
+            .ok_or("Sub-flow delegation requested but no sub-flow registry is configured")?;
+        info!("Delegating sub-flow #{flow_id}");
+        let (mut extracted, input_map) = submission
+            .manifest
+            .delegate_subflow(flow_id)
+            .map_err(|e| format!("Could not delegate sub-flow #{flow_id}: {e}"))?;
+
+        // Rewrite file:// WASM URLs to http:// so the peer can fetch them
+        // from this coordinator's WASM HTTP server
+        if let Some(ref base_url) = self.wasm_base_url {
+            let rewritten = extracted.rewrite_wasm_urls(base_url);
+            if rewritten > 0 {
+                info!("Rewrote {rewritten} file:// WASM URL(s) to http:// for peer delegation");
+            }
+        }
+
+        let subflow_url = url::Url::parse(&format!("subflow://{flow_id}"))
+            .map_err(|e| format!("Invalid subflow URL: {e}"))?;
+        let mut manifests = registry
+            .write()
+            .map_err(|_| "Could not gain write access to the sub-flow registry")?;
+        info!(
+            "Registered sub-flow #{flow_id} with {} functions",
+            extracted.functions().len()
+        );
+        let peer_addr = self
+            .peer_client
+            .as_ref()
+            .map(|c| c.address().to_string())
+            .ok_or("Sub-flow delegation requires a connected peer coordinator")?;
+        info!("Sub-flow #{flow_id} will be executed on remote peer at {peer_addr}");
+        // Preserve the extracted manifest for possible reconstitution
+        submission
+            .extracted_subflows
+            .insert(flow_id, extracted.clone());
+        manifests.insert(subflow_url, (extracted, input_map, Some(peer_addr)));
+        Ok(())
     }
 
     /// Run the inner dispatch/retire loop until no more jobs remain or the debugger

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -427,6 +427,21 @@ impl<'a> Coordinator<'a> {
             if rewritten > 0 {
                 info!("Rewrote {rewritten} file:// WASM URL(s) to http:// for peer delegation");
             }
+        } else {
+            // If no WASM server is running, check whether the extracted manifest
+            // contains file:// URLs that the peer would not be able to access.
+            let file_count = extracted
+                .functions()
+                .values()
+                .filter(|f| f.get_implementation_url().scheme() == "file")
+                .count();
+            if file_count > 0 {
+                return Err(format!(
+                    "Cannot delegate sub-flow #{flow_id}: it contains {file_count} file:// WASM \
+                     function(s) but no WASM server is running to serve them"
+                )
+                .into());
+            }
         }
 
         let subflow_url = url::Url::parse(&format!("subflow://{flow_id}"))

--- a/flowr/src/lib/delegation.rs
+++ b/flowr/src/lib/delegation.rs
@@ -58,7 +58,7 @@ pub fn delegate_subflow(
     let zmq_context = zmq::Context::new();
     let client = PeerClient::connect(&zmq_context, peer_address)?;
 
-    let boundary_outputs = client.submit_subflow(extracted.clone(), inputs)?;
+    let boundary_outputs = client.submit_subflow(extracted.clone(), inputs, None)?;
 
     info!(
         "Peer returned {} boundary outputs for sub-flow #{flow_id}",

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -125,14 +125,14 @@ impl Dispatcher {
     // Send a `Job` for execution to executors.
     //
     // Jobs are routed to two executor pools:
-    // - `lib_job_socket`: library functions (lib://), WASM functions (file://),
-    //   and sub-flow functions (subflow://) — these run on the multi-threaded
-    //   executor pool for parallelism
+    // - `lib_job_socket`: library functions (lib://), WASM functions (file://,
+    //   http://, https://), and sub-flow functions (subflow://) — these run on
+    //   the multi-threaded executor pool for parallelism
     // - `general_job_socket`: context functions (context://) — these interact with
     //   the environment and run on a dedicated executor with spawn support
     pub(crate) fn send_job_for_execution(&mut self, payload: &Payload) -> Result<()> {
         let scheme = payload.implementation_url.scheme();
-        if scheme == "lib" || scheme == "file" || scheme == "subflow" {
+        if matches!(scheme, "lib" | "file" | "http" | "https" | "subflow") {
             self.lib_job_socket
                 .send(serde_json::to_string(payload)?.as_bytes(), 0)
                 .map_err(|e| format!("Could not send Job for execution: {e}"))?;
@@ -276,6 +276,31 @@ mod test {
         let (mut dispatcher, ports) = new_dispatcher();
 
         // subflow:// jobs should be routed to the lib job socket (ports.0),
+        // not the context job socket (ports.1).
+        let context = zmq::Context::new();
+        let job_source = context
+            .socket(zmq::PULL)
+            .expect("Could not create PULL end of job socket");
+        job_source
+            .connect(&format!("tcp://127.0.0.1:{}", ports.0))
+            .expect("Could not bind to PULL end of job socket");
+
+        assert!(dispatcher.send_job_for_execution(&payload).is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn send_http_wasm_job() {
+        let payload = Payload {
+            job_id: 0,
+            input_set: vec![],
+            implementation_url: Url::parse("http://192.168.1.1:12345/path/to/module.wasm")
+                .expect("Could not parse Url"),
+        };
+
+        let (mut dispatcher, ports) = new_dispatcher();
+
+        // http:// WASM jobs should be routed to the lib job socket (ports.0),
         // not the context job socket (ports.1).
         let context = zmq::Context::new();
         let job_source = context

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -219,6 +219,33 @@ mod test {
             .is_ok());
     }
 
+    /// Helper: connect PULL sockets to both the lib (ports.0) and context
+    /// (ports.1) dispatcher queues so tests can observe routing.
+    fn connect_both_queues(
+        context: &zmq::Context,
+        ports: (u16, u16, u16, u16),
+    ) -> (zmq::Socket, zmq::Socket) {
+        let lib_socket = context
+            .socket(zmq::PULL)
+            .expect("Could not create lib PULL socket");
+        lib_socket
+            .connect(&format!("tcp://127.0.0.1:{}", ports.0))
+            .expect("Could not connect to lib job socket");
+        lib_socket
+            .set_rcvtimeo(1000)
+            .expect("Could not set timeout");
+
+        let ctx_socket = context
+            .socket(zmq::PULL)
+            .expect("Could not create context PULL socket");
+        ctx_socket
+            .connect(&format!("tcp://127.0.0.1:{}", ports.1))
+            .expect("Could not connect to context job socket");
+        ctx_socket.set_rcvtimeo(100).expect("Could not set timeout");
+
+        (lib_socket, ctx_socket)
+    }
+
     #[test]
     #[serial]
     fn send_lib_job() {
@@ -230,16 +257,21 @@ mod test {
         };
 
         let (mut dispatcher, ports) = new_dispatcher();
-
         let context = zmq::Context::new();
-        let job_source = context
-            .socket(zmq::PULL)
-            .expect("Could not create PULL end of job socket");
-        job_source
-            .connect(&format!("tcp://127.0.0.1:{}", ports.0))
-            .expect("Could not bind to PULL end of job socket");
+        let (lib_socket, ctx_socket) = connect_both_queues(&context, ports);
 
         assert!(dispatcher.send_job_for_execution(&payload).is_ok());
+
+        let msg = lib_socket
+            .recv_msg(0)
+            .expect("lib:// job should arrive on lib socket");
+        let received: Payload = serde_json::from_str(msg.as_str().unwrap()).unwrap();
+        assert_eq!(received.implementation_url.scheme(), "lib");
+
+        assert!(
+            ctx_socket.recv_msg(0).is_err(),
+            "lib:// job should not be routed to context socket"
+        );
     }
 
     #[test]
@@ -252,16 +284,23 @@ mod test {
         };
 
         let (mut dispatcher, ports) = new_dispatcher();
-
         let context = zmq::Context::new();
-        let context_job_source = context
-            .socket(zmq::PULL)
-            .expect("Could not create PULL end of context-job socket");
-        context_job_source
-            .connect(&format!("tcp://127.0.0.1:{}", ports.1))
-            .expect("Could not bind to PULL end of job-source socket");
+        let (lib_socket, ctx_socket) = connect_both_queues(&context, ports);
 
         assert!(dispatcher.send_job_for_execution(&payload).is_ok());
+
+        // Context timeout is 100ms; bump it so we can receive
+        ctx_socket.set_rcvtimeo(1000).expect("set timeout");
+        let msg = ctx_socket
+            .recv_msg(0)
+            .expect("context:// job should arrive on context socket");
+        let received: Payload = serde_json::from_str(msg.as_str().unwrap()).unwrap();
+        assert_eq!(received.implementation_url.scheme(), "context");
+
+        assert!(
+            lib_socket.recv_msg(0).is_err(),
+            "context:// job should not be routed to lib socket"
+        );
     }
 
     #[test]
@@ -274,18 +313,21 @@ mod test {
         };
 
         let (mut dispatcher, ports) = new_dispatcher();
-
-        // subflow:// jobs should be routed to the lib job socket (ports.0),
-        // not the context job socket (ports.1).
         let context = zmq::Context::new();
-        let job_source = context
-            .socket(zmq::PULL)
-            .expect("Could not create PULL end of job socket");
-        job_source
-            .connect(&format!("tcp://127.0.0.1:{}", ports.0))
-            .expect("Could not bind to PULL end of job socket");
+        let (lib_socket, ctx_socket) = connect_both_queues(&context, ports);
 
         assert!(dispatcher.send_job_for_execution(&payload).is_ok());
+
+        let msg = lib_socket
+            .recv_msg(0)
+            .expect("subflow:// job should arrive on lib socket");
+        let received: Payload = serde_json::from_str(msg.as_str().unwrap()).unwrap();
+        assert_eq!(received.implementation_url.scheme(), "subflow");
+
+        assert!(
+            ctx_socket.recv_msg(0).is_err(),
+            "subflow:// job should not be routed to context socket"
+        );
     }
 
     #[test]
@@ -299,18 +341,21 @@ mod test {
         };
 
         let (mut dispatcher, ports) = new_dispatcher();
-
-        // http:// WASM jobs should be routed to the lib job socket (ports.0),
-        // not the context job socket (ports.1).
         let context = zmq::Context::new();
-        let job_source = context
-            .socket(zmq::PULL)
-            .expect("Could not create PULL end of job socket");
-        job_source
-            .connect(&format!("tcp://127.0.0.1:{}", ports.0))
-            .expect("Could not bind to PULL end of job socket");
+        let (lib_socket, ctx_socket) = connect_both_queues(&context, ports);
 
         assert!(dispatcher.send_job_for_execution(&payload).is_ok());
+
+        let msg = lib_socket
+            .recv_msg(0)
+            .expect("http:// WASM job should arrive on lib socket");
+        let received: Payload = serde_json::from_str(msg.as_str().unwrap()).unwrap();
+        assert_eq!(received.implementation_url.scheme(), "http");
+
+        assert!(
+            ctx_socket.recv_msg(0).is_err(),
+            "http:// job should not be routed to context socket"
+        );
     }
 
     #[test]

--- a/flowr/src/lib/peer_client.rs
+++ b/flowr/src/lib/peer_client.rs
@@ -56,6 +56,9 @@ impl PeerClient {
     /// Submit a sub-flow for execution on the peer coordinator.
     /// Returns the boundary outputs produced by the sub-flow.
     ///
+    /// `wasm_base_url` is the base URL of the parent's WASM HTTP server,
+    /// passed to the peer for potential further delegation.
+    ///
     /// # Errors
     ///
     /// Returns an error if the submission cannot be sent or the response
@@ -64,8 +67,13 @@ impl PeerClient {
         &self,
         manifest: FlowManifest,
         inputs: Vec<(usize, usize, Value)>,
+        wasm_base_url: Option<String>,
     ) -> Result<Vec<BoundaryOutput>> {
-        let request = PeerRequest::Submit(Box::new(SubflowSubmission { manifest, inputs }));
+        let request = PeerRequest::Submit(Box::new(SubflowSubmission {
+            manifest,
+            inputs,
+            wasm_base_url,
+        }));
         let json = serde_json::to_string(&request)
             .map_err(|e| format!("Could not serialize peer request: {e}"))?;
 
@@ -120,6 +128,9 @@ impl PeerClient {
     /// Submit a sub-flow and invoke a callback for each boundary output
     /// as it arrives, rather than collecting them all.
     ///
+    /// `wasm_base_url` is the base URL of the parent's WASM HTTP server,
+    /// passed to the peer for potential further delegation.
+    ///
     /// # Errors
     ///
     /// Returns an error if the submission fails, a response cannot be
@@ -128,12 +139,17 @@ impl PeerClient {
         &self,
         manifest: FlowManifest,
         inputs: Vec<(usize, usize, Value)>,
+        wasm_base_url: Option<String>,
         mut on_boundary_output: F,
     ) -> Result<()>
     where
         F: FnMut(BoundaryOutput) -> Result<()>,
     {
-        let request = PeerRequest::Submit(Box::new(SubflowSubmission { manifest, inputs }));
+        let request = PeerRequest::Submit(Box::new(SubflowSubmission {
+            manifest,
+            inputs,
+            wasm_base_url,
+        }));
         let json = serde_json::to_string(&request)
             .map_err(|e| format!("Could not serialize peer request: {e}"))?;
 

--- a/flowr/src/lib/peer_coordinator.rs
+++ b/flowr/src/lib/peer_coordinator.rs
@@ -106,9 +106,14 @@ pub fn run_peer_coordinator(peer_port: u16, instance_name: &str) -> Result<()> {
         &connect_addrs.3,
     );
 
-    // Start WASM server for sub-flow WASM files
-    let _wasm_server = match WasmServer::start(std::path::Path::new("/")) {
-        Ok(server) => Some(server),
+    // Start WASM server so this peer's executors can fetch WASM modules
+    // over HTTP (e.g. when the delegated sub-flow contains file:// WASMs
+    // that were rewritten to http:// by the parent coordinator)
+    let wasm_server = match WasmServer::start(std::path::Path::new("/")) {
+        Ok(server) => {
+            info!("Peer WASM server at {}", server.base_url());
+            Some(server)
+        }
         Err(e) => {
             log::warn!("Could not start WASM server for peer coordinator: {e}");
             None
@@ -125,6 +130,14 @@ pub fn run_peer_coordinator(peer_port: u16, instance_name: &str) -> Result<()> {
         #[cfg(feature = "debugger")]
         &mut debug_handler,
     );
+
+    // Set the WASM base URL so the peer coordinator can rewrite file:// URLs
+    // for its own executors (and for further delegation if supported)
+    if let Some(ref server) = wasm_server {
+        if let Ok(url) = Url::parse(server.base_url()) {
+            coordinator.set_wasm_base_url(url);
+        }
+    }
 
     info!("Peer coordinator entering submission loop");
     let result = coordinator.submission_loop(true);

--- a/flowr/src/lib/peer_protocol.rs
+++ b/flowr/src/lib/peer_protocol.rs
@@ -27,6 +27,9 @@ pub struct SubflowSubmission {
     /// Initial input values mapped to boundary function inputs.
     /// Each entry is (`destination_function_id`, `destination_io_number`, value).
     pub inputs: Vec<(usize, usize, Value)>,
+    /// Base URL of the parent's WASM HTTP server, so the peer can fetch
+    /// WASM modules that were rewritten from `file://` to `http://` URLs.
+    pub wasm_base_url: Option<String>,
 }
 
 /// Messages sent from peer coordinator back to parent coordinator.

--- a/flowr/src/lib/peer_submission_handler.rs
+++ b/flowr/src/lib/peer_submission_handler.rs
@@ -124,6 +124,9 @@ impl SubmissionHandler for PeerSubmissionHandler {
             PeerRequest::Submit(submission) => {
                 let mut manifest = submission.manifest;
                 let inputs = submission.inputs;
+                if let Some(ref wasm_url) = submission.wasm_base_url {
+                    info!("Parent WASM server at {wasm_url}");
+                }
                 info!(
                     "Peer coordinator received sub-flow with {} functions, {} inputs",
                     manifest.functions().len(),

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -237,6 +237,7 @@ impl RemoteSubFlowImplementation {
         let stream_result = client.submit_subflow_streaming(
             self.manifest.clone(),
             input_triples,
+            None,
             |boundary_output| {
                 let bo_value = serde_json::json!({
                     "destination_id": boundary_output.connection.destination_id,
@@ -308,7 +309,7 @@ impl Implementation for RemoteSubFlowImplementation {
             .map_err(|e| format!("Could not connect to peer at {}: {e}", self.peer_address))?;
 
         let boundary_outputs = client
-            .submit_subflow(self.manifest.clone(), input_triples)
+            .submit_subflow(self.manifest.clone(), input_triples, None)
             .map_err(|e| format!("Peer sub-flow execution failed: {e}"))?;
 
         info!(

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -907,6 +907,236 @@ fn peer_coordinator_streams_boundary_outputs() {
     let _ = peer_thread.join();
 }
 
+/// End-to-end test: delegate a sub-flow containing a WASM function (`add.wasm`)
+/// to a peer coordinator, verifying that:
+/// 1. The root coordinator rewrites the `file://` WASM URL to `http://`
+/// 2. The peer coordinator fetches the WASM module over HTTP from the root's `WasmServer`
+/// 3. The WASM function executes correctly on the peer (not the root)
+/// 4. The boundary outputs are correct
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[allow(clippy::too_many_lines)]
+fn peer_coordinator_executes_wasm_subflow() {
+    use flowcore::meta_provider::MetaProvider;
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::input::{Input, InputInitializer};
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowrlib::peer_client::PeerClient;
+    use flowrlib::wasm_server::WasmServer;
+    use simpath::Simpath;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    // Locate add.wasm in the tests directory
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let wasm_path = manifest_dir.join("tests").join("add.wasm");
+    assert!(
+        wasm_path.exists(),
+        "add.wasm must exist at {}",
+        wasm_path.display()
+    );
+
+    // Build a sub-flow manifest with a WASM function: add(7, 3) -> 10
+    // The function uses a file:// URL pointing to the real add.wasm
+    let wasm_url = url::Url::from_file_path(&wasm_path).expect("wasm URL");
+    let mut manifest = FlowManifest::new(MetaData::default());
+    manifest.add_flow_info(FlowInfo {
+        process_id: 0,
+        parent_id: None,
+        sub_flow_ids: vec![],
+        #[cfg(feature = "debugger")]
+        name: "wasm_subflow".into(),
+        #[cfg(feature = "debugger")]
+        route: "/wasm_subflow".into(),
+    });
+
+    let mut func = RuntimeFunction::new(
+        #[cfg(feature = "debugger")]
+        "add",
+        #[cfg(feature = "debugger")]
+        "/wasm_subflow/add",
+        wasm_url.as_str(),
+        vec![
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i1",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(7))),
+                None,
+            ),
+            Input::new(
+                #[cfg(feature = "debugger")]
+                "i2",
+                0,
+                false,
+                Some(InputInitializer::Once(serde_json::json!(3))),
+                None,
+            ),
+        ],
+        1,
+        0,
+        &[OutputConnection::new(
+            Source::default(),
+            10, // boundary destination (outside sub-flow)
+            0,
+            0,
+            false,
+            String::new(),
+            #[cfg(feature = "debugger")]
+            String::new(),
+        )],
+        false,
+    );
+    let dummy_base = url::Url::parse("file:///dummy/manifest.json").expect("URL");
+    func.set_implementation_url(&dummy_base).expect("set URL");
+    manifest.add_function(func);
+
+    // Verify the function currently has a file:// URL
+    let func_before = manifest.functions().get(&1).expect("function 1");
+    assert_eq!(
+        func_before.get_implementation_url().scheme(),
+        "file",
+        "Before rewriting, URL should be file://"
+    );
+
+    // Start a WasmServer on the root side to serve the WASM file.
+    // Use "/" as root so the absolute path in the file:// URL can be resolved.
+    let wasm_server =
+        WasmServer::start(std::path::Path::new("/")).expect("Could not start WasmServer");
+    let wasm_base_url =
+        url::Url::parse(wasm_server.base_url()).expect("Could not parse WasmServer base URL");
+
+    // Rewrite file:// URLs to http:// (this is what the root coordinator does)
+    let rewritten = manifest.rewrite_wasm_urls(&wasm_base_url);
+    assert_eq!(rewritten, 1, "Should rewrite exactly one file:// URL");
+
+    // Verify the URL was rewritten to http://
+    let func_after = manifest.functions().get(&1).expect("function 1");
+    assert_eq!(
+        func_after.get_implementation_url().scheme(),
+        "http",
+        "After rewriting, URL should be http://"
+    );
+    assert!(
+        func_after
+            .get_implementation_url()
+            .as_str()
+            .contains("add.wasm"),
+        "Rewritten URL should still reference add.wasm"
+    );
+
+    // Start a peer coordinator in a background thread.
+    // Use MetaProvider (not TestProvider) so HTTP URLs can be fetched.
+    let peer_port = portpicker::pick_unused_port().expect("port");
+    let bind_address = format!("tcp://*:{peer_port}");
+    let peer_thread = std::thread::spawn(move || {
+        let zmq_context = zmq::Context::new();
+        let mut handler = flowrlib::peer_submission_handler::PeerSubmissionHandler::new(
+            &zmq_context,
+            &bind_address,
+        )
+        .expect("handler");
+
+        let ports = (
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+        );
+        let bind_addrs = (
+            format!("tcp://*:{}", ports.0),
+            format!("tcp://*:{}", ports.1),
+            format!("tcp://*:{}", ports.2),
+            format!("tcp://*:{}", ports.3),
+        );
+        let connect_addrs = (
+            format!("tcp://127.0.0.1:{}", ports.0),
+            format!("tcp://127.0.0.1:{}", ports.1),
+            format!("tcp://127.0.0.1:{}", ports.2),
+            format!("tcp://127.0.0.1:{}", ports.3),
+        );
+
+        let dispatcher = flowrlib::dispatcher::Dispatcher::new(&bind_addrs).expect("dispatcher");
+
+        // Use MetaProvider so the executor can fetch http:// WASM URLs
+        let provider = Arc::new(MetaProvider::new(Simpath::new(""), PathBuf::default()))
+            as Arc<dyn flowcore::provider::Provider>;
+
+        let mut executor = flowrlib::executor::Executor::new();
+        // Do NOT add flowstdlib — we want to prove the WASM function runs,
+        // not a native lib function
+        executor.start(
+            &provider,
+            1,
+            &connect_addrs.0,
+            &connect_addrs.2,
+            &connect_addrs.3,
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        #[cfg(feature = "debugger")]
+        let mut debug_handler = flowrlib::subflow::NoOpDebugHandler;
+
+        let mut coordinator = flowrlib::coordinator::Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_handler,
+        );
+
+        // Run one submission then exit
+        let _ = coordinator.submission_loop(false);
+        let _ = coordinator.send_done();
+        executor.wait();
+    });
+
+    // Give peer coordinator time to start
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Connect as parent and submit the sub-flow with the rewritten http:// URLs
+    let zmq_context = zmq::Context::new();
+    let peer_address = format!("127.0.0.1:{peer_port}");
+    let client = PeerClient::connect(&zmq_context, &peer_address).expect("connect");
+
+    let outputs = client
+        .submit_subflow(manifest, vec![], Some(wasm_server.base_url().to_string()))
+        .expect("submit failed");
+
+    // The WASM add(7,3) should produce 10 as a boundary output to #10:0
+    assert!(
+        !outputs.is_empty(),
+        "Should have boundary outputs from peer executing WASM"
+    );
+    assert_eq!(
+        outputs.first().map(|o| &o.value),
+        Some(&serde_json::json!(10)),
+        "WASM add(7,3) should return 10"
+    );
+    assert_eq!(
+        outputs.first().map(|o| o.connection.destination_id),
+        Some(10),
+        "Boundary output should target function #10"
+    );
+    assert_eq!(
+        outputs.first().map(|o| o.connection.destination_io_number),
+        Some(0),
+        "Boundary output should target input 0"
+    );
+
+    // The root never ran an executor — the WASM was executed entirely on the peer.
+    // The WasmServer served the file; the peer fetched and ran it.
+    // If the WASM had run locally, we wouldn't have boundary outputs from the peer.
+
+    drop(client);
+    let _ = peer_thread.join();
+    // WasmServer is dropped here, stopping the background HTTP thread
+}
+
 /// Minimal provider that reads files from the filesystem.
 struct TestProvider;
 

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -717,7 +717,7 @@ fn peer_coordinator_executes_subflow() {
     let client = PeerClient::connect(&zmq_context, &peer_address).expect("connect");
 
     let outputs = client
-        .submit_subflow(manifest, vec![])
+        .submit_subflow(manifest, vec![], None)
         .expect("submit failed");
 
     // Should have boundary output: add(7,3)=10 -> #10:0
@@ -887,7 +887,7 @@ fn peer_coordinator_streams_boundary_outputs() {
 
     let mut streamed_outputs = Vec::new();
     client
-        .submit_subflow_streaming(manifest, vec![], |bo| {
+        .submit_subflow_streaming(manifest, vec![], None, |bo| {
             streamed_outputs.push(bo);
             Ok(())
         })

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -702,10 +702,11 @@ fn peer_coordinator_executes_subflow() {
             &mut debug_handler,
         );
 
-        // Run one submission then exit
-        let _ = coordinator.submission_loop(false);
+        // Run one submission then exit, propagating any error
+        let loop_result = coordinator.submission_loop(false);
         let _ = coordinator.send_done();
         executor.wait();
+        loop_result
     });
 
     // Give peer coordinator time to start
@@ -735,11 +736,13 @@ fn peer_coordinator_executes_subflow() {
     );
 
     // Peer exits after one submission (loop_forever = false), no need to signal done.
-    // Drop the client to close the socket.
     drop(client);
 
-    // Wait for peer thread
-    let _ = peer_thread.join();
+    let peer_result = peer_thread.join().expect("peer thread panicked");
+    assert!(
+        peer_result.is_ok(),
+        "peer coordinator failed: {peer_result:?}"
+    );
 }
 
 /// Test streaming boundary outputs from a peer coordinator.
@@ -873,9 +876,10 @@ fn peer_coordinator_streams_boundary_outputs() {
             &mut debug_handler,
         );
 
-        let _ = coordinator.submission_loop(false);
+        let loop_result = coordinator.submission_loop(false);
         let _ = coordinator.send_done();
         executor.wait();
+        loop_result
     });
 
     std::thread::sleep(std::time::Duration::from_millis(200));
@@ -904,7 +908,11 @@ fn peer_coordinator_streams_boundary_outputs() {
     assert_eq!(bo.connection.destination_id, 10);
 
     drop(client);
-    let _ = peer_thread.join();
+    let peer_result = peer_thread.join().expect("peer thread panicked");
+    assert!(
+        peer_result.is_ok(),
+        "peer coordinator failed: {peer_result:?}"
+    );
 }
 
 /// End-to-end test: delegate a sub-flow containing a WASM function (`add.wasm`)
@@ -1089,10 +1097,11 @@ fn peer_coordinator_executes_wasm_subflow() {
             &mut debug_handler,
         );
 
-        // Run one submission then exit
-        let _ = coordinator.submission_loop(false);
+        // Run one submission then exit, propagating any error
+        let loop_result = coordinator.submission_loop(false);
         let _ = coordinator.send_done();
         executor.wait();
+        loop_result
     });
 
     // Give peer coordinator time to start
@@ -1133,7 +1142,11 @@ fn peer_coordinator_executes_wasm_subflow() {
     // If the WASM had run locally, we wouldn't have boundary outputs from the peer.
 
     drop(client);
-    let _ = peer_thread.join();
+    let peer_result = peer_thread.join().expect("peer thread panicked");
+    assert!(
+        peer_result.is_ok(),
+        "peer coordinator failed: {peer_result:?}"
+    );
     // WasmServer is dropped here, stopping the background HTTP thread
 }
 


### PR DESCRIPTION
## Summary

Fixes #3009

Relaxes the delegation eligibility check to allow sub-flows with `file://` (WASM) implementations to be delegated to peer coordinators, not just sub-flows composed entirely of `lib://` functions. Only `context://` functions remain excluded since they interact with the local environment.

When delegating, the root coordinator rewrites `file://` WASM URLs in the extracted sub-flow manifest to `http://` URLs pointing at the root's `WasmServer`, so the peer coordinator can fetch the WASM modules over HTTP.

## Changes

### Eligibility check relaxed (`flowr/src/bin/flowrcli/main.rs`)
- Changed from requiring all functions to use `lib://` to only excluding `context://` functions
- This makes sub-flows with WASM functions (like `render` in mandelbrot) eligible for delegation

### URL rewriting infrastructure
- **`RuntimeFunction::rewrite_file_url_to_http()`** — rewrites a single function's `file://` implementation URL to `http://` using a WASM server base URL
- **`FlowManifest::rewrite_wasm_urls()`** — rewrites all `file://` URLs in a manifest, returns the count of rewrites

### Coordinator delegation (`flowr/src/lib/coordinator.rs`)
- Extracted delegation logic into `setup_delegation()` helper (also fixed `too_many_lines` clippy warning)
- After extracting the sub-flow manifest, rewrites `file://` WASM URLs to `http://` before registering in the subflow registry

### Peer coordinator (`flowr/src/lib/peer_coordinator.rs`)
- Now calls `coordinator.set_wasm_base_url()` using its own `WasmServer` (previously started a server but never used it)

### Protocol (`flowr/src/lib/peer_protocol.rs`)
- Added optional `wasm_base_url` field to `SubflowSubmission` for forward compatibility (hierarchical delegation)

### Delegation rules

| URL scheme | Before | After |
|------------|--------|-------|
| `lib://` | Delegatable | Delegatable |
| `file://` (WASM) | NOT delegatable | **Delegatable** (rewritten to `http://`) |
| `context://` | NOT delegatable | NOT delegatable |

## Testing
- All existing tests pass (`make test`, `make clippy`, `cargo fmt`)
- Added unit tests for `rewrite_file_url_to_http` and `rewrite_wasm_urls`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for delegating WASM-based sub-flows between peers.
  * Local WASM module URLs are automatically converted to accessible HTTP URLs when a WASM server is available.
  * Sub-flow submissions can now carry WASM server connection details.
  * HTTP and HTTPS WASM jobs are routed to the appropriate executor.

* **Bug Fixes**
  * Improved handling of unsupported local WASM URLs when no server is configured.
  * Preserved library-based function URLs during WASM URL processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->