### PR TITLE
Balance-aware delegation scoring computed at compile time

### DIFF
--- a/flowc/src/lib/generator/generate.rs
+++ b/flowc/src/lib/generator/generate.rs
@@ -61,6 +61,9 @@ pub fn create_manifest(
     #[cfg(feature = "debugger")]
     manifest.set_source_urls(source_urls);
 
+    // Compute delegation scores as hints for the runtime
+    manifest.compute_delegation_scores();
+
     Ok(manifest)
 }
 
@@ -82,6 +85,7 @@ fn emit_flow_hierarchy(
         process_id: flow.id,
         parent_id,
         sub_flow_ids,
+        delegation_score: None, // computed after hierarchy is built
         #[cfg(feature = "debugger")]
         name: flow.name.clone(),
         #[cfg(feature = "debugger")]

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -33,7 +33,7 @@ pub struct Cargo {
     pub package: MetaData,
 }
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 /// Describes a flow's direct children: which sub-flow IDs it contains
 pub struct FlowInfo {
     /// The unique process ID of this flow
@@ -42,6 +42,12 @@ pub struct FlowInfo {
     pub parent_id: Option<usize>,
     /// IDs of direct child sub-flows
     pub sub_flow_ids: Vec<usize>,
+    /// Compiler-computed delegation score. `Some(score)` means this sub-flow
+    /// is a candidate for delegation — higher is better. `None` means it
+    /// cannot be delegated (e.g. contains `context://` functions).
+    /// This is a hint: the runtime may follow or ignore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_score: Option<f64>,
     #[cfg(feature = "debugger")]
     #[serde(default, skip_serializing_if = "String::is_empty")]
     /// The name of this flow (for debugging display)
@@ -51,6 +57,16 @@ pub struct FlowInfo {
     /// The route of this flow (for debugging display)
     pub route: String,
 }
+
+impl PartialEq for FlowInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.process_id == other.process_id
+            && self.parent_id == other.parent_id
+            && self.sub_flow_ids == other.sub_flow_ids
+    }
+}
+
+impl Eq for FlowInfo {}
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
 /// A `flows` `Manifest` describes it and describes all the `Functions` it uses as well as
@@ -507,6 +523,131 @@ impl FlowManifest {
         count
     }
 
+    /// Compute delegation scores for all sub-flows in this manifest.
+    ///
+    /// The score reflects how beneficial it would be to delegate each sub-flow
+    /// to a peer coordinator, considering compute weight, balance between root
+    /// and peer, boundary I/O overhead, and nested sub-flow serialization.
+    ///
+    /// Sub-flows containing `context://` functions get `None` (not delegatable).
+    /// Sub-flows with a non-positive score also get `None`.
+    /// The root flow always gets `None`.
+    ///
+    /// This is intended to be called by the compiler after the manifest is
+    /// fully constructed, storing results as hints for the runtime.
+    #[allow(clippy::cast_precision_loss)] // counts are small, precision loss is irrelevant
+    pub fn compute_delegation_scores(&mut self) {
+        // Weight constants (initial values, tunable)
+        const LOOPBACK_MULTIPLIER: f64 = 2.0;
+        const BOUNDARY_WEIGHT: f64 = 0.5;
+        const NESTING_WEIGHT: f64 = 1.0;
+
+        // Compute total flow weight: sum of (1 + loopback_count * multiplier)
+        // for every function in the manifest
+        let total_weight: f64 = self
+            .functions
+            .values()
+            .map(|f| {
+                let loopbacks = f
+                    .get_output_connections()
+                    .iter()
+                    .filter(|c| c.destination_id == f.id())
+                    .count();
+                1.0 + loopbacks as f64 * LOOPBACK_MULTIPLIER
+            })
+            .sum();
+
+        if total_weight <= 0.0 {
+            return;
+        }
+
+        // Collect flow IDs to score (snapshot to avoid borrow conflict)
+        let flow_ids: Vec<usize> = self.flows.keys().copied().collect();
+
+        for flow_id in flow_ids {
+            let is_root = self
+                .flows
+                .get(&flow_id)
+                .is_some_and(|f| f.parent_id.is_none());
+            if is_root {
+                continue; // root flow is never delegated
+            }
+
+            // Collect all descendant flow IDs
+            let mut descendant_flows = HashSet::new();
+            Self::collect_descendant_flows(flow_id, &self.flows, &mut descendant_flows);
+
+            // Gather functions in this sub-flow's descendant tree
+            let subtree_funcs: Vec<&RuntimeFunction> = self
+                .functions
+                .values()
+                .filter(|f| descendant_flows.contains(&f.get_parent_id()))
+                .collect();
+
+            if subtree_funcs.is_empty() {
+                if let Some(info) = self.flows.get_mut(&flow_id) {
+                    info.delegation_score = None;
+                }
+                continue;
+            }
+
+            // Check for context:// functions — cannot delegate
+            let has_context = subtree_funcs
+                .iter()
+                .any(|f| f.get_implementation_location().starts_with("context://"));
+            if has_context {
+                if let Some(info) = self.flows.get_mut(&flow_id) {
+                    info.delegation_score = None;
+                }
+                continue;
+            }
+
+            // Compute peer weight (functions + loopback bonus)
+            let peer_weight: f64 = subtree_funcs
+                .iter()
+                .map(|f| {
+                    let loopbacks = f
+                        .get_output_connections()
+                        .iter()
+                        .filter(|c| c.destination_id == f.id())
+                        .count();
+                    1.0 + loopbacks as f64 * LOOPBACK_MULTIPLIER
+                })
+                .sum();
+
+            // Balance quality: 1.0 at 50/50, 0.0 at 100/0
+            let balance_ratio = peer_weight / total_weight;
+            let balance_quality = 1.0 - 2.0 * (balance_ratio - 0.5).abs();
+
+            // Boundary connections: outputs targeting functions outside the sub-flow
+            let func_ids: HashSet<usize> = subtree_funcs.iter().map(|f| f.id()).collect();
+            let boundary_count: usize = subtree_funcs
+                .iter()
+                .flat_map(|f| f.get_output_connections().iter())
+                .filter(|c| !func_ids.contains(&c.destination_id))
+                .count()
+                + self
+                    .functions
+                    .values()
+                    .filter(|f| !func_ids.contains(&f.id()))
+                    .flat_map(|f| f.get_output_connections().iter())
+                    .filter(|c| func_ids.contains(&c.destination_id))
+                    .count();
+
+            // Nested sub-flow count (excluding the flow itself)
+            let nested_subflows = descendant_flows.len().saturating_sub(1);
+
+            // Compute score
+            let score = peer_weight * balance_quality
+                - boundary_count as f64 * BOUNDARY_WEIGHT
+                - nested_subflows as f64 * NESTING_WEIGHT;
+
+            if let Some(info) = self.flows.get_mut(&flow_id) {
+                info.delegation_score = if score > 0.0 { Some(score) } else { None };
+            }
+        }
+    }
+
     /// Collect all descendant flow IDs (including the given flow itself).
     /// Uses an iterative work list to avoid stack overflow on deep hierarchies
     /// and skips already-visited IDs to handle cycles safely.
@@ -686,6 +827,7 @@ mod test {
             process_id: 0,
             parent_id: None,
             sub_flow_ids: vec![1],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "root".into(),
             #[cfg(feature = "debugger")]
@@ -695,6 +837,7 @@ mod test {
             process_id: 1,
             parent_id: Some(0),
             sub_flow_ids: vec![],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "child".into(),
             #[cfg(feature = "debugger")]
@@ -826,6 +969,7 @@ mod test {
             process_id: 0,
             parent_id: None,
             sub_flow_ids: vec![1],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "a".into(),
             #[cfg(feature = "debugger")]
@@ -835,6 +979,7 @@ mod test {
             process_id: 1,
             parent_id: Some(0),
             sub_flow_ids: vec![0], // cycle back to root
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "b".into(),
             #[cfg(feature = "debugger")]
@@ -861,6 +1006,7 @@ mod test {
             process_id: 0,
             parent_id: None,
             sub_flow_ids: vec![1],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "root".into(),
             #[cfg(feature = "debugger")]
@@ -870,6 +1016,7 @@ mod test {
             process_id: 1,
             parent_id: Some(0),
             sub_flow_ids: vec![],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "child".into(),
             #[cfg(feature = "debugger")]
@@ -999,6 +1146,7 @@ mod test {
             process_id: 0,
             parent_id: None,
             sub_flow_ids: vec![],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "root".into(),
             #[cfg(feature = "debugger")]
@@ -1088,5 +1236,281 @@ mod test {
         let wasm_base = Url::parse("http://192.168.1.1:12345").unwrap();
         let count = manifest.rewrite_wasm_urls(&wasm_base);
         assert_eq!(count, 0, "No file:// URLs to rewrite");
+    }
+
+    #[test]
+    fn delegation_score_context_is_none() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Root flow with one child sub-flow
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "child".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/child".into(),
+        });
+
+        // Root has a lib function
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "root_fn",
+            #[cfg(feature = "debugger")]
+            "/root/root_fn",
+            "lib://flowstdlib/math/add",
+            vec![],
+            10,
+            0,
+            &[],
+            false,
+        ));
+
+        // Child sub-flow has a context:// function — should NOT be delegatable
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "ctx_fn",
+            #[cfg(feature = "debugger")]
+            "/root/child/ctx_fn",
+            "context://stdio/stdout",
+            vec![],
+            20,
+            1,
+            &[],
+            false,
+        ));
+
+        manifest.compute_delegation_scores();
+
+        // Root should have no score
+        assert_eq!(manifest.flows().get(&0).unwrap().delegation_score, None);
+        // Child with context:// should have no score
+        assert_eq!(manifest.flows().get(&1).unwrap().delegation_score, None);
+    }
+
+    #[test]
+    fn delegation_score_balanced_subflow() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Root with child sub-flow
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "child".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/child".into(),
+        });
+
+        // 3 lib functions in root, 3 lib functions in child — perfect 50/50 balance
+        for i in 0..3 {
+            manifest.add_function(RuntimeFunction::new(
+                #[cfg(feature = "debugger")]
+                format!("root_fn_{i}"),
+                #[cfg(feature = "debugger")]
+                format!("/root/root_fn_{i}"),
+                "lib://flowstdlib/math/add",
+                vec![],
+                10 + i,
+                0,
+                &[],
+                false,
+            ));
+            manifest.add_function(RuntimeFunction::new(
+                #[cfg(feature = "debugger")]
+                format!("child_fn_{i}"),
+                #[cfg(feature = "debugger")]
+                format!("/root/child/child_fn_{i}"),
+                "lib://flowstdlib/math/add",
+                vec![],
+                20 + i,
+                1,
+                &[],
+                false,
+            ));
+        }
+
+        manifest.compute_delegation_scores();
+
+        // Child sub-flow should have a positive score (balanced, no context)
+        let score = manifest.flows().get(&1).unwrap().delegation_score;
+        assert!(
+            score.is_some_and(|s| s > 0.0),
+            "Balanced sub-flow should have positive score, got {score:?}"
+        );
+    }
+
+    #[test]
+    fn delegation_score_picks_best_balanced() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        // Root with two child sub-flows
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1, 2],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        // Sub-flow 1: small (1 function out of 10 total) — unbalanced
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "small".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/small".into(),
+        });
+        // Sub-flow 2: medium (5 functions out of 10 total) — well balanced
+        manifest.add_flow_info(FlowInfo {
+            process_id: 2,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "balanced".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/balanced".into(),
+        });
+
+        // 4 functions at root level
+        for i in 0..4 {
+            manifest.add_function(RuntimeFunction::new(
+                #[cfg(feature = "debugger")]
+                format!("root_fn_{i}"),
+                #[cfg(feature = "debugger")]
+                format!("/root/root_fn_{i}"),
+                "lib://flowstdlib/math/add",
+                vec![],
+                100 + i,
+                0,
+                &[],
+                false,
+            ));
+        }
+        // 1 function in sub-flow 1
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "small_fn",
+            #[cfg(feature = "debugger")]
+            "/root/small/small_fn",
+            "lib://flowstdlib/math/add",
+            vec![],
+            10,
+            1,
+            &[],
+            false,
+        ));
+        // 5 functions in sub-flow 2
+        for i in 0..5 {
+            manifest.add_function(RuntimeFunction::new(
+                #[cfg(feature = "debugger")]
+                format!("balanced_fn_{i}"),
+                #[cfg(feature = "debugger")]
+                format!("/root/balanced/balanced_fn_{i}"),
+                "lib://flowstdlib/math/add",
+                vec![],
+                20 + i,
+                2,
+                &[],
+                false,
+            ));
+        }
+
+        manifest.compute_delegation_scores();
+
+        let score1 = manifest.flows().get(&1).unwrap().delegation_score;
+        let score2 = manifest.flows().get(&2).unwrap().delegation_score;
+
+        // Sub-flow 2 (5/10 = 50%) should score higher than sub-flow 1 (1/10 = 10%)
+        assert!(
+            score2 > score1,
+            "Balanced sub-flow should score higher: small={score1:?}, balanced={score2:?}"
+        );
+    }
+
+    #[test]
+    fn delegation_score_empty_subflow_is_none() {
+        use super::FlowInfo;
+
+        let mut manifest = FlowManifest::new(test_meta_data());
+
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![1],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "root".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root".into(),
+        });
+        manifest.add_flow_info(FlowInfo {
+            process_id: 1,
+            parent_id: Some(0),
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "empty".into(),
+            #[cfg(feature = "debugger")]
+            route: "/root/empty".into(),
+        });
+
+        // Root has one function, sub-flow has none
+        manifest.add_function(RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "root_fn",
+            #[cfg(feature = "debugger")]
+            "/root/root_fn",
+            "lib://flowstdlib/math/add",
+            vec![],
+            10,
+            0,
+            &[],
+            false,
+        ));
+
+        manifest.compute_delegation_scores();
+
+        assert_eq!(
+            manifest.flows().get(&1).unwrap().delegation_score,
+            None,
+            "Empty sub-flow should have no delegation score"
+        );
     }
 }

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -570,6 +570,11 @@ impl FlowManifest {
                 .get(&flow_id)
                 .is_some_and(|f| f.parent_id.is_none());
             if is_root {
+                // Clear any score that may have been inherited (e.g. from
+                // extract_subflow cloning a non-root FlowInfo as the new root)
+                if let Some(info) = self.flows.get_mut(&flow_id) {
+                    info.delegation_score = None;
+                }
                 continue; // root flow is never delegated
             }
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -31,7 +31,7 @@ use std::{env, thread};
 
 use clap::{Arg, ArgMatches, Command};
 use env_logger::Builder;
-use log::{error, info, trace, LevelFilter};
+use log::{error, info, trace, warn, LevelFilter};
 use portpicker::pick_unused_port;
 use simpath::Simpath;
 use url::Url;
@@ -729,22 +729,23 @@ fn client(
                 info!("No sub-flows with positive delegation scores — running locally");
             }
         } else if let Ok(flow_id) = delegate_arg.parse::<usize>() {
-            // Explicit flow ID — force delegation
-            if flow_manifest.flows().contains_key(&flow_id) {
-                let score = flow_manifest
-                    .flows()
-                    .get(&flow_id)
-                    .and_then(|info| info.delegation_score);
+            // Explicit flow ID — force delegation (must be a non-root sub-flow)
+            let flow_info = flow_manifest
+                .flows()
+                .get(&flow_id)
+                .filter(|info| info.parent_id.is_some());
+            if let Some(info) = flow_info {
+                let score = info.delegation_score;
                 info!(
                     "Forcing delegation of sub-flow #{flow_id} (score: {})",
                     score.map_or_else(|| "none".to_string(), |s| format!("{s:.2}"))
                 );
                 delegate_flow_id = Some(flow_id);
             } else {
-                info!("Sub-flow #{flow_id} not found in manifest — running locally");
+                warn!("#{flow_id} is not a delegatable sub-flow — running locally");
             }
         } else {
-            info!("Invalid --delegate argument '{delegate_arg}' — running locally");
+            warn!("Invalid --delegate argument '{delegate_arg}' — expected a flow ID; running locally");
         }
     }
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -708,49 +708,43 @@ fn client(
     let job_timeout = matches
         .get_one::<u64>("job-timeout")
         .map(|secs| Duration::from_secs(*secs));
-    // If --delegate is set, find the best sub-flow to delegate.
-    // We pick the sub-flow with the largest function subtree whose functions
-    // use only lib:// or file:// (WASM) implementations. Sub-flows containing
-    // context:// functions cannot be delegated (they interact with the local
-    // environment).
+    // If --delegate is set, select a sub-flow to delegate.
+    // With a flow ID argument: force delegation of that specific sub-flow.
+    // Without an argument: use compiler-computed delegation scores from the
+    // manifest to pick the best candidate.
     let mut delegate_flow_id = None;
-    if matches.get_flag("delegate") {
-        let mut best: Option<(usize, usize)> = None; // (flow_id, function_count)
-        for (&flow_id, flow_info) in flow_manifest.flows() {
-            if flow_info.parent_id.is_none() {
-                continue; // skip root
-            }
-            // Collect all descendant flow IDs (including this one)
-            let mut descendant_flows = vec![flow_id];
-            let mut idx = 0;
-            while let Some(&parent) = descendant_flows.get(idx) {
-                for (&child_id, child_info) in flow_manifest.flows() {
-                    if child_info.parent_id == Some(parent) && !descendant_flows.contains(&child_id)
-                    {
-                        descendant_flows.push(child_id);
-                    }
-                }
-                idx += 1;
-            }
-            // Check all functions in the subtree — reject context:// functions
-            let subtree_funcs: Vec<_> = flow_manifest
-                .functions()
-                .values()
-                .filter(|f| descendant_flows.contains(&f.get_parent_id()))
-                .collect();
-            let no_context = subtree_funcs
+    if let Some(delegate_arg) = matches.get_one::<String>("delegate") {
+        if delegate_arg.is_empty() {
+            // No flow ID specified — use manifest scores
+            let best = flow_manifest
+                .flows()
                 .iter()
-                .all(|f| !f.get_implementation_location().starts_with("context://"));
-            if no_context && !subtree_funcs.is_empty() {
-                let count = subtree_funcs.len();
-                if best.is_none_or(|(_, best_count)| count > best_count) {
-                    best = Some((flow_id, count));
-                }
+                .filter(|(_, info)| info.parent_id.is_some()) // skip root
+                .filter_map(|(&id, info)| info.delegation_score.map(|s| (id, s)))
+                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            if let Some((flow_id, score)) = best {
+                info!("Will delegate sub-flow #{flow_id} (score: {score:.2})");
+                delegate_flow_id = Some(flow_id);
+            } else {
+                info!("No sub-flows with positive delegation scores — running locally");
             }
-        }
-        if let Some((flow_id, count)) = best {
-            info!("Will delegate sub-flow #{flow_id} ({count} functions)");
-            delegate_flow_id = Some(flow_id);
+        } else if let Ok(flow_id) = delegate_arg.parse::<usize>() {
+            // Explicit flow ID — force delegation
+            if flow_manifest.flows().contains_key(&flow_id) {
+                let score = flow_manifest
+                    .flows()
+                    .get(&flow_id)
+                    .and_then(|info| info.delegation_score);
+                info!(
+                    "Forcing delegation of sub-flow #{flow_id} (score: {})",
+                    score.map_or_else(|| "none".to_string(), |s| format!("{s:.2}"))
+                );
+                delegate_flow_id = Some(flow_id);
+            } else {
+                info!("Sub-flow #{flow_id} not found in manifest — running locally");
+            }
+        } else {
+            info!("Invalid --delegate argument '{delegate_arg}' — running locally");
         }
     }
 
@@ -920,8 +914,15 @@ fn get_matches() -> ArgMatches {
     let app = app.arg(
         Arg::new("delegate")
             .long("delegate")
-            .action(clap::ArgAction::SetTrue)
-            .help("Delegate sub-flows to peer coordinators on the network"),
+            .num_args(0..=1)
+            .default_missing_value("")
+            .require_equals(true)
+            .value_name("FLOW_ID")
+            .help(
+                "Delegate a sub-flow to a peer coordinator. Without an argument, \
+                   selects the best sub-flow using compiler-computed scores. \
+                   With --delegate=<flow_id>, forces delegation of that specific sub-flow.",
+            ),
     );
 
     app.get_matches()

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -420,6 +420,21 @@ impl<'a> Coordinator<'a> {
             .delegate_subflow(flow_id)
             .map_err(|e| format!("Could not delegate sub-flow #{flow_id}: {e}"))?;
 
+        // Reject sub-flows containing context:// functions — these interact
+        // with the local environment and cannot run on a remote peer.
+        let context_count = extracted
+            .functions()
+            .values()
+            .filter(|f| f.get_implementation_location().starts_with("context://"))
+            .count();
+        if context_count > 0 {
+            return Err(format!(
+                "Cannot delegate sub-flow #{flow_id}: it contains {context_count} context:// \
+                 function(s) that must run locally"
+            )
+            .into());
+        }
+
         // Rewrite file:// WASM URLs to http:// so the peer can fetch them
         // from this coordinator's WASM HTTP server
         if let Some(ref base_url) = self.wasm_base_url {

--- a/flowr/src/lib/trace.rs
+++ b/flowr/src/lib/trace.rs
@@ -173,6 +173,7 @@ mod test {
             process_id: 0,
             parent_id: None,
             sub_flow_ids: vec![],
+            delegation_score: None,
             #[cfg(feature = "debugger")]
             name: "root".to_string(),
             #[cfg(feature = "debugger")]

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -260,6 +260,7 @@ fn subflow_implementation_executes() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "test".into(),
         #[cfg(feature = "debugger")]
@@ -334,6 +335,7 @@ fn subflow_implementation_with_injected_inputs() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "test".into(),
         #[cfg(feature = "debugger")]
@@ -419,6 +421,7 @@ fn subflow_captures_boundary_outputs() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![1],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "root".into(),
         #[cfg(feature = "debugger")]
@@ -428,6 +431,7 @@ fn subflow_captures_boundary_outputs() {
         process_id: 1,
         parent_id: Some(0),
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "child".into(),
         #[cfg(feature = "debugger")]
@@ -558,6 +562,7 @@ fn executor_registers_subflow_manifest() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "test".into(),
         #[cfg(feature = "debugger")]
@@ -591,6 +596,7 @@ fn peer_coordinator_executes_subflow() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "subflow".into(),
         #[cfg(feature = "debugger")]
@@ -766,6 +772,7 @@ fn peer_coordinator_streams_boundary_outputs() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "subflow".into(),
         #[cfg(feature = "debugger")]
@@ -954,6 +961,7 @@ fn peer_coordinator_executes_wasm_subflow() {
         process_id: 0,
         parent_id: None,
         sub_flow_ids: vec![],
+        delegation_score: None,
         #[cfg(feature = "debugger")]
         name: "wasm_subflow".into(),
         #[cfg(feature = "debugger")]


### PR DESCRIPTION
## Summary

Closes #3004

Replaces the "largest function count" delegation heuristic with a **compiler-computed delegation score** stored in the manifest as a hint for the runtime.

### Design Principles

- **Compiler computes, runtime decides**: The compiler analyzes each sub-flow and computes a score stored in `FlowInfo.delegation_score` in the manifest. The runtime can follow or ignore these hints.
- **Balance-aware**: The score penalizes unbalanced partitions. A sub-flow that would put 90% of compute on the peer and leave the root nearly idle scores lower than one achieving a 50/50 split.
- **Force override for testing**: `--delegate=<flow_id>` forces delegation of a specific sub-flow, bypassing score checks.

### Score Formula

```
peer_weight = function_count + loopback_count * 2.0
total_weight = sum of all function weights
balance_quality = 1.0 - 2.0 * abs(peer_weight/total_weight - 0.5)

score = peer_weight * balance_quality
        - boundary_connections * 0.5
        - nested_subflows * 1.0
```

Sub-flows with `context://` functions or non-positive scores get `None`.

### Score Factors

| Factor | Signal | Effect |
|--------|--------|--------|
| Function count | More compute to offload | Positive |
| Loopback connections | Iterative functions execute many times | Positive (2x multiplier) |
| Balance quality | How close to 50/50 root/peer split | Multiplier (1.0 at 50/50, 0.0 at 100/0) |
| Boundary connections | ZMQ overhead per message | Negative (-0.5 each) |
| Nested sub-flows | Only one instance runs at a time | Negative (-1.0 each) |
| Contains context:// | Must stay on root | Score = None |

### CLI Changes

- `--delegate` (no argument): Selects the sub-flow with the highest score
- `--delegate=<flow_id>`: Forces delegation of a specific sub-flow (for testing/demo)

### Files Changed

| File | Change |
|------|--------|
| `flowcore/src/model/flow_manifest.rs` | Added `delegation_score: Option<f64>` to `FlowInfo`; added `compute_delegation_scores()` method; 4 unit tests |
| `flowc/src/lib/generator/generate.rs` | Calls `compute_delegation_scores()` after manifest generation |
| `flowr/src/bin/flowrcli/main.rs` | `--delegate` accepts optional `=flow_id`; uses manifest scores for selection |
| `flowr/src/lib/trace.rs`, `flowr/tests/subflow.rs` | Added `delegation_score: None` to all `FlowInfo` constructions |

### Testing

- 4 new unit tests: `delegation_score_context_is_none`, `delegation_score_balanced_subflow`, `delegation_score_picks_best_balanced`, `delegation_score_empty_subflow_is_none`
- All existing tests pass (`make test`, `make clippy`, `cargo fmt`)
- The E2E delegation test (`test_delegate_to_peer_flowrcli`) passes with the new score-based selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegation scoring for eligible sub-flows based on flow complexity, structure, and delegation constraints.
  * Delegation can now automatically select the highest-scoring sub-flow when no flow ID is provided.
  * Added support for explicitly selecting a sub-flow by ID.

* **Bug Fixes**
  * Invalid, missing, or malformed delegation selections now safely fall back to local execution.
  * Root, empty, context-backed, and otherwise unsuitable flows are excluded from delegation scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->