### PR TITLE
Batch boundary outputs in a single ZMQ message

### DIFF
--- a/flowr/src/lib/peer_client.rs
+++ b/flowr/src/lib/peer_client.rs
@@ -81,11 +81,24 @@ impl PeerClient {
             .send(json.as_bytes(), 0)
             .map_err(|e| format!("Could not send to peer: {e}"))?;
 
+        // The Completed response arrives only after the whole sub-flow has
+        // executed, so disable the receive timeout for this call. The
+        // 30-second timeout set in connect() is kept for signal_done().
+        self.socket
+            .set_rcvtimeo(-1)
+            .map_err(|e| format!("Could not clear receive timeout: {e}"))?;
+
         // Receive the single Completed response with all boundary outputs
         let msg = self
             .socket
             .recv_msg(0)
             .map_err(|e| format!("Could not receive from peer: {e}"))?;
+
+        // Restore the 30-second timeout for subsequent operations
+        self.socket
+            .set_rcvtimeo(30_000)
+            .map_err(|e| format!("Could not restore receive timeout: {e}"))?;
+
         let msg_str = msg
             .as_str()
             .ok_or("Could not convert peer response to string")?;
@@ -107,12 +120,16 @@ impl PeerClient {
                     .collect())
             }
             PeerResponse::Error(msg) => Err(format!("Peer coordinator error: {msg}").into()),
-            PeerResponse::DoneAck => Ok(Vec::new()),
+            PeerResponse::DoneAck => {
+                Err("Peer returned DoneAck in response to Submit; protocol out of step".into())
+            }
         }
     }
 
-    /// Submit a sub-flow and invoke a callback for each boundary output
-    /// as it arrives, rather than collecting them all.
+    /// Submit a sub-flow for execution and invoke a callback for each
+    /// boundary output. The peer executes the sub-flow and returns all
+    /// boundary outputs in a single batched `Completed` message. The
+    /// callback is invoked once per output from the batch.
     ///
     /// `wasm_base_url` is the base URL of the parent's WASM HTTP server,
     /// passed to the peer for potential further delegation.
@@ -121,7 +138,7 @@ impl PeerClient {
     ///
     /// Returns an error if the submission fails, a response cannot be
     /// parsed, or the callback returns an error.
-    pub fn submit_subflow_streaming<F>(
+    pub fn submit_subflow_for_each<F>(
         &self,
         manifest: FlowManifest,
         inputs: Vec<(usize, usize, Value)>,
@@ -143,11 +160,22 @@ impl PeerClient {
             .send(json.as_bytes(), 0)
             .map_err(|e| format!("Could not send to peer: {e}"))?;
 
-        // Receive the single Completed response with all boundary outputs
+        // The Completed response arrives only after the whole sub-flow has
+        // executed, so disable the receive timeout for this call.
+        self.socket
+            .set_rcvtimeo(-1)
+            .map_err(|e| format!("Could not clear receive timeout: {e}"))?;
+
         let msg = self
             .socket
             .recv_msg(0)
             .map_err(|e| format!("Could not receive from peer: {e}"))?;
+
+        // Restore the 30-second timeout for subsequent operations
+        self.socket
+            .set_rcvtimeo(30_000)
+            .map_err(|e| format!("Could not restore receive timeout: {e}"))?;
+
         let msg_str = msg
             .as_str()
             .ok_or("Could not convert peer response to string")?;
@@ -162,14 +190,13 @@ impl PeerClient {
                         value: entry.value,
                     })?;
                 }
+                Ok(())
             }
-            PeerResponse::DoneAck => {}
-            PeerResponse::Error(msg) => {
-                return Err(format!("Peer coordinator error: {msg}").into());
+            PeerResponse::Error(msg) => Err(format!("Peer coordinator error: {msg}").into()),
+            PeerResponse::DoneAck => {
+                Err("Peer returned DoneAck in response to Submit; protocol out of step".into())
             }
         }
-
-        Ok(())
     }
 
     /// Signal the peer coordinator that the parent flow is done.

--- a/flowr/src/lib/peer_client.rs
+++ b/flowr/src/lib/peer_client.rs
@@ -5,7 +5,7 @@
 
 use flowcore::errors::Result;
 use flowcore::model::flow_manifest::FlowManifest;
-use log::{debug, info};
+use log::info;
 use serde_json::Value;
 
 use crate::peer_protocol::{PeerRequest, PeerResponse, SubflowSubmission};
@@ -81,48 +81,34 @@ impl PeerClient {
             .send(json.as_bytes(), 0)
             .map_err(|e| format!("Could not send to peer: {e}"))?;
 
-        // Receive responses until Idle or Error
-        let mut boundary_outputs = Vec::new();
-        loop {
-            let msg = self
-                .socket
-                .recv_msg(0)
-                .map_err(|e| format!("Could not receive from peer: {e}"))?;
-            let msg_str = msg
-                .as_str()
-                .ok_or("Could not convert peer response to string")?;
-            let response: PeerResponse = serde_json::from_str(msg_str)
-                .map_err(|e| format!("Could not deserialize peer response: {e}"))?;
+        // Receive the single Completed response with all boundary outputs
+        let msg = self
+            .socket
+            .recv_msg(0)
+            .map_err(|e| format!("Could not receive from peer: {e}"))?;
+        let msg_str = msg
+            .as_str()
+            .ok_or("Could not convert peer response to string")?;
+        let response: PeerResponse = serde_json::from_str(msg_str)
+            .map_err(|e| format!("Could not deserialize peer response: {e}"))?;
 
-            match response {
-                PeerResponse::BoundaryOutput { connection, value } => {
-                    debug!(
-                        "Peer boundary output: -> #{}:{}",
-                        connection.destination_id, connection.destination_io_number
-                    );
-                    boundary_outputs.push(BoundaryOutput { connection, value });
-                    // Acknowledge so peer can send next output (REQ/REP pattern)
-                    self.socket
-                        .send("ack".as_bytes(), 0)
-                        .map_err(|e| format!("Could not send ack: {e}"))?;
-                }
-                PeerResponse::Idle => {
-                    info!(
-                        "Peer sub-flow idle ({} boundary outputs)",
-                        boundary_outputs.len()
-                    );
-                    break;
-                }
-                PeerResponse::Error(msg) => {
-                    return Err(format!("Peer coordinator error: {msg}").into());
-                }
-                PeerResponse::DoneAck => {
-                    break;
-                }
+        match response {
+            PeerResponse::Completed(batch) => {
+                info!(
+                    "Peer sub-flow completed with {} boundary outputs",
+                    batch.len()
+                );
+                Ok(batch
+                    .into_iter()
+                    .map(|entry| BoundaryOutput {
+                        connection: entry.connection,
+                        value: entry.value,
+                    })
+                    .collect())
             }
+            PeerResponse::Error(msg) => Err(format!("Peer coordinator error: {msg}").into()),
+            PeerResponse::DoneAck => Ok(Vec::new()),
         }
-
-        Ok(boundary_outputs)
     }
 
     /// Submit a sub-flow and invoke a callback for each boundary output
@@ -157,28 +143,29 @@ impl PeerClient {
             .send(json.as_bytes(), 0)
             .map_err(|e| format!("Could not send to peer: {e}"))?;
 
-        loop {
-            let msg = self
-                .socket
-                .recv_msg(0)
-                .map_err(|e| format!("Could not receive from peer: {e}"))?;
-            let msg_str = msg
-                .as_str()
-                .ok_or("Could not convert peer response to string")?;
-            let response: PeerResponse = serde_json::from_str(msg_str)
-                .map_err(|e| format!("Could not deserialize peer response: {e}"))?;
+        // Receive the single Completed response with all boundary outputs
+        let msg = self
+            .socket
+            .recv_msg(0)
+            .map_err(|e| format!("Could not receive from peer: {e}"))?;
+        let msg_str = msg
+            .as_str()
+            .ok_or("Could not convert peer response to string")?;
+        let response: PeerResponse = serde_json::from_str(msg_str)
+            .map_err(|e| format!("Could not deserialize peer response: {e}"))?;
 
-            match response {
-                PeerResponse::BoundaryOutput { connection, value } => {
-                    on_boundary_output(BoundaryOutput { connection, value })?;
-                    self.socket
-                        .send("ack".as_bytes(), 0)
-                        .map_err(|e| format!("Could not send ack: {e}"))?;
+        match response {
+            PeerResponse::Completed(batch) => {
+                for entry in batch {
+                    on_boundary_output(BoundaryOutput {
+                        connection: entry.connection,
+                        value: entry.value,
+                    })?;
                 }
-                PeerResponse::Idle | PeerResponse::DoneAck => break,
-                PeerResponse::Error(msg) => {
-                    return Err(format!("Peer coordinator error: {msg}").into());
-                }
+            }
+            PeerResponse::DoneAck => {}
+            PeerResponse::Error(msg) => {
+                return Err(format!("Peer coordinator error: {msg}").into());
             }
         }
 

--- a/flowr/src/lib/peer_protocol.rs
+++ b/flowr/src/lib/peer_protocol.rs
@@ -35,23 +35,24 @@ pub struct SubflowSubmission {
 /// Messages sent from peer coordinator back to parent coordinator.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PeerResponse {
-    /// A value produced at a boundary connection, destined for a function
-    /// in the parent flow.
-    BoundaryOutput {
-        /// The output connection that produced this value (contains
-        /// `destination_id`, `destination_io_number`, etc.)
-        connection: OutputConnection,
-        /// The value produced
-        value: Value,
-    },
-
-    /// The sub-flow has processed all current inputs and is idle.
-    /// The parent can send more inputs or signal Done.
-    Idle,
+    /// The sub-flow has completed and produced boundary outputs.
+    /// All outputs are batched in a single message to avoid per-output
+    /// ZMQ round-trip overhead. An empty vec means no boundary outputs.
+    Completed(Vec<BoundaryOutputEntry>),
 
     /// An error occurred during sub-flow execution.
     Error(String),
 
     /// Acknowledgement that the peer received the Done signal.
     DoneAck,
+}
+
+/// A single boundary output entry within a batch.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BoundaryOutputEntry {
+    /// The output connection that produced this value (contains
+    /// `destination_id`, `destination_io_number`, etc.)
+    pub connection: OutputConnection,
+    /// The value produced
+    pub value: Value,
 }

--- a/flowr/src/lib/peer_submission_handler.rs
+++ b/flowr/src/lib/peer_submission_handler.rs
@@ -49,27 +49,22 @@ impl PeerSubmissionHandler {
         Ok(())
     }
 
-    /// Send boundary outputs back to the parent coordinator.
+    /// Send all boundary outputs to the parent coordinator in a single
+    /// `Completed` message, avoiding per-output ZMQ round-trip overhead.
+    /// This also signals that the sub-flow execution is complete (idle).
     ///
     /// # Errors
     ///
-    /// Returns an error if any output cannot be serialized or sent.
-    pub fn relay_boundary_outputs(&self, outputs: &[BoundaryOutput]) -> Result<()> {
-        for output in outputs {
-            self.send_response(&PeerResponse::BoundaryOutput {
-                connection: output.connection.clone(),
-                value: output.value.clone(),
-            })?;
-            // After each send on REP, we need to receive before sending again.
-            // REP socket requires strict recv-send-recv-send alternation.
-            // For streaming, we'd need DEALER/ROUTER instead.
-            // For now, the parent must acknowledge each output.
-            let _ack = self
-                .socket
-                .recv_msg(0)
-                .map_err(|e| format!("Could not receive ack: {e}"))?;
-        }
-        Ok(())
+    /// Returns an error if the message cannot be serialized or sent.
+    fn send_completed(&self, outputs: &[BoundaryOutput]) -> Result<()> {
+        let batch: Vec<crate::peer_protocol::BoundaryOutputEntry> = outputs
+            .iter()
+            .map(|o| crate::peer_protocol::BoundaryOutputEntry {
+                connection: o.connection.clone(),
+                value: o.value.clone(),
+            })
+            .collect();
+        self.send_response(&PeerResponse::Completed(batch))
     }
 }
 
@@ -91,18 +86,13 @@ impl SubmissionHandler for PeerSubmissionHandler {
     ) -> Result<()> {
         debug!("Peer coordinator: flow execution ended");
 
-        // Relay boundary outputs to parent before signaling idle
+        // Send all boundary outputs + completion signal in a single message
         let outputs = state.boundary_outputs();
-        if !outputs.is_empty() {
-            info!(
-                "Peer coordinator relaying {} boundary outputs",
-                outputs.len()
-            );
-            self.relay_boundary_outputs(outputs)?;
-        }
-
-        // Signal idle to parent
-        self.send_response(&PeerResponse::Idle)?;
+        info!(
+            "Peer coordinator completed with {} boundary outputs",
+            outputs.len()
+        );
+        self.send_completed(outputs)?;
         Ok(())
     }
 

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -234,7 +234,7 @@ impl RemoteSubFlowImplementation {
             .map_err(|e| format!("Could not connect to peer at {}: {e}", self.peer_address))?;
 
         let mut output_count = 0usize;
-        let stream_result = client.submit_subflow_streaming(
+        let stream_result = client.submit_subflow_for_each(
             self.manifest.clone(),
             input_triples,
             None,

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -753,7 +753,7 @@ fn peer_coordinator_executes_subflow() {
 
 /// Test streaming boundary outputs from a peer coordinator.
 /// Same setup as `peer_coordinator_executes_subflow` but uses
-/// `submit_subflow_streaming` to verify results arrive individually.
+/// `submit_subflow_for_each` to verify results are delivered via callback.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 #[allow(clippy::too_many_lines)]
@@ -898,7 +898,7 @@ fn peer_coordinator_streams_boundary_outputs() {
 
     let mut streamed_outputs = Vec::new();
     client
-        .submit_subflow_streaming(manifest, vec![], None, |bo| {
+        .submit_subflow_for_each(manifest, vec![], None, |bo| {
             streamed_outputs.push(bo);
             Ok(())
         })


### PR DESCRIPTION
## Summary

Closes #3013

Replaces the per-output synchronous REQ/REP round-trip protocol with a single batched `Completed` message containing all boundary outputs.

### Before (per-output protocol)

For N boundary outputs:
1. Peer sends `BoundaryOutput` (1 output)
2. Parent receives it
3. Parent sends `"ack"`
4. Peer receives ack
5. Repeat N times
6. Peer sends `Idle`

**Total: N * 4 + 2 ZMQ messages**

### After (batched protocol)

1. Peer sends `Completed(Vec<BoundaryOutputEntry>)` (all outputs + completion signal)
2. Parent receives it

**Total: 2 ZMQ messages** (regardless of output count)

### Protocol Changes

| Old | New |
|-----|-----|
| `PeerResponse::BoundaryOutput { connection, value }` | Removed |
| `PeerResponse::Idle` | Removed |
| (none) | `PeerResponse::Completed(Vec<BoundaryOutputEntry>)` |

The `Completed` variant combines the boundary output batch and the idle signal into a single message, respecting the REQ/REP socket pattern (one send per recv).

### Files Changed

| File | Change |
|------|--------|
| `flowr/src/lib/peer_protocol.rs` | Replace `BoundaryOutput` + `Idle` with `Completed(Vec<BoundaryOutputEntry>)` |
| `flowr/src/lib/peer_submission_handler.rs` | Replace per-output `relay_boundary_outputs` with batched `send_completed` |
| `flowr/src/lib/peer_client.rs` | Simplify from loop+ack to single receive; remove `debug` import |

### Net impact: -22 lines (simpler code + better performance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Sub-flow results are now delivered together in a single completion response, improving consistency and reducing communication overhead.
  - Batch processing collects all boundary outputs before reporting completion.
  - Streaming workflows continue to receive each output individually through callbacks using the updated submission interface.
  - Completion and error handling remain supported, with clearer reporting of the number of outputs produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->