### PR TITLE
Multi-sub-flow delegation to multiple peers (Phase 2 of #3019)

### DIFF
--- a/flowcore/src/model/submission.rs
+++ b/flowcore/src/model/submission.rs
@@ -28,16 +28,16 @@ pub struct Submission {
     /// Function IDs that have been delegated to a peer coordinator.
     #[serde(default)]
     pub delegated_functions: std::collections::HashSet<usize>,
-    /// Sub-flow ID to delegate via `SubFlowImplementation`.
+    /// Sub-flow IDs to delegate to peer coordinators.
     #[serde(default)]
-    pub delegate_flow_id: Option<usize>,
+    pub delegate_flow_ids: Vec<usize>,
     /// Preserved extracted sub-flow manifests, keyed by flow ID.
     /// These are kept so the original manifest can be reconstituted if needed.
     #[serde(default)]
     pub extracted_subflows: std::collections::HashMap<usize, FlowManifest>,
-    /// Address of a discovered peer coordinator for remote sub-flow delegation.
+    /// Peer coordinator addresses for delegation, keyed by flow ID.
     #[serde(default)]
-    pub peer_address: Option<String>,
+    pub peer_addresses: std::collections::HashMap<usize, String>,
 }
 
 impl Submission {
@@ -66,9 +66,9 @@ impl Submission {
             trace_file,
             is_subflow: false,
             delegated_functions: std::collections::HashSet::new(),
-            delegate_flow_id: None,
+            delegate_flow_ids: Vec::new(),
             extracted_subflows: std::collections::HashMap::new(),
-            peer_address: None,
+            peer_addresses: std::collections::HashMap::new(),
         }
     }
 }

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -311,6 +311,10 @@ fn client_and_coordinator(
     let blocking_io_client_connection =
         ClientConnection::new(&format!("localhost:{blocking_io_port}"))?;
 
+    let own_peer_instance = format!(
+        "{PEER_COORDINATOR_SERVICE_NAME}-{}-{runtime_port}",
+        std::process::id()
+    );
     let result = client(
         matches,
         lib_search_path,
@@ -318,6 +322,7 @@ fn client_and_coordinator(
         blocking_io_client_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
+        Some(&own_peer_instance),
     );
 
     let _ = coordinator_handle.join();
@@ -705,6 +710,7 @@ fn client_only(
         blocking_io_connection,
         #[cfg(feature = "debugger")]
         debug_this_flow,
+        None, // no local coordinator to filter from peer discovery
     )
 }
 
@@ -716,6 +722,7 @@ fn client(
     client_connection: ClientConnection,
     blocking_io_connection: ClientConnection,
     #[cfg(feature = "debugger")] debug_this_flow: bool,
+    own_peer_instance: Option<&str>,
 ) -> Result<()> {
     let override_args = Arc::new(Mutex::new(Vec::<String>::new()));
 
@@ -730,25 +737,27 @@ fn client(
     let job_timeout = matches
         .get_one::<u64>("job-timeout")
         .map(|secs| Duration::from_secs(*secs));
-    // If --delegate is set, select a sub-flow to delegate.
+    // If --delegate is set, select sub-flow(s) to delegate.
     // With a flow ID argument: force delegation of that specific sub-flow.
     // Without an argument: use compiler-computed delegation scores from the
-    // manifest to pick the best candidate.
-    let mut delegate_flow_id = None;
+    // manifest to pick candidates, up to the number of available peers.
+    let mut delegate_flow_ids: Vec<usize> = Vec::new();
     if let Some(delegate_arg) = matches.get_one::<String>("delegate") {
         if delegate_arg.is_empty() {
-            // No flow ID specified — use manifest scores
-            let best = flow_manifest
+            // No flow ID specified — collect all candidates sorted by score (descending)
+            let mut candidates: Vec<(usize, f64)> = flow_manifest
                 .flows()
                 .iter()
                 .filter(|(_, info)| info.parent_id.is_some()) // skip root
                 .filter_map(|(&id, info)| info.delegation_score.map(|s| (id, s)))
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            if let Some((flow_id, score)) = best {
-                info!("Will delegate sub-flow #{flow_id} (score: {score:.2})");
-                delegate_flow_id = Some(flow_id);
-            } else {
+                .collect();
+            candidates
+                .sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+            delegate_flow_ids = candidates.iter().map(|(id, _)| *id).collect();
+            if delegate_flow_ids.is_empty() {
                 info!("No sub-flows with positive delegation scores — running locally");
+            } else {
+                info!("Found {} delegation candidate(s)", delegate_flow_ids.len());
             }
         } else if let Ok(flow_id) = delegate_arg.parse::<usize>() {
             // Explicit flow ID — force delegation (must be a non-root sub-flow)
@@ -762,7 +771,7 @@ fn client(
                     "Forcing delegation of sub-flow #{flow_id} (score: {})",
                     score.map_or_else(|| "none".to_string(), |s| format!("{s:.2}"))
                 );
-                delegate_flow_id = Some(flow_id);
+                delegate_flow_ids.push(flow_id);
             } else {
                 warn!("#{flow_id} is not a delegatable sub-flow — running locally");
             }
@@ -783,16 +792,28 @@ fn client(
             .map(std::string::ToString::to_string),
     );
 
-    // Only delegate if a peer coordinator is available — otherwise run normally
-    if let Some(flow_id) = delegate_flow_id {
-        match flowrlib::peer_discovery::discover_peer_coordinators(Duration::from_secs(3), None) {
+    // Discover peers and assign sub-flows to them (one sub-flow per peer)
+    if !delegate_flow_ids.is_empty() {
+        match flowrlib::peer_discovery::discover_peer_coordinators(
+            Duration::from_secs(3),
+            own_peer_instance,
+        ) {
             Ok(peers) => {
-                if let Some(addr) = peers.into_iter().next() {
-                    info!("Discovered peer coordinator at {addr} — delegating sub-flow #{flow_id}");
-                    submission.delegate_flow_id = Some(flow_id);
-                    submission.peer_address = Some(addr);
-                } else {
+                if peers.is_empty() {
                     info!("No peer coordinators found — running flow normally");
+                } else {
+                    // Assign sub-flows to peers: one per peer, up to the
+                    // number of available peers or candidates (whichever is smaller)
+                    for (flow_id, addr) in delegate_flow_ids.iter().zip(peers.iter()) {
+                        info!("Will delegate sub-flow #{flow_id} to peer at {addr}");
+                        submission.delegate_flow_ids.push(*flow_id);
+                        submission.peer_addresses.insert(*flow_id, addr.clone());
+                    }
+                    info!(
+                        "Delegating {} sub-flow(s) to {} peer(s)",
+                        submission.delegate_flow_ids.len(),
+                        peers.len()
+                    );
                 }
             }
             Err(e) => info!("Peer discovery failed ({e}) — running flow normally"),

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -799,15 +799,28 @@ fn client(
             own_peer_instance,
         ) {
             Ok(peers) => {
-                if peers.is_empty() {
+                // Deduplicate peers by port — a peer on multiple network
+                // interfaces shows up as multiple addresses with the same port
+                let mut seen_ports = std::collections::HashSet::new();
+                let unique_peers: Vec<&String> = peers
+                    .iter()
+                    .filter(|addr| {
+                        let port = addr
+                            .rsplit_once(':')
+                            .and_then(|(_, p)| p.parse::<u16>().ok());
+                        port.is_some_and(|p| seen_ports.insert(p))
+                    })
+                    .collect();
+
+                if unique_peers.is_empty() {
                     info!("No peer coordinators found — running flow normally");
                 } else {
                     // Assign sub-flows to peers: one per peer, up to the
                     // number of available peers or candidates (whichever is smaller)
-                    for (flow_id, addr) in delegate_flow_ids.iter().zip(peers.iter()) {
+                    for (flow_id, addr) in delegate_flow_ids.iter().zip(unique_peers.iter()) {
                         info!("Will delegate sub-flow #{flow_id} to peer at {addr}");
                         submission.delegate_flow_ids.push(*flow_id);
-                        submission.peer_addresses.insert(*flow_id, addr.clone());
+                        submission.peer_addresses.insert(*flow_id, (*addr).clone());
                     }
                     info!(
                         "Delegating {} sub-flow(s) to {} peer(s)",

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -45,8 +45,7 @@ pub struct Coordinator<'a> {
     /// URLs in job payloads are rewritten to `http://` URLs so remote executors
     /// can fetch WASM modules.
     wasm_base_url: Option<url::Url>,
-    /// Address of the peer coordinator for delegated sub-flow communication.
-    peer_address: Option<String>,
+
     /// Shared sub-flow manifest registry from the executor.
     subflow_registry: Option<crate::executor::SubflowRegistry>,
     #[cfg(feature = "debugger")]
@@ -191,7 +190,7 @@ impl<'a> Coordinator<'a> {
             dispatcher,
             job_timeout: None,
             wasm_base_url: None,
-            peer_address: None,
+
             subflow_registry: None,
             #[cfg(feature = "debugger")]
             debugger: Debugger::new(debug_server),
@@ -205,11 +204,6 @@ impl<'a> Coordinator<'a> {
     /// remote executors can fetch WASM modules.
     pub fn set_wasm_base_url(&mut self, base_url: url::Url) {
         self.wasm_base_url = Some(base_url);
-    }
-
-    /// Set the peer address for delegated sub-flow communication.
-    pub fn set_peer_address(&mut self, address: String) {
-        self.peer_address = Some(address);
     }
 
     /// Set the sub-flow registry shared with the executor.
@@ -280,14 +274,6 @@ impl<'a> Coordinator<'a> {
         Ok(state)
     }
 
-    /// Record the peer coordinator address for delegation.
-    fn record_peer_address(&mut self, peer_addr: &str) {
-        if self.peer_address.as_deref() != Some(peer_addr) {
-            info!("Will delegate sub-flows to peer at {peer_addr}");
-            self.peer_address = Some(peer_addr.to_string());
-        }
-    }
-
     /// Execute a flow by looping while there are jobs to be processed.
     ///
     /// The outer loop exists for the debugger: it allows resetting all state and restarting
@@ -298,14 +284,14 @@ impl<'a> Coordinator<'a> {
     /// Returns an error if the execution of the flow did not complete normally.
     #[allow(unused_variables, unused_mut)]
     pub fn execute_flow(&mut self, mut submission: Submission) -> Result<()> {
-        // Record the discovered peer coordinator address for delegation
-        if let Some(ref peer_addr) = submission.peer_address.clone() {
-            self.record_peer_address(peer_addr);
-        }
-
-        // Handle sub-flow delegation if requested
-        if let Some(flow_id) = submission.delegate_flow_id.take() {
-            self.setup_delegation(flow_id, &mut submission)?;
+        // Handle sub-flow delegation for each flow_id/peer pair
+        let flow_ids = std::mem::take(&mut submission.delegate_flow_ids);
+        let peer_addrs = std::mem::take(&mut submission.peer_addresses);
+        for flow_id in &flow_ids {
+            if let Some(peer_addr) = peer_addrs.get(flow_id) {
+                info!("Delegating sub-flow #{flow_id} to peer at {peer_addr}");
+                self.setup_delegation(*flow_id, peer_addr, &mut submission)?;
+            }
         }
 
         self.job_timeout = submission.job_timeout;
@@ -396,7 +382,12 @@ impl<'a> Coordinator<'a> {
     /// Extract a sub-flow from the submission, rewrite WASM URLs for remote
     /// access, and register it in the sub-flow registry for delegation to
     /// a peer coordinator.
-    fn setup_delegation(&self, flow_id: usize, submission: &mut Submission) -> Result<()> {
+    fn setup_delegation(
+        &self,
+        flow_id: usize,
+        peer_addr: &str,
+        submission: &mut Submission,
+    ) -> Result<()> {
         let registry = self
             .subflow_registry
             .as_ref()
@@ -455,16 +446,15 @@ impl<'a> Coordinator<'a> {
             "Registered sub-flow #{flow_id} with {} functions",
             extracted.functions().len()
         );
-        let peer_addr = self
-            .peer_address
-            .clone()
-            .ok_or("Sub-flow delegation requires a peer coordinator address")?;
         info!("Sub-flow #{flow_id} will be executed on remote peer at {peer_addr}");
         // Preserve the extracted manifest for possible reconstitution
         submission
             .extracted_subflows
             .insert(flow_id, extracted.clone());
-        manifests.insert(subflow_url, (extracted, input_map, Some(peer_addr)));
+        manifests.insert(
+            subflow_url,
+            (extracted, input_map, Some(peer_addr.to_string())),
+        );
         Ok(())
     }
 
@@ -540,7 +530,7 @@ impl<'a> Coordinator<'a> {
 
             // Send any values destined for delegated functions to the peer
             // and receive boundary outputs back into the local flow
-            if self.peer_address.is_some() {
+            if state.has_delegated_functions() {
                 let peer_outputs = state.drain_peer_outputs();
                 if !peer_outputs.is_empty() {
                     info!("Sending {} values to peer coordinator", peer_outputs.len());
@@ -1182,10 +1172,12 @@ mod test {
             &mut debug_server,
         );
 
-        // Set peer_address but no subflow_registry → should fail
+        // Set peer_addresses but no subflow_registry → should fail
         let mut submission = test_submission(vec![]);
-        submission.delegate_flow_id = Some(1);
-        submission.peer_address = Some("127.0.0.1:9999".to_string());
+        submission.delegate_flow_ids = vec![1];
+        submission
+            .peer_addresses
+            .insert(1, "127.0.0.1:9999".to_string());
         let result = coordinator.execute_flow(submission);
         assert!(
             result.is_err(),
@@ -1218,10 +1210,12 @@ mod test {
         coordinator.set_subflow_registry(executor.subflow_registry());
 
         let mut submission = test_submission(vec![]);
-        submission.delegate_flow_id = Some(1);
-        // No peer_address set → connect_to_peer not called
+        submission.delegate_flow_ids = vec![1];
+        submission
+            .peer_addresses
+            .insert(1, "127.0.0.1:9999".to_string());
         // delegate_subflow will fail because flow_id 1 doesn't exist
-        // in the empty manifest, but that's the first error hit
+        // in the empty manifest
         let result = coordinator.execute_flow(submission);
         assert!(
             result.is_err(),

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -288,10 +288,11 @@ impl<'a> Coordinator<'a> {
         let flow_ids = std::mem::take(&mut submission.delegate_flow_ids);
         let peer_addrs = std::mem::take(&mut submission.peer_addresses);
         for flow_id in &flow_ids {
-            if let Some(peer_addr) = peer_addrs.get(flow_id) {
-                info!("Delegating sub-flow #{flow_id} to peer at {peer_addr}");
-                self.setup_delegation(*flow_id, peer_addr, &mut submission)?;
-            }
+            let peer_addr = peer_addrs.get(flow_id).ok_or_else(|| {
+                format!("Sub-flow #{flow_id} requested for delegation but no peer address assigned")
+            })?;
+            info!("Delegating sub-flow #{flow_id} to peer at {peer_addr}");
+            self.setup_delegation(*flow_id, peer_addr, &mut submission)?;
         }
 
         self.job_timeout = submission.job_timeout;

--- a/flowr/src/lib/run_state.rs
+++ b/flowr/src/lib/run_state.rs
@@ -336,6 +336,12 @@ impl RunState {
         self.delegated_functions = func_ids;
     }
 
+    /// Returns true if any functions have been delegated to peer coordinators.
+    #[must_use]
+    pub fn has_delegated_functions(&self) -> bool {
+        !self.delegated_functions.is_empty()
+    }
+
     /// Drain values destined for delegated functions, to be sent to the peer.
     pub fn drain_peer_outputs(&mut self) -> Vec<BoundaryOutput> {
         std::mem::take(&mut self.peer_outputs)


### PR DESCRIPTION
## Summary

Phase 2 of #3019. Enables delegating multiple sub-flows to multiple discovered peer coordinators simultaneously.

### Before

- One sub-flow delegated to one peer
- `delegate_flow_id: Option<usize>`, `peer_address: Option<String>`
- `peers.into_iter().next()` — only first peer used

### After

- N sub-flows delegated to N peers (one per peer, up to available peers or candidates)
- `delegate_flow_ids: Vec<usize>`, `peer_addresses: HashMap<usize, String>`
- Sub-flows sorted by delegation score (best first), assigned round-robin to discovered peers

### What changed

| File | Change |
|------|--------|
| `flowcore/src/model/submission.rs` | `delegate_flow_id` → `Vec`, `peer_address` → `HashMap` |
| `flowr/src/bin/flowrcli/main.rs` | Collect all candidates by score, assign to peers, self-filter via `own_peer_instance` |
| `flowr/src/lib/coordinator.rs` | Loop over delegations, `setup_delegation` takes `peer_addr` param, removed `peer_address` field |
| `flowr/src/lib/run_state.rs` | Added `has_delegated_functions()` helper |

### Already multi-ready (no changes needed)

- Executor registry (`HashMap<Url, ...>`) — handles multiple `subflow://` URLs
- `delegated_functions: HashSet<usize>` — accumulates from multiple delegations
- `extracted_subflows: HashMap<usize, FlowManifest>` — keyed by flow ID
- Peer discovery — already returns `Vec<String>` of all peers

### Pre-commit checks

- `cargo fmt` — clean
- `make clippy` — clean
- `make test` — all 40 test suites pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submissions can now delegate multiple sub-flows to different peer coordinators.
  * Delegated work is distributed across available peers based on scored sub-flows.
  * Embedded coordinators no longer discover themselves as peers.

* **Bug Fixes**
  * Improved delegated-output handling when multiple delegated functions are present.
  * Peer addresses are now tracked per delegated sub-flow for more accurate result routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->