### PR TITLE
Dynamic executor sharing: idle coordinators help remote coordinators

### DIFF
--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -492,10 +492,11 @@ fn discover_and_set_remote_coordinator(coordinator: &mut Coordinator, local_job_
         return;
     };
 
-    // Find a remote job service (different port from ours)
+    // Find a remote job service — exclude our own by matching the exact local endpoint
+    let local_endpoint = format!("127.0.0.1:{local_job_port}");
     let Some((remote_job_addr, _)) = job_services
         .iter()
-        .find(|(_, port)| *port != local_job_port)
+        .find(|(addr, _)| *addr != local_endpoint)
     else {
         return;
     };
@@ -504,12 +505,14 @@ fn discover_and_set_remote_coordinator(coordinator: &mut Coordinator, local_job_
         return;
     };
 
-    // Find the results service on the same host/port range
-    let remote_job_host = remote_job_addr.split(':').next().unwrap_or("");
-    if let Some((remote_results_addr, _)) = result_services
-        .iter()
-        .find(|(addr, _)| addr.starts_with(remote_job_host))
-    {
+    // Find the results service from the same coordinator (same host)
+    let remote_host = remote_job_addr
+        .rsplit_once(':')
+        .map_or("", |(host, _)| host);
+    if let Some((remote_results_addr, _)) = result_services.iter().find(|(addr, _)| {
+        addr.rsplit_once(':')
+            .is_some_and(|(host, _)| host == remote_host)
+    }) {
         info!(
             "Discovered remote coordinator: jobs={remote_job_addr} results={remote_results_addr}"
         );

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -492,11 +492,11 @@ fn discover_and_set_remote_coordinator(coordinator: &mut Coordinator, local_job_
         return;
     };
 
-    // Find a remote job service — exclude our own by matching the exact local endpoint
-    let local_endpoint = format!("127.0.0.1:{local_job_port}");
+    // Find a remote job service — exclude our own by port number
+    // (our port is unique on this machine regardless of which IP it's discovered under)
     let Some((remote_job_addr, _)) = job_services
         .iter()
-        .find(|(addr, _)| *addr != local_endpoint)
+        .find(|(_, port)| *port != local_job_port)
     else {
         return;
     };

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -449,6 +449,15 @@ fn coordinator(
     // Share the executor's sub-flow registry with the coordinator
     coordinator.set_subflow_registry(executor.subflow_registry());
 
+    // Set local addresses for reconnection after remote executor mode
+    coordinator.set_local_addresses(job_source_name.clone(), results_sink.clone());
+
+    // If FLOW_REMOTE_EXECUTORS is set, try to discover a remote coordinator
+    // to help while idle (dynamic executor sharing). Only for --server mode.
+    if loop_forever && std::env::var("FLOW_REMOTE_EXECUTORS").is_ok() {
+        discover_and_set_remote_coordinator(&mut coordinator, ports.0);
+    }
+
     #[cfg(feature = "submission")]
     let result = coordinator.submission_loop(loop_forever);
     #[cfg(not(feature = "submission"))]
@@ -468,6 +477,47 @@ fn coordinator(
     drop(blocking_bridge_handle);
 
     result
+}
+
+/// Try to discover a remote coordinator's job/results services via mDNS.
+/// If found (and it's a different coordinator), configure the coordinator
+/// to reconnect its executors to the remote when idle.
+fn discover_and_set_remote_coordinator(coordinator: &mut Coordinator, local_job_port: u16) {
+    use flowcore::discovery::discover_services;
+
+    // Use a short timeout — this is best-effort discovery at startup
+    let timeout = Duration::from_secs(3);
+
+    let Ok(job_services) = discover_services(JOB_SERVICE_NAME, timeout) else {
+        return;
+    };
+
+    // Find a remote job service (different port from ours)
+    let Some((remote_job_addr, _)) = job_services
+        .iter()
+        .find(|(_, port)| *port != local_job_port)
+    else {
+        return;
+    };
+
+    let Ok(result_services) = discover_services(RESULTS_JOB_SERVICE_NAME, timeout) else {
+        return;
+    };
+
+    // Find the results service on the same host/port range
+    let remote_job_host = remote_job_addr.split(':').next().unwrap_or("");
+    if let Some((remote_results_addr, _)) = result_services
+        .iter()
+        .find(|(addr, _)| addr.starts_with(remote_job_host))
+    {
+        info!(
+            "Discovered remote coordinator: jobs={remote_job_addr} results={remote_results_addr}"
+        );
+        coordinator.set_remote_addresses(
+            format!("tcp://{remote_job_addr}"),
+            format!("tcp://{remote_results_addr}"),
+        );
+    }
 }
 
 /// Bridge thread for blocking IO (readline/stdin) on a separate ZMQ socket.

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -45,7 +45,16 @@ pub struct Coordinator<'a> {
     /// URLs in job payloads are rewritten to `http://` URLs so remote executors
     /// can fetch WASM modules.
     wasm_base_url: Option<url::Url>,
-
+    /// Local job/results addresses for the executor threads.
+    /// Used to reconnect executors back to local after helping a remote coordinator.
+    local_job_address: Option<String>,
+    local_results_address: Option<String>,
+    /// Remote job/results addresses discovered via mDNS.
+    /// When set, executors connect to these while idle (no local flow running).
+    remote_job_address: Option<String>,
+    remote_results_address: Option<String>,
+    /// Whether executor threads are currently connected to a remote coordinator
+    executors_remote: bool,
     /// Shared sub-flow manifest registry from the executor.
     subflow_registry: Option<crate::executor::SubflowRegistry>,
     #[cfg(feature = "debugger")]
@@ -190,7 +199,11 @@ impl<'a> Coordinator<'a> {
             dispatcher,
             job_timeout: None,
             wasm_base_url: None,
-
+            local_job_address: None,
+            local_results_address: None,
+            remote_job_address: None,
+            remote_results_address: None,
+            executors_remote: false,
             subflow_registry: None,
             #[cfg(feature = "debugger")]
             debugger: Debugger::new(debug_server),
@@ -204,6 +217,53 @@ impl<'a> Coordinator<'a> {
     /// remote executors can fetch WASM modules.
     pub fn set_wasm_base_url(&mut self, base_url: url::Url) {
         self.wasm_base_url = Some(base_url);
+    }
+
+    /// Configure local executor addresses (for reconnecting back after remote mode).
+    pub fn set_local_addresses(&mut self, job_address: String, results_address: String) {
+        self.local_job_address = Some(job_address);
+        self.local_results_address = Some(results_address);
+    }
+
+    /// Configure remote executor addresses (for helping other coordinators when idle).
+    pub fn set_remote_addresses(&mut self, job_address: String, results_address: String) {
+        self.remote_job_address = Some(job_address);
+        self.remote_results_address = Some(results_address);
+    }
+
+    /// Reconnect executor threads to remote job/results sockets (idle mode).
+    /// Only sends RECONNECT if remote addresses are configured and executors
+    /// are not already connected to remote.
+    fn connect_executors_to_remote(&mut self) -> Result<()> {
+        if self.executors_remote {
+            return Ok(()); // already remote
+        }
+        if let (Some(ref job), Some(ref results)) =
+            (&self.remote_job_address, &self.remote_results_address)
+        {
+            info!("Connecting executors to remote coordinator: jobs={job} results={results}");
+            self.dispatcher.send_reconnect(job, results)?;
+            self.executors_remote = true;
+        }
+        Ok(())
+    }
+
+    /// Reconnect executor threads back to local job/results sockets (busy mode).
+    /// Only sends RECONNECT if executors are currently in remote mode.
+    fn connect_executors_to_local(&mut self) -> Result<()> {
+        if !self.executors_remote {
+            return Ok(()); // already local
+        }
+        if let (Some(ref job), Some(ref results)) =
+            (&self.local_job_address, &self.local_results_address)
+        {
+            info!("Reconnecting executors to local dispatcher: jobs={job} results={results}");
+            self.dispatcher.send_reconnect(job, results)?;
+            self.executors_remote = false;
+            // Give executors time to process the reconnection
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        Ok(())
     }
 
     /// Set the sub-flow registry shared with the executor.
@@ -230,7 +290,23 @@ impl<'a> Coordinator<'a> {
     #[cfg(feature = "submission")]
     pub fn submission_loop(&mut self, loop_forever: bool) -> Result<()> {
         let mut last_result: Result<()> = Ok(());
-        while let Some(submission) = self.submission_handler.wait_for_submission()? {
+
+        loop {
+            // While idle, connect executors to remote coordinator (if configured)
+            if let Err(e) = self.connect_executors_to_remote() {
+                info!("Could not connect to remote coordinator: {e}");
+            }
+
+            let submission = self.submission_handler.wait_for_submission()?;
+            let Some(submission) = submission else {
+                break;
+            };
+
+            // Reconnect executors to local dispatcher before executing
+            if let Err(e) = self.connect_executors_to_local() {
+                error!("Could not reconnect executors to local: {e}");
+            }
+
             last_result = self.execute_flow(submission);
             if let Err(ref e) = last_result {
                 error!("Flow execution failed: {e}");

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -1302,4 +1302,59 @@ mod test {
             "Delegation without a valid sub-flow should fail"
         );
     }
+
+    #[test]
+    #[serial]
+    fn remote_reconnection_state_tracking() {
+        let dispatcher = test_dispatcher();
+        #[cfg(feature = "submission")]
+        let mut submission_handler = DummySubmissionHandler;
+        #[cfg(feature = "debugger")]
+        let mut debug_server = DummyDebugServer {
+            exit_immediately: false,
+        };
+
+        let mut coordinator = Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut submission_handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_server,
+        );
+
+        // Initially not remote
+        assert!(!coordinator.executors_remote);
+
+        // Without remote addresses configured, connect_to_remote is a no-op
+        assert!(coordinator.connect_executors_to_remote().is_ok());
+        assert!(!coordinator.executors_remote);
+
+        // Without local addresses, connect_to_local is a no-op
+        assert!(coordinator.connect_executors_to_local().is_ok());
+        assert!(!coordinator.executors_remote);
+
+        // Configure remote addresses
+        coordinator.set_remote_addresses(
+            "tcp://10.0.0.1:5555".to_string(),
+            "tcp://10.0.0.1:5556".to_string(),
+        );
+        assert!(coordinator.connect_executors_to_remote().is_ok());
+        assert!(coordinator.executors_remote);
+
+        // Second call is a no-op (already remote)
+        assert!(coordinator.connect_executors_to_remote().is_ok());
+        assert!(coordinator.executors_remote);
+
+        // Configure local addresses and reconnect back
+        coordinator.set_local_addresses(
+            "tcp://127.0.0.1:6666".to_string(),
+            "tcp://127.0.0.1:6667".to_string(),
+        );
+        assert!(coordinator.connect_executors_to_local().is_ok());
+        assert!(!coordinator.executors_remote);
+
+        // Second call is a no-op (already local)
+        assert!(coordinator.connect_executors_to_local().is_ok());
+        assert!(!coordinator.executors_remote);
+    }
 }

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -260,8 +260,11 @@ impl<'a> Coordinator<'a> {
             info!("Reconnecting executors to local dispatcher: jobs={job} results={results}");
             self.dispatcher.send_reconnect(job, results)?;
             self.executors_remote = false;
-            // Give executors time to process the reconnection
-            std::thread::sleep(std::time::Duration::from_millis(50));
+            // Give executors time to process the reconnection.
+            // Executors poll the control socket every 100-5000ms depending on mode.
+            // This sleep is best-effort; a proper ack mechanism would be more robust
+            // but significantly more complex for marginal benefit.
+            std::thread::sleep(std::time::Duration::from_millis(100));
         }
         Ok(())
     }

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -172,7 +172,11 @@ impl Dispatcher {
     /// # Errors
     ///
     /// Returns an error if the message cannot be sent.
-    pub fn send_reconnect(&mut self, job_address: &str, results_address: &str) -> Result<()> {
+    pub(crate) fn send_reconnect(
+        &mut self,
+        job_address: &str,
+        results_address: &str,
+    ) -> Result<()> {
         let msg = format!("RECONNECT:lib:{job_address}:{results_address}");
         debug!("Dispatcher announcing {msg}");
         self.control_socket

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -159,6 +159,23 @@ impl Dispatcher {
             .send("DONE".as_bytes(), DONTWAIT)
             .chain_err(|| "Could not send 'DONE' message")
     }
+
+    /// Send a "RECONNECT" message to executor threads, telling them to
+    /// disconnect from their current job/results sockets and reconnect
+    /// to new addresses. The control socket itself is not reconnected.
+    ///
+    /// Format: `RECONNECT:<job_address>:<results_address>`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be sent.
+    pub fn send_reconnect(&mut self, job_address: &str, results_address: &str) -> Result<()> {
+        let msg = format!("RECONNECT:{job_address}:{results_address}");
+        debug!("Dispatcher announcing {msg}");
+        self.control_socket
+            .send(msg.as_bytes(), DONTWAIT)
+            .chain_err(|| "Could not send RECONNECT message")
+    }
 }
 
 impl Drop for Dispatcher {

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -406,4 +406,46 @@ mod test {
         assert_eq!(job_id, 0);
         assert_eq!(executor_id, "test-executor");
     }
+
+    #[test]
+    #[serial]
+    fn send_reconnect_delivers_to_control_socket() {
+        let (mut dispatcher, ports) = new_dispatcher();
+
+        let context = zmq::Context::new();
+        let control_sub = context
+            .socket(zmq::SUB)
+            .expect("Could not create SUB socket");
+        control_sub
+            .connect(&format!("tcp://127.0.0.1:{}", ports.3))
+            .expect("Could not connect to control socket");
+        control_sub.set_subscribe(&[]).expect("Could not subscribe");
+        control_sub
+            .set_rcvtimeo(1000)
+            .expect("Could not set timeout");
+
+        // Give ZMQ time to establish the subscription
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        assert!(dispatcher
+            .send_reconnect("tcp://10.0.0.1:5555", "tcp://10.0.0.1:5556")
+            .is_ok());
+
+        let msg = control_sub
+            .recv_msg(0)
+            .expect("Should receive RECONNECT on control socket");
+        let msg_str = msg.as_str().expect("Should be valid UTF-8");
+        assert!(
+            msg_str.starts_with("RECONNECT:lib:"),
+            "RECONNECT should have lib: prefix, got: {msg_str}"
+        );
+        assert!(
+            msg_str.contains("tcp://10.0.0.1:5555"),
+            "Should contain job address"
+        );
+        assert!(
+            msg_str.contains("tcp://10.0.0.1:5556"),
+            "Should contain results address"
+        );
+    }
 }

--- a/flowr/src/lib/dispatcher.rs
+++ b/flowr/src/lib/dispatcher.rs
@@ -160,17 +160,20 @@ impl Dispatcher {
             .chain_err(|| "Could not send 'DONE' message")
     }
 
-    /// Send a "RECONNECT" message to executor threads, telling them to
-    /// disconnect from their current job/results sockets and reconnect
-    /// to new addresses. The control socket itself is not reconnected.
+    /// Send a "RECONNECT" message to normal executor threads (not context
+    /// executors), telling them to disconnect from their current job/results
+    /// sockets and reconnect to new addresses.
     ///
-    /// Format: `RECONNECT:<job_address>:<results_address>`
+    /// Format: `RECONNECT:lib:<job_address>:<results_address>`
+    ///
+    /// Context executors (whose names start with `"ctx:"`) ignore this
+    /// message and stay connected to the context job queue.
     ///
     /// # Errors
     ///
     /// Returns an error if the message cannot be sent.
     pub fn send_reconnect(&mut self, job_address: &str, results_address: &str) -> Result<()> {
-        let msg = format!("RECONNECT:{job_address}:{results_address}");
+        let msg = format!("RECONNECT:lib:{job_address}:{results_address}");
         debug!("Dispatcher announcing {msg}");
         self.control_socket
             .send(msg.as_bytes(), DONTWAIT)

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -292,6 +292,10 @@ fn execution_loop(
         .connect(&results_service)
         .map_err(|e| format!("Could not connect to PUSH end of results socket: {e}"))?;
 
+    // Track current addresses for reconnection support
+    let mut current_job_addr = job_service;
+    let mut current_results_addr = results_service;
+
     let control_socket = context
         .socket(zmq::SocketType::SUB)
         .map_err(|e| format!("Could not create SUB end of control socket: {e}"))?;
@@ -421,6 +425,34 @@ fn execution_loop(
                         Ok("DONE") => {
                             trace!("'DONE' message received in executor");
                             return Ok(());
+                        }
+                        Ok(ctrl_msg) if ctrl_msg.starts_with("RECONNECT:") => {
+                            // Format: RECONNECT:<job_addr>:<results_addr>
+                            // The job_addr contains a colon (tcp://host:port)
+                            // so split from the end to get the two addresses
+                            let payload = &ctrl_msg["RECONNECT:".len()..];
+                            if let Some(sep) = payload.rfind("tcp://") {
+                                if sep > 0 {
+                                    let new_job = &payload[..sep - 1]; // strip trailing ':'
+                                    let new_results = &payload[sep..];
+                                    info!(
+                                        "Executor '{name}' reconnecting: jobs={new_job} results={new_results}"
+                                    );
+                                    // Disconnect from current and connect to new
+                                    let _ = job_source.disconnect(&current_job_addr);
+                                    job_source
+                                        .connect(new_job)
+                                        .map_err(|e| format!("Reconnect job failed: {e}"))?;
+                                    let _ = results_sink.disconnect(&current_results_addr);
+                                    results_sink
+                                        .connect(new_results)
+                                        .map_err(|e| format!("Reconnect results failed: {e}"))?;
+                                    current_job_addr = new_job.to_string();
+                                    current_results_addr = new_results.to_string();
+                                    // Reset idle timer
+                                    last_activity = std::time::Instant::now();
+                                }
+                            }
                         }
                         Ok(_) => error!("Unexpected Control message"),
                         _ => error!("Error parsing Control message"),

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -1715,4 +1715,70 @@ mod test {
         // Wait for the thread to exit
         executor.wait();
     }
+
+    /// Test that executor threads handle RECONNECT messages without crashing
+    /// and continue to respond to DONE after reconnection.
+    #[test]
+    #[serial]
+    fn executor_handles_reconnect() {
+        let mut executor = Executor::new();
+        let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+
+        let ports = (
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+            pick_unused_port().expect("no port"),
+        );
+
+        let new_job_port = pick_unused_port().expect("no port");
+        let new_results_port = pick_unused_port().expect("no port");
+
+        let context = zmq::Context::new();
+
+        // Bind dispatcher sockets
+        let _job_socket = {
+            let s = context.socket(zmq::PUSH).expect("PUSH");
+            s.bind(&format!("tcp://*:{}", ports.0)).expect("bind");
+            s
+        };
+        let _results_socket = {
+            let s = context.socket(zmq::PULL).expect("PULL");
+            s.bind(&format!("tcp://*:{}", ports.2)).expect("bind");
+            s
+        };
+        let control_socket = context.socket(zmq::PUB).expect("PUB");
+        control_socket
+            .bind(&format!("tcp://*:{}", ports.3))
+            .expect("bind");
+
+        executor.start(
+            &provider,
+            1,
+            &format!("tcp://127.0.0.1:{}", ports.0),
+            &format!("tcp://127.0.0.1:{}", ports.2),
+            &format!("tcp://127.0.0.1:{}", ports.3),
+        );
+
+        // Give the thread time to connect
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // Send RECONNECT — executor should process it without crashing
+        let reconnect_msg = format!(
+            "RECONNECT:lib:tcp://127.0.0.1:{new_job_port}:tcp://127.0.0.1:{new_results_port}"
+        );
+        control_socket
+            .send(reconnect_msg.as_bytes(), 0)
+            .expect("send RECONNECT");
+
+        // Give executor time to process RECONNECT
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // Executor should still be alive and respond to DONE
+        control_socket
+            .send("DONE".as_bytes(), 0)
+            .expect("send DONE");
+        executor.wait();
+        // If we get here, the executor handled RECONNECT and DONE correctly
+    }
 }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -427,10 +427,14 @@ fn execution_loop(
                             return Ok(());
                         }
                         Ok(ctrl_msg) if ctrl_msg.starts_with("RECONNECT:") => {
-                            // Format: RECONNECT:<job_addr>:<results_addr>
-                            // The job_addr contains a colon (tcp://host:port)
-                            // so split from the end to get the two addresses
-                            let payload = &ctrl_msg["RECONNECT:".len()..];
+                            // Format: RECONNECT:lib:<job_addr>:<results_addr>
+                            // Context executors (name starts with "ctx:") ignore
+                            // this message to stay on the context job queue.
+                            if name.starts_with("ctx:") {
+                                trace!("Context executor '{name}' ignoring RECONNECT");
+                                continue;
+                            }
+                            let payload = &ctrl_msg["RECONNECT:lib:".len()..];
                             if let Some(sep) = payload.rfind("tcp://") {
                                 if sep > 0 {
                                     let new_job = &payload[..sep - 1]; // strip trailing ':'

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -1716,13 +1716,23 @@ mod test {
         executor.wait();
     }
 
-    /// Test that executor threads handle RECONNECT messages without crashing
-    /// and continue to respond to DONE after reconnection.
+    /// Test that executor threads handle RECONNECT messages by switching
+    /// to new job/results sockets, executing jobs there, and then
+    /// responding to DONE.
+    #[cfg(feature = "flowstdlib")]
     #[test]
     #[serial]
     fn executor_handles_reconnect() {
         let mut executor = Executor::new();
         let provider = Arc::new(TestProvider { test_content: "" }) as Arc<dyn Provider>;
+
+        // Add flowstdlib so the executor can handle lib:// jobs
+        executor
+            .add_lib(
+                flowstdlib::manifest::get().expect("flowstdlib"),
+                Url::parse("memory://").expect("url"),
+            )
+            .expect("add_lib");
 
         let ports = (
             pick_unused_port().expect("no port"),
@@ -1736,7 +1746,7 @@ mod test {
 
         let context = zmq::Context::new();
 
-        // Bind dispatcher sockets
+        // Bind original dispatcher sockets
         let _job_socket = {
             let s = context.socket(zmq::PUSH).expect("PUSH");
             s.bind(&format!("tcp://*:{}", ports.0)).expect("bind");
@@ -1752,6 +1762,16 @@ mod test {
             .bind(&format!("tcp://*:{}", ports.3))
             .expect("bind");
 
+        // Bind new target sockets
+        let new_job_socket = context.socket(zmq::PUSH).expect("PUSH");
+        new_job_socket
+            .bind(&format!("tcp://*:{new_job_port}"))
+            .expect("bind new job");
+        let new_results_socket = context.socket(zmq::PULL).expect("PULL");
+        new_results_socket
+            .bind(&format!("tcp://*:{new_results_port}"))
+            .expect("bind new results");
+
         executor.start(
             &provider,
             1,
@@ -1763,7 +1783,7 @@ mod test {
         // Give the thread time to connect
         std::thread::sleep(std::time::Duration::from_millis(200));
 
-        // Send RECONNECT — executor should process it without crashing
+        // Send RECONNECT to switch to new addresses
         let reconnect_msg = format!(
             "RECONNECT:lib:tcp://127.0.0.1:{new_job_port}:tcp://127.0.0.1:{new_results_port}"
         );
@@ -1774,11 +1794,39 @@ mod test {
         // Give executor time to process RECONNECT
         std::thread::sleep(std::time::Duration::from_millis(200));
 
-        // Executor should still be alive and respond to DONE
+        // Send a job on the NEW job socket — executor should execute it there
+        let payload = Payload {
+            job_id: 42,
+            input_set: vec![serde_json::json!(7), serde_json::json!(3)],
+            implementation_url: Url::parse("lib://flowstdlib/math/add").expect("url"),
+        };
+        new_job_socket
+            .send(
+                serde_json::to_string(&payload)
+                    .expect("serialize")
+                    .as_bytes(),
+                0,
+            )
+            .expect("send job on new socket");
+
+        // Receive result on the NEW results socket
+        new_results_socket.set_rcvtimeo(5000).expect("set timeout");
+        let result_msg = new_results_socket
+            .recv_msg(0)
+            .expect("Should receive result on new results socket after RECONNECT");
+        let (job_id, _, result): (
+            usize,
+            String,
+            Result<(Option<serde_json::Value>, flowcore::RunAgain)>,
+        ) = serde_json::from_str(result_msg.as_str().expect("utf8")).expect("deserialize");
+        assert_eq!(job_id, 42, "Job ID should match");
+        let (value, _) = result.expect("Job should succeed");
+        assert_eq!(value, Some(serde_json::json!(10)), "add(7,3) should be 10");
+
+        // Send DONE to clean up
         control_socket
             .send("DONE".as_bytes(), 0)
             .expect("send DONE");
         executor.wait();
-        // If we get here, the executor handled RECONNECT and DONE correctly
     }
 }


### PR DESCRIPTION
## Summary

Closes #3017. Phase 3 of #3019.

When a coordinator has no local work (`--server` mode, idle), its executor threads can dynamically connect to a remote coordinator's job queue and help execute jobs. When a local submission arrives, the executors disconnect from the remote and reconnect to the local dispatcher.

### How it works

```
IDLE                                        BUSY
┌─────────────────────────┐                 ┌─────────────────────────┐
│ Executors connected to  │  ──submission─► │ Executors connected to  │
│ REMOTE job queue        │                 │ LOCAL job queue          │
│ (helping other coord.)  │  ◄──complete──  │ (running own flow)      │
└─────────────────────────┘                 └─────────────────────────┘
```

### Implementation

| Component | Change |
|-----------|--------|
| **Dispatcher** | New `send_reconnect(job_addr, results_addr)` method broadcasts `RECONNECT:<job>:<results>` on the PUB control socket |
| **Executor** | `execution_loop` handles `RECONNECT` control messages by disconnecting from current job/results sockets and connecting to new addresses |
| **Coordinator** | Tracks `local_job_address`, `remote_job_address`, `executors_remote` state. `submission_loop` calls `connect_executors_to_remote()` when idle and `connect_executors_to_local()` when a submission arrives |
| **main.rs** | Discovers remote coordinator job services via mDNS when `FLOW_REMOTE_EXECUTORS` env var is set (`--server` mode only) |

### Opt-in activation

Remote executor discovery is enabled by setting `FLOW_REMOTE_EXECUTORS=1` when running `flowrcli --server`. This avoids adding mDNS discovery latency to every coordinator startup. Without the env var, coordinators behave exactly as before.

### Pre-commit checks

- `cargo fmt` — clean
- `make clippy` — clean
- `make test` — all 40 test suites pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of remote execution services in server mode.
  * Remote executors can switch between standby services and local execution as needed.
  * Added automatic reconnection when job or results service endpoints change.

* **Reliability Improvements**
  * Improved coordination between local and remote execution services.
  * Added connection failure handling and reconnection tracking for smoother recovery.
  * Preserved local execution when remote services are unavailable.
  * Improved recovery when execution service endpoints are replaced or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->