### PR TITLE
Context function proxying for delegated sub-flows (Phase 4 of #3019)

### DIFF
--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -529,8 +529,9 @@ impl FlowManifest {
     /// to a peer coordinator, considering compute weight, balance between root
     /// and peer, boundary I/O overhead, and nested sub-flow serialization.
     ///
-    /// Sub-flows containing `context://` functions get `None` (not delegatable).
-    /// Sub-flows with a non-positive score also get `None`.
+    /// Sub-flows containing `context://` functions get a heavy penalty
+    /// (each context call incurs a network round-trip when proxied).
+    /// Sub-flows with a non-positive score get `None`.
     /// The root flow always gets `None`.
     ///
     /// This is intended to be called by the compiler after the manifest is
@@ -541,6 +542,7 @@ impl FlowManifest {
         const LOOPBACK_MULTIPLIER: f64 = 2.0;
         const BOUNDARY_WEIGHT: f64 = 0.5;
         const NESTING_WEIGHT: f64 = 1.0;
+        const CONTEXT_PENALTY: f64 = 3.0;
 
         // Compute total flow weight: sum of (1 + loopback_count * multiplier)
         // for every function in the manifest
@@ -596,16 +598,12 @@ impl FlowManifest {
                 continue;
             }
 
-            // Check for context:// functions — cannot delegate
-            let has_context = subtree_funcs
+            // Count context:// functions — each incurs a network round-trip
+            // penalty when delegated (proxied back to origin)
+            let context_count = subtree_funcs
                 .iter()
-                .any(|f| f.get_implementation_location().starts_with("context://"));
-            if has_context {
-                if let Some(info) = self.flows.get_mut(&flow_id) {
-                    info.delegation_score = None;
-                }
-                continue;
-            }
+                .filter(|f| f.get_implementation_location().starts_with("context://"))
+                .count();
 
             // Compute peer weight (functions + loopback bonus)
             let peer_weight: f64 = subtree_funcs
@@ -642,10 +640,12 @@ impl FlowManifest {
             // Nested sub-flow count (excluding the flow itself)
             let nested_subflows = descendant_flows.len().saturating_sub(1);
 
-            // Compute score
+            // Compute score — context functions add heavy penalty since each
+            // invocation incurs a network round-trip for proxying
             let score = peer_weight * balance_quality
                 - boundary_count as f64 * BOUNDARY_WEIGHT
-                - nested_subflows as f64 * NESTING_WEIGHT;
+                - nested_subflows as f64 * NESTING_WEIGHT
+                - context_count as f64 * CONTEXT_PENALTY;
 
             if let Some(info) = self.flows.get_mut(&flow_id) {
                 info.delegation_score = if score > 0.0 { Some(score) } else { None };

--- a/flowcore/src/model/flow_manifest.rs
+++ b/flowcore/src/model/flow_manifest.rs
@@ -542,7 +542,7 @@ impl FlowManifest {
         const LOOPBACK_MULTIPLIER: f64 = 2.0;
         const BOUNDARY_WEIGHT: f64 = 0.5;
         const NESTING_WEIGHT: f64 = 1.0;
-        const CONTEXT_PENALTY: f64 = 3.0;
+        const CONTEXT_PENALTY: f64 = 10.0;
 
         // Compute total flow weight: sum of (1 + loopback_count * multiplier)
         // for every function in the manifest

--- a/flowr/src/bin/flowrcli/context/mod.rs
+++ b/flowr/src/bin/flowrcli/context/mod.rs
@@ -1,6 +1,5 @@
 //! Module of context functions for Cli Flowr Runner
 
-use std::sync::mpsc;
 use std::sync::Arc;
 
 use flowcore::errors::{Result, ResultExt};
@@ -9,86 +8,14 @@ use flowcore::model::lib_manifest::LibraryManifest;
 use flowcore::model::metadata::MetaData;
 use url::Url;
 
-use flowrlib::client_protocol::{ClientMessage, CoordinatorMessage};
+// Re-export from library
+pub use flowrlib::context_io::{ContextIO, ContextRequest};
 
 mod args;
 mod file;
 mod image;
 mod stdio;
 mod time;
-
-/// A request sent from a context function to the ZMQ bridge thread.
-pub struct ContextRequest {
-    /// The message to send to the client
-    pub message: CoordinatorMessage,
-    /// If `Some`, the bridge sends the client's response back on this channel.
-    /// If `None`, the message is fire-and-forget (no response expected).
-    pub response_tx: Option<mpsc::Sender<ClientMessage>>,
-}
-
-/// Channel-based IO handle for context functions, replacing `Arc<Mutex<CoordinatorConnection>>`.
-///
-/// Uses two channels: one for non-blocking IO (stdout, stderr, file, image, args)
-/// and one for blocking IO (readline, stdin). This allows blocking IO to be
-/// handled on a separate ZMQ socket so it doesn't block non-blocking IO.
-#[derive(Clone)]
-pub struct ContextIO {
-    /// Channel for non-blocking context function requests (stdout, stderr, etc.)
-    tx: mpsc::Sender<ContextRequest>,
-    /// Channel for blocking context function requests (readline, stdin)
-    blocking_tx: mpsc::Sender<ContextRequest>,
-}
-
-impl ContextIO {
-    /// Create a new `ContextIO` backed by the given channel senders.
-    pub fn new(
-        tx: mpsc::Sender<ContextRequest>,
-        blocking_tx: mpsc::Sender<ContextRequest>,
-    ) -> Self {
-        ContextIO { tx, blocking_tx }
-    }
-
-    /// Send a message on the non-blocking channel and wait for the client's response.
-    pub fn send_and_receive(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
-        let (response_tx, response_rx) = mpsc::channel();
-        self.tx
-            .send(ContextRequest {
-                message,
-                response_tx: Some(response_tx),
-            })
-            .map_err(|e| format!("Could not send to bridge: {e}"))?;
-        response_rx
-            .recv()
-            .map_err(|e| format!("Could not receive from bridge: {e}").into())
-    }
-
-    /// Send a message on the blocking IO channel and wait for the client's response.
-    /// Used by context functions that may block for user input (readline, stdin).
-    pub fn send_and_receive_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
-        let (response_tx, response_rx) = mpsc::channel();
-        self.blocking_tx
-            .send(ContextRequest {
-                message,
-                response_tx: Some(response_tx),
-            })
-            .map_err(|e| format!("Could not send to blocking bridge: {e}"))?;
-        response_rx
-            .recv()
-            .map_err(|e| format!("Could not receive from blocking bridge: {e}").into())
-    }
-
-    /// Send a message without waiting for a response (fire-and-forget).
-    /// The bridge thread still completes the ZMQ round-trip.
-    #[allow(dead_code)]
-    pub fn send_no_reply(&self, message: CoordinatorMessage) -> Result<()> {
-        self.tx
-            .send(ContextRequest {
-                message,
-                response_tx: None,
-            })
-            .map_err(|e| format!("Could not send to bridge: {e}").into())
-    }
-}
 
 /// Return a `LibraryManifest` for the context functions
 pub fn get_manifest(context_io: ContextIO) -> Result<LibraryManifest> {

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -451,6 +451,8 @@ fn coordinator(
 
     // Share the executor's sub-flow registry with the coordinator
     coordinator.set_subflow_registry(executor.subflow_registry());
+    // Mark that the executor has context proxy capability
+    coordinator.set_has_context_proxy();
 
     // Set local addresses for reconnection after remote executor mode
     coordinator.set_local_addresses(job_source_name.clone(), results_sink.clone());

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -523,10 +523,53 @@ fn discover_and_set_remote_coordinator(coordinator: &mut Coordinator, local_job_
     }
 }
 
-/// Bridge thread for blocking IO (readline/stdin) on a separate ZMQ socket.
-///
-/// Protocol:
-/// 1. Wait for a blocking IO request from a context function via `blocking_rx`
+/// Relay context function messages from a delegated sub-flow back to the
+/// origin coordinator. Loops until `FlowEnd` is received.
+fn subflow_context_relay(
+    connection: &mut CoordinatorConnection,
+    context_rx: &std::sync::mpsc::Receiver<context::ContextRequest>,
+) {
+    use flowrlib::client_protocol::{ClientMessage, CoordinatorMessage};
+    use flowrlib::connections::WAIT;
+
+    while let Ok(ctx_request) = context_rx.recv() {
+        let is_flow_end = matches!(ctx_request.message, CoordinatorMessage::FlowEnd(..));
+
+        // Send the message as the ZMQ REP response
+        if let Err(e) = connection.send(ctx_request.message) {
+            error!("Bridge: failed to send sub-flow context message: {e}");
+            if let Some(tx) = ctx_request.response_tx {
+                let _ = tx.send(ClientMessage::Error(format!("{e}")));
+            }
+            return;
+        }
+
+        if is_flow_end {
+            // FlowEnd is the final message — ack the handler and exit
+            if let Some(tx) = ctx_request.response_tx {
+                let _ = tx.send(ClientMessage::Ack);
+            }
+            return;
+        }
+
+        // Receive the origin's context result as the next ZMQ REQ
+        match connection.receive::<ClientMessage>(WAIT) {
+            Ok(response) => {
+                if let Some(tx) = ctx_request.response_tx {
+                    let _ = tx.send(response);
+                }
+            }
+            Err(e) => {
+                error!("Bridge: failed to receive context result: {e}");
+                if let Some(tx) = ctx_request.response_tx {
+                    let _ = tx.send(ClientMessage::Error(format!("{e}")));
+                }
+                return;
+            }
+        }
+    }
+}
+
 /// 2. Wait for the client's `Ack` on ZMQ (client polls this socket)
 /// 3. Send the blocking IO request (GetLine/GetStdin) to the client
 /// 4. Wait for the client's response (Line/Stdin/etc.)
@@ -671,26 +714,14 @@ fn coordinator_bridge(
             }
 
             if is_subflow {
-                // Sub-flow from a peer coordinator: skip the interactive
-                // FlowStart/Ack protocol. Wait for the coordinator to finish
-                // and send FlowEnd directly as the REP response.
-                debug!("[BRIDGE] sub-flow submission — waiting for completion");
+                // Sub-flow from a peer coordinator: relay context messages
+                // back to the origin as ZMQ REP responses, receive context
+                // results as the next ZMQ REQ, until FlowEnd arrives.
+                debug!("[BRIDGE] sub-flow submission — entering context relay loop");
                 if let Some(response_tx) = request.response_tx {
                     let _ = response_tx.send(ClientMessage::Ack);
                 }
-                // Wait for FlowEnd from the handler
-                if let Ok(end_request) = context_rx.recv() {
-                    let response = match connection.send(end_request.message) {
-                        Ok(()) => ClientMessage::Ack,
-                        Err(e) => {
-                            error!("Bridge: failed to send sub-flow result: {e}");
-                            ClientMessage::Error(format!("{e}"))
-                        }
-                    };
-                    if let Some(tx) = end_request.response_tx {
-                        let _ = tx.send(response);
-                    }
-                }
+                subflow_context_relay(&mut connection, &context_rx);
                 continue;
             }
 

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -389,6 +389,9 @@ fn coordinator(
         get_connect_addresses(ports);
 
     let mut executor = Executor::new();
+    // Give the executor a ContextIO handle so delegated sub-flows can
+    // proxy context function calls back to the origin coordinator's client
+    executor.set_context_io(context_io.clone());
     #[cfg(feature = "flowstdlib")]
     if native_flowstdlib {
         executor.add_lib(

--- a/flowr/src/lib/context_io.rs
+++ b/flowr/src/lib/context_io.rs
@@ -1,0 +1,135 @@
+//! Channel-based IO handle for context functions and context proxying.
+//!
+//! `ContextIO` provides a way for context function implementations to
+//! communicate with the client (for stdio, file, image operations) through
+//! the coordinator's bridge threads. It is also used by the context proxy
+//! to relay context requests from delegated sub-flows back to the origin.
+
+use std::sync::mpsc;
+
+use flowcore::errors::Result;
+
+use crate::client_protocol::{ClientMessage, CoordinatorMessage};
+
+/// A request sent from a context function to the ZMQ bridge thread.
+pub struct ContextRequest {
+    /// The message to send to the client
+    pub message: CoordinatorMessage,
+    /// If `Some`, the bridge sends the client's response back on this channel.
+    /// If `None`, the message is fire-and-forget (no response expected).
+    pub response_tx: Option<mpsc::Sender<ClientMessage>>,
+}
+
+/// Channel-based IO handle for context functions.
+///
+/// Uses two channels: one for non-blocking IO (stdout, stderr, file, image, args)
+/// and one for blocking IO (readline, stdin). This allows blocking IO to be
+/// handled on a separate ZMQ socket so it doesn't block non-blocking IO.
+#[derive(Clone)]
+pub struct ContextIO {
+    /// Channel for non-blocking context function requests (stdout, stderr, etc.)
+    tx: mpsc::Sender<ContextRequest>,
+    /// Channel for blocking context function requests (readline, stdin)
+    blocking_tx: mpsc::Sender<ContextRequest>,
+}
+
+impl ContextIO {
+    /// Create a new `ContextIO` backed by the given channel senders.
+    #[must_use]
+    pub fn new(
+        tx: mpsc::Sender<ContextRequest>,
+        blocking_tx: mpsc::Sender<ContextRequest>,
+    ) -> Self {
+        ContextIO { tx, blocking_tx }
+    }
+
+    /// Send a message on the non-blocking channel and wait for the client's response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be sent or the response cannot be received.
+    pub fn send_and_receive(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        let (response_tx, response_rx) = mpsc::channel();
+        self.tx
+            .send(ContextRequest {
+                message,
+                response_tx: Some(response_tx),
+            })
+            .map_err(|e| format!("Could not send to bridge: {e}"))?;
+        response_rx
+            .recv()
+            .map_err(|e| format!("Could not receive from bridge: {e}").into())
+    }
+
+    /// Send a message on the blocking IO channel and wait for the client's response.
+    /// Used by context functions that may block for user input (readline, stdin).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be sent or the response cannot be received.
+    pub fn send_and_receive_blocking(&self, message: CoordinatorMessage) -> Result<ClientMessage> {
+        let (response_tx, response_rx) = mpsc::channel();
+        self.blocking_tx
+            .send(ContextRequest {
+                message,
+                response_tx: Some(response_tx),
+            })
+            .map_err(|e| format!("Could not send to blocking bridge: {e}"))?;
+        response_rx
+            .recv()
+            .map_err(|e| format!("Could not receive from blocking bridge: {e}").into())
+    }
+
+    /// Send a message without waiting for a response (fire-and-forget).
+    /// The bridge thread still completes the ZMQ round-trip.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be sent.
+    pub fn send_no_reply(&self, message: CoordinatorMessage) -> Result<()> {
+        self.tx
+            .send(ContextRequest {
+                message,
+                response_tx: None,
+            })
+            .map_err(|e| format!("Could not send to bridge: {e}").into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn send_and_receive_roundtrip() {
+        let (tx, rx) = mpsc::channel();
+        let (blocking_tx, _blocking_rx) = mpsc::channel();
+        let context_io = ContextIO::new(tx, blocking_tx);
+
+        // Spawn a thread to simulate the bridge
+        std::thread::spawn(move || {
+            let request = rx.recv().unwrap();
+            assert!(matches!(request.message, CoordinatorMessage::GetArgs));
+            if let Some(response_tx) = request.response_tx {
+                response_tx
+                    .send(ClientMessage::Args(vec!["test".into()]))
+                    .unwrap();
+            }
+        });
+
+        let result = context_io.send_and_receive(CoordinatorMessage::GetArgs);
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), ClientMessage::Args(_)));
+    }
+
+    #[test]
+    fn send_no_reply_succeeds() {
+        let (tx, _rx) = mpsc::channel();
+        let (blocking_tx, _blocking_rx) = mpsc::channel();
+        let context_io = ContextIO::new(tx, blocking_tx);
+
+        let result = context_io.send_no_reply(CoordinatorMessage::StdoutEof);
+        assert!(result.is_ok());
+    }
+}

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -478,19 +478,17 @@ impl<'a> Coordinator<'a> {
             .delegate_subflow(flow_id)
             .map_err(|e| format!("Could not delegate sub-flow #{flow_id}: {e}"))?;
 
-        // Reject sub-flows containing context:// functions — these interact
-        // with the local environment and cannot run on a remote peer.
+        // Log context functions — they will be proxied back to the origin
         let context_count = extracted
             .functions()
             .values()
             .filter(|f| f.get_implementation_location().starts_with("context://"))
             .count();
         if context_count > 0 {
-            return Err(format!(
-                "Cannot delegate sub-flow #{flow_id}: it contains {context_count} context:// \
-                 function(s) that must run locally"
-            )
-            .into());
+            info!(
+                "Sub-flow #{flow_id} contains {context_count} context:// function(s) — \
+                 will be proxied back to origin during execution"
+            );
         }
 
         // Rewrite file:// WASM URLs to http:// so the peer can fetch them

--- a/flowr/src/lib/coordinator.rs
+++ b/flowr/src/lib/coordinator.rs
@@ -55,6 +55,8 @@ pub struct Coordinator<'a> {
     remote_results_address: Option<String>,
     /// Whether executor threads are currently connected to a remote coordinator
     executors_remote: bool,
+    /// Whether the executor has `ContextIO` configured for context proxying
+    has_context_proxy: bool,
     /// Shared sub-flow manifest registry from the executor.
     subflow_registry: Option<crate::executor::SubflowRegistry>,
     #[cfg(feature = "debugger")]
@@ -204,6 +206,7 @@ impl<'a> Coordinator<'a> {
             remote_job_address: None,
             remote_results_address: None,
             executors_remote: false,
+            has_context_proxy: false,
             subflow_registry: None,
             #[cfg(feature = "debugger")]
             debugger: Debugger::new(debug_server),
@@ -267,6 +270,12 @@ impl<'a> Coordinator<'a> {
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
         Ok(())
+    }
+
+    /// Mark that the executor has `ContextIO` configured, enabling
+    /// delegation of sub-flows containing context:// functions.
+    pub fn set_has_context_proxy(&mut self) {
+        self.has_context_proxy = true;
     }
 
     /// Set the sub-flow registry shared with the executor.
@@ -478,17 +487,25 @@ impl<'a> Coordinator<'a> {
             .delegate_subflow(flow_id)
             .map_err(|e| format!("Could not delegate sub-flow #{flow_id}: {e}"))?;
 
-        // Log context functions — they will be proxied back to the origin
+        // Check for context functions — they require proxy capability
         let context_count = extracted
             .functions()
             .values()
             .filter(|f| f.get_implementation_location().starts_with("context://"))
             .count();
         if context_count > 0 {
-            info!(
-                "Sub-flow #{flow_id} contains {context_count} context:// function(s) — \
-                 will be proxied back to origin during execution"
-            );
+            if self.has_context_proxy {
+                info!(
+                    "Sub-flow #{flow_id} contains {context_count} context:// function(s) — \
+                     will be proxied back to origin during execution"
+                );
+            } else {
+                return Err(format!(
+                    "Cannot delegate sub-flow #{flow_id}: it contains {context_count} context:// \
+                     function(s) but no context proxy is configured"
+                )
+                .into());
+            }
         }
 
         // Rewrite file:// WASM URLs to http:// so the peer can fetch them
@@ -1354,5 +1371,30 @@ mod test {
         // Second call is a no-op (already local)
         assert!(coordinator.connect_executors_to_local().is_ok());
         assert!(!coordinator.executors_remote);
+    }
+
+    #[test]
+    #[serial]
+    fn context_proxy_flag_default_false() {
+        let dispatcher = test_dispatcher();
+        #[cfg(feature = "submission")]
+        let mut submission_handler = DummySubmissionHandler;
+        #[cfg(feature = "debugger")]
+        let mut debug_server = DummyDebugServer {
+            exit_immediately: false,
+        };
+
+        let mut coordinator = Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut submission_handler,
+            #[cfg(feature = "debugger")]
+            &mut debug_server,
+        );
+
+        assert!(!coordinator.has_context_proxy);
+
+        coordinator.set_has_context_proxy();
+        assert!(coordinator.has_context_proxy);
     }
 }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -599,6 +599,7 @@ fn get_or_load_implementation(
                         manifest.clone(),
                         interface_inputs,
                         addr.clone(),
+                        None, // TODO: pass ContextIO for context proxying
                     )) as Arc<dyn Implementation>
                 }
                 _ => bail!("Unsupported scheme on implementation_url"),
@@ -709,6 +710,7 @@ fn execute_subflow_job(
         manifest.clone(),
         interface_inputs,
         addr.clone(),
+        None, // TODO: pass ContextIO for context proxying
     );
     // Drop the read lock before blocking on the peer
     drop(manifests);

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -84,6 +84,9 @@ pub struct Executor {
     // input_map: [(dest_func_id, dest_io_number)] maps proxy inputs to sub-flow inputs.
     loaded_subflow_manifests: SubflowRegistry,
     executors: Vec<JoinHandle<()>>,
+    // Optional ContextIO for relaying context function requests from delegated
+    // sub-flows back to the origin coordinator's client.
+    context_io: Option<crate::context_io::ContextIO>,
 }
 
 impl Default for Executor {
@@ -102,7 +105,14 @@ impl Executor {
             )),
             loaded_subflow_manifests: Arc::new(RwLock::new(HashMap::new())),
             executors: vec![],
+            context_io: None,
         }
+    }
+
+    /// Set the `ContextIO` for relaying context function requests from
+    /// delegated sub-flows back to the origin coordinator's client.
+    pub fn set_context_io(&mut self, context_io: crate::context_io::ContextIO) {
+        self.context_io = Some(context_io);
     }
 
     /// Add a library manifest so that it can be used later on to load implementations that are
@@ -228,6 +238,7 @@ impl Executor {
             let results_sink = results_service.into();
             let job_source = job_service.into();
             let control_address = control_service.into();
+            let thread_context_io = self.context_io.clone();
             let executor_id = if spawn_jobs {
                 format!("ctx:{}", make_executor_id())
             } else {
@@ -246,6 +257,7 @@ impl Executor {
                     results_sink,
                     control_address,
                     spawn_jobs,
+                    thread_context_io,
                 ) {
                     error!("Execution loop error: {e}");
                 }
@@ -274,6 +286,7 @@ fn execution_loop(
     results_service: String,
     control_address: String,
     spawn_jobs: bool,
+    context_io: Option<crate::context_io::ContextIO>,
 ) -> Result<()> {
     // After this many seconds of silence, assume the coordinator is gone and exit.
     const IDLE_EXIT_SECS: u64 = 60;
@@ -385,12 +398,21 @@ fn execution_loop(
                         let si = loaded_implementations.clone();
                         let sm = loaded_lib_manifests.clone();
                         let ssm = loaded_subflow_manifests.clone();
+                        let scio = context_io.clone();
                         let stx = spawn_result_tx
                             .as_ref()
                             .map(|(tx, _)| tx.clone())
                             .ok_or("spawn_result_tx missing")?;
                         thread::spawn(move || {
-                            match execute_job_to_string(&sp, &payload, &sn, &si, &sm, &ssm) {
+                            match execute_job_to_string(
+                                &sp,
+                                &payload,
+                                &sn,
+                                &si,
+                                &sm,
+                                &ssm,
+                                scio.as_ref(),
+                            ) {
                                 Ok(serialized) => {
                                     let _ = stx.send(serialized);
                                 }
@@ -406,6 +428,7 @@ fn execution_loop(
                             &loaded_implementations.clone(),
                             &loaded_lib_manifests.clone(),
                             &loaded_subflow_manifests.clone(),
+                            context_io.as_ref(),
                         ) {
                             Ok(keep_processing) => process_jobs = keep_processing,
                             Err(e) => error!("{e}"),
@@ -481,6 +504,7 @@ fn execute_job_to_string(
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
     loaded_subflow_manifests: &SubflowRegistry,
+    context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<String> {
     let implementation = get_or_load_implementation(
         provider,
@@ -488,6 +512,7 @@ fn execute_job_to_string(
         loaded_implementations,
         loaded_lib_manifests,
         loaded_subflow_manifests,
+        context_io,
     )?;
 
     trace!(
@@ -526,6 +551,7 @@ fn get_or_load_implementation(
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
     loaded_subflow_manifests: &SubflowRegistry,
+    context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<Arc<dyn Implementation>> {
     // Always reload subflow:// — registry may change between submissions.
     let needs_load = payload.implementation_url.scheme() == "subflow" || {
@@ -599,7 +625,7 @@ fn get_or_load_implementation(
                         manifest.clone(),
                         interface_inputs,
                         addr.clone(),
-                        None, // TODO: pass ContextIO for context proxying
+                        context_io.cloned(),
                     )) as Arc<dyn Implementation>
                 }
                 _ => bail!("Unsupported scheme on implementation_url"),
@@ -633,6 +659,7 @@ fn get_or_load_implementation(
 }
 
 // Return Ok(keep_processing) flag as true or false to keep processing
+#[allow(clippy::too_many_arguments)]
 fn execute_job(
     provider: &Arc<dyn Provider>,
     payload: &Payload,
@@ -641,11 +668,18 @@ fn execute_job(
     loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_lib_manifests: &Arc<RwLock<HashMap<Url, (LibraryManifest, Url)>>>,
     loaded_subflow_manifests: &SubflowRegistry,
+    context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<bool> {
     // Sub-flow jobs stream results back individually via run_streaming,
     // bypassing the normal single-result path.
     if payload.implementation_url.scheme() == "subflow" {
-        return execute_subflow_job(payload, results_sink, executor_id, loaded_subflow_manifests);
+        return execute_subflow_job(
+            payload,
+            results_sink,
+            executor_id,
+            loaded_subflow_manifests,
+            context_io,
+        );
     }
 
     let implementation = get_or_load_implementation(
@@ -654,6 +688,7 @@ fn execute_job(
         loaded_implementations,
         loaded_lib_manifests,
         loaded_subflow_manifests,
+        context_io,
     )?;
 
     trace!(
@@ -682,6 +717,7 @@ fn execute_subflow_job(
     results_sink: &zmq::Socket,
     executor_id: &str,
     loaded_subflow_manifests: &SubflowRegistry,
+    context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<bool> {
     let manifests = loaded_subflow_manifests
         .read()
@@ -710,7 +746,7 @@ fn execute_subflow_job(
         manifest.clone(),
         interface_inputs,
         addr.clone(),
-        None, // TODO: pass ContextIO for context proxying
+        context_io.cloned(),
     );
     // Drop the read lock before blocking on the peer
     drop(manifests);
@@ -1045,6 +1081,7 @@ mod test {
             &loaded_implementations,
             &loaded_lib_manifests,
             &empty_subflow_manifests(),
+            None,
         );
 
         assert!(result.is_err(), "Unsupported scheme should return an error");
@@ -1100,6 +1137,7 @@ mod test {
             &loaded_implementations,
             &loaded_lib_manifests,
             &empty_subflow_manifests(),
+            None,
         );
 
         assert!(
@@ -1157,6 +1195,7 @@ mod test {
             &loaded_implementations,
             &loaded_lib_manifests,
             &empty_subflow_manifests(),
+            None,
         );
 
         assert!(
@@ -1211,6 +1250,7 @@ mod test {
             &loaded_implementations,
             &loaded_lib_manifests,
             &empty_subflow_manifests(),
+            None,
         );
 
         assert!(
@@ -1402,6 +1442,7 @@ mod test {
                 &loaded_implementations,
                 &loaded_lib_manifests,
                 &empty_subflow_manifests(),
+                None,
             )
             .is_err());
         }
@@ -1455,6 +1496,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("first get_or_load failed");
 
@@ -1465,6 +1507,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("second get_or_load failed");
 
@@ -1489,6 +1532,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("execute_job_to_string failed");
 
@@ -1520,6 +1564,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         );
         assert!(result.is_err(), "should fail for unknown implementation");
     }
@@ -1559,6 +1604,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("first load from manifest failed");
 
@@ -1575,6 +1621,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("second load (cached) failed");
 
@@ -1624,6 +1671,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         )
         .expect("execute_job should succeed");
 
@@ -1661,6 +1709,7 @@ mod test {
             &loaded_impls,
             &loaded_manifests,
             &empty_subflow_manifests(),
+            None,
         );
         assert!(
             result.is_err(),

--- a/flowr/src/lib/lib.rs
+++ b/flowr/src/lib/lib.rs
@@ -55,6 +55,9 @@ pub mod connections;
 /// Unified protocol messages for client-coordinator communication
 pub mod client_protocol;
 
+/// Channel-based IO handle for context functions and context proxying
+pub mod context_io;
+
 /// Re-export well-known service names from flowcore
 pub use flowcore::services;
 

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -178,6 +178,9 @@ pub(crate) struct RemoteSubFlowImplementation {
     manifest: FlowManifest,
     interface_inputs: Vec<InterfaceInput>,
     peer_address: String,
+    /// Optional `ContextIO` for relaying context function requests from the
+    /// peer back to the origin coordinator's client.
+    context_io: Option<crate::context_io::ContextIO>,
 }
 
 impl RemoteSubFlowImplementation {
@@ -187,11 +190,13 @@ impl RemoteSubFlowImplementation {
         manifest: FlowManifest,
         interface_inputs: Vec<InterfaceInput>,
         peer_address: String,
+        context_io: Option<crate::context_io::ContextIO>,
     ) -> Self {
         RemoteSubFlowImplementation {
             manifest,
             interface_inputs,
             peer_address,
+            context_io,
         }
     }
 
@@ -223,6 +228,11 @@ impl RemoteSubFlowImplementation {
     }
 
     /// Submit to a remote coordinator and return boundary outputs.
+    ///
+    /// If the sub-flow contains context functions, the peer sends context
+    /// requests as intermediate messages before `FlowEnd`. This method
+    /// relays them through the origin's `ContextIO` and sends the responses
+    /// back to the peer.
     fn submit_to_peer(
         &self,
         submission: Submission,
@@ -233,28 +243,44 @@ impl RemoteSubFlowImplementation {
         let connection = ClientConnection::new(&self.peer_address)
             .map_err(|e| format!("Could not connect to peer at {}: {e}", self.peer_address))?;
 
-        // Disable receive timeout — sub-flow execution may take longer than 30s
         connection
             .set_receive_timeout(300_000)
-            .map_err(|e| format!("Could not clear receive timeout: {e}"))?;
+            .map_err(|e| format!("Could not set receive timeout: {e}"))?;
 
         connection
             .send(ClientMessage::ClientSubmission(Box::new(submission)))
             .map_err(|e| format!("Could not send submission to peer: {e}"))?;
 
-        let response: CoordinatorMessage = connection
-            .receive()
-            .map_err(|e| format!("Could not receive from peer: {e}"))?;
+        // Loop receiving messages from the peer. Context function requests
+        // are relayed through ContextIO; FlowEnd terminates the loop.
+        loop {
+            let response: CoordinatorMessage = connection
+                .receive()
+                .map_err(|e| format!("Could not receive from peer: {e}"))?;
 
-        match response {
-            #[cfg(feature = "metrics")]
-            CoordinatorMessage::FlowEnd(boundary_outputs, _) => Ok(boundary_outputs),
-            #[cfg(not(feature = "metrics"))]
-            CoordinatorMessage::FlowEnd(boundary_outputs) => Ok(boundary_outputs),
-            CoordinatorMessage::CoordinatorExiting(result) => {
-                Err(format!("Peer coordinator exited: {result:?}").into())
+            match response {
+                #[cfg(feature = "metrics")]
+                CoordinatorMessage::FlowEnd(boundary_outputs, _) => return Ok(boundary_outputs),
+                #[cfg(not(feature = "metrics"))]
+                CoordinatorMessage::FlowEnd(boundary_outputs) => return Ok(boundary_outputs),
+                CoordinatorMessage::CoordinatorExiting(result) => {
+                    return Err(format!("Peer coordinator exited: {result:?}").into());
+                }
+                context_msg => {
+                    // Relay the context request through our ContextIO
+                    let client_response = if let Some(ref cio) = self.context_io {
+                        cio.send_and_receive(context_msg)
+                            .unwrap_or(ClientMessage::Error("ContextIO relay failed".into()))
+                    } else {
+                        info!("No ContextIO available — acking context message");
+                        ClientMessage::Ack
+                    };
+                    // Send the client's response back to the peer
+                    connection
+                        .send(client_response)
+                        .map_err(|e| format!("Could not send context response to peer: {e}"))?;
+                }
             }
-            other => Err(format!("Unexpected response from peer: {other}").into()),
         }
     }
 }

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -267,13 +267,21 @@ impl RemoteSubFlowImplementation {
                     return Err(format!("Peer coordinator exited: {result:?}").into());
                 }
                 context_msg => {
-                    // Relay the context request through our ContextIO
+                    // Relay the context request through our ContextIO.
+                    // GetStdin/GetLine use the blocking channel since they
+                    // may block waiting for user input.
                     let client_response = if let Some(ref cio) = self.context_io {
-                        cio.send_and_receive(context_msg)
-                            .unwrap_or(ClientMessage::Error("ContextIO relay failed".into()))
+                        let result = match &context_msg {
+                            CoordinatorMessage::GetStdin | CoordinatorMessage::GetLine(_) => {
+                                cio.send_and_receive_blocking(context_msg)
+                            }
+                            _ => cio.send_and_receive(context_msg),
+                        };
+                        result.unwrap_or(ClientMessage::Error("ContextIO relay failed".into()))
                     } else {
-                        info!("No ContextIO available — acking context message");
-                        ClientMessage::Ack
+                        return Err("Context function in delegated sub-flow but no ContextIO \
+                             configured — cannot proxy"
+                            .into());
                     };
                     // Send the client's response back to the peer
                     connection


### PR DESCRIPTION
## Summary

Closes #3018. Phase 4 of #3019 — the final phase.

Enables delegating sub-flows that contain `context://` functions. When a context function executes on a remote coordinator, its invocation is proxied back to the origin coordinator's client through the existing submission connection. No new sockets, threads, or protocol types.

### How it works

```
Origin (client)                   Peer (remote coordinator)
     │                                    │
     │ ClientSubmission (REQ) ──────────► │ receives submission
     │                                    │ executes sub-flow...
     │ ◄───────── Stdout("hello") (REP)   │ context function runs
     │                                    │
     │ Ack (REQ) ─────────────────►       │ receives context result
     │                                    │ continues execution...
     │ ◄───────── FlowEnd (REP)           │ sub-flow complete
```

The existing `ClientConnection` REQ/REP carries context requests as intermediate messages between `ClientSubmission` and `FlowEnd`.

### Changes

| File | Change |
|------|--------|
| **`flowr/src/lib/context_io.rs`** (new) | `ContextIO` and `ContextRequest` moved from binary to library |
| **`flowr/src/lib/subflow.rs`** | `RemoteSubFlowImplementation` loops receiving context messages, relays through `ContextIO` |
| **`flowr/src/bin/flowrcli/main.rs`** | `subflow_context_relay()` — bridge loops relaying context messages as ZMQ REP/REQ |
| **`flowr/src/lib/executor.rs`** | `ContextIO` threaded through executor → `RemoteSubFlowImplementation` |
| **`flowr/src/lib/coordinator.rs`** | Removed context:// rejection in `setup_delegation()` |
| **`flowcore/src/model/flow_manifest.rs`** | Delegation scoring: context:// penalty (3.0) instead of exclusion |

### Delegation scoring

Context functions no longer exclude a sub-flow from delegation. Instead, each context function adds a heavy penalty (`CONTEXT_PENALTY = 3.0`) to the delegation score. A sub-flow with many context functions will score low (discouraging delegation), but one with a deeply nested single context function among many compute functions can still be delegated.

### Pre-commit checks

- `cargo fmt` — clean
- `make clippy` — clean
- `make test` — all 40 test suites pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegated sub-flows can now use context functions, with requests relayed to the originating client during execution.
  * Context-enabled sub-flows can receive delegation scores instead of being automatically excluded.
  * Added support for context requests that wait for a response or continue without one.

* **Bug Fixes**
  * Improved delegated sub-flow communication by processing context messages until execution completes.
  * Added clearer handling for communication failures and coordinator shutdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->