### PR TITLE
Keep sub-flow connection alive between invocations

### DIFF
--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -671,6 +671,7 @@ fn execute_job(
             payload,
             results_sink,
             executor_id,
+            loaded_implementations,
             loaded_subflow_manifests,
             context_io,
         );
@@ -705,14 +706,35 @@ fn execute_job(
     Ok(true)
 }
 
-/// Execute a sub-flow job by streaming boundary outputs back individually.
+/// Execute a sub-flow job. If a cached implementation exists (from a
+/// previous invocation), reuses it (and its cached connection).
 fn execute_subflow_job(
     payload: &Payload,
     results_sink: &zmq::Socket,
     executor_id: &str,
+    loaded_implementations: &Arc<RwLock<HashMap<Url, Arc<dyn Implementation>>>>,
     loaded_subflow_manifests: &SubflowRegistry,
     context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<bool> {
+    // Check if we already have a cached implementation (with its connection)
+    let cached = {
+        let impls = loaded_implementations
+            .read()
+            .map_err(|_| "Could not read loaded implementations")?;
+        impls.get(&payload.implementation_url).cloned()
+    };
+    if let Some(impl_arc) = cached {
+        // Reuse cached implementation — connection stays alive
+        let result = impl_arc.run(&payload.input_set);
+        results_sink
+            .send(
+                serde_json::to_string(&(payload.job_id, executor_id, result))?.as_bytes(),
+                0,
+            )
+            .map_err(|_| "Could not send result of Job")?;
+        return Ok(true);
+    }
+
     let manifests = loaded_subflow_manifests
         .read()
         .map_err(|_| "Could not read subflow manifests")?;
@@ -736,21 +758,27 @@ fn execute_subflow_job(
             destination_io_number: *dest_io,
         })
         .collect();
-    let remote = crate::subflow::RemoteSubFlowImplementation::new(
+    let remote = Arc::new(crate::subflow::RemoteSubFlowImplementation::new(
         manifest.clone(),
         interface_inputs,
         addr.clone(),
         context_io.cloned(),
-    );
+    ));
     // Drop the read lock before blocking on the peer
     drop(manifests);
 
+    // First invocation uses run_streaming for backward compatibility
     remote.run_streaming(
         &payload.input_set,
         payload.job_id,
         executor_id,
         results_sink,
     )?;
+
+    // Cache for subsequent invocations (which will use run() via the cache path)
+    if let Ok(mut impls) = loaded_implementations.write() {
+        impls.insert(payload.implementation_url.clone(), remote);
+    }
 
     Ok(true)
 }

--- a/flowr/src/lib/executor.rs
+++ b/flowr/src/lib/executor.rs
@@ -553,8 +553,7 @@ fn get_or_load_implementation(
     loaded_subflow_manifests: &SubflowRegistry,
     context_io: Option<&crate::context_io::ContextIO>,
 ) -> Result<Arc<dyn Implementation>> {
-    // Always reload subflow:// — registry may change between submissions.
-    let needs_load = payload.implementation_url.scheme() == "subflow" || {
+    let needs_load = {
         let implementations = loaded_implementations
             .read()
             .map_err(|_| "Could not gain read access to loaded implementations map")?;
@@ -630,11 +629,6 @@ fn get_or_load_implementation(
                 }
                 _ => bail!("Unsupported scheme on implementation_url"),
             };
-            // Don't cache subflow:// implementations — the registry entry
-            // may change between submissions (different manifest or peer).
-            if payload.implementation_url.scheme() == "subflow" {
-                return Ok(impl_arc);
-            }
             implementations.insert(payload.implementation_url.clone(), impl_arc);
             trace!(
                 "Implementation '{}' added to executor",

--- a/flowr/src/lib/subflow.rs
+++ b/flowr/src/lib/subflow.rs
@@ -4,7 +4,7 @@
 //! by creating a nested coordinator with its own dispatcher and executor
 //! threads.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use flowcore::model::flow_manifest::FlowManifest;
 use flowcore::model::submission::Submission;
@@ -181,6 +181,9 @@ pub(crate) struct RemoteSubFlowImplementation {
     /// Optional `ContextIO` for relaying context function requests from the
     /// peer back to the origin coordinator's client.
     context_io: Option<crate::context_io::ContextIO>,
+    /// Cached connection to the peer coordinator, reused across invocations.
+    /// The peer's bridge loops back after `FlowEnd`, ready for the next submission.
+    cached_connection: Mutex<Option<crate::connections::ClientConnection>>,
 }
 
 impl RemoteSubFlowImplementation {
@@ -197,6 +200,7 @@ impl RemoteSubFlowImplementation {
             interface_inputs,
             peer_address,
             context_io,
+            cached_connection: Mutex::new(None),
         }
     }
 
@@ -240,12 +244,24 @@ impl RemoteSubFlowImplementation {
         use crate::client_protocol::{ClientMessage, CoordinatorMessage};
         use crate::connections::ClientConnection;
 
-        let connection = ClientConnection::new(&self.peer_address)
-            .map_err(|e| format!("Could not connect to peer at {}: {e}", self.peer_address))?;
-
-        connection
-            .set_receive_timeout(300_000)
-            .map_err(|e| format!("Could not set receive timeout: {e}"))?;
+        // Reuse the cached connection if available, otherwise create a new one.
+        // The peer's bridge loops back after FlowEnd, ready for the next submission.
+        let connection = {
+            let mut cached = self
+                .cached_connection
+                .lock()
+                .map_err(|_| "Could not lock cached connection")?;
+            if let Some(conn) = cached.take() {
+                conn
+            } else {
+                let conn = ClientConnection::new(&self.peer_address).map_err(|e| {
+                    format!("Could not connect to peer at {}: {e}", self.peer_address)
+                })?;
+                conn.set_receive_timeout(300_000)
+                    .map_err(|e| format!("Could not set receive timeout: {e}"))?;
+                conn
+            }
+        };
 
         connection
             .send(ClientMessage::ClientSubmission(Box::new(submission)))
@@ -260,10 +276,22 @@ impl RemoteSubFlowImplementation {
 
             match response {
                 #[cfg(feature = "metrics")]
-                CoordinatorMessage::FlowEnd(boundary_outputs, _) => return Ok(boundary_outputs),
+                CoordinatorMessage::FlowEnd(boundary_outputs, _) => {
+                    // Cache the connection for the next invocation
+                    if let Ok(mut cached) = self.cached_connection.lock() {
+                        *cached = Some(connection);
+                    }
+                    return Ok(boundary_outputs);
+                }
                 #[cfg(not(feature = "metrics"))]
-                CoordinatorMessage::FlowEnd(boundary_outputs) => return Ok(boundary_outputs),
+                CoordinatorMessage::FlowEnd(boundary_outputs) => {
+                    if let Ok(mut cached) = self.cached_connection.lock() {
+                        *cached = Some(connection);
+                    }
+                    return Ok(boundary_outputs);
+                }
                 CoordinatorMessage::CoordinatorExiting(result) => {
+                    // Don't cache — the peer exited
                     return Err(format!("Peer coordinator exited: {result:?}").into());
                 }
                 context_msg => {

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -791,6 +791,246 @@ fn peer_coordinator_executes_subflow() {
     );
 }
 
+/// Test that multiple sub-flow submissions work on the same peer coordinator,
+/// verifying that the peer's bridge loops back correctly after each `FlowEnd`.
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+#[allow(clippy::too_many_lines)]
+fn peer_handles_multiple_submissions() {
+    use flowcore::model::flow_manifest::FlowInfo;
+    use flowcore::model::input::{Input, InputInitializer};
+    use flowcore::model::metadata::MetaData;
+    use flowcore::model::output_connection::{OutputConnection, Source};
+    use flowcore::model::runtime_function::RuntimeFunction;
+    use flowrlib::client_protocol::{ClientMessage, CoordinatorMessage};
+    use flowrlib::connections::{ClientConnection, CoordinatorConnection, WAIT};
+    use std::sync::Arc;
+
+    // Build a sub-flow: add(a,b) with boundary output to #10:0
+    let build_manifest = |a: i64, b: i64| {
+        let mut manifest = FlowManifest::new(MetaData::default());
+        manifest.add_flow_info(FlowInfo {
+            process_id: 0,
+            parent_id: None,
+            sub_flow_ids: vec![],
+            delegation_score: None,
+            #[cfg(feature = "debugger")]
+            name: "subflow".into(),
+            #[cfg(feature = "debugger")]
+            route: "/subflow".into(),
+        });
+
+        let mut func = RuntimeFunction::new(
+            #[cfg(feature = "debugger")]
+            "add",
+            #[cfg(feature = "debugger")]
+            "/subflow/add",
+            "lib://flowstdlib/math/add",
+            vec![
+                Input::new(
+                    #[cfg(feature = "debugger")]
+                    "i1",
+                    0,
+                    false,
+                    Some(InputInitializer::Once(serde_json::json!(a))),
+                    None,
+                ),
+                Input::new(
+                    #[cfg(feature = "debugger")]
+                    "i2",
+                    0,
+                    false,
+                    Some(InputInitializer::Once(serde_json::json!(b))),
+                    None,
+                ),
+            ],
+            1,
+            0,
+            &[OutputConnection::new(
+                Source::default(),
+                10,
+                0,
+                0,
+                false,
+                String::new(),
+                #[cfg(feature = "debugger")]
+                String::new(),
+            )],
+            false,
+        );
+        let dummy_url = url::Url::parse("file:///dummy/manifest.json").expect("URL");
+        func.set_implementation_url(&dummy_url).expect("set URL");
+        manifest.add_function(func);
+        manifest
+    };
+
+    let peer_port = portpicker::pick_unused_port().expect("port");
+
+    // Peer coordinator that accepts TWO submissions
+    let peer_thread = std::thread::spawn(move || {
+        let mut conn = CoordinatorConnection::new("peer", peer_port).expect("conn");
+
+        let ports = (
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+            portpicker::pick_unused_port().expect("port"),
+        );
+        let bind_addrs = (
+            format!("tcp://*:{}", ports.0),
+            format!("tcp://*:{}", ports.1),
+            format!("tcp://*:{}", ports.2),
+            format!("tcp://*:{}", ports.3),
+        );
+        let connect_addrs = (
+            format!("tcp://127.0.0.1:{}", ports.0),
+            format!("tcp://127.0.0.1:{}", ports.1),
+            format!("tcp://127.0.0.1:{}", ports.2),
+            format!("tcp://127.0.0.1:{}", ports.3),
+        );
+
+        let dispatcher = flowrlib::dispatcher::Dispatcher::new(&bind_addrs).expect("dispatcher");
+        let provider = Arc::new(TestProvider) as Arc<dyn flowcore::provider::Provider>;
+
+        let mut executor = flowrlib::executor::Executor::new();
+        #[cfg(feature = "flowstdlib")]
+        executor
+            .add_lib(
+                flowstdlib::manifest::get().expect("flowstdlib"),
+                url::Url::parse("memory://").expect("url"),
+            )
+            .expect("add_lib");
+        executor.start(
+            &provider,
+            1,
+            &connect_addrs.0,
+            &connect_addrs.2,
+            &connect_addrs.3,
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        #[cfg(feature = "debugger")]
+        let mut debug_handler = flowrlib::subflow::NoOpDebugHandler;
+        #[cfg(feature = "submission")]
+        let mut no_op = flowrlib::subflow::NoOpSubmissionHandler;
+
+        let mut coordinator = flowrlib::coordinator::Coordinator::new(
+            dispatcher,
+            #[cfg(feature = "submission")]
+            &mut no_op,
+            #[cfg(feature = "debugger")]
+            &mut debug_handler,
+        );
+
+        // Process TWO submissions sequentially
+        let mut results = Vec::new();
+        for _ in 0..2 {
+            let msg: ClientMessage = conn.receive(WAIT).expect("receive submission");
+            if let ClientMessage::ClientSubmission(submission) = msg {
+                let state = coordinator
+                    .execute_subflow(*submission)
+                    .expect("execute subflow");
+                let boundary_outputs: Vec<flowrlib::client_protocol::BoundaryOutputEntry> = state
+                    .boundary_outputs()
+                    .iter()
+                    .map(|bo| flowrlib::client_protocol::BoundaryOutputEntry {
+                        connection: bo.connection.clone(),
+                        value: bo.value.clone(),
+                    })
+                    .collect();
+                #[cfg(feature = "metrics")]
+                let flow_end = CoordinatorMessage::FlowEnd(
+                    boundary_outputs.clone(),
+                    flowcore::model::metrics::Metrics::new(0, 0),
+                );
+                #[cfg(not(feature = "metrics"))]
+                let flow_end = CoordinatorMessage::FlowEnd(boundary_outputs.clone());
+                conn.send(flow_end).expect("send FlowEnd");
+                results.push(boundary_outputs);
+            }
+        }
+
+        let _ = coordinator.send_done();
+        executor.wait();
+        results
+    });
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Submit TWO sub-flows on the SAME connection
+    let peer_address = format!("127.0.0.1:{peer_port}");
+    let connection = ClientConnection::new(&peer_address).expect("connect");
+    connection.set_receive_timeout(300_000).expect("timeout");
+
+    // First submission: add(7, 3) = 10
+    let manifest1 = build_manifest(7, 3);
+    let mut sub1 = Submission::new(
+        manifest1,
+        None,
+        None,
+        #[cfg(feature = "debugger")]
+        false,
+        #[cfg(feature = "trace")]
+        None,
+    );
+    sub1.is_subflow = true;
+    connection
+        .send(ClientMessage::ClientSubmission(Box::new(sub1)))
+        .expect("send sub1");
+    let resp1: CoordinatorMessage = connection.receive().expect("receive resp1");
+
+    // Second submission: add(100, 200) = 300
+    let manifest2 = build_manifest(100, 200);
+    let mut sub2 = Submission::new(
+        manifest2,
+        None,
+        None,
+        #[cfg(feature = "debugger")]
+        false,
+        #[cfg(feature = "trace")]
+        None,
+    );
+    sub2.is_subflow = true;
+    connection
+        .send(ClientMessage::ClientSubmission(Box::new(sub2)))
+        .expect("send sub2");
+    let resp2: CoordinatorMessage = connection.receive().expect("receive resp2");
+
+    // Extract boundary outputs from FlowEnd responses
+    #[cfg(feature = "metrics")]
+    let get_outputs = |msg: CoordinatorMessage| match msg {
+        CoordinatorMessage::FlowEnd(outputs, _) => outputs,
+        other => panic!("Expected FlowEnd, got: {other}"),
+    };
+    #[cfg(not(feature = "metrics"))]
+    let get_outputs = |msg: CoordinatorMessage| match msg {
+        CoordinatorMessage::FlowEnd(outputs) => outputs,
+        other => panic!("Expected FlowEnd, got: {other}"),
+    };
+    let outputs1 = get_outputs(resp1);
+    let outputs2 = get_outputs(resp2);
+
+    assert_eq!(
+        outputs1.first().map(|o| &o.value),
+        Some(&serde_json::json!(10)),
+        "First invocation: add(7,3) should be 10"
+    );
+    assert_eq!(
+        outputs2.first().map(|o| &o.value),
+        Some(&serde_json::json!(300)),
+        "Second invocation: add(100,200) should be 300"
+    );
+
+    drop(connection);
+    let peer_results = peer_thread.join().expect("peer thread panicked");
+    assert_eq!(
+        peer_results.len(),
+        2,
+        "Peer should have processed 2 submissions"
+    );
+}
+
 /// End-to-end test: delegate a sub-flow containing a WASM function (`add.wasm`)
 /// to a coordinator, verifying that:
 /// 1. The root coordinator rewrites the `file://` WASM URL to `http://`


### PR DESCRIPTION
## Summary

Closes #3020.

When a delegated sub-flow is invoked repeatedly (proxy function returns `RUN_AGAIN`), the connection to the peer coordinator is now reused instead of being recreated. The `RemoteSubFlowImplementation` is also cached in the executor instead of being reconstructed per invocation.

### Before

N invocations of a delegated sub-flow:
- N new ZMQ connections created and torn down
- N manifest clones 
- N ZMQ socket setups (bind/connect/linger)
- N TCP handshakes

### After

N invocations:
- 1 ZMQ connection (reused across all invocations)
- 1 `RemoteSubFlowImplementation` instance (cached in executor)
- The peer's bridge already loops back after `FlowEnd`, ready for the next submission

### Changes

| File | Change |
|------|--------|
| `flowr/src/lib/subflow.rs` | `RemoteSubFlowImplementation` holds `Mutex<Option<ClientConnection>>`. After `FlowEnd`, connection is cached. On next invocation, cached connection is reused. |
| `flowr/src/lib/executor.rs` | Removed `subflow://` caching skip. Implementations are now cached in `loaded_implementations` like all other schemes. |

### Pre-commit checks

- `cargo fmt` — clean
- `make clippy` — clean
- `make test` — all 40 test suites pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved sub-flow execution efficiency by reusing loaded implementations and remote connections across invocations.
  * Reduced connection setup overhead for repeated sub-flow submissions.
  * Added reliable reconnection when a connection is unavailable.
  * Safely releases connections when the remote process exits.
  * Improved handling of sequential sub-flow submissions while preserving correct results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->