### PR TITLE
Remove --server flag: default to coordinator-only mode when no manifest provided

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -73,7 +73,7 @@
 - [Exceptions and Panics](book/running/panics.md)
 - [Running Flows using `flowr`](book/running/flowr.md)
 - [Running a flow in client/server mode of `flowr`](book/running/client_server.md)
-- [Distributed execution with `flowrcli --server`](book/running/distributed.md)
+- [Distributed execution with `flowrcli`](book/running/distributed.md)
 
 # Debugging Flows
 - [The Debugger](book/debugging/debugger.md)

--- a/book/running/client_server.md
+++ b/book/running/client_server.md
@@ -51,9 +51,10 @@ flowr/examples/fibonacci/manifest.json
 ```
 
 In Terminal 1, lets start the server that will wait for a flow to be submitted for execution,
-using `flowrcli` with debug logging verbosity level to be able to see what it's doing.
+using `flowrcli` with no flow manifest argument and debug logging verbosity level to be able
+to see what it's doing.
 
-`> flowrcli -n -s -v debug`
+`> flowrcli -n -v debug`
 
 which will log some lines, ending with:
 

--- a/book/running/distributed.md
+++ b/book/running/distributed.md
@@ -69,7 +69,7 @@ The same approach works across machines. Start `flowrcli` (with no manifest) on 
 remote machine on the same network. The mDNS discovery protocol will find it
 automatically — no configuration needed.
 
-```
+```shell
 # Machine A (peer coordinator)
 flowrcli -v info
 

--- a/book/running/distributed.md
+++ b/book/running/distributed.md
@@ -15,9 +15,9 @@ in the parent flow.
 
 ### How It Works
 
-1. Start a second `flowrcli` instance in server mode (`--server`). This instance
-   advertises itself as a peer coordinator via mDNS and waits for sub-flow
-   submissions.
+1. Start a second `flowrcli` instance with no flow manifest argument. This starts
+   in coordinator-only mode, advertising itself as a peer coordinator via mDNS
+   and waiting for sub-flow submissions.
 
 2. Run your flow with `flowrcli --delegate`. The `--delegate` flag tells
    `flowrcli` to look for a peer coordinator on the network. If one is found,
@@ -41,11 +41,11 @@ The sub-flow with the largest number of eligible functions is selected.
 #### Terminal 1 — start a peer coordinator
 
 ```
-flowrcli --peer -v info
+flowrcli -v info
 ```
 
-This starts `flowrcli` in server mode. It advertises itself via mDNS and
-waits for sub-flow submissions.
+This starts `flowrcli` in coordinator-only mode (no flow manifest provided).
+It advertises itself via mDNS and waits for sub-flow submissions.
 
 #### Terminal 2 — compile and run a flow with delegation
 
@@ -65,13 +65,13 @@ The resulting image is identical to running without `--delegate`.
 
 ### Cross-Machine Execution
 
-The same approach works across machines. Start `flowrcli --peer` on a remote
-machine on the same network. The mDNS discovery protocol will find it
+The same approach works across machines. Start `flowrcli` (with no manifest) on a
+remote machine on the same network. The mDNS discovery protocol will find it
 automatically — no configuration needed.
 
 ```
 # Machine A (peer coordinator)
-flowrcli --peer -v info
+flowrcli -v info
 
 # Machine B (run the flow)
 flowrcli --delegate -v info flowr/examples/mandlebrot/manifest.json -- output.png '[200,150]' '[[-1.20,0.35],[-1,0.20]]'
@@ -90,7 +90,7 @@ startup. Future versions may support discovering peers mid-execution.
 
 ### Architecture
 
-Each `flowrcli --peer` instance runs its own coordinator with:
+Each `flowrcli` peer instance runs its own coordinator with:
 - A ZMQ REP socket for receiving sub-flow submissions
 - Its own dispatcher and executor pool for running received sub-flows
 - mDNS advertisement so parent coordinators can discover it

--- a/book/running/flowr.md
+++ b/book/running/flowr.md
@@ -27,7 +27,6 @@ Options:
   -d, --debugger                     Enable the debugger when running a flow
   -m, --metrics                      Calculate metrics during flow execution and print them out when done
   -n, --native                       Link with native (not WASM) version of flowstdlib
-  -s, --server                       Launch flowr with a coordinator only, no client
   -c, --client <port>                Launch flowr with a client only, no coordinator, to connect to a flowr coordinator
   -C, --context                      Execute only 'context' (not general) jobs in the coordinator
   -j, --jobs <MAX_JOBS>              Set maximum number of jobs that can be running in parallel)
@@ -46,7 +45,8 @@ environment variable, or using one or more instance of the `-L, --libdir <LIB_DI
 After the Options you can supply an optional field for where to load the root flow from. This can be a relative or 
 absolute path when no Url scheme is used, an absolute path if the `file://` scheme is used or a web resources if
 either the `http` or `https` scheme is used.
-* If no argument is supplied, it assumes the current directory as the argument, and continues as below
+* If no argument is supplied, `flowrcli` starts in coordinator-only mode, waiting for client submissions 
+  and peer sub-flow delegations (see [distributed execution](distributed.md))
 * If it's a directory then it attempts to load "root.toml" from within the directory
 * If it's a file then it attempts to load the root flow from that file
 

--- a/book/running/flowr.md
+++ b/book/running/flowr.md
@@ -45,8 +45,8 @@ environment variable, or using one or more instance of the `-L, --libdir <LIB_DI
 After the Options you can supply an optional field for where to load the root flow from. This can be a relative or 
 absolute path when no Url scheme is used, an absolute path if the `file://` scheme is used or a web resources if
 either the `http` or `https` scheme is used.
-* If no argument is supplied, `flowrcli` starts in coordinator-only mode, waiting for client submissions 
-  and peer sub-flow delegations (see [distributed execution](distributed.md))
+* If no argument is supplied (and `--client` is not set), `flowrcli` starts in coordinator-only mode,
+  waiting for client submissions and peer sub-flow delegations (see [distributed execution](distributed.md))
 * If it's a directory then it attempts to load "root.toml" from within the directory
 * If it's a file then it attempts to load the root flow from that file
 

--- a/flowr/README.md
+++ b/flowr/README.md
@@ -41,6 +41,6 @@ Those functions are organized into the following modules, each with multiple fun
 * [stdio](src/bin/flowrcli/context/stdio/stdio.md) - used to interact with stdio
 
 ## Distributed Execution
-`flowrcli` (with no flow manifest argument) starts in coordinator-only mode, acting as a peer
-coordinator that accepts delegated sub-flows from other coordinators over the network.
+`flowrcli` (with no flow manifest argument and without `--client`) starts in coordinator-only mode,
+acting as a peer coordinator that accepts delegated sub-flows from other coordinators over the network.
 See the [distributed](../book/running/distributed.md) section for details.

--- a/flowr/README.md
+++ b/flowr/README.md
@@ -41,5 +41,6 @@ Those functions are organized into the following modules, each with multiple fun
 * [stdio](src/bin/flowrcli/context/stdio/stdio.md) - used to interact with stdio
 
 ## Distributed Execution
-`flowrcli --server` can act as a peer coordinator, accepting delegated sub-flows from other coordinators
-over the network. See the [distributed](../book/running/distributed.md) section for details.
+`flowrcli` (with no flow manifest argument) starts in coordinator-only mode, acting as a peer
+coordinator that accepts delegated sub-flows from other coordinators over the network.
+See the [distributed](../book/running/distributed.md) section for details.

--- a/flowr/src/bin/flowrcli/main.rs
+++ b/flowr/src/bin/flowrcli/main.rs
@@ -149,7 +149,9 @@ fn run() -> Result<()> {
             #[cfg(feature = "debugger")]
             debug_this_flow,
         )
-    } else if matches.get_flag("server") {
+    } else if matches.get_one::<String>("flow-manifest").is_none() {
+        // No flow manifest provided — start as a coordinator-only server,
+        // waiting for client submissions and peer sub-flow delegations
         coordinator_only(num_threads, lib_search_path, native_flowstdlib)
     } else {
         client_and_coordinator(
@@ -458,7 +460,7 @@ fn coordinator(
     coordinator.set_local_addresses(job_source_name.clone(), results_sink.clone());
 
     // If FLOW_REMOTE_EXECUTORS is set, try to discover a remote coordinator
-    // to help while idle (dynamic executor sharing). Only for --server mode.
+    // to help while idle (dynamic executor sharing). Only for coordinator-only mode.
     if loop_forever && std::env::var("FLOW_REMOTE_EXECUTORS").is_ok() {
         discover_and_set_remote_coordinator(&mut coordinator, ports.0);
     }
@@ -987,19 +989,10 @@ fn get_matches() -> ArgMatches {
     );
 
     let app = app
-        .arg(Arg::new("server")
-             .short('s')
-             .long("server")
-             .action(clap::ArgAction::SetTrue)
-             .conflicts_with("client")
-             .help("Launch only a Coordinator (no client). Accepts both client \
-                    submissions and sub-flow delegations from other coordinators."),
-        )
         .arg(Arg::new("client")
              .short('c')
              .long("client")
              .action(clap::ArgAction::SetTrue)
-             .conflicts_with("server")
              .help("Launch only a client (no coordinator) to connect to a remote coordinator"),
         )
         .arg(Arg::new("jobs")
@@ -1037,7 +1030,9 @@ fn get_matches() -> ArgMatches {
             .help("Set verbosity level for output (trace, debug, info, warn, error(default), off)"))
         .arg(Arg::new("flow-manifest")
             .num_args(1)
-            .help("the file path of the 'flow' manifest file"))
+            .required(false)
+            .help("the file path of the 'flow' manifest file. If omitted (and --client is not set), \
+                   starts in coordinator-only mode, waiting for submissions."))
         .arg(Arg::new("flow_args")
             .num_args(0..)
             .trailing_var_arg(true)

--- a/flowr/tests/delegation.rs
+++ b/flowr/tests/delegation.rs
@@ -3,10 +3,10 @@
 use serial_test::serial;
 
 /// End-to-end test: `flowrcli --delegate` delegates a sub-flow to a second
-/// `flowrcli --server` instance acting as a peer coordinator.
+/// `flowrcli` instance (no manifest, coordinator-only mode) acting as a peer.
 ///
 /// 1. Compiles the mandlebrot example
-/// 2. Starts `flowrcli --server` as the peer coordinator
+/// 2. Starts `flowrcli` (no manifest) as the peer coordinator
 /// 3. Runs `flowrcli --delegate` with the mandlebrot manifest
 /// 4. Verifies the output PNG matches the expected file
 /// 5. Confirms delegation happened remotely via log
@@ -41,13 +41,13 @@ fn test_delegate_to_peer_flowrcli() {
     // This ensures coverage instrumentation is captured when running under cargo llvm-cov.
     let flowrcli = env!("CARGO_BIN_EXE_flowrcli");
 
-    // Start a second flowrcli as a peer coordinator
+    // Start a second flowrcli as a peer coordinator (no manifest = coordinator-only mode)
     let mut peer = Command::new(flowrcli)
-        .args(["--server", "-v", "info"])
+        .args(["-v", "info"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("Could not spawn flowrcli --server");
+        .expect("Could not spawn flowrcli peer");
 
     // Wait for the peer to start and advertise via mDNS
     thread::sleep(Duration::from_secs(8));

--- a/flowr/utilities/src/lib.rs
+++ b/flowr/utilities/src/lib.rs
@@ -381,8 +381,8 @@ pub fn execute_flow_client_server(example_name: &str, manifest: PathBuf) {
 
     let mut server_command = Command::new("flowrcli");
 
-    // separate 'flowr' server process args: -n for native libs, -s to get a server process
-    let server_args = vec!["-n", "-s"];
+    // No manifest argument = coordinator-only mode; -n for native libs
+    let server_args = vec!["-n"];
 
     println!(
         "Starting 'flowrcli' as server with command line: 'flowrcli {}'",


### PR DESCRIPTION
## Summary

When `flowrcli` is invoked without a flow manifest argument (and without `--client`), it now starts in coordinator-only mode automatically. This replaces the `--server`/`-s` flag, simplifying the CLI:

- `flowrcli manifest.json -- args` — runs the flow (unchanged)
- `flowrcli` — coordinator-only mode (was `--server`)
- `flowrcli -c manifest.json` — client-only (unchanged)

## Changes

### Code (`flowr/src/bin/flowrcli/main.rs`)
- Removed the `--server`/`-s` CLI argument definition
- Removed `conflicts_with("server")` from the `--client` argument
- Made the `flow-manifest` positional arg optional with `.required(false)`
- Updated `run()` to check for missing manifest and route to `coordinator_only()`
- Updated internal comment ("coordinator-only mode" instead of "--server mode")

### Tests
- `flowr/tests/delegation.rs` — peer now spawned without `--server`
- `flowr/utilities/src/lib.rs` — client/server test utility updated (removed `-s`)

### Documentation
- `book/running/flowr.md` — removed `-s, --server` from CLI help, updated `flow-manifest` description
- `book/running/distributed.md` — updated all references from `--server`/`--peer` to no-manifest invocation
- `book/running/client_server.md` — updated example command
- `flowr/README.md` — updated distributed execution section
- `SUMMARY.md` — updated link text

## Testing
- `make clippy` passes
- `cargo fmt` clean
- All unit tests pass (1181+ tests)
- Delegation integration test passes (peer spawned without `--server`)
- Manual verification: `flowrcli -n` starts coordinator-only mode, prints "ready"

**Note:** The `client_server` integration test hangs — this is a pre-existing issue on master, not introduced by this PR.

Closes #3027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Running `flowrcli` without a flow manifest now starts coordinator-only mode.
  * Coordinator-only instances wait for client submissions and delegated sub-flow work.

* **Bug Fixes**
  * Simplified distributed execution setup by removing the need for the `--server` option.

* **Documentation**
  * Updated distributed execution, client-server, and command-line usage guidance with the new startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->