### PR TITLE
flowrgui: defer ImageWrite rendering to FlowEnd (latest frame wins)

### DIFF
--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3259,8 +3259,10 @@ impl FlowrGui {
             if data.width != width || data.height != height {
                 data.width = width;
                 data.height = height;
-                data.data = RgbaImage::new(width, height);
             }
+            // Always recreate the buffer so shorter rows don't retain
+            // stale pixels from a previous frame
+            data.data = RgbaImage::new(width, height);
             let buf_width = data.width as usize;
             let buf = data.data.as_mut();
             for (y, row) in grid.iter().enumerate() {
@@ -4522,5 +4524,33 @@ mod test {
         assert_eq!(img.width, 2);
         assert_eq!(img.data.get_pixel(0, 1), &Rgba([30, 30, 30, 255]));
         assert_eq!(img.data.get_pixel(1, 1), &Rgba([40, 40, 40, 255]));
+    }
+
+    #[test]
+    fn image_write_shorter_row_clears_stale_pixels() {
+        let mut gui = test_gui();
+        gui.running = true;
+        // First write: full 3x2 grid
+        let grid1 = vec![vec![10, 20, 30], vec![40, 50, 60]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid1,
+                "test.png".into(),
+            ))),
+        );
+        gui.flush_pending_grids();
+        // Second write: same dimensions but shorter second row
+        let grid2 = vec![vec![1, 2, 3], vec![4]];
+        drop(
+            gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
+                grid2,
+                "test.png".into(),
+            ))),
+        );
+        gui.flush_pending_grids();
+        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
+        // Trailing pixels should be zero (cleared), not stale from grid1
+        assert_eq!(img.data.get_pixel(1, 1), &Rgba([0, 0, 0, 0]));
+        assert_eq!(img.data.get_pixel(2, 1), &Rgba([0, 0, 0, 0]));
     }
 }

--- a/flowr/src/bin/flowrgui/main.rs
+++ b/flowr/src/bin/flowrgui/main.rs
@@ -3237,6 +3237,62 @@ impl FlowrGui {
         }
     }
 
+    /// Materialize a single pending grid into the rendered image buffer.
+    /// Called before `PixelWrite` operations on the same image to preserve
+    /// message ordering.
+    fn materialize_pending_grid(&mut self, name: &str) {
+        if let Some(grid) = self.tab_set.images_tab.pending_grids.remove(name) {
+            let height = u32::try_from(grid.len()).unwrap_or(0);
+            let width = grid
+                .first()
+                .map_or(0, |row| u32::try_from(row.len()).unwrap_or(0));
+            let data = self
+                .tab_set
+                .images_tab
+                .images
+                .entry(name.to_string())
+                .or_insert_with(|| ImageReference {
+                    width,
+                    height,
+                    data: RgbaImage::new(width, height),
+                });
+            if data.width != width || data.height != height {
+                data.width = width;
+                data.height = height;
+                data.data = RgbaImage::new(width, height);
+            }
+            let buf_width = data.width as usize;
+            let buf = data.data.as_mut();
+            for (y, row) in grid.iter().enumerate() {
+                let row_offset = y * buf_width * 4;
+                for (x, &val) in row.iter().take(buf_width).enumerate() {
+                    let offset = row_offset + x * 4;
+                    if let Some([r, g, b, a]) = buf.get_mut(offset..offset + 4) {
+                        *r = val;
+                        *g = val;
+                        *b = val;
+                        *a = 255;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Materialize all pending grids. Called on `FlowEnd` to ensure the
+    /// final frame of every image is rendered.
+    fn flush_pending_grids(&mut self) {
+        let names: Vec<String> = self
+            .tab_set
+            .images_tab
+            .pending_grids
+            .keys()
+            .cloned()
+            .collect();
+        for name in names {
+            self.materialize_pending_grid(&name);
+        }
+    }
+
     /// Send a response for a blocking IO request (GetLine/GetStdin) via the
     /// dedicated blocking IO channel.
     fn send_blocking(&mut self, msg: ClientMessage) {
@@ -3547,6 +3603,7 @@ impl FlowrGui {
             }
             #[cfg(feature = "metrics")]
             CoordinatorMessage::FlowEnd(_, metrics) => {
+                self.flush_pending_grids();
                 self.running = false;
                 self.submitted = false;
                 self.pending_getline = false;
@@ -3564,6 +3621,7 @@ impl FlowrGui {
             }
             #[cfg(not(feature = "metrics"))]
             CoordinatorMessage::FlowEnd(_) => {
+                self.flush_pending_grids();
                 self.running = false;
                 self.submitted = false;
                 self.pending_getline = false;
@@ -3768,6 +3826,9 @@ impl FlowrGui {
                 (width, height),
                 ref name,
             ) => {
+                // Materialize any pending grid for this image before applying
+                // pixel writes, preserving message ordering.
+                self.materialize_pending_grid(name);
                 if self.tab_set.images_tab.images.is_empty() {
                     let data = RgbaImage::new(width, height);
                     self.tab_set.images_tab.images.insert(
@@ -3793,41 +3854,13 @@ impl FlowrGui {
                 self.send(ClientMessage::Ack);
             }
             CoordinatorMessage::ImageWrite(grid, ref name) => {
-                let height = u32::try_from(grid.len()).unwrap_or(0);
-                let width = grid
-                    .first()
-                    .map_or(0, |row| u32::try_from(row.len()).unwrap_or(0));
-                let data = self
-                    .tab_set
+                // Store the latest grid — rendering is deferred to FlowEnd.
+                // This avoids per-pixel rendering on every frame; only the
+                // final frame for each image name is materialized.
+                self.tab_set
                     .images_tab
-                    .images
-                    .entry(name.clone())
-                    .or_insert_with(|| ImageReference {
-                        width,
-                        height,
-                        data: RgbaImage::new(width, height),
-                    });
-                // Recreate the buffer when dimensions change
-                if data.width != width || data.height != height {
-                    data.width = width;
-                    data.height = height;
-                    data.data = RgbaImage::new(width, height);
-                }
-                // Use buffer width for row stride, not grid row length
-                let buf_width = data.width as usize;
-                let buf = data.data.as_mut();
-                for (y, row) in grid.iter().enumerate() {
-                    let row_offset = y * buf_width * 4;
-                    for (x, &val) in row.iter().take(buf_width).enumerate() {
-                        let offset = row_offset + x * 4;
-                        if let Some([r, g, b, a]) = buf.get_mut(offset..offset + 4) {
-                            *r = val;
-                            *g = val;
-                            *b = val;
-                            *a = 255;
-                        }
-                    }
-                }
+                    .pending_grids
+                    .insert(name.clone(), grid);
                 if self.tab_set.active_tab != 3 {
                     self.tab_set.images_tab.new_activity = true;
                 }
@@ -4413,7 +4446,7 @@ mod test {
     }
 
     #[test]
-    fn image_write_stores_pixels() {
+    fn image_write_stores_pending_grid() {
         let mut gui = test_gui();
         gui.running = true;
         let grid = vec![vec![255, 0], vec![0, 128]];
@@ -4423,22 +4456,33 @@ mod test {
                 "test.png".into(),
             ))),
         );
+        // Grid should be pending, not yet rendered
+        assert!(
+            gui.tab_set
+                .images_tab
+                .pending_grids
+                .contains_key("test.png"),
+            "Grid should be stored in pending_grids"
+        );
+        assert!(
+            !gui.tab_set.images_tab.images.contains_key("test.png"),
+            "Image should not be rendered yet"
+        );
+        // Flush materializes the grid
+        gui.flush_pending_grids();
         let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
         assert_eq!(img.width, 2);
         assert_eq!(img.height, 2);
-        // Top-left pixel should be (255,255,255,255)
         assert_eq!(img.data.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
-        // Top-right pixel should be (0,0,0,255)
         assert_eq!(img.data.get_pixel(1, 0), &Rgba([0, 0, 0, 255]));
-        // Bottom-right pixel should be (128,128,128,255)
         assert_eq!(img.data.get_pixel(1, 1), &Rgba([128, 128, 128, 255]));
     }
 
     #[test]
-    fn image_write_recreates_on_dimension_change() {
+    fn image_write_latest_frame_wins() {
         let mut gui = test_gui();
         gui.running = true;
-        // First write: 2x1
+        // First write
         let grid1 = vec![vec![10, 20]];
         drop(
             gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
@@ -4446,10 +4490,7 @@ mod test {
                 "test.png".into(),
             ))),
         );
-        let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
-        assert_eq!(img.width, 2);
-        assert_eq!(img.height, 1);
-        // Second write: 3x2 — should recreate the buffer
+        // Second write with different dimensions — should replace
         let grid2 = vec![vec![1, 2, 3], vec![4, 5, 6]];
         drop(
             gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
@@ -4457,6 +4498,8 @@ mod test {
                 "test.png".into(),
             ))),
         );
+        // Only the latest grid should be pending
+        gui.flush_pending_grids();
         let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
         assert_eq!(img.width, 3);
         assert_eq!(img.height, 2);
@@ -4467,7 +4510,6 @@ mod test {
     fn image_write_truncates_long_rows() {
         let mut gui = test_gui();
         gui.running = true;
-        // Grid with a row longer than the first row — should truncate
         let grid = vec![vec![10, 20], vec![30, 40, 50]];
         drop(
             gui.update(Message::CoordinatorSent(CoordinatorMessage::ImageWrite(
@@ -4475,9 +4517,9 @@ mod test {
                 "test.png".into(),
             ))),
         );
+        gui.flush_pending_grids();
         let img = gui.tab_set.images_tab.images.get("test.png").unwrap();
         assert_eq!(img.width, 2);
-        // Only first 2 values of the second row should be written
         assert_eq!(img.data.get_pixel(0, 1), &Rgba([30, 30, 30, 255]));
         assert_eq!(img.data.get_pixel(1, 1), &Rgba([40, 40, 40, 255]));
     }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -658,6 +658,10 @@ impl Tab for StdOutTab {
 pub(crate) struct ImageTab {
     name: String,
     pub images: HashMap<String, ImageReference>,
+    /// Grids waiting to be rendered — only the latest grid per image name
+    /// is kept. Rendering is deferred until `FlowEnd` or a `PixelWrite` on
+    /// the same image, so intermediate frames are naturally skipped.
+    pub pending_grids: HashMap<String, Vec<Vec<u8>>>,
     pub new_activity: bool,
 }
 
@@ -666,6 +670,7 @@ impl ImageTab {
         Self {
             name: name.to_owned(),
             images: HashMap::default(),
+            pending_grids: HashMap::default(),
             new_activity: false,
         }
     }

--- a/flowr/src/bin/flowrgui/tabs.rs
+++ b/flowr/src/bin/flowrgui/tabs.rs
@@ -758,6 +758,7 @@ impl Tab for ImageTab {
 
     fn clear(&mut self) {
         self.images = HashMap::default();
+        self.pending_grids.clear();
     }
 }
 


### PR DESCRIPTION
## Summary

Optimizes image rendering in `flowrgui` by deferring `ImageWrite` grid materialization to `FlowEnd`. This skips intermediate frames when the GUI cannot keep up with rapid `ImageWrite` messages from the coordinator.

## Problem

Previously, every `ImageWrite` message immediately rendered the full grid pixel-by-pixel into the RGBA image buffer. For flows that produce many image frames (e.g., animations or iterative rendering), this caused redundant rendering work since only the final frame matters for display.

## Solution

Mirror the existing CLI optimization (`cli_client.rs` `pending_grids` pattern):

1. **`ImageWrite` handler**: Store the grid in `pending_grids` instead of rendering immediately. Only the latest grid per image name is kept — if a new grid arrives before the previous one was rendered, the old one is discarded.

2. **`FlowEnd` handler**: Call `flush_pending_grids()` to materialize all pending grids into rendered image buffers.

3. **`PixelWrite` handler**: Call `materialize_pending_grid()` for the target image before applying the pixel write, preserving message ordering.

## Changes

- `flowr/src/bin/flowrgui/tabs.rs`: Add `pending_grids: HashMap<String, Vec<Vec<u8>>>` to `ImageTab`
- `flowr/src/bin/flowrgui/main.rs`:
  - Add `materialize_pending_grid()` and `flush_pending_grids()` methods
  - Simplify `ImageWrite` handler to just store the grid
  - Add `materialize_pending_grid()` call before `PixelWrite`
  - Add `flush_pending_grids()` call in both `FlowEnd` variants
  - Update tests to verify deferred rendering behavior

## Testing

- `image_write_stores_pending_grid`: Verifies grid is stored, not rendered, then materialized on flush
- `image_write_latest_frame_wins`: Verifies second write replaces first, only final frame rendered
- `image_write_truncates_long_rows`: Existing test updated for deferred rendering

Closes #2679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image rendering to preserve the correct order of updates.
  - Ensured only the latest frame is displayed when multiple updates arrive for the same image.
  - Improved handling of image dimension changes, truncated rows, and stale pixels.
  - Pending image updates are now applied reliably before pixel writes and when processing completes.
  - Cleared pending image updates when resetting image views to prevent outdated content from reappearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->