### PR TITLE
fix: serialize subflow integration tests to prevent flaky CI

### DIFF
--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -699,7 +699,7 @@ fn peer_coordinator_executes_subflow() {
             &connect_addrs.3,
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_secs(1));
 
         #[cfg(feature = "submission")]
         let mut no_op_handler = flowrlib::subflow::NoOpSubmissionHandler;
@@ -748,7 +748,7 @@ fn peer_coordinator_executes_subflow() {
     });
 
     // Give coordinator time to start
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
     // Connect as parent and submit the sub-flow
     let peer_address = format!("127.0.0.1:{peer_port}");
@@ -916,7 +916,7 @@ fn peer_handles_multiple_submissions() {
             &connect_addrs.3,
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_secs(1));
 
         #[cfg(feature = "debugger")]
         let mut debug_handler = flowrlib::subflow::NoOpDebugHandler;
@@ -964,12 +964,12 @@ fn peer_handles_multiple_submissions() {
         results
     });
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
     // Submit TWO sub-flows on the SAME connection
     let peer_address = format!("127.0.0.1:{peer_port}");
     let connection = ClientConnection::new(&peer_address).expect("connect");
-    connection.set_receive_timeout(300_000).expect("timeout");
+    connection.set_receive_timeout(30_000).expect("timeout");
 
     // First submission: add(7, 3) = 10
     let manifest1 = build_manifest(7, 3);
@@ -1206,7 +1206,7 @@ fn peer_coordinator_executes_wasm_subflow() {
             &connect_addrs.3,
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_secs(1));
 
         #[cfg(feature = "submission")]
         let mut no_op_handler = flowrlib::subflow::NoOpSubmissionHandler;
@@ -1255,7 +1255,7 @@ fn peer_coordinator_executes_wasm_subflow() {
     });
 
     // Give coordinator time to start
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
     // Connect as parent and submit the sub-flow with the rewritten http:// URLs
     let peer_address = format!("127.0.0.1:{peer_port}");

--- a/flowr/tests/subflow.rs
+++ b/flowr/tests/subflow.rs
@@ -9,12 +9,14 @@ use flowcore::model::flow_manifest::FlowManifest;
 use flowcore::model::submission::Submission;
 use flowcore::provider::Provider;
 use flowrlib::run_state::RunState;
+use serial_test::serial;
 
 /// Test that a sub-flow can be extracted from a compiled manifest,
 /// wrapped in a `Submission`, and used to construct a `RunState` that
 /// initializes correctly.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 fn extract_and_init_subflow() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -169,6 +171,7 @@ fn extract_and_init_subflow() {
 /// crossing a sub-flow's boundary.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 fn subflow_interface_identifies_boundary_connections() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let project_root = manifest_dir.parent().expect("Could not find project root");
@@ -244,6 +247,7 @@ fn subflow_interface_identifies_boundary_connections() {
 /// initializers, so it can run to completion without external inputs.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 fn subflow_implementation_executes() {
     use flowcore::model::flow_manifest::FlowInfo;
     use flowcore::model::input::{Input, InputInitializer};
@@ -319,6 +323,7 @@ fn subflow_implementation_executes() {
 /// Test that `SubFlowImplementation` can receive injected inputs through the interface.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 fn subflow_implementation_with_injected_inputs() {
     use flowcore::model::flow_manifest::FlowInfo;
     use flowcore::model::input::Input;
@@ -401,6 +406,7 @@ fn subflow_implementation_with_injected_inputs() {
 /// output on a connection targeting a function outside the sub-flow.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 fn subflow_captures_boundary_outputs() {
     use flowcore::model::flow_manifest::FlowInfo;
@@ -581,6 +587,7 @@ fn executor_registers_subflow_manifest() {
 /// verify boundary outputs come back.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 fn peer_coordinator_executes_subflow() {
     use flowcore::model::flow_manifest::FlowInfo;
@@ -795,6 +802,7 @@ fn peer_coordinator_executes_subflow() {
 /// verifying that the peer's bridge loops back correctly after each `FlowEnd`.
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 fn peer_handles_multiple_submissions() {
     use flowcore::model::flow_manifest::FlowInfo;
@@ -1039,6 +1047,7 @@ fn peer_handles_multiple_submissions() {
 /// 4. The boundary outputs are correct
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 fn peer_coordinator_executes_wasm_subflow() {
     use flowcore::meta_provider::MetaProvider;


### PR DESCRIPTION
## Problem

The subflow integration tests in `flowr/tests/subflow.rs` all run in parallel by default. Most spawn ZMQ infrastructure (Dispatcher, Executor, Coordinator) on random ports, and some shell out to `flowc`. Under CI load this causes intermittent failures from:

- ZMQ socket setup timing issues (the 100ms sleep is sometimes insufficient)
- Port contention between concurrent `portpicker` calls and ZMQ binds
- Panic output lost because it occurs in spawned executor threads, not the test thread

This caused the flaky failure in [run #34330956950](https://github.com/andrewdavidmackenzie/flow/actions/runs/34330956950) where `subflow_implementation_with_injected_inputs` failed on `ubuntu-24.04` with no visible error message.

## Fix

Add `#[serial]` (from `serial_test`, already a dependency) to all 8 integration tests that use ZMQ or external processes, matching the pattern already used in `delegation.rs`. The pure unit test (`executor_registers_subflow_manifest`) remains parallel since it doesn't use ZMQ.

## Verification

- `make clippy` passes
- `cargo fmt` passes
- `make test` passes — all 9 subflow tests pass, plus all other tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated subflow-related tests to run sequentially, improving test execution stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->